### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/BACSU/comK/comK-ai-review.html
+++ b/genes/BACSU/comK/comK-ai-review.html
@@ -1690,6 +1690,449 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(comK-hypotheses/prediction-atp-binding/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40396" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">AIGR Gene Hypothesis Deep Research — Final Report</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+                    <span class="report-badge">7 citations</span>
+
+
+                    <span class="report-badge">4 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-10T04:19:20.415263</span>
+
+
+
+                    <a href="comK-hypotheses/prediction-atp-binding/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="comK-hypotheses/prediction-atp-binding/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="comK-hypotheses/prediction-atp-binding/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="comK-hypotheses/prediction-atp-binding/openscientist_artifacts/provenance_comK_ATP_evidence_matrix.csv" class="term-link">OpenScientist comK ATP evidence matrix</a>
+                        <span>(text/csv)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="comK-hypotheses/prediction-atp-binding/openscientist_artifacts/provenance_comK_GO_decision_table.csv" class="term-link">OpenScientist comK GO decision table</a>
+                        <span>(text/csv)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="aigr-gene-hypothesis-deep-research-final-report">AIGR Gene Hypothesis Deep Research — Final Report</h1>
+<h2 id="comk-bacsu-uniprot-p40396-atp-binding-go0005524-computational-prediction">ComK (BACSU, UniProt P40396): ATP binding (GO:0005524) computational prediction</h2>
+<p><strong>Gene:</strong> comK / Competence transcription factor · <strong>Organism:</strong> <em>Bacillus subtilis</em> 168 (BACSU, NCBITaxon:224308) · <strong>UniProt:</strong> P40396<br />
+<strong>Predicted term under review:</strong> ATP binding (GO:0005524), from BioReason-Pro SFT<br />
+<strong>Focus type:</strong> computational_prediction · <strong>Reference context:</strong> doi:10.64898/2026.03.19.712954</p>
+<hr />
+<h2 id="summary">Summary</h2>
+<p>The BioReason-Pro SFT prediction of <strong>ATP binding (GO:0005524)</strong> for <em>Bacillus subtilis</em> ComK (P40396) is <strong>refuted</strong>. ComK is a compact, 192-amino-acid, single-domain <strong>sequence-specific DNA-binding transcription factor</strong> — the master regulator of genetic competence development — and it contains <strong>no ATP-binding motif or nucleotide-binding fold</strong>. Five independent evidence types converge on this conclusion: (1) the protein sequence lacks a Walker A P-loop and a classic Walker B motif; (2) its domain family (Pfam PF06338 / InterPro IPR010461, the ComK family) carries no nucleotide-binding, kinase, or ATPase signature; (3) the curated UniProt record contains no ATP-binding annotation, keyword, or binding-site feature; (4) cryo-EM structures of the ComK–promoter complex show a DNA-binding, DNA-bending mechanism with no ATP site; and (5) mechanistic transcription studies show ComK activates transcription by stabilizing RNA polymerase at target promoters, with no ATP-hydrolysis step by ComK.</p>
+<p>The one genuine link between ComK and ATP is <strong>indirect and does not confer ATP binding on ComK</strong>: ComK is a <em>substrate</em> of the ATP-dependent MecA–ClpCP protease. In that complex, the ATPase activity resides entirely in the AAA+ chaperone <strong>ClpC</strong>, while ComK is the passive degradation target. Because ComK biology is routinely discussed alongside "the ATP-dependent ClpCP protease," a model that keys on co-occurrence can easily misattribute the ATPase's ATP-dependence to the substrate. This pathway-context/co-mention bias — combined with the fact that GO:0005524 is among the most frequently over-assigned molecular-function terms — is the most plausible origin of the false-positive prediction.</p>
+<p><strong>Recommended curation action:</strong> Do NOT add GO:0005524. Retain and prioritize the DNA-binding transcription-factor terms that are actually supported (sequence-specific DNA binding; DNA-binding transcription activator activity), together with the well-supported process terms (DNA-templated transcription; establishment of competence for transformation). The prediction should be recorded as an over-annotation to reject.</p>
+<hr />
+<h2 id="key-findings">Key Findings</h2>
+<h3 id="finding-1-comk-is-a-sequence-specific-dna-binding-transcription-factor-with-no-atp-binding-motif-prediction-refuted">Finding 1 — ComK is a sequence-specific DNA-binding transcription factor with no ATP-binding motif (prediction REFUTED)</h3>
+<p>ComK's primary molecular function is <strong>sequence-specific DNA binding</strong> driving transcriptional activation, and there is no evidence of a nucleotide-binding fold anywhere in the 192-residue protein.</p>
+<p><strong>Sequence-level evidence.</strong> A direct scan of the P40396 sequence found <strong>no Walker A P-loop motif</strong> (consensus <code>[AG]x4GK[ST]</code>, the glycine-rich loop that cradles the β/γ-phosphates of ATP/GTP) and <strong>no classic Walker B motif</strong> (the hhhhDE aspartate/glutamate that coordinates the catalytic Mg²⁺–water). The absence of both halves of the canonical P-loop NTPase signature is strong negative evidence against ATP binding, because these motifs constitute the minimal structural hallmark shared across the overwhelming majority of ATP- and GTP-binding proteins.</p>
+<p><strong>Domain-level evidence.</strong> ComK is the founding and essentially sole member of the <strong>ComK family (Pfam PF06338 / InterPro IPR010461)</strong>, a family defined by the transcription-factor function of ComK and its orthologs across Bacilli. It carries no annotation for nucleotide binding, ATPase, kinase, AAA+, or ABC architecture, and P40396 contains no auxiliary domain that could supply an ATP pocket.</p>
+<p><strong>Database-level evidence.</strong> UniProt annotates P40396 with keywords <strong>DNA-binding, Activator, Repressor, Transcription regulation</strong>, and with GO terms <strong>GO:0003677 (DNA binding)</strong>, <strong>GO:0006351 (DNA-templated transcription)</strong>, and <strong>GO:0030420 (establishment of competence for transformation)</strong>. There is <strong>no ATP-binding annotation (GO:0005524)</strong> in the curated record — the prediction conflicts with, rather than derives from, the curated evidence — and there is no EC number, cofactor, or nucleotide binding-site feature.</p>
+<p><strong>Structural evidence.</strong> Cryo-EM structures of the complex between ComK and its promoter DNA (<a href="https://pubmed.ncbi.nlm.nih.gov/34016970/">PMID: 34016970</a>) demonstrate that ComK functions through <strong>mechanical forces that alter DNA curvature</strong> — an allosteric, DNA-bending mechanism — not a catalytic nucleotide-dependent step. Verified quote: <em>"Cryo-EM structures of the complex between ComK and its promoter demonstrate that this coupling is due to mechanical forces that alter DNA curvature."</em> No ATP or nucleotide participates in the described functional mechanism.</p>
+<p><strong>Mechanistic evidence.</strong> ComK activates transcription by <strong>stabilizing RNA polymerase binding</strong> at the target promoter (<a href="https://pubmed.ncbi.nlm.nih.gov/14762007/">PMID: 14762007</a>; verified quote: <em>"ComK stabilizes the binding of RNA polymerase to the comG promoter"</em>). This is a classic activator recruitment/stabilization mechanism and involves no ATP binding or hydrolysis by ComK. Foundational work (<a href="https://pubmed.ncbi.nlm.nih.gov/7783616/">PMID: 7783616</a>; verified quote: <em>"we demonstrate that ComK specifically binds to DNA fragments containing promoter and upstream sequences of the genes it affects"</em>) established the sequence-specific DNA-binding activity that defines ComK, and mutational studies of the K-box AT-boxes (<a href="https://pubmed.ncbi.nlm.nih.gov/17468244/">PMID: 17468244</a>) confirmed base-specific DNA recognition.</p>
+<p>Together, five independent evidence types — sequence, domain, curated database, structure, and mechanism — all point away from ATP binding and toward DNA binding. This is the central finding that refutes the seed hypothesis.</p>
+<h3 id="finding-2-comks-only-genuine-atp-connection-is-as-a-substrate-of-the-atp-dependent-mecaclpcp-protease-explains-the-false-positive">Finding 2 — ComK's only genuine ATP connection is as a substrate of the ATP-dependent MecA–ClpCP protease (explains the false positive)</h3>
+<p>The prediction most plausibly arises from <strong>pathway-context/co-mention bias</strong>, not from any intrinsic ComK property. In <em>B. subtilis</em>, ComK protein levels are controlled by regulated proteolysis: a ternary complex of the <strong>adaptor protein MecA</strong> and the <strong>ATP-dependent protease ClpCP</strong> targets ComK for degradation (<a href="https://pubmed.ncbi.nlm.nih.gov/12598648/">PMID: 12598648</a>, <a href="https://pubmed.ncbi.nlm.nih.gov/19767395/">PMID: 19767395</a>).</p>
+<p>The decisive point for curation is the <strong>division of labor</strong> within this complex:</p>
+<ul>
+<li><strong>ClpC</strong> is an HSP100/Clp <strong>AAA+ ATPase</strong>; it binds and hydrolyzes ATP to power substrate unfolding and translocation. The ATP-binding activity belongs to ClpC.</li>
+<li><strong>MecA</strong> is the adaptor that recognizes ComK, delivers it to ClpC, and stimulates ClpC's ATPase activity.</li>
+<li><strong>ComK is the passive substrate.</strong> It contributes no ATP-binding or ATPase activity; it is the protein being degraded.</li>
+</ul>
+<p>Verified quotes: <em>"A complex of ClpC with the protease ClpP and the adaptor protein MecA also controls competence development by regulated proteolysis of the transcription factor ComK"</em> (<a href="https://pubmed.ncbi.nlm.nih.gov/12598648/">PMID: 12598648</a>); <em>"the degradation of the competence transcription factor ComK is mediated by a ternary complex involving the adaptor protein MecA and the ATP-dependent protease ClpCP"</em> (<a href="https://pubmed.ncbi.nlm.nih.gov/19767395/">PMID: 19767395</a>).</p>
+<p>Because ComK is routinely discussed in the same sentences as the "<strong>ATP-dependent</strong> protease ClpCP," a text- or co-occurrence-influenced model can mis-attribute the ATP-dependence of the <em>degradation machinery</em> to ComK itself. This is a textbook instance of pathway-context bias generating a false ATP-binding call for a protein that is merely a substrate. Notably, no paralog with an ATPase fold shares the ComK family, so paralog over-annotation can be ruled out as the source.</p>
+<hr />
+<h2 id="mechanistic-model-interpretation">Mechanistic Model / Interpretation</h2>
+<p>The following schematic separates <strong>what ComK actually does</strong> from <strong>the ATP-dependent process in which ComK is a substrate</strong>, clarifying why GO:0005524 is a misassignment.</p>
+<div class="codehilite"><pre><span></span><code><span class="w">   </span><span class="n">ComK</span><span class="err">&#39;</span><span class="n">s</span><span class="w"> </span><span class="n">ACTUAL</span><span class="w"> </span><span class="n">molecular</span><span class="w"> </span><span class="k">function</span><span class="w"> </span><span class="p">(</span><span class="k">no</span><span class="w"> </span><span class="n">ATP</span><span class="w"> </span><span class="n">involved</span><span class="p">)</span>
+<span class="w">   </span><span class="err">───────────────────────────────────────────────────</span>
+<span class="w"> </span><span class="n">ComK</span><span class="w"> </span><span class="p">(</span><span class="mi">192</span><span class="w"> </span><span class="n">aa</span><span class="p">,</span><span class="w"> </span><span class="n">PF06338</span><span class="p">)</span>
+<span class="w">        </span><span class="err">│</span>
+<span class="w">     </span><span class="k">sequence</span><span class="o">-</span><span class="k">specific</span><span class="w"> </span><span class="n">DNA</span><span class="w"> </span><span class="n">binding</span>
+<span class="p">(</span><span class="n">K</span><span class="o">-</span><span class="nl">box</span><span class="p">:</span><span class="w"> </span><span class="n">paired</span><span class="w"> </span><span class="k">AT</span><span class="o">-</span><span class="n">boxes</span><span class="p">,</span><span class="w"> </span><span class="n">AAAA</span><span class="o">-</span><span class="n">N5</span><span class="o">-</span><span class="n">TTTT</span><span class="p">)</span>
+<span class="w">        </span><span class="err">│</span>
+<span class="w">        </span><span class="err">▼</span>
+<span class="err">┌───────────────────────────────────┐</span>
+<span class="err">│</span><span class="w">  </span><span class="n">bends</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">curves</span><span class="w"> </span><span class="n">promoter</span><span class="w"> </span><span class="n">DNA</span><span class="w">       </span><span class="err">│</span><span class="w">  </span><span class="p">(</span><span class="n">cryo</span><span class="o">-</span><span class="n">EM</span><span class="p">,</span><span class="w"> </span><span class="n">PMID</span><span class="w"> </span><span class="mi">34016970</span><span class="p">)</span>
+<span class="err">│</span><span class="w">  </span><span class="n">stabilizes</span><span class="w"> </span><span class="n">RNA</span><span class="w"> </span><span class="n">polymerase</span><span class="w"> </span><span class="n">binding</span><span class="w"> </span><span class="err">│</span><span class="w">  </span><span class="p">(</span><span class="n">PMID</span><span class="w"> </span><span class="mi">14762007</span><span class="p">)</span>
+<span class="err">└───────────────────────────────────┘</span>
+<span class="w">        </span><span class="err">│</span>
+<span class="w">        </span><span class="err">▼</span>
+<span class="w">  </span><span class="n">activation</span><span class="w"> </span><span class="k">of</span><span class="w"> </span><span class="n">the</span><span class="w"> </span><span class="n">K</span><span class="o">-</span><span class="n">regulon</span><span class="w"> </span><span class="err">→</span><span class="w"> </span><span class="n">competence</span>
+<span class="w"> </span><span class="p">(</span><span class="k">GO</span><span class="err">:</span><span class="mi">0030420</span><span class="p">,</span><span class="w"> </span><span class="k">GO</span><span class="err">:</span><span class="mi">0006351</span><span class="p">)</span>
+
+<span class="w">   </span><span class="k">NO</span><span class="w"> </span><span class="n">Walker</span><span class="w"> </span><span class="n">A</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">Walker</span><span class="w"> </span><span class="n">B</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">P</span><span class="o">-</span><span class="n">loop</span><span class="w">  </span><span class="err">→</span><span class="w">  </span><span class="k">NO</span><span class="w"> </span><span class="n">ATP</span><span class="w"> </span><span class="n">binding</span><span class="w"> </span><span class="k">by</span><span class="w"> </span><span class="n">ComK</span>
+
+
+<span class="w">   </span><span class="n">The</span><span class="w"> </span><span class="n">ATP</span><span class="w"> </span><span class="n">link</span><span class="w"> </span><span class="k">is</span><span class="w"> </span><span class="k">EXTERNAL</span><span class="w"> </span><span class="k">to</span><span class="w"> </span><span class="n">ComK</span><span class="w"> </span><span class="p">(</span><span class="n">ComK</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">substrate</span><span class="p">)</span>
+<span class="w">   </span><span class="err">───────────────────────────────────────────────────</span>
+<span class="w">      </span><span class="n">MecA</span><span class="w"> </span><span class="p">(</span><span class="n">adaptor</span><span class="p">)</span><span class="w"> </span><span class="err">──</span><span class="w"> </span><span class="n">recognizes</span><span class="w"> </span><span class="err">──►</span><span class="w"> </span><span class="n">ComK</span><span class="w"> </span><span class="p">(</span><span class="n">SUBSTRATE</span><span class="p">)</span>
+<span class="w">                          </span><span class="err">│</span>
+<span class="n">ClpC</span><span class="w"> </span><span class="p">(</span><span class="n">AAA</span><span class="o">+</span><span class="w"> </span><span class="n">ATPase</span><span class="p">)</span><span class="w"> </span><span class="err">──</span><span class="w"> </span><span class="n">ATP</span><span class="w"> </span><span class="n">hydrolysis</span><span class="w"> </span><span class="err">──►</span><span class="w"> </span><span class="n">unfolds</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">translocates</span>
+<span class="w">                          </span><span class="err">│</span>
+<span class="n">ClpP</span><span class="w"> </span><span class="p">(</span><span class="n">protease</span><span class="p">)</span><span class="w"> </span><span class="err">─────────────────►</span><span class="w"> </span><span class="n">degrades</span><span class="w"> </span><span class="n">ComK</span>
+
+<span class="w">      </span><span class="n">ATP</span><span class="w"> </span><span class="k">is</span><span class="w"> </span><span class="n">bound</span><span class="w"> </span><span class="o">&amp;</span><span class="w"> </span><span class="n">hydrolyzed</span><span class="w"> </span><span class="k">by</span><span class="w"> </span><span class="n">ClpC</span><span class="p">,</span><span class="w"> </span><span class="ow">NOT</span><span class="w"> </span><span class="k">by</span><span class="w"> </span><span class="n">ComK</span>
+<span class="w">      </span><span class="p">(</span><span class="n">PMID</span><span class="w"> </span><span class="mi">12598648</span><span class="p">,</span><span class="w"> </span><span class="n">PMID</span><span class="w"> </span><span class="mi">19767395</span><span class="p">)</span>
+</code></pre></div>
+
+<p><strong>Interpretation.</strong> The two findings form a single coherent narrative. ComK is a compact, single-domain DNA-binding activator whose entire biochemistry — K-box recognition, DNA bending, and RNA polymerase recruitment — is nucleotide-independent. Its cellular abundance is set post-translationally by an ATP-powered protease, but that ATP dependence is a property of ClpC, not ComK. A predictor keying on the strong statistical association between "ComK" and "ATP-dependent ClpCP" in the literature would produce exactly the false-positive ATP-binding call observed. Distinguishing the substrate (ComK) from the enzyme (ClpC) is the crux of the correct curation decision.</p>
+<h3 id="comparison-table-expected-features-of-an-atp-binding-protein-vs-observed-for-comk">Comparison table: expected features of an ATP-binding protein vs. observed for ComK</h3>
+<table>
+<thead>
+<tr>
+<th>Feature diagnostic of ATP binding</th>
+<th>Expected if hypothesis true</th>
+<th>Observed for ComK (P40396)</th>
+<th>Verdict</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Walker A P-loop (<code>[AG]x4GK[ST]</code>)</td>
+<td>Present</td>
+<td><strong>Absent</strong></td>
+<td>Refutes</td>
+</tr>
+<tr>
+<td>Walker B motif (hhhhDE)</td>
+<td>Present</td>
+<td><strong>Absent</strong></td>
+<td>Refutes</td>
+</tr>
+<tr>
+<td>P-loop NTPase / AAA+ / ABC / kinase domain</td>
+<td>Present</td>
+<td><strong>Absent</strong> (ComK family PF06338 only)</td>
+<td>Refutes</td>
+</tr>
+<tr>
+<td>UniProt ATP-binding keyword / site feature</td>
+<td>Present</td>
+<td><strong>Absent</strong></td>
+<td>Refutes</td>
+</tr>
+<tr>
+<td>GO:0005524 in curated record</td>
+<td>Present</td>
+<td><strong>Absent</strong></td>
+<td>Refutes</td>
+</tr>
+<tr>
+<td>ATP/nucleotide density in structure</td>
+<td>Present</td>
+<td><strong>Absent</strong> (DNA-bound cryo-EM)</td>
+<td>Refutes</td>
+</tr>
+<tr>
+<td>Functional need for ATP in mechanism</td>
+<td>Required</td>
+<td><strong>Not required</strong> (recruitment / DNA bending)</td>
+<td>Refutes</td>
+</tr>
+<tr>
+<td>Sequence-specific DNA-binding activity</td>
+<td>Not required</td>
+<td><strong>Present, defining</strong></td>
+<td>Competing correct function</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="evidence-base-evidence-matrix">Evidence Base / Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Direction</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence / limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>This analysis (P40396 seq)</td>
+<td>Computational (motif scan)</td>
+<td><strong>Refutes</strong></td>
+<td>ComK contains an ATP-binding motif</td>
+<td>No Walker A P-loop, no classic Walker B in 192 aa</td>
+<td>In silico</td>
+<td>High; motif absence is strong but not exhaustive of atypical folds</td>
+</tr>
+<tr>
+<td>UniProt P40396 (database)</td>
+<td>Review/database</td>
+<td><strong>Refutes</strong></td>
+<td>Curated ATP-binding function exists</td>
+<td>No ATP keyword/GO; only DNA-binding &amp; transcription terms</td>
+<td>Curated record</td>
+<td>High; database-level orientation</td>
+</tr>
+<tr>
+<td>Pfam PF06338 / InterPro IPR010461</td>
+<td>Structural/evolutionary</td>
+<td><strong>Refutes</strong></td>
+<td>Nucleotide-binding fold in family</td>
+<td>ComK-specific family; no NTPase/kinase signature</td>
+<td>Domain model</td>
+<td>High; no P-loop lineage</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/34016970/">PMID: 34016970</a></td>
+<td>Structural (cryo-EM)</td>
+<td><strong>Refutes / qualifies</strong></td>
+<td>Mechanism requires ATP</td>
+<td>Function via DNA binding + DNA-curvature allostery; no ATP site</td>
+<td><em>B. subtilis</em>, in vitro</td>
+<td>High</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/7783616/">PMID: 7783616</a></td>
+<td>Direct assay (DNA binding)</td>
+<td><strong>Supports DNA (competing correct fn)</strong></td>
+<td>Primary function is DNA binding</td>
+<td>ComK binds specific promoter/upstream DNA</td>
+<td><em>B. subtilis</em></td>
+<td>High; establishes core function</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/14762007/">PMID: 14762007</a></td>
+<td>Direct assay (in vitro transcription)</td>
+<td><strong>Refutes (ATP not needed)</strong></td>
+<td>Activation is ATP-dependent</td>
+<td>ComK stabilizes RNAP binding; no ATP step</td>
+<td><em>B. subtilis</em>, in vitro</td>
+<td>High</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/17468244/">PMID: 17468244</a></td>
+<td>Mutant / binding</td>
+<td><strong>Qualifies (supports DNA)</strong></td>
+<td>DNA sequence specificity</td>
+<td>K-box AT-box T2 base critical for binding/activation</td>
+<td><em>B. subtilis</em></td>
+<td>High</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/15598897/">PMID: 15598897</a></td>
+<td>Mutant / promoter mapping</td>
+<td><strong>Qualifies (regulatory context)</strong></td>
+<td>How comK is regulated</td>
+<td>DegU binds inverted repeat in comK promoter</td>
+<td><em>B. subtilis</em></td>
+<td>Medium; concerns comK regulation, not ComK ATP</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/12598648/">PMID: 12598648</a></td>
+<td>Interaction / proteolysis</td>
+<td><strong>Competing / qualifies</strong></td>
+<td>ComK–ATP link</td>
+<td>ComK is substrate of ATP-dependent ClpCP; ATPase is ClpC</td>
+<td><em>B. subtilis</em></td>
+<td>High; explains misassignment</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/19767395/">PMID: 19767395</a></td>
+<td>Interaction / proteolysis</td>
+<td><strong>Competing / qualifies</strong></td>
+<td>ComK ATP link is intrinsic</td>
+<td>MecA targets ComK to ClpCP; ATP dependence is ClpCP's</td>
+<td><em>B. subtilis</em></td>
+<td>High; ComK is substrate, not ATP binder</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="go-curation-implications">GO Curation Implications</h2>
+<p><strong>Lead requiring curator verification:</strong></p>
+<ol>
+<li>
+<p><strong>Do NOT add GO:0005524 (ATP binding).</strong> The molecular-function prediction is a false positive. No sequence motif, domain, curated annotation, structural feature, or mechanistic requirement supports ATP binding by ComK. If GO:0005524 has been auto-propagated onto P40396, it should be rejected / not accepted.</p>
+</li>
+<li>
+<p><strong>Retain and prioritize the informative Molecular Function terms</strong> that are actually supported:</p>
+</li>
+<li><strong>GO:0003677 — DNA binding</strong> (already curated; supported by <a href="https://pubmed.ncbi.nlm.nih.gov/7783616/">PMID: 7783616</a>).</li>
+<li>
+<p><strong>GO:0043565 — sequence-specific DNA binding</strong> and <strong>GO:0001216 — DNA-binding transcription activator activity</strong> as the precise MF terms (K-box specificity, <a href="https://pubmed.ncbi.nlm.nih.gov/17468244/">PMID: 17468244</a>; RNAP stabilization, <a href="https://pubmed.ncbi.nlm.nih.gov/14762007/">PMID: 14762007</a>). These are strictly more informative than "protein binding" and should be preferred. ComK also acts as a repressor in some contexts.</p>
+</li>
+<li>
+<p><strong>Retain the Biological Process terms</strong>: <strong>GO:0006351 (DNA-templated transcription)</strong> / <strong>GO:0006355 (regulation of transcription)</strong> and <strong>GO:0030420 (establishment of competence for transformation)</strong>.</p>
+</li>
+<li>
+<p><strong>Frame the ATP link correctly, if annotated at all:</strong> ComK's relationship to ATP is as a <strong>substrate of an ATP-dependent protease (ClpCP)</strong>. Any ATP-related annotation belongs to ClpC, not ComK. This relationship should not become an ATP-binding MF term on ComK.</p>
+</li>
+</ol>
+<p><strong>Summary GO decision table:</strong></p>
+<table>
+<thead>
+<tr>
+<th>GO term</th>
+<th>Aspect</th>
+<th>Recommended action</th>
+<th>Basis</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0005524 ATP binding</td>
+<td>MF</td>
+<td><strong>Reject / do not add</strong></td>
+<td>No motif, domain, structure, or mechanism; substrate-only ATP link</td>
+</tr>
+<tr>
+<td>GO:0003677 DNA binding</td>
+<td>MF</td>
+<td>Retain</td>
+<td>PMID 7783616</td>
+</tr>
+<tr>
+<td>GO:0043565 sequence-specific DNA binding</td>
+<td>MF</td>
+<td>Add / upgrade (more specific)</td>
+<td>PMID 17468244, 34016970</td>
+</tr>
+<tr>
+<td>GO:0001216 DNA-binding transcription activator activity</td>
+<td>MF</td>
+<td>Add / consider</td>
+<td>PMID 14762007</td>
+</tr>
+<tr>
+<td>GO:0006351 / GO:0006355 transcription (regulation)</td>
+<td>BP</td>
+<td>Retain</td>
+<td>Curated</td>
+</tr>
+<tr>
+<td>GO:0030420 establishment of competence</td>
+<td>BP</td>
+<td>Retain</td>
+<td>Curated</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p><strong>Immediate molecular function under test:</strong> whether ComK directly binds ATP (GO:0005524). The answer is no. ComK's direct, primary molecular activity is <strong>sequence-specific binding to K-box DNA elements</strong> (paired AT-boxes) and, through that binding, <strong>DNA bending and stabilization of RNA polymerase</strong> at target promoters.</p>
+<p><strong>What must be kept separate (not ComK's direct molecular function):</strong><br />
+- <em>Downstream developmental outcome:</em> establishment of genetic competence, DNA uptake, and homologous recombination — consequences of ComK's transcriptional activity, not evidence for ATP binding.<br />
+- <em>Pathway context:</em> ATP-dependent proteolysis of ComK by MecA–ClpCP — an external regulatory process in which ComK is the substrate and ClpC is the ATPase.<br />
+- <em>Upstream regulation:</em> DegU binding to the comK promoter (<a href="https://pubmed.ncbi.nlm.nih.gov/15598897/">PMID: 15598897</a>) governs comK <em>expression</em>, unrelated to any ComK ATP activity.</p>
+<p>The ATP-binding hypothesis fails precisely because it conflates a pathway-level ATP dependence (proteolysis) with a gene-product-level molecular function (nucleotide binding).</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ul>
+<li><strong>Substrate-vs-enzyme confusion (most likely artifact):</strong> The strongest ComK–ATP link in the literature is that ComK is a <strong>substrate</strong> of the ATP-dependent MecA–ClpCP protease (<a href="https://pubmed.ncbi.nlm.nih.gov/12598648/">PMID: 12598648</a>, <a href="https://pubmed.ncbi.nlm.nih.gov/19767395/">PMID: 19767395</a>). Attributing ClpC's ATP dependence to ComK is the error.</li>
+<li><strong>Frequency / prior bias:</strong> GO:0005524 is one of the most common MF terms; a model with a strong prior can over-assign it in the absence of any real signal.</li>
+<li><strong>Paralog / family confusion — ruled out:</strong> ComK is the sole defining member of PF06338; there is no ATP-binding paralog within the family that could seed annotation transfer.</li>
+<li><strong>Organism-specific differences — none:</strong> ComK's role as a competence transcription factor is conserved across Bacilli; no ortholog is reported to have acquired a nucleotide-binding domain.</li>
+<li><strong>In vitro-only artifact — none:</strong> No in vitro study reports ATP binding by ComK; the relevant assays (DNA binding, transcription activation) are ATP-independent for ComK.</li>
+<li><strong>Database carry-over — absent:</strong> UniProt P40396 does not carry GO:0005524, so the prediction contradicts, rather than inherits from, the curated record.</li>
+</ul>
+<p>All conflicts point the same direction: away from ATP binding by ComK.</p>
+<hr />
+<h2 id="limitations-and-knowledge-gaps">Limitations and Knowledge Gaps</h2>
+<ol>
+<li><strong>Motif scan scope.</strong> The Walker A/B scan used canonical consensus patterns; degenerate or atypical nucleotide pockets can occasionally escape simple motif matching. <em>Why it matters:</em> a hidden atypical site would be missed by motif search alone. <em>Resolution:</em> the gap is largely closed by the DNA-bound cryo-EM structure and by the ComK-family domain assignment, neither of which reveals a nucleotide pocket; a full HMMER/InterProScan and structure-based pocket analysis (e.g., on the AlphaFold model) would formally confirm.</li>
+<li><strong>Direct negative biochemical assay.</strong> No published experiment explicitly reports the <em>absence</em> of ATP binding by ComK (negative results are rarely published). <em>Why it matters:</em> absence of ATP binding is inferred from motif/domain/structure/mechanism rather than a dedicated binding assay. <em>Resolution:</em> an ITC, DSF/thermal-shift, DRaCALA, or ATP-agarose pulldown assay would provide a direct negative control.</li>
+<li><strong>Structure interpretation is literature-based.</strong> The cryo-EM conclusion is drawn from the published report (<a href="https://pubmed.ncbi.nlm.nih.gov/34016970/">PMID: 34016970</a>); the raw coordinates were not re-analyzed here for ligand density (none expected). <em>Resolution:</em> inspect the deposited PDB/EMDB entry for any nucleotide ligand.</li>
+<li><strong>Provenance of the prediction.</strong> The exact features BioReason-Pro SFT used are unknown. <em>Why it matters:</em> confirming co-mention/frequency bias would strengthen the "reject" recommendation. <em>Resolution:</em> inspect model attributions if available.</li>
+</ol>
+<p>None of these gaps materially weakens the refutation; they are avenues for formal confirmation.</p>
+<hr />
+<h2 id="discriminating-tests-proposed-follow-up-experiments">Discriminating Tests / Proposed Follow-up Experiments</h2>
+<p>Concrete, prioritized actions to definitively distinguish ATP binding from the established DNA-binding function:</p>
+<ol>
+<li><strong>ITC or thermal-shift (DSF) with ATP</strong> on purified ComK (± Mg²⁺). <em>Expected if hypothesis true:</em> measurable K_d / thermal stabilization. <em>Predicted outcome:</em> no binding — a clean direct negative control. <strong>Highest-value, low-cost test.</strong></li>
+<li><strong>Inspect the ComK–DNA cryo-EM structure / PDB</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/34016970/">PMID: 34016970</a>) for any bound nucleotide density or P-loop-like pocket. <em>Expected:</em> none.</li>
+<li><strong>Structure-based pocket/ligand-site prediction</strong> on an AlphaFold model of P40396 and superposition against known P-loop NTPases. <em>Expected:</em> a DNA-binding surface, not an ATP pocket.</li>
+<li><strong>Full domain/HMM re-scan</strong> (InterProScan, HMMER vs. Pfam-A). <em>Expected:</em> PF06338-only architecture; no AAA+/P-loop/kinase domain.</li>
+<li><strong>ATP-agarose or DRaCALA binding assay</strong> on purified ComK. <em>Predicted:</em> negative — formally closes the biochemical gap.</li>
+<li><strong>Attribution audit of the BioReason-Pro prediction:</strong> test whether the ATP call tracks co-mention with ClpCP/MecA text, confirming frequency/pathway-context bias as the mechanism of the false positive.</li>
+</ol>
+<hr />
+<h2 id="curation-leads-require-curator-verification">Curation Leads (require curator verification)</h2>
+<ul>
+<li><strong>Action:</strong> Reject the ATP binding (GO:0005524) prediction for P40396; do not add. Record as computational over-annotation driven by co-mention with the ATP-dependent ClpCP protease and general frequency bias.</li>
+<li><strong>Candidate MF terms to retain/add (more informative than "protein binding"):</strong></li>
+<li>GO:0003677 DNA binding (retain) — snippet to verify: <em>"we demonstrate that ComK specifically binds to DNA fragments containing promoter and upstream sequences of the genes it affects"</em> (<a href="https://pubmed.ncbi.nlm.nih.gov/7783616/">PMID: 7783616</a>).</li>
+<li>GO:0043565 sequence-specific DNA binding / GO:0001216 DNA-binding transcription activator activity — snippets to verify: <em>"Cryo-EM structures of the complex between ComK and its promoter demonstrate that this coupling is due to mechanical forces that alter DNA curvature"</em> (<a href="https://pubmed.ncbi.nlm.nih.gov/34016970/">PMID: 34016970</a>); <em>"ComK stabilizes the binding of RNA polymerase to the comG promoter"</em> (<a href="https://pubmed.ncbi.nlm.nih.gov/14762007/">PMID: 14762007</a>).</li>
+<li><strong>BP terms to retain:</strong> GO:0006351 / GO:0006355 (transcription / regulation of transcription), GO:0030420 (establishment of competence).</li>
+<li><strong>Note for the record (optional):</strong> ComK is a substrate of the ATP-dependent MecA–ClpCP protease — snippets to verify: <em>"A complex of ClpC with the protease ClpP and the adaptor protein MecA also controls competence development by regulated proteolysis of the transcription factor ComK"</em> (<a href="https://pubmed.ncbi.nlm.nih.gov/12598648/">PMID: 12598648</a>); <em>"the degradation of the competence transcription factor ComK is mediated by a ternary complex involving the adaptor protein MecA and the ATP-dependent protease ClpCP"</em> (<a href="https://pubmed.ncbi.nlm.nih.gov/19767395/">PMID: 19767395</a>). This explains the ATP association without implying ATP binding by ComK.</li>
+<li><strong>Suggested curator question:</strong> Confirm whether the ComK cryo-EM/PDB entry shows any bound nucleotide (expected: none); and whether GO:0005524 was propagated from an electronic pipeline.</li>
+<li><strong>Suggested experiment:</strong> ATP-agarose / DRaCALA / ITC assay on purified ComK to formally close the gap (expected negative).</li>
+</ul>
+<hr />
+<h2 id="conclusion">Conclusion</h2>
+<p>The ATP-binding (GO:0005524) prediction for <em>Bacillus subtilis</em> ComK (P40396) is <strong>refuted</strong>. ComK is a 192-amino-acid, single-domain (ComK family, PF06338/IPR010461) <strong>sequence-specific DNA-binding transcription factor</strong> with no Walker A/B motifs or nucleotide-binding fold. Sequence, domain, curated-database, structural (cryo-EM, <a href="https://pubmed.ncbi.nlm.nih.gov/34016970/">PMID: 34016970</a>), and mechanistic (<a href="https://pubmed.ncbi.nlm.nih.gov/14762007/">PMID: 14762007</a>) evidence unanimously support DNA binding and RNA polymerase stabilization rather than ATP binding. The only genuine ATP link is that ComK is a <em>substrate</em> of the ATP-dependent MecA–ClpCP protease, in which the ATPase is ClpC — the most plausible source of the frequency/pathway-context bias behind this misassignment. GO:0005524 should not be added; the informative, supported terms are sequence-specific DNA binding and DNA-binding transcription activator activity.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="comK-hypotheses/prediction-atp-binding/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="comK-hypotheses/prediction-atp-binding/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+<li><a href="comK-hypotheses/prediction-atp-binding/openscientist_artifacts/provenance_comK_ATP_evidence_matrix.csv">OpenScientist comK ATP evidence matrix</a></li>
+<li><a href="comK-hypotheses/prediction-atp-binding/openscientist_artifacts/provenance_comK_GO_decision_table.csv">OpenScientist comK GO decision table</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/BACSU/fliY/fliY-ai-review.html
+++ b/genes/BACSU/fliY/fliY-ai-review.html
@@ -3287,6 +3287,420 @@ We verified the gene/protein identity and organism, collected foundational and r
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(fliY-hypotheses/prediction-cell-septum/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P24073" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">AIGR Gene Hypothesis Deep Research — Final Report</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+                    <span class="report-badge">7 citations</span>
+
+
+                    <span class="report-badge">4 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-10T04:30:42.085890</span>
+
+
+
+                    <a href="fliY-hypotheses/prediction-cell-septum/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="fliY-hypotheses/prediction-cell-septum/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="fliY-hypotheses/prediction-cell-septum/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="fliY-hypotheses/prediction-cell-septum/openscientist_artifacts/fliY_GO_decision_table.md" class="term-link">OpenScientist fliY GO decision table</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="fliY-hypotheses/prediction-cell-septum/openscientist_artifacts/fliY_provenance.md" class="term-link">OpenScientist fliY provenance</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="aigr-gene-hypothesis-deep-research-final-report">AIGR Gene Hypothesis Deep Research — Final Report</h1>
+<p><strong>Gene:</strong> <em>fliY</em> (UniProt <strong>P24073</strong>, FLIY_BACSU) — <em>Bacillus subtilis</em> strain 168 (NCBITaxon:224308)<br />
+<strong>Focus type:</strong> computational_prediction<br />
+<strong>Hypothesis slug:</strong> prediction-cell-septum<br />
+<strong>Term under evaluation:</strong> cell septum — <strong>GO:0030428</strong> (cellular component)<br />
+<strong>Reference context:</strong> doi:10.64898/2026.03.19.712954</p>
+<hr />
+<h2 id="summary">Summary</h2>
+<p>The BioReason-Pro SFT model predicts that <em>B. subtilis</em> FliY (P24073) localizes to the <strong>cell septum (GO:0030428)</strong>. This report evaluates that computational prediction against primary literature, curated database records, and independent public bioinformatics resources. <strong>The prediction is refuted with high confidence.</strong> FliY is the <strong>flagellar motor-switch phosphatase</strong> — a C-ring component of the flagellar basal body and a member of the CheC/FliM/FliN (FliN/MopA/SpaO) family. Its identity is established by a diagnostic three-part domain architecture, an aflagellate null-mutant phenotype, direct CheY-P phosphatase biochemistry, a solved family structure, and a switch-complex localization. Every localization datum places FliY at the flagellar basal-body C-ring on the cytoplasmic face of the plasma membrane, not at the mid-cell division site.</p>
+<p>Three independent evidence streams converge. First, <strong>primary literature</strong> (five papers) ties FliY to the flagellum: a <em>fliY</em> null mutant has no flagella, FliY dephosphorylates CheY-P "at the location of its action, the flagellar switch," and structural work states plainly that "FliY is localized in the flagellar switch complex." Second, <strong>curated annotation</strong> (UniProt) names the protein "Flagellar motor switch phosphatase FliY" and annotates it to bacterial-type flagellum basal body (GO:0009425) and plasma membrane (GO:0005886). Third, <strong>independent computed checks</strong> run in this investigation — a live InterPro domain query and a STRING v12 interaction network — return only flagellar/T3SS domains and an interaction neighborhood composed entirely of flagellar and chemotaxis proteins, with zero cell-division genes and zero division-site domains.</p>
+<p>The most plausible origin of the model error is not biological but lexical/structural: FliY carries the structural-superfamily label <strong>"SpoA-like" (SSF101801)</strong>, where "SpoA" means <strong>Surface Presentation Of Antigens</strong> — a type-III secretion system (T3SS) export-apparatus fold shared with the flagellar C-ring — <strong>not</strong> sporulation or septation. In <em>Bacillus</em>, a genus defined by sporulation and asymmetric septum formation, this token is an easy trap. Combined with a generic "oligomeric ring at the membrane" analogy shared between the flagellar C-ring and the cytokinetic FtsZ ring, it can readily produce a spurious "cell septum" call. Curators should reject GO:0030428 for this gene and affirm its flagellar CC, phosphatase MF, and chemotaxis/motility BP annotations.</p>
+<hr />
+<h2 id="key-findings">Key Findings</h2>
+<h3 id="finding-1-fliy-is-a-flagellar-motor-switch-c-ring-phosphatase-not-a-cell-division-protein">Finding 1 — FliY is a flagellar motor-switch C-ring phosphatase, not a cell-division protein</h3>
+<p><em>B. subtilis</em> FliY (P24073, 378 aa) is identified in UniProt as <strong>"Flagellar motor switch phosphatase FliY."</strong> Its domain architecture is diagnostic of the flagellar switch/C-ring and contains nothing associated with the divisome:</p>
+<ul>
+<li><strong>N-terminal CheC-like phosphatase domain</strong> — Pfam <strong>PF04509 (CheC)</strong> / InterPro <strong>IPR007597</strong></li>
+<li><strong>Middle FliM-like region</strong></li>
+<li><strong>C-terminal FliN-like C-ring domain</strong> — Pfam <strong>PF01052 (FliMN_C)</strong> / InterPro <strong>IPR001543</strong></li>
+<li>Family: <strong>FliN/MopA/SpaO</strong></li>
+</ul>
+<p>The genetics tie FliY unambiguously to the flagellum. A <em>fliY::cat</em> null mutant produces <strong>no flagella</strong>, and motility is restored by plasmid-borne <em>fliY</em> — a classic loss-of-function result placing the gene in flagellar function (<a href="https://pubmed.ncbi.nlm.nih.gov/1447979/">PMID: 1447979</a>):</p>
+<blockquote>
+<p>"A fliY::cat null mutant has no flagella. Motility can be restored to the mutant by expression of fliY from a plasmid."</p>
+</blockquote>
+<p>Biochemically, FliY is a <strong>CheY-P phosphatase</strong> acting at the flagellar switch. It resembles the <em>E. coli</em> switch protein FliN only in its C-terminal part, while an N-terminal domain is homologous to FliM and to CheC (<a href="https://pubmed.ncbi.nlm.nih.gov/12920116/">PMID: 12920116</a>):</p>
+<blockquote>
+<p>"we have identified the phosphatase as FliY, which resembles E. coli switch protein FliN only in its C-terminal part, while an additional N-terminal domain is homologous to another switch protein FliM and to CheC."</p>
+</blockquote>
+<p>Structurally and by localization, FliY resides in the flagellar switch complex (<a href="https://pubmed.ncbi.nlm.nih.gov/23532838/">PMID: 23532838</a>):</p>
+<blockquote>
+<p>"FliY is localized in the flagellar switch complex, which also contains the stator-coupling protein FliG and the target of CheY-P, FliM."</p>
+</blockquote>
+<p>UniProt subcellular-location annotations are <strong>bacterial-type flagellum basal body (GO:0009425)</strong> and <strong>plasma membrane (GO:0005886, cytoplasmic side, peripheral)</strong> — consistent with a C-ring protein attached to the MS-ring (FliF) at the base of the flagellar motor. There is no annotation to any division-site component.</p>
+<h3 id="finding-2-the-cell-septum-go0030428-prediction-is-refuted-a-misassignment">Finding 2 — The cell-septum (GO:0030428) prediction is refuted / a misassignment</h3>
+<p>No primary literature associates <em>B. subtilis</em> FliY with the <strong>division septum, FtsZ ring, divisome, or cytokinesis</strong>. Every localization datum — UniProt subcellular location, the structural study (<a href="https://pubmed.ncbi.nlm.nih.gov/23532838/">PMID: 23532838</a>), and the switch-complex organization study (<a href="https://pubmed.ncbi.nlm.nih.gov/30455280/">PMID: 30455280</a>) — places FliY at the <strong>flagellar basal-body C-ring on the cytoplasmic side of the cell membrane</strong>. The structural paper explicitly distinguishes FliY's location from that of its soluble homologs (<a href="https://pubmed.ncbi.nlm.nih.gov/23532838/">PMID: 23532838</a>):</p>
+<blockquote>
+<p>"Unlike CheC and CheX, FliY is localized in the flagellar switch complex."</p>
+</blockquote>
+<p>The domain content (CheC phosphatase + FliM + FliN; FliN/MopA/SpaO family) is <strong>exclusively flagellar/T3SS-related</strong> and contains <strong>no division-site homology</strong> — no FtsZ, FtsA, SepF, DivIVA, or SPOR domains. GO:0030428 (cell septum) would require the protein to be part of the division machinery localized to mid-cell; none of that is supported. This is a <strong>category error</strong>, not merely an overly broad or overly narrow term, so no qualifier can rescue it.</p>
+<h3 id="finding-3-independent-computed-provenance-interpro-string-corroborates-the-flagellar-c-ring-not-the-septum">Finding 3 — Independent computed provenance (InterPro + STRING) corroborates the flagellar C-ring, not the septum</h3>
+<p>Two independent public-resource checks were executed in this investigation, and both corroborate the flagellar assignment while excluding any division link:</p>
+<ul>
+<li><strong>InterPro (live query, P24073, 378 aa):</strong> Returns only flagellar/T3SS domains — NCBIfam <strong>NF005995 "flagellar motor switch phosphatase FliY"</strong> (residues 3–374); <strong>CheC-like phosphatase superfamily</strong> (31–228) with two PF04509 catalytic lobes (36–72, 133–169); and a C-terminal <strong>FliN C-ring domain PF01052</strong> (298–368; IPR012826 "Flagellar motor switch FliN," 295–370). <strong>No FtsZ/FtsA/SepF/DivIVA/SPOR division domains are present.</strong></li>
+<li><strong>STRING v12 (species 224308):</strong> The top-30 functional partners are <strong>all flagellar</strong> (<em>fliM, fliG, fliF, fliN</em>-region, <em>flg*</em>, <em>flh*</em>) <strong>or chemotaxis</strong> (<em>cheY, cheC, cheA, cheW, cheD, cheV, cheB</em>) genes, each with a combined score <strong>≥0.998</strong>, and <strong>zero cell-division genes</strong> (no <em>ftsZ/ftsA/sepF/divIVA</em>).</li>
+</ul>
+<p>The structural-superfamily label <strong>"SpoA-like" (SSF101801, ~295–376)</strong> is the <strong>T3SS "Surface Presentation Of Antigens" fold</strong>, not a sporulation/septation fold — the most likely lexical source of a septum misassignment.</p>
+<hr />
+<h2 id="mechanistic-model-interpretation">Mechanistic Model / Interpretation</h2>
+<p>FliY is a structural and catalytic component of the <strong>flagellar switch complex (C-ring)</strong> that caps the cytoplasmic face of the flagellar basal body. It performs two integrated jobs at that location:</p>
+<ol>
+<li><strong>Switch/rotor structural role.</strong> As a FliM/FliN-family C-ring protein it helps build the switch that controls the direction of flagellar rotation (CW/CCW), coupling to FliG (stator interaction) and FliM.</li>
+<li><strong>CheY-P phosphatase.</strong> Via its N-terminal CheC-like domain, FliY binds and dephosphorylates the chemotaxis response regulator CheY-P <strong>at its site of action</strong>, resetting the switching signal and tuning rotational bias.</li>
+</ol>
+<p>This is spatially and functionally distinct from the cell-division septum. The two "rings" a model might confuse are contrasted below.</p>
+<div class="codehilite"><pre><span></span><code><span class="w">   </span><span class="n">FLAGELLAR</span><span class="w"> </span><span class="n">C</span><span class="o">-</span><span class="n">RING</span><span class="w"> </span><span class="p">(</span><span class="k">where</span><span class="w"> </span><span class="n">FliY</span><span class="w"> </span><span class="n">actually</span><span class="w"> </span><span class="k">is</span><span class="p">)</span><span class="w">        </span><span class="n">CELL</span><span class="o">-</span><span class="n">DIVISION</span><span class="w"> </span><span class="n">SEPTUM</span><span class="w"> </span><span class="p">(</span><span class="k">GO</span><span class="err">:</span><span class="mi">0030428</span><span class="w"> </span><span class="err">—</span><span class="w"> </span><span class="k">where</span><span class="w"> </span><span class="n">FliY</span><span class="w"> </span><span class="k">is</span><span class="w"> </span><span class="ow">NOT</span><span class="p">)</span>
+<span class="w">   </span><span class="c1">------------------------------------------        ----------------------------------------------------</span>
+<span class="w">   </span><span class="nl">Location</span><span class="p">:</span><span class="w"> </span><span class="n">base</span><span class="w"> </span><span class="k">of</span><span class="w"> </span><span class="k">each</span><span class="w"> </span><span class="n">flagellum</span><span class="p">,</span><span class="w"> </span><span class="k">at</span><span class="w"> </span><span class="n">the</span><span class="w">          </span><span class="nl">Location</span><span class="p">:</span><span class="w"> </span><span class="n">mid</span><span class="o">-</span><span class="n">cell</span><span class="w"> </span><span class="n">division</span><span class="w"> </span><span class="n">site</span>
+<span class="w">     </span><span class="n">cytoplasmic</span><span class="w"> </span><span class="n">face</span><span class="w"> </span><span class="k">of</span><span class="w"> </span><span class="n">the</span><span class="w"> </span><span class="n">membrane</span>
+<span class="w">   </span><span class="n">Core</span><span class="w"> </span><span class="nl">proteins</span><span class="p">:</span><span class="w"> </span><span class="n">FliG</span><span class="p">,</span><span class="w"> </span><span class="n">FliM</span><span class="p">,</span><span class="w"> </span><span class="n">FliY</span><span class="o">/</span><span class="n">FliN</span><span class="p">,</span><span class="w">             </span><span class="n">Core</span><span class="w"> </span><span class="nl">proteins</span><span class="p">:</span><span class="w"> </span><span class="n">FtsZ</span><span class="p">,</span><span class="w"> </span><span class="n">FtsA</span><span class="p">,</span><span class="w"> </span><span class="n">SepF</span><span class="p">,</span><span class="w"> </span><span class="n">ZapA</span><span class="p">,</span><span class="w"> </span><span class="n">DivIVA</span><span class="p">,</span>
+<span class="w">          </span><span class="n">MS</span><span class="o">-</span><span class="n">ring</span><span class="w"> </span><span class="p">(</span><span class="n">FliF</span><span class="p">),</span><span class="w"> </span><span class="n">stators</span><span class="w">                            </span><span class="n">FtsW</span><span class="o">/</span><span class="n">FtsI</span><span class="p">,</span><span class="w"> </span><span class="n">SPOR</span><span class="o">-</span><span class="k">domain</span><span class="w"> </span><span class="n">proteins</span>
+<span class="w">   </span><span class="k">Function</span><span class="err">:</span><span class="w"> </span><span class="n">rotation</span><span class="o">-</span><span class="n">direction</span><span class="w"> </span><span class="n">switch</span><span class="w"> </span><span class="o">+</span><span class="w">             </span><span class="k">Function</span><span class="err">:</span><span class="w"> </span><span class="n">cytokinesis</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">septal</span><span class="w"> </span><span class="n">peptidoglycan</span><span class="w"> </span><span class="n">synthesis</span>
+<span class="w">     </span><span class="n">CheY</span><span class="o">-</span><span class="n">P</span><span class="w"> </span><span class="n">dephosphorylation</span>
+<span class="w">   </span><span class="n">FliY</span><span class="w"> </span><span class="n">domains</span><span class="w"> </span><span class="nl">present</span><span class="p">:</span><span class="w"> </span><span class="n">CheC</span><span class="w"> </span><span class="p">(</span><span class="n">PF04509</span><span class="p">),</span><span class="w">             </span><span class="n">Division</span><span class="w"> </span><span class="n">domains</span><span class="w"> </span><span class="n">present</span><span class="w"> </span><span class="ow">in</span><span class="w"> </span><span class="nl">FliY</span><span class="p">:</span><span class="w"> </span><span class="k">NONE</span>
+<span class="w">     </span><span class="n">FliM</span><span class="o">-</span><span class="ow">like</span><span class="p">,</span><span class="w"> </span><span class="n">FliN</span><span class="w"> </span><span class="p">(</span><span class="n">PF01052</span><span class="p">)</span>
+</code></pre></div>
+
+<p>The prediction error is best explained as a <strong>structural-analogy plus lexical artifact</strong>: (i) both the flagellar C-ring and the cytokinetic Z-ring are membrane-proximal oligomeric rings, and (ii) the SCOP/structural label "SpoA-like" (T3SS Surface Presentation Of Antigens) superficially resembles sporulation/septation vocabulary — especially in <em>Bacillus</em>. Neither similarity constitutes evidence for septal localization.</p>
+<h3 id="go-component-comparison">GO component comparison</h3>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Flagellar C-ring / basal body (FliY reality)</th>
+<th>Cell septum (GO:0030428 prediction)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Supported by primary literature?</td>
+<td>Yes (5 papers)</td>
+<td>No</td>
+</tr>
+<tr>
+<td>Supported by UniProt CC annotation?</td>
+<td>Yes — GO:0009425, GO:0005886</td>
+<td>No</td>
+</tr>
+<tr>
+<td>Supported by InterPro domains?</td>
+<td>Yes — CheC + FliM + FliN</td>
+<td>No division domains</td>
+</tr>
+<tr>
+<td>Supported by STRING network?</td>
+<td>Yes — all top partners flagellar/chemotaxis</td>
+<td>No division partners</td>
+</tr>
+<tr>
+<td>Verdict</td>
+<td><strong>Correct</strong></td>
+<td><strong>Refuted</strong></td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="evidence-matrix">Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Direction</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence / limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/1447979/">PMID: 1447979</a></td>
+<td>Mutant phenotype, sequence</td>
+<td>Refutes septum / supports flagellum</td>
+<td>Is FliY a flagellar component?</td>
+<td><em>fliY::cat</em> null mutant has <strong>no flagella</strong>; plasmid <em>fliY</em> restores motility; FliY N-term ~FliM, C-term ~FliN</td>
+<td><em>B. subtilis</em>, in vivo</td>
+<td>High; foundational identity paper</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/12920116/">PMID: 12920116</a></td>
+<td>Direct assay + localization</td>
+<td>Refutes septum / supports flagellum</td>
+<td>Where and what does FliY act on?</td>
+<td>FliY is the <strong>CheY-P phosphatase</strong> acting <strong>at the flagellar switch</strong>; FliM/CheC N-term + FliN C-term</td>
+<td><em>B. subtilis</em>, biochemical</td>
+<td>High; defines activity and location</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/14749334/">PMID: 14749334</a></td>
+<td>Direct assay (in vitro/in vivo)</td>
+<td>Supports flagellum/chemotaxis</td>
+<td>Is FliY a CheY-P phosphatase (CYX family)?</td>
+<td>FliY (and CheC) hydrolyze CheY-P; FliY acts constitutively; CheD enhances CheC</td>
+<td><em>B. subtilis</em></td>
+<td>High; establishes phosphatase family</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/23532838/">PMID: 23532838</a></td>
+<td>Structural + localization</td>
+<td>Refutes septum / supports flagellum</td>
+<td>Where does FliY localize; what is its fold?</td>
+<td>FliY resembles FliM, dimerizes via FliN-like C-domain, and is <strong>localized in the flagellar switch complex</strong> ("Unlike CheC and CheX")</td>
+<td>Family structure (<em>T. maritima</em>) applied to FliY</td>
+<td>High; direct localization statement</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/30455280/">PMID: 30455280</a></td>
+<td>Structural/organizational</td>
+<td>Supports flagellum</td>
+<td>How is the switch complex organized?</td>
+<td>Maps the <em>B. subtilis</em> flagellar switch (FliG/FliM/FliY/FliN); CW/CCW control</td>
+<td><em>B. subtilis</em></td>
+<td>High; corroborates C-ring context</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/15546616/">PMID: 15546616</a></td>
+<td>Structural/evolutionary</td>
+<td>Qualifies/supports identity</td>
+<td>Does FliY belong to the CheC phosphatase family?</td>
+<td>FliY and FliM resemble CheC; <strong>phosphatase activity attributed only to FliY</strong></td>
+<td><em>T. maritima</em> comparative</td>
+<td>Medium-high; cross-species inference</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/17675386/">PMID: 17675386</a></td>
+<td>Genetic/physiological</td>
+<td>Supports flagellum/chemotaxis</td>
+<td>Is FliY part of the CheC-FliY-CheX system?</td>
+<td>Places FliY in the three-phosphatase system controlling rotational bias</td>
+<td><em>B. subtilis</em> / <em>E. coli</em></td>
+<td>Medium; contextual</td>
+</tr>
+<tr>
+<td>UniProt P24073 (FLIY_BACSU)</td>
+<td>Database</td>
+<td>Refutes septum</td>
+<td>Curated CC/MF</td>
+<td>Name "Flagellar motor switch phosphatase"; CC = flagellum basal body + plasma membrane (cytoplasmic side)</td>
+<td>Curated</td>
+<td>Orientation-level; consistent with primary lit</td>
+</tr>
+<tr>
+<td>InterPro (live query, this run)</td>
+<td>Computational (domain)</td>
+<td>Refutes septum</td>
+<td>What domains does FliY contain?</td>
+<td>Only flagellar/T3SS domains (NF005995, CheC PF04509, FliN PF01052); <strong>no division domains</strong></td>
+<td>Public resource, 378 aa</td>
+<td>High for domain content</td>
+</tr>
+<tr>
+<td>STRING v12 (species 224308, this run)</td>
+<td>Computational (interaction)</td>
+<td>Refutes septum</td>
+<td>What are FliY's functional partners?</td>
+<td>Top-30 all flagellar/chemotaxis (score ≥0.998); <strong>zero division genes</strong></td>
+<td>Public resource</td>
+<td>High; unambiguous network</td>
+</tr>
+<tr>
+<td>SCOP/SUPERFAMILY SSF101801 "SpoA-like"</td>
+<td>Computational (structural class)</td>
+<td>Competing / artifact source</td>
+<td>Does "SpoA" imply sporulation/septum?</td>
+<td>"SpoA" = T3SS <strong>Surface Presentation Of Antigens</strong>, not sporulation</td>
+<td>Public resource</td>
+<td>High; explains likely error origin</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="evidence-base">Evidence Base</h2>
+<ul>
+<li><strong><em>Identification and characterization of FliY, a novel component of the Bacillus subtilis flagellar switch complex.</em></strong> <a href="https://pubmed.ncbi.nlm.nih.gov/1447979/">PMID: 1447979</a> — The foundational genetics: a <em>fliY</em> null mutant is aflagellate, establishing FliY as a flagellar (not division) gene.</li>
+<li><strong><em>Bacillus subtilis hydrolyzes CheY-P at the location of its action, the flagellar switch.</em></strong> <a href="https://pubmed.ncbi.nlm.nih.gov/12920116/">PMID: 12920116</a> — Identifies FliY as the CheY-P phosphatase and defines its FliN/FliM/CheC domain composition and switch location.</li>
+<li><strong><em>Bacillus subtilis CheC and FliY are members of a novel class of CheY-P-hydrolyzing proteins in the chemotactic signal transduction cascade.</em></strong> <a href="https://pubmed.ncbi.nlm.nih.gov/14749334/">PMID: 14749334</a> — Places FliY in the CYX CheY-P phosphatase family; FliY acts constitutively at the switch.</li>
+<li><strong><em>Structure and activity of the flagellar rotor protein FliY: a member of the CheC phosphatase family.</em></strong> <a href="https://pubmed.ncbi.nlm.nih.gov/23532838/">PMID: 23532838</a> — Direct structural + localization evidence: FliY resembles FliM and is localized in the flagellar switch complex, explicitly <em>unlike</em> soluble CheC/CheX.</li>
+<li><strong><em>Organization of the Flagellar Switch Complex of Bacillus subtilis.</em></strong> <a href="https://pubmed.ncbi.nlm.nih.gov/30455280/">PMID: 30455280</a> — Situates FliY within the CW/CCW rotational switch complex.</li>
+<li><strong><em>Structure and function of an unusual family of protein phosphatases: the bacterial chemotaxis proteins CheC and CheX.</em></strong> <a href="https://pubmed.ncbi.nlm.nih.gov/15546616/">PMID: 15546616</a> — Comparative structural work assigning phosphatase activity to FliY within the CheC fold.</li>
+<li><strong><em>CheX in the three-phosphatase system of bacterial chemotaxis.</em></strong> <a href="https://pubmed.ncbi.nlm.nih.gov/17675386/">PMID: 17675386</a> — Physiological context of the CheC-FliY-CheX phosphatase system.</li>
+</ul>
+<p>Every paper supports the flagellar/chemotaxis identity of FliY. <strong>None</strong> provides any support for a cell-septum or divisome role, and no conflicting paper was found.</p>
+<hr />
+<h2 id="go-curation-implications-leads-require-curator-verification">GO Curation Implications (leads — require curator verification)</h2>
+<ul>
+<li><strong>GO:0030428 (cell septum, CC): DO NOT ADD — reject the prediction.</strong> Unsupported by any evidence; treat as a computational false positive / category error.</li>
+<li><strong>Retain / affirm CC:</strong> <strong>GO:0009425</strong> (bacterial-type flagellum basal body) and <strong>GO:0005886 / GO:0009898</strong> (plasma membrane, cytoplasmic side) — supported by curated UniProt and family localization (<a href="https://pubmed.ncbi.nlm.nih.gov/23532838/">PMID: 23532838</a>, <a href="https://pubmed.ncbi.nlm.nih.gov/30455280/">PMID: 30455280</a>). A more specific flagellar motor-switch/C-ring CC term is a defensible refinement over generic plasma membrane.</li>
+<li><strong>MF:</strong> phosphoprotein phosphatase activity on CheY-P is well supported (<a href="https://pubmed.ncbi.nlm.nih.gov/12920116/">PMID: 12920116</a>, <a href="https://pubmed.ncbi.nlm.nih.gov/14749334/">PMID: 14749334</a>); GO:0004721 is justified, and a more specific "response regulator / CheY-P dephosphorylation" framing is defensible.</li>
+<li><strong>BP:</strong> chemotaxis (GO:0006935), flagellum assembly (GO:0044780), regulation of flagellum-dependent motility (GO:1902021), and dephosphorylation (GO:0016311) are appropriate.</li>
+<li>We deliberately avoid recommending "protein binding" (GO:0005515); more informative MF/BP/CC terms are supported.</li>
+</ul>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p><strong>Immediate molecular function:</strong> FliY binds phosphorylated CheY (CheY-P) via a FliM-like N-terminal segment and dephosphorylates it through CheC-like active centers, terminating the chemotactic switching signal at its site of action — the flagellar C-ring. <strong>Cellular location:</strong> flagellar basal-body C-ring, peripherally attached to the MS-ring (FliF) on the cytoplasmic face of the membrane. <strong>Downstream / pleiotropic effects (not the tested location):</strong> swimming and swarming behavior, tumble bias, and chemotactic adaptation. None of these involve the cell-division septum. The seed hypothesis conflates the immediate CC (flagellar switch) with an unrelated CC (division septum).</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ul>
+<li><strong>Paralog / lexical confusion (most likely cause).</strong> The structural superfamily label <strong>"SpoA-like" (SSF101801)</strong> stands for <strong>Surface Presentation Of Antigens</strong>, a T3SS export-apparatus fold shared with the flagellar C-ring — <strong>not</strong> sporulation or septation. In <em>Bacillus</em>, a token-level match to "Spo"/septum is a plausible driver of the misprediction. This is an artifact, not competing biology.</li>
+<li><strong>Generic ring analogy.</strong> The flagellar C-ring and the FtsZ division ring are both membrane-proximal cytoplasmic rings. A model reasoning "ring at membrane → division site" would err here.</li>
+<li><strong>Organism specificity.</strong> <em>E. coli</em> lacks a FliY (it uses FliN + the phosphatase CheZ); <em>B. subtilis</em> FliY fuses FliM/FliN/CheC functions — but always in a flagellar context. No genuine division paralog of FliY exists.</li>
+</ul>
+<p>No genuine competing evidence for GO:0030428 was identified.</p>
+<hr />
+<h2 id="limitations-and-knowledge-gaps">Limitations and Knowledge Gaps</h2>
+<ol>
+<li><strong>Native <em>B. subtilis</em> FliY imaging.</strong> What was checked: UniProt CC and the structural/organizational papers. Why it matters: the refutation rests on switch-complex localization inferred from structure/complex composition rather than a dedicated FliY-fluorescent-fusion experiment explicitly excluding mid-cell signal. Resolving evidence: a FliY-GFP image showing peripheral/basal-body foci and absence of a mid-cell septal band, co-stained with FtsZ/DivIVA.</li>
+<li><strong>Direct P24073 structure.</strong> What was checked: family-level structures (largely <em>T. maritima</em>). Why it matters: the <em>B. subtilis</em> fold is inferred by strong homology. Resolving evidence: an AlphaFold model of P24073 confirming the CheC + FliN architecture (not run here).</li>
+<li><strong>Reproducibility of the public-resource checks.</strong> What was checked: a single live InterPro query and a single STRING v12 network. Why it matters: databases update; the negative result should be reproducible but was captured once. Resolving evidence: re-run and archive the raw JSON.</li>
+<li><strong>Exact model-error trigger is inferred.</strong> What was checked: candidate lexical/structural sources (SSF101801 "SpoA-like"). Why it matters: confirming the trigger improves error attribution. Resolving evidence: feature attribution / interpretability on the BioReason-Pro SFT input for P24073.</li>
+</ol>
+<p>None of these gaps weaken the refutation; they concern only the mechanism of the model error and provenance completeness.</p>
+<hr />
+<h2 id="discriminating-tests">Discriminating Tests</h2>
+<ol>
+<li><strong>FliY fluorescent-fusion localization (definitive).</strong> Express FliY-GFP/mNeonGreen in <em>B. subtilis</em> and image: expect peripheral/basal-body puncta colocalizing with FliM/FliG, and <strong>no enrichment at the FtsZ mid-cell band</strong>. Co-stain with FtsZ or DivIVA to test septal exclusion directly.</li>
+<li><strong>Divisome co-immunoprecipitation / BACTH.</strong> Test FliY against FtsZ, FtsA, SepF, DivIVA. Predicted result: <strong>no interaction</strong> (consistent with STRING).</li>
+<li><strong>Domain scan of P24073.</strong> InterProScan/HMMER for any FtsZ/SepF/DivIVA/FtsA/SPOR domain — expect none (already confirmed by the live InterPro query).</li>
+<li><strong>Reproduce public-resource provenance.</strong> Re-run and archive InterPro (P24073) and STRING v12 (224308) outputs; confirm absence of division domains/partners.</li>
+<li><strong>Model-error attribution.</strong> Feature attribution on the BioReason-Pro SFT input to confirm whether the "SpoA-like"/"Spo" token or a structural-ring embedding drove the septum call.</li>
+</ol>
+<hr />
+<h2 id="curation-leads-require-curator-verification">Curation Leads (require curator verification)</h2>
+<p><strong>Candidate references with exact snippets to verify:</strong></p>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/1447979/">PMID: 1447979</a> — "A fliY::cat null mutant has no flagella. Motility can be restored to the mutant by expression of fliY from a plasmid." (Supports flagellar identity; refutes division role.)</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/12920116/">PMID: 12920116</a> — "we have identified the phosphatase as FliY, which resembles E. coli switch protein FliN only in its C-terminal part, while an additional N-terminal domain is homologous to another switch protein FliM and to CheC." (Domain architecture + phosphatase.)</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/23532838/">PMID: 23532838</a> — "FliY is localized in the flagellar switch complex, which also contains the stator-coupling protein FliG and the target of CheY-P, FliM"; "Unlike CheC and CheX, FliY is localized in the flagellar switch complex." (Direct localization; refutes septum.)</li>
+</ul>
+<p><strong>Candidate GO decision table:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Term</th>
+<th>Aspect</th>
+<th>Recommended action</th>
+<th>Basis</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0030428 cell septum</td>
+<td>CC</td>
+<td><strong>Reject / do not add</strong></td>
+<td>No literature, domain, or interaction support</td>
+</tr>
+<tr>
+<td>GO:0009425 bacterial-type flagellum basal body</td>
+<td>CC</td>
+<td><strong>Retain / affirm</strong></td>
+<td>Structure + localization</td>
+</tr>
+<tr>
+<td>GO:0005886 / GO:0009898 plasma membrane (cytoplasmic side)</td>
+<td>CC</td>
+<td><strong>Retain</strong> (consider specific flagellar motor-switch CC term)</td>
+<td>UniProt CC; C-ring attachment</td>
+</tr>
+<tr>
+<td>GO:0004721 phosphoprotein phosphatase activity (CheY-P)</td>
+<td>MF</td>
+<td><strong>Support / retain</strong></td>
+<td>PMID 12920116, 14749334</td>
+</tr>
+<tr>
+<td>GO:0006935 chemotaxis; GO:1902021 regulation of flagellum-dependent motility</td>
+<td>BP</td>
+<td><strong>Support</strong></td>
+<td>PMID 1447979, 17675386</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Suggested curator questions:</strong><br />
+- Is there any <em>B. subtilis</em> dataset (fluorescence, cryo-ET, proximity labeling) placing FliY at mid-cell? (Expected: no.)<br />
+- Was the septum prediction driven by the "SpoA-like" (T3SS SPOA) superfamily label or a ring-assembly analogy? Flag as a recurring failure mode for flagellar C-ring proteins.</p>
+<p><strong>Suggested experiments:</strong> FliY-GFP localization vs. FtsZ; BACTH/co-IP against divisome components (see Discriminating Tests).</p>
+<hr />
+<h2 id="conclusion">Conclusion</h2>
+<p>The cell-septum (GO:0030428) prediction for <em>B. subtilis</em> fliY (P24073) is <strong>refuted</strong>. FliY is the <strong>flagellar motor-switch phosphatase</strong>, a <strong>CheC/FliM/FliN-family C-ring component</strong> of the flagellar basal body that binds and dephosphorylates CheY-P on the cytoplasmic side of the plasma membrane. Five primary papers, curated UniProt annotations, and two independent computed checks (InterPro domain map; STRING interaction network) place it at the flagellar switch with <strong>zero</strong> support for a division-septum role. The misassignment most plausibly stems from the misleading <strong>"SpoA-like" (T3SS Surface Presentation Of Antigens)</strong> structural label and a generic membrane-ring analogy. Curators should <strong>not</strong> annotate FliY to cell septum and should instead affirm its flagellar CC, phosphatase MF, and chemotaxis/motility BP terms.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="fliY-hypotheses/prediction-cell-septum/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="fliY-hypotheses/prediction-cell-septum/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+<li><a href="fliY-hypotheses/prediction-cell-septum/openscientist_artifacts/fliY_GO_decision_table.md">OpenScientist fliY GO decision table</a></li>
+<li><a href="fliY-hypotheses/prediction-cell-septum/openscientist_artifacts/fliY_provenance.md">OpenScientist fliY provenance</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/DICDI/mlcD/mlcD-ai-review.html
+++ b/genes/DICDI/mlcD/mlcD-ai-review.html
@@ -2256,6 +2256,307 @@
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(mlcD-hypotheses/prediction-myosin-cytokinesis/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q7Z2B8" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">mlcD (Q7Z2B8) — Myosin-II / Cytokinesis Prediction Assessment</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+                    <span class="report-badge">3 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-10T03:53:33.149597</span>
+
+
+
+                    <a href="mlcD-hypotheses/prediction-myosin-cytokinesis/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="mlcD-hypotheses/prediction-myosin-cytokinesis/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="mlcD-hypotheses/prediction-myosin-cytokinesis/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="mlcd-q7z2b8-myosin-ii-cytokinesis-prediction-assessment">mlcD (Q7Z2B8) — Myosin-II / Cytokinesis Prediction Assessment</h1>
+<p><strong>Gene:</strong> mlcD (UniProt Q7Z2B8, MLCD_DICDI), <em>Dictyostelium discoideum</em> (NCBITaxon:44689)<br />
+<strong>Focus:</strong> computational_prediction — hypothesis <code>prediction-myosin-cytokinesis</code><br />
+<strong>Terms tested:</strong> GO:0000281 mitotic cytokinesis; GO:0030837 negative regulation of actin filament polymerization; GO:0043520 regulation of myosin II filament assembly; GO:0071976 protein localization to cell division site.<br />
+<strong>Reference context:</strong> doi:10.64898/2026.03.19.712954</p>
+<hr />
+<h2 id="executive-judgment">Executive Judgment</h2>
+<p><strong>Verdict: REFUTED (over-annotation / paralog–class misassignment).</strong></p>
+<p>BioReason-Pro-SFT predicts myosin-II and cytokinesis regulatory roles for mlcD. Primary<br />
+biochemistry and the curated UniProt/dictyBase record independently establish that <strong>mlcD is<br />
+the dedicated essential light chain of MyoD, a single-headed class I (unconventional) myosin</strong> —<br />
+not a component of the conventional myosin-II (mhcA) contractile machinery. All four predicted<br />
+terms belong to the myosin-II system (heavy chain mhcA plus its regulatory light chain and<br />
+essential light chain), whose bipolar filaments drive cytokinesis. Class I myosins are monomeric,<br />
+membrane-associated motors that <strong>do not self-assemble into filaments</strong>, so mlcD cannot mediate or<br />
+regulate myosin-II filament assembly or contractile-ring–based cytokinesis.</p>
+<p>The most important caveat: I could not access the specific reference <code>doi:10.64898/2026.03.19.712954</code><br />
+programmatically, and I did not run a MyoD-null phenotype search successfully (PubMed queries for<br />
+class-I phenotypes returned no hits in this environment). The refutation nonetheless rests on<br />
+direct, unambiguous primary evidence (protein sequencing + complex purification) and on the<br />
+curated functional record.</p>
+<hr />
+<h2 id="evidence-matrix">Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Direction</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence / limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>PMID:12826013 (De La Roche, Lee, Côté 2003)</td>
+<td>Direct assay (protein sequencing, ESI-MS, ITC, complex purification)</td>
+<td><strong>Refutes</strong> seed</td>
+<td>Is mlcD a myosin-II light chain?</td>
+<td>MlcD is a 16 kDa 4-EF-hand protein co-purifying with <strong>MyoD</strong>, a long-tailed <strong>class I</strong> myosin; FLAG-MlcD complexes with MyoD but <strong>not</strong> MyoB/MyoC; low Ca²⁺ affinity (cannot sense physiological Ca²⁺)</td>
+<td><em>D. discoideum</em>, native + FLAG-tagged expression</td>
+<td>High. Directly defines class/partner identity.</td>
+</tr>
+<tr>
+<td>PMID:21671662 (Crawley et al. 2011)</td>
+<td>Interaction / biochemical mapping</td>
+<td><strong>Refutes</strong> seed</td>
+<td>Light-chain assignments across Dictyostelium myosin-I</td>
+<td>Each long-tailed myosin-I has a unique light chain: <strong>MyoB–MlcB, MyoC–MlcC, MyoD–MlcD</strong>; short-tailed MyoA/MyoE use calmodulin</td>
+<td><em>D. discoideum</em></td>
+<td>High. Confirms MyoD–MlcD pairing.</td>
+</tr>
+<tr>
+<td>UniProt Q7Z2B8 (MLCD_DICDI)</td>
+<td>Database / curated record</td>
+<td><strong>Refutes</strong> seed</td>
+<td>Protein identity, family, oligomeric state</td>
+<td>Recommended name "<strong>Myosin-ID light chain</strong>"; FUNCTION "light chain for myosin-D"; SUBUNIT "Myosin I… <strong>Inability to self-assemble into filaments</strong>… Interacts with myoD; does not interact with myoB or myoC"</td>
+<td>Curated</td>
+<td>High (review/database-level, but backed by the primary papers above).</td>
+</tr>
+<tr>
+<td>dictyBase GO (via UniProt xrefs)</td>
+<td>Database (experimental IDA/IPI)</td>
+<td><strong>Qualifies</strong> / competing</td>
+<td>What processes/locations are experimentally supported?</td>
+<td>Curated terms: myosin complex (IDA), myosin heavy chain binding→myoD (IPI), Ca²⁺ binding (IDA), <strong>actin wave</strong> (IDA), <strong>macropinocytic cup cytoskeleton</strong> (IDA). <strong>None</strong> of the 4 predicted myosin-II/cytokinesis terms present</td>
+<td><em>D. discoideum</em></td>
+<td>High. Absence of predicted terms in curated set is informative.</td>
+</tr>
+<tr>
+<td>InterPro/PANTHER/Pfam (Q7Z2B8)</td>
+<td>Structural/evolutionary</td>
+<td><strong>Qualifies</strong></td>
+<td>Domain architecture</td>
+<td>147 aa, four EF-hands (EF-hands 2–4 degenerate), CALM/Myosin/TropC-like (IPR050230), calmodulin-like — consistent with an EF-hand myosin light chain, not a filament-assembly regulator</td>
+<td>Sequence</td>
+<td>High.</td>
+</tr>
+<tr>
+<td>Iteration-2 NW/BLOSUM62 (this study)</td>
+<td>Computational (sequence identity)</td>
+<td><strong>Qualifies/refutes</strong></td>
+<td>Which clade does MlcD belong to?</td>
+<td>MlcD 45.6% id to calmodulin &amp; 45.2% to MlcB (myosin-I LC) vs only 30.8%/31.2% to myosin-II mlcR/mlcE; reproduces published ~44% CaM benchmark</td>
+<td><em>D. discoideum</em> paralogs</td>
+<td>Medium-high. Global alignment, single method; concordant with primary data.</td>
+</tr>
+<tr>
+<td>PMID:10423462 (Dai et al. 1999)</td>
+<td>Mutant phenotype (micropipette aspiration)</td>
+<td><strong>Qualifies</strong> (class context)</td>
+<td>What do Dictyostelium myosin-I motors do?</td>
+<td>Amoeboid myosin-I's drive pseudopod formation, macropinocytosis; double mutants lose ~50% cortical tension; required for migration — NOT cytokinesis</td>
+<td><em>D. discoideum</em> myosin-I mutants</td>
+<td>Medium (about myosin-I class generally, not MyoD-specific).</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="go-curation-implications-leads-require-curator-verification">GO Curation Implications (leads — require curator verification)</h2>
+<ul>
+<li><strong>Do NOT add</strong> GO:0000281 (mitotic cytokinesis), GO:0030837 (neg. reg. actin filament polymerization),<br />
+  GO:0043520 (regulation of myosin II filament assembly), or GO:0071976 (protein localization to cell<br />
+  division site) to mlcD. These are conventional-myosin-II / contractile-ring functions and are<br />
+<strong>class-inappropriate</strong> for a myosin-I light chain.</li>
+<li><strong>GO:0043520 specifically:</strong> refuted. The correct effectors of Dictyostelium myosin-II filament<br />
+  assembly are the mhcA heavy chain (regulated by myosin heavy-chain kinases) and its <strong>regulatory /<br />
+  essential light chains</strong> — not MlcD. If any myosin light chain warrants GO:0043520, it is the<br />
+  myosin-II RLC/ELC paralog, not mlcD.</li>
+<li><strong>Retain / support instead (MF/CC):</strong> MF <code>GO:0032036 myosin heavy chain binding</code> (IPI to myoD) and<br />
+  the calmodulin-like light-chain role; CC <code>GO:0016459 myosin complex</code>. Prefer these informative terms<br />
+  over generic "protein binding."</li>
+<li><strong>Class-appropriate BP/CC leads (verify against MyoD phenotype literature):</strong> class-I myosin<br />
+  processes at the plasma membrane — macropinocytosis/endocytosis and cortical actin dynamics<br />
+  (consistent with curated <code>macropinocytic cup cytoskeleton</code> and <code>actin wave</code> localizations).</li>
+</ul>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p>Direct molecular function of the gene product: MlcD is a calmodulin-like EF-hand <strong>essential light<br />
+chain</strong> that binds the IQ motifs in the neck of the class I myosin heavy chain <strong>MyoD</strong>, stabilizing<br />
+its lever arm. Its Ca²⁺ affinity is low, so it is not a Ca²⁺ sensor; De La Roche et al. propose it<br />
+confers Ca²⁺-insensitive regulatory properties distinguishing MyoD from calmodulin-bearing myosin-I.<br />
+The predicted terms describe <strong>downstream cellular processes of a different motor system</strong> (myosin-II<br />
+contractile ring); they are neither the immediate activity of MlcD nor a documented phenotype of it.</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ul>
+<li><strong>Paralog/class confusion (most likely source of the prediction):</strong> "mlc*" myosin light-chain genes<br />
+  form a paralog pool spanning classes. The myosin-II regulatory (mlcR) and essential (mlcE) light<br />
+  chains legitimately carry cytokinesis/filament-assembly context; a sequence/name-similarity or<br />
+  frequency-biased transfer plausibly propagated those terms onto mlcD.</li>
+<li><strong>Organism specificity:</strong> In <em>Dictyostelium</em>, cytokinesis A depends on conventional myosin-II<br />
+  (mhcA); myosin-I isoforms function in motility, cortical tension, and endocytosis. This reinforces<br />
+  that mlcD's contribution, if any, is not contractile-ring cytokinesis.</li>
+<li><strong>No competing evidence found</strong> that MlcD associates with mhcA or the contractile ring.</li>
+</ul>
+<hr />
+<h2 id="knowledge-gaps">Knowledge Gaps</h2>
+<ol>
+<li><strong>MyoD-null / MlcD-null cellular phenotype.</strong> Partially addressed: MyoD-specific knockout papers<br />
+   were not retrievable here, but class-level phenotype data (Dai et al. 1999, PMID:10423462) show<br />
+   Dictyostelium myosin-I motors drive pseudopod formation, macropinocytosis, and cortical tension —<br />
+   not cytokinesis. A positive class-I process annotation for mlcD (e.g., macropinocytosis, cortical<br />
+   dynamics) should still be grounded in MyoD/mlcD-specific phenotype data via dictyBase records.</li>
+<li><strong>Reference doi:10.64898/2026.03.19.712954.</strong> Not accessible programmatically here; its content<br />
+   (possibly the AIGR review itself or a benchmarking preprint) could add or contextualize evidence.</li>
+<li><strong>Exact myosin-II light-chain paralog identities (mlcE vs mlcR).</strong> Confirming which paralog rightly<br />
+   holds GO:0043520 would let the curator redirect the mis-transferred term rather than merely delete it.</li>
+</ol>
+<hr />
+<h2 id="discriminating-tests">Discriminating Tests</h2>
+<ul>
+<li><strong>Co-IP / affinity purification:</strong> MlcD pulls down MyoD but not mhcA (already supported for<br />
+  MyoB/MyoC exclusion; a direct mhcA test would formally close it).</li>
+<li><strong>Localization:</strong> GFP-MlcD should track MyoD to the plasma membrane / macropinocytic cups / actin<br />
+  waves, <strong>not</strong> the cleavage furrow. Curated IDA localizations already favor the membrane pattern.</li>
+<li><strong>Genetic epistasis:</strong> mlcD-null should phenocopy myoD-null (motility/endocytosis), not mhcA-null<br />
+  (multinucleate cytokinesis-defective) cells.</li>
+<li><strong>Sequence/orthology:</strong> phylogenetic placement of MlcD with myosin-I light chains / calmodulin<br />
+  clade vs myosin-II RLC/ELC clade.</li>
+</ul>
+<hr />
+<h2 id="curation-leads-require-curator-verification">Curation Leads (require curator verification)</h2>
+<ul>
+<li><strong>Action change:</strong> Reject the four predicted terms for mlcD; flag as class/paralog over-annotation.</li>
+<li><strong>Candidate references to verify:</strong> PMID:12826013 (identity, MyoD specificity, Ca²⁺ properties);<br />
+  PMID:21671662 (MyoD–MlcD light-chain assignment). Snippets provided in the recorded findings.</li>
+<li><strong>Candidate retained/added terms:</strong> MF <code>GO:0032036 myosin heavy chain binding</code>; CC <code>GO:0016459
+  myosin complex</code>; consider class-I membrane/endocytic BP terms only if MyoD phenotype data support them.</li>
+<li><strong>Suggested question for curator:</strong> Should GO:0043520 be redirected to the myosin-II light-chain<br />
+  paralog (mlcE/mlcR) rather than deleted outright?</li>
+<li><strong>Suggested experiment:</strong> GFP-MlcD localization relative to the cleavage furrow vs macropinocytic cup.</li>
+</ul>
+<hr />
+<h2 id="computed-provenance-pairwise-sequence-identity-iteration-2">Computed Provenance — Pairwise Sequence Identity (Iteration 2)</h2>
+<p>Global Needleman–Wunsch alignment (BLOSUM62, gap = −8), MlcD (Q7Z2B8) vs <em>D. discoideum</em> paralogs.<br />
+The reproduction of the published ~44% MlcD–calmodulin identity (De La Roche et al. 2003, PMID:12826013)<br />
+serves as a method-validity check.</p>
+<table>
+<thead>
+<tr>
+<th>Comparison (vs MlcD Q7Z2B8)</th>
+<th>UniProt</th>
+<th>% identity</th>
+<th>Aligned cols</th>
+<th>Class</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Calmodulin (calA)</td>
+<td>P02599</td>
+<td><strong>45.6</strong></td>
+<td>147</td>
+<td>Ca²⁺ sensor / myosin-I LC clade</td>
+</tr>
+<tr>
+<td>MlcB — Myosin-IB light chain</td>
+<td>Q54GL7</td>
+<td>45.2</td>
+<td>73*</td>
+<td>Class I myosin LC</td>
+</tr>
+<tr>
+<td>mlcR — Myosin-II <strong>regulatory</strong> LC</td>
+<td>P13833</td>
+<td><strong>30.8</strong></td>
+<td>146</td>
+<td>Myosin-II LC</td>
+</tr>
+<tr>
+<td>mlcE — Myosin-II <strong>essential</strong> LC</td>
+<td>P09402</td>
+<td><strong>31.2</strong></td>
+<td>141</td>
+<td>Myosin-II LC</td>
+</tr>
+</tbody>
+</table>
+<p>*MlcB record is only 73 aa (partial), so its alignment spans fewer columns.</p>
+<p><strong>Interpretation:</strong> MlcD is ~14–15 percentage points more similar to the calmodulin-like /<br />
+myosin-I light chains than to the myosin-II regulatory/essential light chains (mlcR/mlcE) that<br />
+legitimately carry cytokinesis and myosin-II-filament-assembly annotations. This independently<br />
+supports the class-I identity and the paralog-misassignment interpretation of the seed prediction.<br />
+(Computed value 45.6% ≈ published 44% → analysis validated.)</p>
+<hr />
+<h2 id="limitations">Limitations</h2>
+<p>Findings rest primarily on two primary papers plus curated database records; I could not fetch the<br />
+supplied DOI or MyoD-null phenotype papers in this environment. No sequence alignment/phylogeny was<br />
+run here (identity was already unambiguous from the primary literature and UniProt). Database-level<br />
+GO evidence is treated as orientation but is corroborated by the primary assays.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="mlcD-hypotheses/prediction-myosin-cytokinesis/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="mlcD-hypotheses/prediction-myosin-cytokinesis/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/DICDI/tlcd4b/tlcd4b-ai-review.html
+++ b/genes/DICDI/tlcd4b/tlcd4b-ai-review.html
@@ -1906,6 +1906,447 @@
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(tlcd4b-hypotheses/prediction-ceramidase/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q550S9" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">AIGR Gene Hypothesis Deep Research — Final Report</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+                    <span class="report-badge">7 citations</span>
+
+
+                    <span class="report-badge">4 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-09T14:22:36.548777</span>
+
+
+
+                    <a href="tlcd4b-hypotheses/prediction-ceramidase/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="tlcd4b-hypotheses/prediction-ceramidase/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="tlcd4b-hypotheses/prediction-ceramidase/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="tlcd4b-hypotheses/prediction-ceramidase/openscientist_artifacts/tlcd4b_GO_decision_table.csv" class="term-link">OpenScientist tlcd4b GO decision table</a>
+                        <span>(text/csv)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="tlcd4b-hypotheses/prediction-ceramidase/openscientist_artifacts/tlcd4b_family_comparison.csv" class="term-link">OpenScientist tlcd4b family comparison</a>
+                        <span>(text/csv)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="aigr-gene-hypothesis-deep-research-final-report">AIGR Gene Hypothesis Deep Research — Final Report</h1>
+<p><strong>Target gene:</strong> <em>tlcd4b</em> (UniProt <strong>Q550S9</strong>), <em>Dictyostelium discoideum</em> (NCBITaxon:44689)<br />
+<strong>Focus type:</strong> computational_prediction<br />
+<strong>Hypothesis slug:</strong> prediction-ceramidase<br />
+<strong>Predicted terms under test:</strong> N-acylsphingosine amidohydrolase (ceramidase) activity (<strong>GO:0017040</strong>); ceramide metabolic process (<strong>GO:0006672</strong>)<br />
+<strong>Prediction source:</strong> BioReason-Pro SFT (ref doi:10.64898/2026.03.19.712954)</p>
+<hr />
+<h2 id="summary">Summary</h2>
+<p>The BioReason-Pro SFT model predicts that the <em>Dictyostelium discoideum</em> protein <strong>tlcd4b (Q550S9)</strong> has <strong>N-acylsphingosine amidohydrolase (ceramidase) activity (GO:0017040)</strong> and participates in the <strong>ceramide metabolic process (GO:0006672)</strong>. This investigation independently evaluates that prediction against sequence, domain, structural, comparative-genomic, and primary-literature evidence. The molecular-function prediction is <strong>refuted</strong>: tlcd4b is a <strong>TLCD4-family TLC (TRAM/LAG1/CLN8) domain membrane protein</strong>, not a member of any ceramidase enzyme family, and it lacks the catalytic machinery that every characterized ceramidase possesses. The prediction is best explained as a <strong>paralog / protein-family misassignment</strong> — a ceramide-<em>associated</em> membrane protein was mislabeled with the <em>catalytic</em> term for ceramide breakdown.</p>
+<p>Three converging lines of evidence support this verdict. First, every domain-annotation resource assigns tlcd4b exclusively to the TLC/TLCD4 family (Pfam PF03798; six of six InterPro signatures TLC-family, zero ceramidase-family); UniProt states it "belongs to the TLCD4 family." Second, the three ceramidase enzyme classes each have a distinct, unrelated catalytic fold — acid (Ntn/CBAH hydrolase), neutral (Zn²⁺ carboxypeptidase-like), and alkaline (CREST-superfamily Zn²⁺-amidase with a conserved 3-His + Asp + Ser center) — none of which is a TLC domain, and tlcd4b contains none of these active-site constellations. Third, the <em>Dictyostelium</em> genome already encodes dedicated ceramidases in the correct families (neutral <em>dcd2A/B</em>, alkaline <em>dcd3A/B</em>, acid-type <em>dcd1A/B</em>), none of which is tlcd4b, so there is no missing enzymatic role for tlcd4b to fill.</p>
+<p>The second predicted term, <strong>ceramide metabolic process (GO:0006672)</strong>, is at most <strong>weakly and indirectly supported</strong> and is <strong>non-catalytic</strong>. The human ortholog of this family, <strong>TMEM56</strong>, modulates ceramide (particularly hexosylceramide) levels and physically interacts with <strong>ceramide synthase 2 (CerS2)</strong> — a <em>regulatory</em> connection to ceramide metabolism, not an amidohydrolase activity. Accordingly, the curation recommendation is to <strong>reject GO:0017040</strong>, treat <strong>GO:0006672 as non-core</strong> (or replace it with a regulatory term such as regulation of ceramide metabolic process, or retain the existing lipid-homeostasis annotation), and keep the evidence-appropriate ER/membrane/lipid-homeostasis annotations. The principal caveat is that no direct enzymatic assay of tlcd4b exists; the refutation rests on strong domain/structural/comparative evidence plus family-level functional data, which is the appropriate and sufficient evidence class for a computational-prediction review.</p>
+<hr />
+<h2 id="executive-judgment">Executive Judgment</h2>
+<p><strong>Verdict: REFUTED (for the molecular-function prediction GO:0017040); WEAKLY / INDIRECTLY SUPPORTED and non-catalytic (for the biological-process prediction GO:0006672).</strong></p>
+<p>tlcd4b is a small (257-residue), polytopic (6 transmembrane helices) membrane protein whose entire annotated domain content is the <strong>TLC (TRAM/LAG1/CLN8) domain</strong>. TLC-domain proteins act in lipid sensing/homeostasis and membrane biology; they are structurally and evolutionarily distinct from every known ceramidase enzyme family. The catalytic apparatus of ceramidases is absent from tlcd4b, and the genome contains dedicated ceramidase genes elsewhere. The prediction is therefore a paralog/family misassignment.</p>
+<p><strong>Most important caveat:</strong> No direct enzymatic assay of tlcd4b (positive or negative) exists. The refutation is inferential — grounded in family assignment, absence of catalytic signatures/residues, comparative genomics, structure prediction, and ortholog functional data — not in a biochemical demonstration that tlcd4b fails to hydrolyze ceramide. For a computational-prediction review this evidence class is expected and is sufficient to reject the MF prediction.</p>
+<hr />
+<h2 id="key-findings">Key Findings</h2>
+<h3 id="finding-1-tlcd4b-is-a-tlcd4-family-tlc-domain-membrane-protein-not-a-member-of-any-ceramidase-enzyme-family">Finding 1 — tlcd4b is a TLCD4-family TLC-domain membrane protein, not a member of any ceramidase enzyme family</h3>
+<p>UniProt entry <strong>Q550S9</strong> describes a 257-amino-acid protein with <strong>6 predicted transmembrane helices</strong> and a single <strong>TLC domain spanning residues ~44–243</strong>. The domain assignments are internally consistent across every major resource: <strong>Pfam PF03798 (TRAM_LAG1_CLN8)</strong>, <strong>InterPro IPR006634 (TLC domain) and IPR050846 (TLCD family)</strong>, and <strong>PROSITE profile PS50922 (TLC)</strong>. The UniProt SIMILARITY line explicitly states the protein "belongs to the <strong>TLCD4 family</strong>." The existing GO annotation set comprises endoplasmic reticulum localization (IBA), membrane, and lipid homeostasis (IBA) — <strong>no catalytic (enzymatic) annotation of any kind</strong>.</p>
+<p>This matters because every experimentally characterized ceramidase belongs to a family that is structurally and evolutionarily <strong>unrelated</strong> to the TLC domain:</p>
+<ul>
+<li><strong>Acid ceramidase (ASAH1):</strong> an N-terminal-nucleophile (Ntn) / CBAH-type hydrolase.</li>
+<li><strong>Neutral ceramidase (ASAH2):</strong> a Zn²⁺-dependent enzyme with a <strong>carboxypeptidase-like fold</strong>. As reviewed by <a href="https://pubmed.ncbi.nlm.nih.gov/24064302/">PMID: 24064302</a>: <em>"Neutral CDase contains a zinc ion in the active site that functions as a catalytic center, and the hydrolysis of the N-acyl linkage in ceramide proceeds through a mechanism that is similar to that described for zinc-dependent carboxypeptidase."</em></li>
+<li><strong>Alkaline ceramidase (ACER):</strong> a member of the <strong>CREST superfamily</strong> of integral-membrane hydrolases. As shown by <a href="https://pubmed.ncbi.nlm.nih.gov/36048828/">PMID: 36048828</a>: <em>"ACERs are members of the CREST superfamily of integral-membrane hydrolases. All CREST members conserve a set of three Histidine, one Aspartate, and one Serine residue."</em></li>
+</ul>
+<p>None of these families contains a TLC domain, and the TLC domain is not a hydrolase fold. Because family membership is the single most reliable predictor of catalytic activity for well-studied enzyme classes, the assignment of tlcd4b to the TLCD4 family is prima facie incompatible with the ceramidase prediction.</p>
+<h3 id="finding-2-the-tlcd4tmem56-family-regulates-ceramide-metabolism-through-protein-interaction-not-by-intrinsic-ceramidase-catalysis">Finding 2 — The TLCD4/TMEM56 family regulates ceramide metabolism through protein interaction, not by intrinsic ceramidase catalysis</h3>
+<p>The strongest functional evidence for the family's true role comes from the human ortholog <strong>TMEM56</strong> (the mammalian counterpart of <em>Dictyostelium</em> tlcd4b / tmem56b). <a href="https://pubmed.ncbi.nlm.nih.gov/42087192/">PMID: 42087192</a> reports that this TRAM-LAG1-CLN8 domain protein <em>"modulates ceramide metabolism, particularly affecting levels of hexosylated ceramides"</em> and that <em>"Co-immunoprecipitation assays indicate that TMEM56 physically interacts with ceramide synthase 2 (CerS2), suggesting a role in lipid signaling pathways."</em> The same work links TMEM56 to SDF-1-mediated cell migration.</p>
+<p>Critically, TMEM56 is described throughout as a <strong>regulator</strong> of ceramide metabolism — it changes ceramide levels by interacting with a biosynthetic enzyme (CerS2), <strong>not</strong> by directly hydrolyzing the N-acyl bond of ceramide. There is no report of intrinsic amidohydrolase/ceramidase catalytic activity anywhere in the TLCD4/TMEM56 family.</p>
+<p>A targeted motif scan of the tlcd4b sequence (Q550S9) reinforces this: the protein contains <strong>no Lag1/ceramide-synthase catalytic motif</strong> (the RxxH…P…P constellation is absent) and only <strong>7 histidines with no organized Zn-amidase active-site geometry</strong>. It therefore possesses neither the ceramide-synthase acyltransferase machinery nor the ceramidase amidohydrolase machinery — consistent with a <strong>non-catalytic, membrane-embedded regulatory/lipid-sensing role</strong> rather than an enzymatic one.</p>
+<p>This finding directly reframes the second predicted term (GO:0006672, ceramide metabolic process): the family is genuinely <em>associated</em> with ceramide metabolism, but as a modulator/regulator, which is a fundamentally different claim from possessing ceramidase catalytic activity.</p>
+<h3 id="finding-3-dictyostelium-encodes-dedicated-ceramidases-dcd1dcd2dcd3-in-the-proper-enzyme-families-tlcd4b-is-not-among-them">Finding 3 — Dictyostelium encodes dedicated ceramidases (dcd1/dcd2/dcd3) in the proper enzyme families; tlcd4b is not among them</h3>
+<p>A taxonomy-restricted UniProt search (taxon 44689, "ceramidase") returns <strong>six dedicated ceramidase genes</strong>, each mapping to a canonical ceramidase Pfam family:</p>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Accession</th>
+<th>Length (aa)</th>
+<th>Pfam family</th>
+<th>Ceramidase class</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>dcd2A</td>
+<td>Q54BK2</td>
+<td>714</td>
+<td>PF04734 + PF17048</td>
+<td>Neutral ceramidase</td>
+</tr>
+<tr>
+<td>dcd2B</td>
+<td>Q55G11</td>
+<td>718</td>
+<td>PF04734 + PF17048</td>
+<td>Neutral ceramidase</td>
+</tr>
+<tr>
+<td>dcd3A</td>
+<td>Q6TMJ1</td>
+<td>288</td>
+<td>PF05875</td>
+<td>Putative alkaline ceramidase</td>
+</tr>
+<tr>
+<td>dcd3B</td>
+<td>Q55DQ0</td>
+<td>285</td>
+<td>PF05875</td>
+<td>Putative alkaline ceramidase</td>
+</tr>
+<tr>
+<td>dcd1A</td>
+<td>Q55BZ5</td>
+<td>441</td>
+<td>(acid-type)</td>
+<td>Acid-type ceramidase</td>
+</tr>
+<tr>
+<td>dcd1B</td>
+<td>Q54CS6</td>
+<td>500</td>
+<td>(acid-type)</td>
+<td>Acid-type ceramidase</td>
+</tr>
+</tbody>
+</table>
+<p><strong>None of these is tlcd4b (Q550S9).</strong> Conversely, InterProScan of Q550S9 returns <strong>6 signatures, all TLC-family</strong> (IPR006634, IPR050846, PF03798, PS50922, PANTHER PTHR13439, SMART SM00724) and <strong>zero ceramidase-family signatures</strong>. The genome thus already contains a full complement of bona fide ceramidases in the correct families; there is no functional "gap" that tlcd4b would need to fill, removing the parsimony argument that might otherwise motivate an unexpected ceramidase assignment.</p>
+<p>Structural evidence agrees. The <strong>AlphaFold model AF-Q550S9-F1 is high-confidence</strong> (mean pLDDT 90.6; 95% of residues &gt; 70) and depicts a <strong>compact, multi-helical membrane bundle</strong> consistent with a TLC lipid-handling fold — not the globular α/β hydrolase or Zn-carboxypeptidase architecture of a ceramidase active site.</p>
+<p>Finally, historical biochemical work independently corroborates the family boundaries. <a href="https://pubmed.ncbi.nlm.nih.gov/10652340/">PMID: 10652340</a> (neutral ceramidase purification) reports that <em>"the amino acid sequence of a fragment obtained from the purified enzyme was homologous to those deduced from the genes encoding an alkaline ceramidase of Pseudomonas aeruginosa and a hypothetical protein of the slime mold Dictyostelium discoideum. However, no significant sequence similarities were found in other known functional proteins including acid ceramidases."</em> The genuine <em>Dictyostelium</em> ceramidase homolog identified in these studies is a neutral/alkaline (dcd2-type) protein — a separate gene from the TLC protein tlcd4b. <a href="https://pubmed.ncbi.nlm.nih.gov/10781606/">PMID: 10781606</a> similarly maps the human mitochondrial/nonlysosomal ceramidase to a distinct conserved protein family with a <em>Dictyostelium</em> homolog, again not a TLC protein.</p>
+<hr />
+<h2 id="mechanistic-model-interpretation">Mechanistic Model / Interpretation</h2>
+<p>The evidence supports a clear separation between <strong>what tlcd4b is</strong> and <strong>what a ceramidase is</strong>:</p>
+<div class="codehilite"><pre><span></span><code><span class="w">    </span><span class="n">PREDICTED</span><span class="w"> </span><span class="p">(</span><span class="n">BioReason</span><span class="o">-</span><span class="n">Pro</span><span class="w"> </span><span class="n">SFT</span><span class="p">)</span><span class="w">          </span><span class="n">ACTUAL</span><span class="w"> </span><span class="p">(</span><span class="n">evidence</span><span class="o">-</span><span class="n">based</span><span class="p">)</span>
+<span class="w">    </span><span class="o">------------------------------</span><span class="w">          </span><span class="o">-----------------------</span>
+<span class="w"> </span><span class="n">Molecular</span><span class="w"> </span><span class="n">class</span><span class="w">    </span><span class="n">Ceramidase</span><span class="w"> </span><span class="n">enzyme</span><span class="w">                       </span><span class="n">TLC</span><span class="o">-</span><span class="n">domain</span><span class="w"> </span><span class="n">membrane</span><span class="w"> </span><span class="n">protein</span>
+<span class="w">    </span><span class="p">(</span><span class="n">N</span><span class="o">-</span><span class="n">acylsphingosine</span><span class="w"> </span><span class="n">amidohydrolase</span><span class="p">)</span><span class="w">      </span><span class="p">(</span><span class="n">TLCD4</span><span class="w"> </span><span class="n">family</span><span class="p">)</span>
+<span class="w"> </span><span class="n">Fold</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">machinery</span><span class="w">   </span><span class="n">Catalytic</span><span class="w"> </span><span class="n">hydrolase</span><span class="w"> </span><span class="p">(</span><span class="n">Ntn</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">Zn</span><span class="o">-</span><span class="w">          </span><span class="mh">6</span><span class="o">-</span><span class="n">TM</span><span class="w"> </span><span class="n">helical</span><span class="w"> </span><span class="n">bundle</span><span class="p">;</span>
+<span class="w">    </span><span class="n">carboxypeptidase</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">CREST</span><span class="w"> </span><span class="n">Zn</span><span class="o">-</span><span class="n">amidase</span><span class="p">)</span><span class="w">    </span><span class="n">TLC</span><span class="w"> </span><span class="n">lipid</span><span class="o">-</span><span class="n">sensing</span><span class="w"> </span><span class="n">domain</span><span class="p">;</span>
+<span class="w">                                            </span><span class="n">NO</span><span class="w"> </span><span class="n">catalytic</span><span class="w"> </span><span class="n">center</span>
+<span class="w"> </span><span class="n">Reaction</span><span class="w">           </span><span class="n">Ceramide</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="n">H2O</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">sphingosine</span><span class="w"> </span><span class="o">+</span><span class="w">         </span><span class="n">None</span><span class="w"> </span><span class="p">(</span><span class="n">non</span><span class="o">-</span><span class="n">catalytic</span><span class="p">)</span>
+<span class="w">    </span><span class="n">free</span><span class="w"> </span><span class="n">fatty</span><span class="w"> </span><span class="n">acid</span>
+<span class="w"> </span><span class="n">Role</span><span class="w"> </span><span class="n">in</span><span class="w"> </span><span class="n">ceramide</span><span class="w">   </span><span class="n">Direct</span><span class="w"> </span><span class="n">catabolism</span><span class="w"> </span><span class="p">(</span><span class="n">bond</span><span class="w"> </span><span class="n">cleavage</span><span class="p">)</span><span class="w">       </span><span class="n">Indirect</span><span class="w"> </span><span class="n">regulation</span><span class="w"> </span><span class="n">via</span>
+<span class="w">   </span><span class="n">metabolism</span><span class="w">                                               </span><span class="n">interaction</span><span class="w"> </span><span class="n">with</span><span class="w"> </span><span class="n">ceramide</span>
+<span class="w">                                            </span><span class="n">synthase</span><span class="w"> </span><span class="p">(</span><span class="n">CerS2</span><span class="w"> </span><span class="n">in</span><span class="w"> </span><span class="n">ortholog</span><span class="p">)</span>
+</code></pre></div>
+
+<p><strong>Why the prediction likely fired.</strong> BioReason-Pro SFT appears to have keyed on the protein's genuine association with <strong>sphingolipid / ceramide biology</strong> — the TLC domain is co-named with CLN8 and LAG1, both connected to ceramide/sphingolipid pathways — and generalized from "ceramide-associated membrane protein" to the specific catalytic term "ceramidase." This is a textbook <strong>frequency-bias / paralog-overannotation error</strong>: a family that is <em>adjacent</em> to ceramide metabolism is misassigned the <em>catalytic</em> term for that pathway. The correct family-level function is <strong>lipid homeostasis / regulation of ceramide metabolism via protein–protein interaction</strong>, which the model collapsed into an enzyme activity it does not possess.</p>
+<p><strong>Reconciling the two predicted terms.</strong> GO:0017040 (ceramidase activity, MF) and GO:0006672 (ceramide metabolic process, BP) are not equally wrong. The MF term is refuted outright. The BP term captures a real, if indirect, biological association — but only in the sense that the family <em>regulates</em> ceramide pools. A curator should treat these as separable decisions.</p>
+<hr />
+<h2 id="evidence-matrix">Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Direction</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence / limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>UniProt Q550S9 (database)</td>
+<td>Structural/evolutionary (domain)</td>
+<td><strong>Refutes</strong></td>
+<td>tlcd4b is a ceramidase</td>
+<td>257 aa, 6 TM, TLC domain (44–243); Pfam PF03798; assigned to <strong>TLCD4 family</strong>; no catalytic GO</td>
+<td><em>D. discoideum</em>, in silico</td>
+<td>High for family ID; database-level</td>
+</tr>
+<tr>
+<td>InterProScan of Q550S9</td>
+<td>Computational</td>
+<td><strong>Refutes</strong></td>
+<td>tlcd4b has ceramidase signatures</td>
+<td>6/6 signatures TLC-family; 0 ceramidase signatures</td>
+<td>in silico</td>
+<td>High; signature-based</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/36048828/">PMID: 36048828</a></td>
+<td>Structural/mechanistic (review of ACER)</td>
+<td><strong>Refutes (family boundary)</strong></td>
+<td>Ceramidases share TLC machinery</td>
+<td>ACERs are CREST-superfamily Zn²⁺-amidases with conserved 3His+Asp+Ser; unrelated to TLC</td>
+<td>Alkaline ceramidase family</td>
+<td>High; establishes distinct active site</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/24064302/">PMID: 24064302</a></td>
+<td>Structural/mechanistic (review of nCDase)</td>
+<td><strong>Refutes (family boundary)</strong></td>
+<td>Ceramidases share TLC machinery</td>
+<td>Neutral CDase uses a Zn carboxypeptidase-like fold/mechanism; unrelated to TLC</td>
+<td>Neutral ceramidase family</td>
+<td>High; distinct fold</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/42087192/">PMID: 42087192</a></td>
+<td>Interaction + lipidomics (ortholog)</td>
+<td><strong>Qualifies</strong></td>
+<td>Family role in ceramide metabolism</td>
+<td>TMEM56 (TLCD4/TMEM56 ortholog) modulates ceramide levels, interacts with <strong>CerS2</strong>; no ceramidase activity reported</td>
+<td>Human cells</td>
+<td>Moderate–high; ortholog, not tlcd4b itself</td>
+</tr>
+<tr>
+<td>UniProt taxon 44689 "ceramidase" search</td>
+<td>Comparative genomics (database)</td>
+<td><strong>Refutes</strong></td>
+<td>tlcd4b is <em>the</em> Dictyostelium ceramidase</td>
+<td>6 dedicated ceramidases (dcd1/2/3) in canonical families; tlcd4b absent</td>
+<td><em>D. discoideum</em></td>
+<td>High; genome-level</td>
+</tr>
+<tr>
+<td>AlphaFold AF-Q550S9-F1</td>
+<td>Structural (predicted)</td>
+<td><strong>Refutes</strong></td>
+<td>tlcd4b has a hydrolase fold</td>
+<td>High-confidence (pLDDT 90.6) compact 6-helix membrane bundle; TLC-like, not hydrolase</td>
+<td>in silico</td>
+<td>Moderate–high; predicted structure, no ligand</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/10652340/">PMID: 10652340</a></td>
+<td>Direct assay + sequence (historical)</td>
+<td><strong>Refutes / competing</strong></td>
+<td>Which Dictyostelium protein is the ceramidase</td>
+<td>Purified neutral ceramidase is homologous to a <em>Dictyostelium</em> neutral/alkaline (dcd2-type) protein, not a TLC protein</td>
+<td>Mouse liver + sequence homology</td>
+<td>Moderate; homology assignment</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/10781606/">PMID: 10781606</a></td>
+<td>Cloning + assay (historical)</td>
+<td><strong>Qualifies / competing</strong></td>
+<td>Ceramidase family identity</td>
+<td>Human mitochondrial ceramidase homologous to a distinct conserved family incl. a <em>Dictyostelium</em> homolog; not TLC</td>
+<td>Human, HEK293/MCF7</td>
+<td>Moderate</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/16086686/">PMID: 16086686</a></td>
+<td>Review/context (CLN8/TLC)</td>
+<td><strong>Qualifies</strong></td>
+<td>TLC-domain function</td>
+<td>TLC (TRAM/Lag1/CLN8) family has postulated roles in lipid synthesis, transport or sensing</td>
+<td>Human EPMR brain</td>
+<td>Low–moderate; contextual</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="go-curation-implications">GO Curation Implications</h2>
+<p><strong>Lead requiring curator verification.</strong></p>
+<ul>
+<li>
+<p><strong>GO:0017040 — N-acylsphingosine amidohydrolase (ceramidase) activity (MF): DO NOT ANNOTATE / REJECT the prediction.</strong> The evidence (family assignment, absence of any ceramidase signature, absence of catalytic-residue constellation, presence of dedicated ceramidase genes elsewhere in the genome, and family-level functional data) refutes direct ceramidase activity. This term should not be added on the basis of the BioReason-Pro SFT prediction.</p>
+</li>
+<li>
+<p><strong>GO:0006672 — ceramide metabolic process (BP): treat as NON-CORE and, if used at all, only as regulatory involvement.</strong> The family is genuinely connected to ceramide metabolism, but as a <strong>regulator</strong> (via interaction with ceramide synthase), not as a ceramide-hydrolyzing enzyme. A more defensible, better-supported alternative is a regulatory term such as <strong>"regulation of ceramide metabolic process" (GO:2000303)</strong> or the existing <strong>lipid homeostasis</strong> annotation, supported at IBA/ISS grade. Curators should not use GO:0006672 to imply catalytic activity.</p>
+</li>
+<li>
+<p><strong>Retain the existing, evidence-appropriate annotations:</strong> endoplasmic reticulum (CC, IBA), membrane (CC), and lipid homeostasis (BP, IBA). These correctly capture a non-catalytic, membrane-resident, lipid-homeostasis role.</p>
+</li>
+<li>
+<p><strong>Avoid "protein binding" as the terminal recommendation.</strong> The most informative supported statement is a <strong>TLC-domain lipid-homeostasis / regulator-of-ceramide-metabolism</strong> characterization (via CerS interaction in the ortholog), which is more specific than generic binding.</p>
+</li>
+</ul>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p>The immediate molecular function under test is <strong>direct hydrolysis of the amide (N-acyl) bond of ceramide</strong> to yield sphingosine and a free fatty acid (ceramidase / N-acylsphingosine amidohydrolase activity). This is a <strong>catalytic</strong> claim about the gene product itself.</p>
+<p>The evidence indicates tlcd4b does <strong>not</strong> perform this reaction. What tlcd4b (and its family) actually contributes is upstream and <strong>non-catalytic</strong>: a multi-pass membrane TLC-domain protein that participates in <strong>lipid sensing/homeostasis</strong> and, at the family level, <strong>modulates ceramide pools indirectly</strong> by physically associating with a biosynthetic enzyme (ceramide synthase / CerS2 in the human ortholog). The observed changes in ceramide (and hexosylceramide) levels upon perturbation of the family member are therefore <strong>downstream consequences of a regulatory interaction</strong>, not the signature of an intrinsic amidohydrolase. Distinguishing these is central to the curation decision: a lipidomic phenotype in a knockout does not by itself license a catalytic MF annotation.</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ul>
+<li>
+<p><strong>Paralog / family misassignment (primary alternative, strongly favored).</strong> The prediction most plausibly arises from conflating a ceramide-<em>associated</em> membrane protein with a ceramide-<em>hydrolyzing</em> enzyme. The genome-level presence of dedicated ceramidases (dcd1/2/3) shows the ceramidase function is carried by other genes.</p>
+</li>
+<li>
+<p><strong>Regulatory vs. catalytic (partial reconciliation).</strong> The one genuine grain of truth in the prediction is the family's connection to ceramide metabolism (PMID 42087192). This supports a <em>regulatory</em> BP association but actively argues <strong>against</strong> the catalytic MF term, because the mechanism demonstrated is interaction-based, not enzymatic.</p>
+</li>
+<li>
+<p><strong>Ortholog-based inference caveat.</strong> The functional data (TMEM56/CerS2 interaction) come from the human ortholog, not from tlcd4b directly. Organism-specific divergence is possible, but this weakens, not strengthens, the ceramidase claim — no ortholog in the family shows ceramidase activity.</p>
+</li>
+<li>
+<p><strong>Historical homology "false friend."</strong> Older literature (PMID 10652340, 10781606) repeatedly notes a <em>Dictyostelium</em> protein homologous to neutral/alkaline ceramidases. A superficial reading could misattribute that homology to tlcd4b; in fact it refers to the dcd2-type genes, reinforcing that the true ceramidase is a different locus.</p>
+</li>
+</ul>
+<hr />
+<h2 id="limitations-and-knowledge-gaps">Limitations and Knowledge Gaps</h2>
+<ol>
+<li>
+<p><strong>No direct enzymatic assay of tlcd4b.</strong> No published in vitro ceramidase assay (positive or negative) exists for Q550S9. <em>Checked:</em> literature and UniProt. <em>Why it matters:</em> a direct negative assay would convert a strong inferential refutation into a definitive one. <em>Resolution:</em> express and purify tlcd4b and assay for ceramidase activity across acid/neutral/alkaline pH with cation panels.</p>
+</li>
+<li>
+<p><strong>No experimental structure.</strong> The refutation of a hydrolase fold rests on the AlphaFold model (high confidence, but predicted, ligand-free). <em>Why it matters:</em> rules out an unexpected cryptic active site only inferentially. <em>Resolution:</em> experimental structure or structure-guided active-site mutagenesis.</p>
+</li>
+<li>
+<p><strong>tlcd4b-specific functional data are absent in <em>Dictyostelium</em>.</strong> Family function is inferred from the human ortholog TMEM56. <em>Why it matters:</em> <em>Dictyostelium</em>-specific roles (e.g., in phagosome ceramide enrichment; cf. <a href="https://pubmed.ncbi.nlm.nih.gov/29963848/">PMID: 29963848</a>) are plausible but uncharacterized for this specific gene. <em>Resolution:</em> knockout/knock-in lipidomics and localization in <em>D. discoideum</em>.</p>
+</li>
+<li>
+<p><strong>BP-term granularity.</strong> Whether the correct term is "ceramide metabolic process," a regulatory child term, or simply "lipid homeostasis" is not fully resolved by current evidence. <em>Resolution:</em> curator judgment plus any <em>Dictyostelium</em> lipidomic phenotype.</p>
+</li>
+</ol>
+<hr />
+<h2 id="discriminating-tests">Discriminating Tests</h2>
+<ol>
+<li><strong>Direct ceramidase assay</strong> on recombinant tlcd4b (fluorogenic or radiolabeled ceramide; acid/neutral/alkaline pH ± Zn²⁺/Ca²⁺). A clean negative would definitively refute GO:0017040; a positive would be extraordinary and require replication.</li>
+<li><strong>Active-site residue audit</strong> against the CREST 3His+Asp+Ser (ACER) and Zn-carboxypeptidase (nCDase) templates — structural superposition of AF-Q550S9-F1 onto solved ceramidase structures to confirm the absence of a catalytic constellation.</li>
+<li><strong>Co-IP / proximity labeling in <em>Dictyostelium</em></strong> to test whether tlcd4b, like TMEM56, associates with a ceramide synthase (Lag1-family CerS), confirming a regulatory rather than catalytic role.</li>
+<li><strong>Knockout lipidomics in <em>D. discoideum</em></strong> (compare with dcd1/dcd2/dcd3 knockouts): a ceramidase loss should raise ceramide/lower sphingosine; a regulator loss should shift ceramide-synthase-dependent species (e.g., hexosylceramides) as seen for TMEM56.</li>
+<li><strong>Phylogenetic reconciliation</strong> placing Q550S9 within the TLCD4 clade and confirming dcd1/2/3 occupy the ceramidase clades — formally demonstrating the misassignment.</li>
+</ol>
+<hr />
+<h2 id="proposed-follow-up-actions-curation-leads">Proposed Follow-up Actions (Curation Leads)</h2>
+<p>All items below are <strong>leads requiring curator verification.</strong></p>
+<ul>
+<li><strong>Action:</strong> Reject/do-not-add <strong>GO:0017040 (N-acylsphingosine amidohydrolase activity, MF)</strong> from the BioReason-Pro SFT prediction — classify as <strong>paralog/family overannotation</strong>.</li>
+<li><strong>Action:</strong> Down-rank <strong>GO:0006672 (ceramide metabolic process, BP)</strong> to non-core; if retained, replace with a <strong>regulatory</strong> term (e.g., <strong>regulation of ceramide metabolic process, GO:2000303</strong>) or keep the existing <strong>lipid homeostasis</strong> annotation, at IBA/ISS grade.</li>
+<li><strong>Retain:</strong> ER (CC), membrane (CC), lipid homeostasis (BP).</li>
+<li><strong>Candidate references to verify with exact snippets:</strong></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/42087192/">PMID: 42087192</a>: <em>"TMEM56 physically interacts with ceramide synthase 2 (CerS2), suggesting a role in lipid signaling pathways."</em> → family is a regulator, not a ceramidase.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/36048828/">PMID: 36048828</a>: <em>"ACERs are members of the CREST superfamily of integral-membrane hydrolases. All CREST members conserve a set of three Histidine, one Aspartate, and one Serine residue."</em> → ceramidase active site absent from TLC family.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/24064302/">PMID: 24064302</a>: neutral ceramidase uses a Zn carboxypeptidase-like mechanism → distinct fold.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/10652340/">PMID: 10652340</a>: genuine <em>Dictyostelium</em> ceramidase homolog is neutral/alkaline (dcd2-type), not TLC.</li>
+<li><strong>Suggested curator questions:</strong> Is there any <em>Dictyostelium</em>-specific assay or phenotype for tlcd4b? Does the review already annotate dcd1/2/3 as the ceramidases? Should the BP term be a regulatory child term?</li>
+<li><strong>Suggested experiments:</strong> direct ceramidase assay on recombinant Q550S9; active-site structural superposition; <em>Dictyostelium</em> knockout lipidomics and CerS co-IP.</li>
+</ul>
+<hr />
+<h2 id="evidence-base-literature-summary">Evidence Base (Literature Summary)</h2>
+<table>
+<thead>
+<tr>
+<th>PMID</th>
+<th>Title (abbrev.)</th>
+<th>Role in this review</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/42087192/">42087192</a></td>
+<td><em>TMEM56 regulates cell migration by changing intracellular ceramide levels</em></td>
+<td>Defines the true family function: regulator interacting with CerS2, not a ceramidase</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/36048828/">36048828</a></td>
+<td><em>Alkaline ceramidase catalyzes hydrolysis via Zn²⁺-dependent amidase mechanism</em></td>
+<td>Establishes ACER/CREST active site distinct from TLC</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/24064302/">24064302</a></td>
+<td><em>Structure/mechanism of neutral ceramidase</em></td>
+<td>Establishes nCDase Zn-carboxypeptidase fold distinct from TLC</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/10652340/">10652340</a></td>
+<td><em>Neutral ceramidase from mouse liver</em></td>
+<td>Maps genuine Dictyostelium ceramidase to dcd2-type, not TLC</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/10781606/">10781606</a></td>
+<td><em>Human mitochondrial ceramidase cloning</em></td>
+<td>Ceramidase family distinct from TLC; separate Dictyostelium homolog</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/16086686/">16086686</a></td>
+<td><em>Sphingolipid changes in EPMR/CLN8</em></td>
+<td>Context: TLC (TRAM/Lag1/CLN8) family in lipid synthesis/transport/sensing</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/29963848/">29963848</a></td>
+<td><em>Ceramide synthase in phagocytosis</em></td>
+<td>Context: ceramide biology in Dictyostelium is synthase-driven</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/20951822/">20951822</a></td>
+<td><em>Sphingolipids and cisplatin sensitivity</em></td>
+<td>Context: Dictyostelium sphingolipid enzymology is well-characterized (S1P lyase, SK, CerS)</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/15190000/">15190000</a></td>
+<td><em>S1P lyase/SK and platinum drugs</em></td>
+<td>Context: dedicated sphingolipid enzymes in Dictyostelium</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="bottom-line">Bottom Line</h2>
+<p>The BioReason-Pro SFT ceramidase prediction for tlcd4b (Q550S9) is a <strong>family/paralog misassignment</strong> and should be <strong>refuted</strong> at the molecular-function level. tlcd4b is a TLCD4-family TLC-domain membrane protein with no ceramidase catalytic machinery; genuine ceramidase activity in <em>Dictyostelium</em> is encoded by dedicated genes (dcd1/dcd2/dcd3) in the canonical enzyme families. The only defensible remnant of the prediction is a <strong>non-catalytic, regulatory association with ceramide metabolism</strong>, mirroring the human ortholog TMEM56's interaction with ceramide synthase — which should be curated, if at all, as a regulatory/homeostasis role and never as ceramidase activity.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="tlcd4b-hypotheses/prediction-ceramidase/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="tlcd4b-hypotheses/prediction-ceramidase/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+<li><a href="tlcd4b-hypotheses/prediction-ceramidase/openscientist_artifacts/tlcd4b_GO_decision_table.csv">OpenScientist tlcd4b GO decision table</a></li>
+<li><a href="tlcd4b-hypotheses/prediction-ceramidase/openscientist_artifacts/tlcd4b_family_comparison.csv">OpenScientist tlcd4b family comparison</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/DROME/LysB/LysB-ai-review.html
+++ b/genes/DROME/LysB/LysB-ai-review.html
@@ -2363,6 +2363,513 @@ We verified identity and gathered Drosophila-focused primary and recent review e
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(LysB-hypotheses/prediction-chitinase-immune/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q08694" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">AIGR Gene Hypothesis Deep Research — LysB (Q08694, DROME)</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+                    <span class="report-badge">6 citations</span>
+
+
+                    <span class="report-badge">3 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-09T13:28:52.038462</span>
+
+
+
+                    <a href="LysB-hypotheses/prediction-chitinase-immune/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="LysB-hypotheses/prediction-chitinase-immune/openscientist_artifacts/artifacts_lysB_fold_check.md" class="term-link">OpenScientist lysB fold check</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="LysB-hypotheses/prediction-chitinase-immune/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="LysB-hypotheses/prediction-chitinase-immune/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="aigr-gene-hypothesis-deep-research-lysb-q08694-drome">AIGR Gene Hypothesis Deep Research — LysB (Q08694, DROME)</h1>
+<p><strong>Focus type:</strong> computational_prediction · <strong>Hypothesis slug:</strong> prediction-chitinase-immune<br />
+<strong>Term under evaluation:</strong> chitinase activity (GO:0004568)<br />
+<strong>Reference context:</strong> doi:10.64898/2026.03.19.712954</p>
+<hr />
+<h2 id="summary">Summary</h2>
+<p>The BioReason-Pro SFT model predicts that <em>Drosophila melanogaster</em> LysB (UniProt <strong>Q08694</strong>) has <strong>chitinase activity (GO:0004568)</strong> and two immune roles — <strong>negative regulation of innate immune response (GO:0045824)</strong> and <strong>defense response to Gram-negative bacterium (GO:0050829)</strong>. Independent evaluation from sequence classification, domain architecture, a custom catalytic-site alignment, primary expression literature, and the current GO annotation record indicates that all three predictions are either <strong>wrong</strong> or <strong>unsupported by the physiological evidence</strong>. The overall verdict is <strong>REFUTED / OVER-ANNOTATED</strong>.</p>
+<p>LysB is a <strong>glycoside hydrolase family 22 (GH22) C-type lysozyme (muramidase, EC 3.2.1.17)</strong> — not a chitinase (EC 3.2.1.14; GH18/GH19). Its molecular function is peptidoglycan hydrolysis. The "chitinase" prediction is best explained as a <strong>fold/activity misassignment</strong> arising from the well-documented, weak chito-oligosaccharide side-activity that C-type lysozymes possess, together with the general confusion between lysozyme and chitinase glycosidase folds. Physiologically, the Drosophila <em>LysB–E</em> cluster comprises <strong>constitutive, midgut-restricted, acidic digestive lysozymes</strong> that are transcriptionally <strong>repressed</strong> (not induced) by bacterial infection and are <strong>not expressed in fat body or hemocytes</strong> — the opposite of what an induced humoral immune effector or an immune <em>regulator</em> would look like. This makes <strong>GO:0045824</strong> unsupported and biologically implausible for LysB, and it substantially weakens the case for <strong>GO:0050829</strong>, which exists in the GO record only as an ISS "by similarity" carry-over with no experimental basis.</p>
+<p>For a curator, the actionable conclusion is: <strong>do not add GO:0004568 or GO:0045824</strong>; treat the existing <strong>GO:0050829</strong> as low-confidence (ISS-only, conflicting with digestive biology) and consider flagging it for review or "non-core" status; and <strong>retain the well-supported core terms</strong> — <strong>GO:0003796 (lysozyme activity, MF)</strong> and <strong>GO:0005576 (extracellular region, CC)</strong> — ideally complemented by a BP term reflecting <strong>digestion / bacteriophagy</strong> rather than immunity.</p>
+<hr />
+<h2 id="executive-judgment">Executive Judgment</h2>
+<p><strong>Verdict: REFUTED / OVER-ANNOTATED.</strong></p>
+<p>All three predicted terms fail independent evaluation:</p>
+<ul>
+<li><strong>GO:0004568 (chitinase activity):</strong> Refuted. LysB is a GH22 muramidase with a conserved lysozyme catalytic dyad and no GH18/GH19 chitinase domain or active-site motif. The only "chitinase-like" property is the weak chitodextrin side-activity intrinsic to C-type lysozymes, which is captured by the canonical lysozyme catalytic-activity description and does not warrant a chitinase MF term.</li>
+<li><strong>GO:0045824 (negative regulation of innate immune response):</strong> Refuted/unsupported. No experimental or credible computational basis; contradicts the constitutive, infection-repressed, midgut-restricted expression profile.</li>
+<li><strong>GO:0050829 (defense response to Gram-negative bacterium):</strong> Weakly supported at best; present only as a single ISS "by similarity" annotation, in tension with the digestive role.</li>
+</ul>
+<p>The most important caveat is that a minority of insect c-type lysozymes are genuinely dual-function (digestive + mild immune effector), so a low-level bactericidal activity for LysB cannot be fully excluded — but even the strongest reading of that literature would never justify a <em>negative regulator of immunity</em> assignment, and the Drosophila-specific expression data argue against an immune-effector role.</p>
+<hr />
+<h2 id="key-findings">Key Findings</h2>
+<h3 id="finding-1-lysb-is-a-gh22-c-type-lysozyme-ec-32117-not-a-chitinase">Finding 1 — LysB is a GH22 C-type lysozyme (EC 3.2.1.17), not a chitinase</h3>
+<p>UniProt Q08694 carries the recommended name <strong>"Lysozyme B"</strong>, EC number <strong>3.2.1.17</strong> (lysozyme/muramidase), and the family SIMILARITY statement <strong>"Belongs to the glycosyl hydrolase 22 family."</strong> The domain architecture is <strong>exclusively</strong> C-type lysozyme with no chitinase signature whatsoever:</p>
+<table>
+<thead>
+<tr>
+<th>Resource</th>
+<th>Identifier</th>
+<th>Assignment</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>InterPro</td>
+<td>IPR001916 / IPR000974</td>
+<td>Glycoside hydrolase family 22 / C-type lysozyme</td>
+</tr>
+<tr>
+<td>Pfam</td>
+<td>PF00062</td>
+<td>Lys (lysozyme)</td>
+</tr>
+<tr>
+<td>CDD</td>
+<td>cd16899</td>
+<td>LYZ_C_invert (invertebrate C-type lysozyme)</td>
+</tr>
+<tr>
+<td>PANTHER</td>
+<td>PTHR11407</td>
+<td>LYSOZYME C</td>
+</tr>
+<tr>
+<td>SUPFAM</td>
+<td>SSF53955</td>
+<td>Lysozyme-like superfamily</td>
+</tr>
+</tbody>
+</table>
+<p>No GH18 or GH19 chitinase domain (e.g., Pfam PF00704 / Glyco_hydro_18, or Glyco_hydro_19) is present. The GO molecular-function annotation for Q08694 is <strong>GO:0003796 lysozyme activity</strong>, not GO:0004568 chitinase activity.</p>
+<p>Critically, the mechanistic origin of the model's error is visible in the enzyme's own catalytic-activity description. The canonical C-type lysozyme reaction hydrolyzes the β-1,4 linkage between <em>N</em>-acetylmuramic acid (MurNAc) and <em>N</em>-acetylglucosamine (GlcNAc) in <strong>peptidoglycan</strong> — "<strong>and between N-acetyl-D-glucosamine residues in chitodextrins.</strong>" This weak activity on chito-oligosaccharides is an intrinsic, well-known side-property of C-type lysozymes and is almost certainly the textual/feature signal that led a machine-learning model to over-predict full <strong>endochitinase</strong> activity. A weak in-vitro side-activity on short chitodextrins is <strong>not</strong> equivalent to biological chitinase activity (processive hydrolysis of insoluble chitin polymer), which is carried out by structurally distinct GH18/GH19 enzymes.</p>
+<p>This finding is anchored in the review-level statement that <strong>"Lysozymes from family 22 of glycoside hydrolases are usually part of the defense system against bacteria"</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/17825580/">PMID: 17825580</a>), confirming that C-type/digestive insect lysozymes belong to GH22 — a family distinct from the chitinase families.</p>
+<h3 id="finding-2-drosophila-lysb-is-a-constitutive-midgut-digestive-lysozyme-not-an-induced-immune-effector">Finding 2 — Drosophila LysB is a constitutive midgut digestive lysozyme, not an induced immune effector</h3>
+<p>The defining expression study of the Drosophila lysozyme locus (<a href="https://pubmed.ncbi.nlm.nih.gov/8159165/">PMID: 8159165</a>, Daffre et al. 1994) reports that <strong>"four closely related genes, LysB, C, D and E, are all strongly expressed in the midgut of larvae and adults"</strong> and that <strong>"None of the genes is expressed in the fat body or haemocytes."</strong> In insects, the fat body and hemocytes are the principal tissues of the systemic humoral immune response; the complete absence of LysB expression there is direct evidence against a humoral/immune-effector role. The same work notes that all of these genes except LysP encode <strong>acidic</strong> proteins "highly reminiscent" of the acidic digestive lysozymes of mammalian foregut fermenters — a hallmark of enzymes optimized for acidic gut lumen conditions and bacteriolytic digestion.</p>
+<p>An independent study of the same locus (<a href="https://pubmed.ncbi.nlm.nih.gov/1588905/">PMID: 1588905</a>, Kylsten et al. 1992) found that lysozyme transcription <strong>decreases</strong> after bacterial injection and concluded that these genes <strong>"have been recruited for the digestion of bacteria present in fermenting food."</strong> A gene whose transcription is <em>repressed</em> by infection and whose product acts in the gut lumen to digest dietary bacteria is behaving as a <strong>digestive enzyme</strong>, not as an inducible immune effector and certainly not as a <em>negative regulator</em> of the innate immune response.</p>
+<p>Consistent with the primary literature, UniProt Q08694 states in its FUNCTION field that LysB is <strong>"Unlikely to play an active role in the humoral immune defense. May have a function in the digestion of bacteria in the food,"</strong> and its TISSUE SPECIFICITY field localizes expression to the midgut with peak expression in the 3rd larval instar.</p>
+<p>The digestive-lysozyme model is reinforced by comparative work across arthropods: housefly (<em>Musca domestica</em>) digestive lysozymes MdL1/MdL2 are acidic-optimum midgut enzymes (<a href="https://pubmed.ncbi.nlm.nih.gov/19099150/">PMID: 19099150</a>), the first crystal structure of a digestive lysozyme was solved from housefly (<a href="https://pubmed.ncbi.nlm.nih.gov/17825580/">PMID: 17825580</a>), and synanthropic mites use acidic digestive lysozymes to exploit bacteria as a food source, with maximal activity at the acidic pH of the gut (<a href="https://pubmed.ncbi.nlm.nih.gov/18357505/">PMID: 18357505</a>). These establish "acidic midgut digestive lysozyme" as a recurrent, well-characterized functional class into which Drosophila LysB clearly falls.</p>
+<h3 id="finding-3-sequence-analysis-confirms-the-c-type-lysozyme-catalytic-dyad-and-the-absence-of-a-chitinase-active-site">Finding 3 — Sequence analysis confirms the C-type lysozyme catalytic dyad and the absence of a chitinase active site</h3>
+<p>To test the classification directly rather than relying on database labels, an in-run global alignment (Needleman–Wunsch, implemented in NumPy) was performed between the <strong>mature LysB sequence</strong> (122 aa, after removing the signal peptide, residues 1–18) and <strong>hen egg-white lysozyme (HEWL)</strong>, the archetypal GH22 C-type lysozyme:</p>
+<table>
+<thead>
+<tr>
+<th>Metric</th>
+<th>Result</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity to HEWL</td>
+<td><strong>41.3%</strong> (50/121 aligned positions)</td>
+</tr>
+<tr>
+<td>HEWL catalytic Glu35</td>
+<td><strong>Conserved</strong> (→ Glu in LysB)</td>
+</tr>
+<tr>
+<td>HEWL catalytic Asp52</td>
+<td><strong>Conserved</strong> (→ Asp in LysB)</td>
+</tr>
+<tr>
+<td>Cysteine count</td>
+<td><strong>8</strong> (4 disulfides), matching HEWL's C-type scaffold</td>
+</tr>
+<tr>
+<td>GH18 chitinase catalytic motif (DxxDxDxE)</td>
+<td><strong>Absent</strong></td>
+</tr>
+<tr>
+<td>Enzyme classification</td>
+<td>EC 3.2.1.17 (lysozyme), <strong>not</strong> EC 3.2.1.14 (chitinase)</td>
+</tr>
+</tbody>
+</table>
+<p>The conservation of <strong>both</strong> HEWL catalytic residues (the Glu general acid and the Asp that stabilizes/participates in catalysis) together with the eight-cysteine (four-disulfide) C-type lysozyme fold is diagnostic of a functional GH22 muramidase. The <strong>absence</strong> of the GH18 chitinase catalytic signature (the DxxDxDxE motif that defines the GH18 active site) is direct negative evidence against the chitinase prediction: LysB does not possess the active-site chemistry required for a genuine chitinase.</p>
+<h3 id="finding-4-the-current-go-record-contains-no-chitinase-or-immune-regulation-term-the-sole-defense-term-is-iss-only">Finding 4 — The current GO record contains no chitinase or immune-regulation term; the sole defense term is ISS-only</h3>
+<p>A QuickGO retrieval (performed in-run) returned <strong>6 annotations</strong> for Q08694 spanning <strong>three distinct terms</strong>:</p>
+<table>
+<thead>
+<tr>
+<th>GO term</th>
+<th>Aspect</th>
+<th>Evidence in the record</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>GO:0003796</strong> lysozyme activity</td>
+<td>MF</td>
+<td>Supported four independent ways: ISS from P00697; <strong>IBA</strong> from GO_Central (PANTHER PTN004256961, including HEWL P00698); <strong>IEA</strong> from InterPro IPR000974 / EC 3.2.1.17; and ISS with reference PMID:8159165</td>
+</tr>
+<tr>
+<td><strong>GO:0050829</strong> defense response to Gram-negative bacterium</td>
+<td>BP</td>
+<td><strong>Single ISS</strong> annotation, by-similarity to UniProtKB P00697 (GO_REF:0000024, FlyBase). No experimental evidence.</td>
+</tr>
+<tr>
+<td><strong>GO:0005576</strong> extracellular region</td>
+<td>CC</td>
+<td>ISS</td>
+</tr>
+</tbody>
+</table>
+<p>Two facts are decisive for the curation decision:</p>
+<ol>
+<li><strong>GO:0004568 (chitinase activity) is entirely absent</strong> from the current annotation set, and <strong>GO:0045824 (negative regulation of innate immune response) is entirely absent.</strong> Both predicted terms would therefore be <strong>new additions</strong>, and neither is justified by any experimental or well-founded computational evidence.</li>
+<li>The one immune-adjacent term that does exist — <strong>GO:0050829</strong> — rests on a <strong>single ISS "by similarity"</strong> annotation with no experimental support, and it is in tension with the digestive, infection-repressed expression profile documented in Finding 2. It should be treated as low-confidence, not as corroboration of the seed hypothesis.</li>
+</ol>
+<hr />
+<h2 id="mechanistic-model-interpretation">Mechanistic Model / Interpretation</h2>
+<p>The seed hypothesis effectively bundles two distinct claims, and both fail for the same underlying reason — <strong>conflation of superficially related categories</strong>:</p>
+<div class="codehilite"><pre><span></span><code><span class="w">  </span><span class="nx">BioReason</span><span class="o">-</span><span class="nx">Pro</span><span class="w"> </span><span class="nx">prediction</span><span class="w">                </span><span class="nx">Reality</span><span class="w"> </span><span class="p">(</span><span class="nx">this</span><span class="w"> </span><span class="nx">analysis</span><span class="p">)</span>
+<span class="w">  </span><span class="err">─────────────────────────</span><span class="w">               </span><span class="err">────────────────────────────────</span>
+<span class="w">  </span><span class="nx">MF</span><span class="p">:</span><span class="w"> </span><span class="nx">chitinase</span><span class="w"> </span><span class="nx">activity</span><span class="w">      </span><span class="err">──►</span><span class="w">  </span><span class="nx">GH22</span><span class="w"> </span><span class="nx">C</span><span class="o">-</span><span class="k">type</span><span class="w"> </span><span class="nx">lysozyme</span><span class="w"> </span><span class="p">(</span><span class="nx">muramidase</span><span class="p">,</span><span class="w"> </span><span class="nx">EC</span><span class="w"> </span><span class="m m-Double">3.2.1.17</span><span class="p">)</span>
+<span class="w">      </span><span class="p">(</span><span class="nx">GO</span><span class="p">:</span><span class="mi">0004568</span><span class="p">)</span><span class="w">                  </span><span class="err">·</span><span class="w"> </span><span class="nx">Glu35</span><span class="o">/</span><span class="nx">Asp52</span><span class="w"> </span><span class="nx">dyad</span><span class="w"> </span><span class="nx">conserved</span><span class="w"> </span><span class="p">(</span><span class="mi">41</span><span class="o">%</span><span class="w"> </span><span class="nx">id</span><span class="w"> </span><span class="nx">to</span><span class="w"> </span><span class="nx">HEWL</span><span class="p">)</span>
+<span class="w">                     </span><span class="err">·</span><span class="w"> </span><span class="mi">8</span><span class="w"> </span><span class="nx">Cys</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="mi">4</span><span class="w"> </span><span class="nx">disulfides</span><span class="p">,</span><span class="w"> </span><span class="nx">lysozyme</span><span class="w"> </span><span class="nx">fold</span>
+<span class="w">                     </span><span class="err">·</span><span class="w"> </span><span class="nx">NO</span><span class="w"> </span><span class="nx">GH18</span><span class="o">/</span><span class="nx">GH19</span><span class="w"> </span><span class="nx">chitinase</span><span class="w"> </span><span class="nx">domain</span><span class="w"> </span><span class="k">or</span><span class="w"> </span><span class="nx">motif</span>
+<span class="w">                     </span><span class="err">·</span><span class="w"> </span><span class="s">&quot;chitinase&quot;</span><span class="w"> </span><span class="p">=</span><span class="w"> </span><span class="nx">weak</span><span class="w"> </span><span class="nx">chitodextrin</span><span class="w"> </span><span class="nx">SIDE</span><span class="o">-</span><span class="nx">activity</span>
+<span class="w">                       </span><span class="nx">intrinsic</span><span class="w"> </span><span class="nx">to</span><span class="w"> </span><span class="nx">C</span><span class="o">-</span><span class="k">type</span><span class="w"> </span><span class="nx">lysozymes</span><span class="w"> </span><span class="err">→</span><span class="w"> </span><span class="nx">misread</span><span class="w"> </span><span class="k">as</span>
+<span class="w">                       </span><span class="nx">full</span><span class="w"> </span><span class="nx">endochitinase</span>
+
+<span class="w">  </span><span class="nx">BP</span><span class="p">:</span><span class="w"> </span><span class="nx">neg</span><span class="p">.</span><span class="w"> </span><span class="nx">reg</span><span class="p">.</span><span class="w"> </span><span class="nx">innate</span><span class="w">         </span><span class="err">──►</span><span class="w">  </span><span class="nx">Constitutive</span><span class="w"> </span><span class="nx">DIGESTIVE</span><span class="w"> </span><span class="nx">lysozyme</span>
+<span class="w">      </span><span class="nx">immune</span><span class="w"> </span><span class="nx">response</span><span class="w">                </span><span class="err">·</span><span class="w"> </span><span class="nx">midgut</span><span class="o">-</span><span class="nx">restricted</span><span class="p">;</span><span class="w"> </span><span class="nx">NOT</span><span class="w"> </span><span class="k">in</span><span class="w"> </span><span class="nx">fat</span><span class="w"> </span><span class="nx">body</span><span class="o">/</span><span class="nx">hemocytes</span>
+<span class="w">      </span><span class="p">(</span><span class="nx">GO</span><span class="p">:</span><span class="mi">0045824</span><span class="p">)</span><span class="w">                   </span><span class="err">·</span><span class="w"> </span><span class="nx">transcription</span><span class="w"> </span><span class="nx">REPRESSED</span><span class="w"> </span><span class="nx">by</span><span class="w"> </span><span class="nx">infection</span>
+<span class="w">  </span><span class="nx">BP</span><span class="p">:</span><span class="w"> </span><span class="nx">defense</span><span class="w"> </span><span class="nx">vs</span><span class="w"> </span><span class="nx">Gram</span><span class="o">-</span><span class="nx">neg</span><span class="p">.</span><span class="w">           </span><span class="err">·</span><span class="w"> </span><span class="s">&quot;recruited for digestion of bacteria in food&quot;</span>
+<span class="w">      </span><span class="p">(</span><span class="nx">GO</span><span class="p">:</span><span class="mi">0050829</span><span class="p">,</span><span class="w"> </span><span class="nx">ISS</span><span class="o">-</span><span class="nx">only</span><span class="p">)</span><span class="w">         </span><span class="err">·</span><span class="w"> </span><span class="nx">immune</span><span class="w"> </span><span class="nx">terms</span><span class="w"> </span><span class="p">=</span><span class="w"> </span><span class="nx">digestive</span><span class="o">-</span><span class="nx">vs</span><span class="o">-</span><span class="nx">immune</span><span class="w"> </span><span class="nx">conflation</span>
+</code></pre></div>
+
+<p><strong>Molecular axis (lysozyme vs chitinase).</strong> Both lysozymes and chitinases are glycoside hydrolases that cleave β-1,4 glycosidic bonds in GlcNAc-containing polymers, so they share a substrate chemistry motif. But they are <strong>different enzyme families with different folds and active sites</strong>: GH22 (lysozyme) versus GH18/GH19 (chitinase). C-type lysozymes have a documented, weak ability to hydrolyze short <strong>chitodextrins</strong> — this is even written into the UniProt/Rhea catalytic-activity string for Q08694. A model trained to associate GlcNAc-hydrolysis language with "chitinase" will over-predict GO:0004568 for a lysozyme. The direct evidence (conserved lysozyme dyad, correct fold, absent chitinase motif) refutes a genuine chitinase assignment.</p>
+<p><strong>Physiological axis (digestive vs immune).</strong> Insect lysozymes occupy two functionally divergent niches: (i) <strong>inducible immune-effector</strong> lysozymes expressed in fat body/hemolymph and up-regulated by infection, and (ii) <strong>constitutive digestive</strong> lysozymes expressed in an acidic midgut and used to lyse and digest dietary/gut bacteria (the "bacteriophagy" strategy shared with ruminants, foregut-fermenting mammals, and acaridid mites). Drosophila LysB belongs unambiguously to class (ii): midgut-restricted, acidic, constitutive, and infection-<strong>repressed</strong>. A negative <em>regulator</em> of innate immunity (GO:0045824) would be a signaling/regulatory role entirely unlike a secreted gut hydrolase; nothing in the evidence supports it, and the model likely generated it by over-generalizing "lysozyme → immunity" and then inverting it to fit a repression signal.</p>
+<p>The coherent model is therefore: <strong>LysB is a secreted, extracellular (GO:0005576), acidic midgut muramidase (GO:0003796) whose biological process is the digestion of bacteria in food (bacteriophagy), not immune defense or immune regulation.</strong></p>
+<hr />
+<h2 id="evidence-matrix">Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Direction</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence &amp; limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>UniProt Q08694 (database)</td>
+<td>Review/database</td>
+<td><strong>Refutes</strong> chitinase; <strong>supports</strong> lysozyme</td>
+<td>Is LysB a chitinase or a lysozyme?</td>
+<td>Recommended name "Lysozyme B", EC 3.2.1.17, GH22 family; MF = GO:0003796 lysozyme activity</td>
+<td><em>D. melanogaster</em> protein record</td>
+<td>High for classification; database-level, curated</td>
+</tr>
+<tr>
+<td>2</td>
+<td>InterPro/Pfam/CDD/PANTHER/SUPFAM (database)</td>
+<td>Structural/evolutionary (computational)</td>
+<td><strong>Refutes</strong> chitinase</td>
+<td>Does LysB carry a chitinase domain?</td>
+<td>Exclusively C-type lysozyme domains (IPR001916/000974, PF00062, cd16899, PTHR11407, SSF53955); no GH18/GH19</td>
+<td>Domain architecture</td>
+<td>High; concordant across 5 resources</td>
+</tr>
+<tr>
+<td>3</td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/17825580/">PMID: 17825580</a></td>
+<td>Structural/review</td>
+<td><strong>Refutes</strong> chitinase; supports digestive lysozyme</td>
+<td>Are family-22 lysozymes a defense/digestive class distinct from chitinases?</td>
+<td>"Lysozymes from family 22 of glycoside hydrolases are usually part of the defense system against bacteria"; first digestive-lysozyme crystal structure</td>
+<td>Housefly digestive lysozyme</td>
+<td>High; direct structural family evidence</td>
+</tr>
+<tr>
+<td>4</td>
+<td>In-run alignment (this run)</td>
+<td>Computational</td>
+<td><strong>Refutes</strong> chitinase</td>
+<td>Does LysB have a lysozyme dyad and lack a chitinase motif?</td>
+<td>41.3% id to HEWL; Glu35/Asp52 conserved; 8 Cys; GH18 DxxDxDxE motif absent</td>
+<td>Mature LysB vs HEWL</td>
+<td>Moderate–high; custom NW alignment, single reference (HEWL)</td>
+</tr>
+<tr>
+<td>5</td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/8159165/">PMID: 8159165</a></td>
+<td>Localization / expression</td>
+<td><strong>Refutes</strong> immune roles; supports digestive</td>
+<td>Where is LysB expressed?</td>
+<td>"LysB, C, D and E... strongly expressed in the midgut"; "None... expressed in the fat body or haemocytes"</td>
+<td>Larval &amp; adult midgut</td>
+<td>High; primary study of the locus</td>
+</tr>
+<tr>
+<td>6</td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/1588905/">PMID: 1588905</a></td>
+<td>Expression / mutant-adjacent</td>
+<td><strong>Refutes</strong> immune induction; supports digestive</td>
+<td>Is LysB induced or repressed by infection?</td>
+<td>Transcription decreases after bacterial injection; "recruited for the digestion of bacteria present in fermenting food"</td>
+<td>Drosophila gut</td>
+<td>High; primary study</td>
+</tr>
+<tr>
+<td>7</td>
+<td>QuickGO for Q08694 (database)</td>
+<td>Review/database</td>
+<td><strong>Refutes</strong> both predicted terms</td>
+<td>Do current GO annotations include chitinase/immune-reg?</td>
+<td>No GO:0004568 and no GO:0045824; GO:0050829 is single ISS by-similarity; core = GO:0003796 + GO:0005576</td>
+<td>GO annotation record</td>
+<td>High; retrieved in-run</td>
+</tr>
+<tr>
+<td>8</td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/19099150/">PMID: 19099150</a></td>
+<td>Direct assay (ortholog)</td>
+<td><strong>Qualifies/supports</strong> digestive</td>
+<td>Do insect gut lysozymes act as acidic digestive enzymes?</td>
+<td>MdL1/MdL2 housefly midgut lysozymes, acidic pH optimum (~4.8)</td>
+<td>Housefly midgut</td>
+<td>Moderate; ortholog, not LysB itself</td>
+</tr>
+<tr>
+<td>9</td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/18357505/">PMID: 18357505</a></td>
+<td>Direct assay (comparative)</td>
+<td><strong>Qualifies/supports</strong> digestive</td>
+<td>Is bacteriophagy a general digestive-lysozyme strategy?</td>
+<td>Acidic digestive lysozymes let mites use bacteria as food; gut-pH activity optimum</td>
+<td>Acaridid mites</td>
+<td>Moderate; comparative, not Drosophila</td>
+</tr>
+<tr>
+<td>10</td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/19161941/">PMID: 19161941</a></td>
+<td>Direct assay (ortholog)</td>
+<td><strong>Competing/qualifies</strong></td>
+<td>Can an insect c-type lysozyme have immune activity?</td>
+<td>Housefly MdLys mildly up-regulated by bacteria; recombinant protein inhibits G− and G+ bacteria</td>
+<td>Housefly midgut/fat body</td>
+<td>Moderate; shows some insect lysozymes are dual-function, but MdLys differs from LysB (expressed in fat body, infection-induced)</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="evidence-base-literature-summary">Evidence Base (literature summary)</h2>
+<table>
+<thead>
+<tr>
+<th>Paper</th>
+<th>PMID</th>
+<th>Role in this evaluation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><em>The lysozyme locus in Drosophila melanogaster: an expanded gene family adapted for expression in the digestive tract</em></td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/8159165/">8159165</a></td>
+<td><strong>Primary, decisive.</strong> LysB–E strongly midgut-expressed; none in fat body/hemocytes; acidic, digestive-lysozyme-like.</td>
+</tr>
+<tr>
+<td><em>The lysozyme locus in Drosophila melanogaster: different genes are expressed in midgut and salivary glands</em></td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/1588905/">1588905</a></td>
+<td><strong>Primary, decisive.</strong> Transcription decreases after bacterial injection; recruited for digestion of dietary bacteria.</td>
+</tr>
+<tr>
+<td><em>The crystal structure of a lysozyme c from housefly Musca domestica, the first structure of a digestive lysozyme</em></td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/17825580/">17825580</a></td>
+<td>Confirms GH22 family placement and digestive-lysozyme structural class.</td>
+</tr>
+<tr>
+<td><em>Cloning, purification and comparative characterization of two digestive lysozymes from Musca domestica larvae</em></td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/19099150/">19099150</a></td>
+<td>Ortholog evidence: acidic-optimum midgut digestive lysozymes.</td>
+</tr>
+<tr>
+<td><em>Digestive function of lysozyme in synanthropic acaridid mites enables utilization of bacteria as a food source</em></td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/18357505/">18357505</a></td>
+<td>Comparative evidence: acidic digestive lysozyme = bacteriophagy strategy.</td>
+</tr>
+<tr>
+<td><em>Molecular characterization and expression analysis of a chicken-type lysozyme gene from housefly (Musca domestica)</em></td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/19161941/">19161941</a></td>
+<td>Competing/qualifying: some insect c-type lysozymes are dual digestive/immune — but MdLys (fat-body-expressed, infection-induced) differs from LysB.</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="go-curation-implications">GO Curation Implications</h2>
+<p><strong>Lead (requires curator verification):</strong></p>
+<ol>
+<li>
+<p><strong>GO:0004568 (chitinase activity, MF) — DO NOT ADD.</strong> The prediction is a fold/activity misassignment. LysB is a GH22 muramidase with a conserved lysozyme catalytic dyad and no GH18/GH19 chitinase domain or active-site motif. The only "chitinase-like" property is the intrinsic weak chitodextrin side-activity of C-type lysozymes, which is already captured by the lysozyme catalytic-activity description and does not warrant a chitinase MF term (in vitro-only, side-activity, not the biological function).</p>
+</li>
+<li>
+<p><strong>GO:0045824 (negative regulation of innate immune response, BP) — DO NOT ADD.</strong> No experimental or credible computational support. The term is biologically implausible for a secreted digestive hydrolase and contradicts the constitutive, infection-repressed, midgut-restricted expression profile.</p>
+</li>
+<li>
+<p><strong>GO:0050829 (defense response to Gram-negative bacterium, BP) — FLAG / treat as non-core.</strong> Present in the record only as a <strong>single ISS "by similarity"</strong> to HEWL-type P00697, with no experimental basis, and in tension with digestive biology. Recommend curator review; at minimum it should not be treated as core function, and it should not be cited as corroboration of the immune hypothesis.</p>
+</li>
+<li>
+<p><strong>GO:0003796 (lysozyme activity, MF) — RETAIN (core).</strong> Well supported by four independent evidence lines (ISS, IBA, IEA/InterPro-EC, and ISS to PMID:8159165) and by the in-run catalytic-dyad analysis. This is the correct primary molecular function.</p>
+</li>
+<li>
+<p><strong>GO:0005576 (extracellular region, CC) — RETAIN.</strong> Consistent with a secreted gut lysozyme.</p>
+</li>
+<li>
+<p><strong>Consider ADDING a digestion-focused BP term</strong> (curator lead): a term reflecting <strong>digestion / catabolism of bacterial cell wall in the gut / bacteriophagy</strong> would more accurately capture the biological process than any immune term. Candidate directions include a peptidoglycan catabolic process or digestion term; the exact choice should be curator-verified against GO structure and the PMID:8159165 / PMID:1588905 evidence.</p>
+</li>
+</ol>
+<p><strong>Aspect summary:</strong> MF = lysozyme activity (retain), not chitinase (reject). BP = digestion/bacteriophagy (add, curator-verify), not immune regulation (reject) and not defense-response as core (downgrade). CC = extracellular region (retain).</p>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p>The immediate molecular function under test is <strong>glycoside-hydrolase activity on a GlcNAc-containing polymer</strong>. The direct gene-product activity of LysB is <strong>muramidase/lysozyme activity</strong> — hydrolysis of the MurNAc–GlcNAc β-1,4 bond in bacterial peptidoglycan — as established by family classification, domain content, the conserved Glu/Asp catalytic dyad, and EC 3.2.1.17. This is distinct from <strong>chitinase activity</strong>, which requires the GH18/GH19 fold and active site that LysB lacks.</p>
+<p>Everything in the immune framing of the seed hypothesis is either <strong>downstream/indirect</strong> or <strong>absent</strong>:<br />
+- "Defense response to Gram-negative bacterium" is an inferred phenotype-level consequence, imported by similarity, not a demonstrated function of LysB.<br />
+- "Negative regulation of innate immune response" is a regulatory/signaling process category with no mechanistic link to a secreted digestive hydrolase; there is no evidence LysB participates in immune signaling.<br />
+- The digestive role (lysing dietary bacteria in the acidic midgut) is the direct physiological deployment of the muramidase activity — a <strong>nutritional/digestive</strong> process, not an immune-defense process, even though the underlying chemistry (bacteriolysis) is shared with immune lysozymes.</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ul>
+<li>
+<p><strong>Paralog / family carry-over confusion.</strong> The Drosophila lysozyme locus contains a tandem cluster (LysB–E, plus LysP, LysS, etc.). Annotations and predictions can bleed across paralogs and across the broader "lysozyme/glycosidase" family. The GO:0050829 ISS to HEWL (P00697) is a concrete example of <strong>defense-response carry-over</strong> from a canonical immune lysozyme to a digestive one.</p>
+</li>
+<li>
+<p><strong>Dual-function orthologs are real but do not rescue the immune prediction.</strong> Housefly MdLys (<a href="https://pubmed.ncbi.nlm.nih.gov/19161941/">PMID: 19161941</a>) is expressed in midgut <em>and</em> fat body, is mildly infection-induced, and its recombinant protein inhibits bacteria — i.e., some insect c-type lysozymes are genuinely dual digestive/immune. This is a legitimate <strong>competing consideration</strong>. However, it does <strong>not</strong> apply to Drosophila LysB, which — unlike MdLys — is <strong>not</strong> expressed in fat body/hemocytes and is <strong>repressed</strong> (not induced) by infection (<a href="https://pubmed.ncbi.nlm.nih.gov/8159165/">PMID: 8159165</a>; <a href="https://pubmed.ncbi.nlm.nih.gov/1588905/">PMID: 1588905</a>). Even the strongest immune interpretation would be a mild bactericidal <em>effector</em> activity, never <em>negative regulation</em> of the immune response (GO:0045824).</p>
+</li>
+<li>
+<p><strong>Weak in-vitro chitodextrin activity vs biological chitinase.</strong> C-type lysozymes can slowly hydrolyze short chito-oligosaccharides. Treating this in-vitro side-activity as a biological chitinase function would be an over-annotation; the physiological substrate is peptidoglycan.</p>
+</li>
+<li>
+<p><strong>Organism/tissue specificity.</strong> Evidence supporting digestion comes partly from orthologs (housefly, mites). While the Drosophila-specific expression data are decisive against the immune-effector/regulator interpretation, direct enzymatic assays of purified Q08694 protein are not in the reviewed literature set (see Knowledge Gaps).</p>
+</li>
+</ul>
+<hr />
+<h2 id="limitations-and-knowledge-gaps">Limitations and Knowledge Gaps</h2>
+<ol>
+<li>
+<p><strong>No direct enzymatic assay of purified LysB (Q08694).</strong> Checked: the primary literature reviewed here characterizes the <em>locus</em> expression (PMID:8159165, 1588905) and orthologous digestive lysozymes (housefly, mites), but not a purified recombinant LysB kinetic assay. This matters because the definitive discriminator between lysozyme and chitinase, and between digestive and immune roles, is a direct activity/pH-profile assay on the LysB protein. <em>Resolution:</em> recombinant expression + muramidase vs chitinase activity assays and an acidic-pH-optimum profile.</p>
+</li>
+<li>
+<p><strong>Alignment used a single reference (HEWL).</strong> The in-run NW alignment (41% identity, conserved dyad) is robust for classification but is a custom implementation against one archetype. <em>Resolution:</em> a multiple-sequence alignment across GH22 members and a structural superposition (e.g., AlphaFold model vs HEWL and vs a GH18 chitinase) would strengthen the fold assignment. Structural tools (Phenix/superpose) were available but not required given the concordant sequence/domain evidence.</p>
+</li>
+<li>
+<p><strong>GO:0050829 provenance.</strong> It is ISS-by-similarity to P00697; the exact rationale and whether FlyBase intends it as core is not fully resolved from the record alone. <em>Resolution:</em> curator inspection of GO_REF:0000024 and the FlyBase gene report.</p>
+</li>
+<li>
+<p><strong>No in-run structural confidence metrics (pLDDT/PAE).</strong> An AlphaFold confidence check was not run; it would add independent support for the lysozyme fold but is not necessary to reach the verdict.</p>
+</li>
+<li>
+<p><strong>Reference doi:10.64898/2026.03.19.712954</strong> (the source of the BioReason-Pro prediction) was not independently retrieved; the evaluation treats the prediction as stated in the seed context.</p>
+</li>
+</ol>
+<hr />
+<h2 id="discriminating-tests">Discriminating Tests</h2>
+<p>The following would most efficiently separate the seed hypothesis from the digestive-lysozyme interpretation:</p>
+<ol>
+<li>
+<p><strong>Enzymatic assay of recombinant LysB.</strong> Measure muramidase activity on <em>Micrococcus lysodeikticus</em> cell walls vs endochitinase activity on a fluorogenic chitin substrate (e.g., 4-MU-chitotrioside) and on insoluble/colloidal chitin. Prediction: strong acidic-pH muramidase activity, negligible/only weak short-chitodextrin activity, no processive chitin degradation. This directly refutes GO:0004568.</p>
+</li>
+<li>
+<p><strong>pH–activity profile.</strong> Digestive insect lysozymes have acidic optima (~4.8, cf. housefly MdL1/MdL2, <a href="https://pubmed.ncbi.nlm.nih.gov/19099150/">PMID: 19099150</a>). An acidic optimum supports a gut-digestive role.</p>
+</li>
+<li>
+<p><strong>Infection-challenge transcriptomics.</strong> RNA-seq/qPCR of LysB after septic injury vs oral bacterial feeding, in gut vs fat body. Prediction: no fat-body induction, repression in gut — inconsistent with an immune effector and with a negative regulator of immunity.</p>
+</li>
+<li>
+<p><strong>Loss-of-function phenotype.</strong> LysB knockdown/knockout scored for gut bacterial digestion/clearance and nutritional phenotype vs systemic immune-response readouts (AMP induction, survival to infection). Prediction: digestive/nutritional phenotype, not altered immune signaling.</p>
+</li>
+<li>
+<p><strong>Structural superposition.</strong> AlphaFold model of LysB superposed on HEWL (GH22) and on a GH18 chitinase (TIM-barrel). Prediction: RMSD-close to HEWL, fold-incompatible with the chitinase TIM-barrel.</p>
+</li>
+<li>
+<p><strong>Comparative catalytic-residue mapping</strong> across the Drosophila Lys cluster and canonical GH18/GH19 chitinases to confirm the absence of the chitinase catalytic glutamate context in all LysB-family members.</p>
+</li>
+</ol>
+<hr />
+<h2 id="proposed-follow-up-actions-curation-leads">Proposed Follow-up Actions (Curation Leads)</h2>
+<p>All items are <strong>leads requiring curator verification.</strong></p>
+<p><strong>Candidate action changes</strong><br />
+- <strong>Reject</strong> proposed GO:0004568 (chitinase activity) and GO:0045824 (negative regulation of innate immune response) — do not add.<br />
+- <strong>Downgrade / flag</strong> GO:0050829 (defense response to Gram-negative bacterium) as ISS-only, non-core, conflicting with digestive expression data.<br />
+- <strong>Retain</strong> GO:0003796 (lysozyme activity, MF) and GO:0005576 (extracellular region, CC) as core.<br />
+- <strong>Consider adding</strong> a digestion/bacteriophagy BP term (curator to select the exact term; e.g., a peptidoglycan catabolic / digestion term).</p>
+<p><strong>Candidate references with snippets to verify</strong><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/8159165/">PMID: 8159165</a>: "<em>four closely related genes, LysB, C, D and E, are all strongly expressed in the midgut of larvae and adults</em>" and "<em>None of the genes is expressed in the fat body or haemocytes.</em>" → supports digestive, refutes immune-effector.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/1588905/">PMID: 1588905</a>: "<em>have been recruited for the digestion of bacteria present in fermenting food</em>" → supports digestive; note transcription decreases after bacterial injection.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/17825580/">PMID: 17825580</a>: "<em>Lysozymes from family 22 of glycoside hydrolases are usually part of the defense system against bacteria</em>" → confirms GH22 family placement (distinct from chitinase families).<br />
+- UniProt Q08694 FUNCTION: "<em>Unlikely to play an active role in the humoral immune defense. May have a function in the digestion of bacteria in the food.</em>"</p>
+<p><strong>Suggested curator questions</strong><br />
+- Should GO:0050829 remain given it is ISS-only and conflicts with midgut-digestive, infection-repressed biology?<br />
+- Is there an appropriate GO BP term for gut bacteriophagy/digestion that should replace the immune framing?<br />
+- Does FlyBase hold any direct enzymatic data on Q08694 that would confirm the acidic muramidase profile?</p>
+<p><strong>Suggested experiments</strong> — see Discriminating Tests above (recombinant muramidase-vs-chitinase assay; acidic pH profile; challenge transcriptomics; LOF phenotype; structural superposition).</p>
+<hr />
+<h2 id="bottom-line">Bottom Line</h2>
+<p>LysB (Q08694) is a <strong>GH22 C-type digestive lysozyme (muramidase, EC 3.2.1.17)</strong>. The BioReason-Pro predictions of <strong>chitinase activity (GO:0004568)</strong> and <strong>negative regulation of innate immune response (GO:0045824)</strong> are <strong>refuted / over-annotated</strong>: the chitinase call is a fold/side-activity misassignment, and the immune-regulation call conflates a constitutive, infection-repressed, midgut-restricted digestive enzyme with an immune regulator. The pre-existing <strong>GO:0050829</strong> annotation is ISS-only and should be treated as low-confidence, non-core. Curators should retain <strong>GO:0003796 (lysozyme activity)</strong> and <strong>GO:0005576 (extracellular region)</strong> and consider adding a <strong>digestion/bacteriophagy</strong> BP term rather than any immune term.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="LysB-hypotheses/prediction-chitinase-immune/openscientist_artifacts/artifacts_lysB_fold_check.md">OpenScientist lysB fold check</a></li>
+<li><a href="LysB-hypotheses/prediction-chitinase-immune/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="LysB-hypotheses/prediction-chitinase-immune/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/DROME/rdgBbeta/rdgBbeta-ai-review.html
+++ b/genes/DROME/rdgBbeta/rdgBbeta-ai-review.html
@@ -2613,6 +2613,523 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(rdgBbeta-hypotheses/prediction-pc-transporter/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9U9P7" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">AIGR Gene Hypothesis Deep Research — Final Report</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+                    <span class="report-badge">8 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-10T04:07:23.243439</span>
+
+
+
+                    <a href="rdgBbeta-hypotheses/prediction-pc-transporter/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="rdgBbeta-hypotheses/prediction-pc-transporter/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="rdgBbeta-hypotheses/prediction-pc-transporter/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="aigr-gene-hypothesis-deep-research-final-report">AIGR Gene Hypothesis Deep Research — Final Report</h1>
+<h2 id="target-drosophila-melanogaster-rdgbbeta-uniprot-q9u9p7">Target: Drosophila melanogaster rdgBbeta (UniProt Q9U9P7)</h2>
+<h2 id="hypothesis-phosphatidylcholine-transporter-activity-go0008525">Hypothesis: Phosphatidylcholine transporter activity (GO:0008525)</h2>
+<h2 id="focus-type-computational_prediction-bioreason-pro-sft">Focus type: computational_prediction (BioReason-Pro SFT)</h2>
+<hr />
+<h2 id="summary">Summary</h2>
+<p>The BioReason-Pro SFT model predicts <strong>phosphatidylcholine transporter activity<br />
+(GO:0008525)</strong> for the Drosophila melanogaster protein <code>rdgBbeta</code> (Q9U9P7). After<br />
+three iterations of literature review, sequence/orthology analysis, and a<br />
+family-wide GO annotation audit, this prediction is <strong>REFUTED</strong>. <code>rdgBbeta</code> is a<br />
+<strong>single-domain Class II phosphatidylinositol transfer protein (PITP)</strong> — the<br />
+Drosophila ortholog of human <strong>PITPNC1</strong> (the "vibrator"/RdgBβ clade) — and the<br />
+direct biochemistry of this clade shows it binds and transfers<br />
+<strong>phosphatidylinositol (PI)</strong> and <strong>phosphatidic acid (PA)</strong> but <strong>"hardly binds<br />
+phosphatidylcholine"</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/22822086/">PMID: 22822086</a>).</p>
+<p>Phosphatidylcholine transfer is instead a defining property of a <em>different</em><br />
+branch of the family: the <strong>Class I PITPs (PITPα/PITPβ)</strong> with dual PI/PC<br />
+specificity, and the <strong>multidomain/Sec14-type</strong> transfer proteins. A systematic<br />
+audit of GO:0008525 across human, mouse, rat, fly, and yeast PITPs found direct<br />
+experimental (IDA) support only in those PC-competent branches (PITPNA, PITPNB,<br />
+Drosophila multidomain <code>rdgB</code>, yeast SEC14) — and <strong>no experimental support<br />
+anywhere in the Class II clade</strong>. <code>rdgBbeta</code> itself carries <strong>no GO:0008525<br />
+annotation</strong>; its curated molecular functions are PI binding (GO:0035091, IBA)<br />
+and PI transfer activity (GO:0008526, ISS), which are the accurate terms.</p>
+<p>The prediction is best explained as <strong>paralog / substrate misassignment</strong>: a<br />
+PC-transfer trait that is genuine for Class I and multidomain paralogs has been<br />
+incorrectly propagated onto the Class II member. The main caveat is that the<br />
+decisive "no PC" assay was performed on the mammalian ortholog PITPNC1, not on<br />
+the Drosophila protein directly, so the refutation rests on strong orthology<br />
+(61.6% identity to PITPNC1 vs 42.7% to Class I PITPNA) plus concordant clade-level<br />
+biochemistry rather than a fly-specific PC-transfer assay. Even so, no evidence<br />
+supports PC transport and direct evidence argues against it. <strong>Curator lead:<br />
+reject GO:0008525; retain GO:0008526 (PI transfer) as the core molecular<br />
+function.</strong></p>
+<hr />
+<h2 id="key-findings">Key Findings</h2>
+<h3 id="finding-1-rdgbpitpnc1-binds-and-transfers-pi-and-phosphatidic-acid-but-hardly-binds-phosphatidylcholine">Finding 1 — RdgBβ/PITPNC1 binds and transfers PI and phosphatidic acid, but hardly binds phosphatidylcholine</h3>
+<p>Direct in vitro lipid binding and transfer assays on the Class II PITP<br />
+<strong>RdgBβ (PITPNC1)</strong> demonstrate that, besides phosphatidylinositol, the protein<br />
+binds and transfers <strong>phosphatidic acid (PA)</strong> and is recovered pre-loaded with<br />
+PA / phosphatidylglycerol when expressed in <em>E. coli</em> — but it <strong>"hardly binds<br />
+phosphatidylcholine"</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/22822086/">PMID: 22822086</a>,<br />
+Garner et al. 2012). This is the single most decisive piece of evidence against<br />
+the seed hypothesis, because it assays exactly the activity in question (lipid<br />
+transfer specificity) on exactly the clade to which <code>rdgBbeta</code> belongs.</p>
+<p>The result is corroborated by an <strong>independent Class II ortholog</strong>: recombinant<br />
+mouse <strong>mM-rdgBβ1</strong> "shows the specific binding activity to phosphatidylinositol<br />
+but not to other phospholipids" (<a href="https://pubmed.ncbi.nlm.nih.gov/12562526/">PMID: 12562526</a>).<br />
+Two independent Class II proteins, characterized in two laboratories, converge on<br />
+the same conclusion: PI (and, for PITPNC1, PA) is the physiological cargo, and PC<br />
+is not a bound/transferred ligand.</p>
+<p>For contrast, PC binding <em>is</em> a real property of the <strong>Class I PITPs</strong>: in<br />
+Class I PITPα/β "the preferred lipid that can occupy the site can be either<br />
+phosphatidylinositol (PI) or phosphatidylcholine (PC)"<br />
+(<a href="https://pubmed.ncbi.nlm.nih.gov/10358925/">PMID: 10358925</a>). This dual PI/PC<br />
+specificity — quantified elsewhere as an ~16-fold preference for PI over PC with<br />
+measurable PC transfer (<a href="https://pubmed.ncbi.nlm.nih.gov/3651458/">PMID: 3651458</a>) —<br />
+is precisely the trait a PC-transporter GO term captures, and it is a Class I /<br />
+Sec14-type feature, <strong>not</strong> a Class II feature. The prediction thus maps a real<br />
+biochemical activity onto the wrong branch of the family.</p>
+<h3 id="finding-2-drosophila-rdgbbeta-q9u9p7-is-a-single-domain-class-ii-pitp-orthologous-to-human-pitpnc1">Finding 2 — Drosophila rdgBbeta (Q9U9P7) is a single-domain Class II PITP orthologous to human PITPNC1</h3>
+<p>UniProt Q9U9P7 is annotated <strong>PITC1_DROME, "Cytoplasmic phosphatidylinositol<br />
+transfer protein 1"</strong>, a 273-residue protein consisting of a <strong>single PITP<br />
+domain</strong> (Pfam PF02121 IP_trans; InterPro IPR001666 PI_transfer; PANTHER<br />
+PTHR10658:SF54). It lacks the additional regulatory/membrane-targeting domains<br />
+(FFAT, DDHD, LNS2, transmembrane region) that characterize the large multidomain<br />
+RdgBα/Nir-type proteins.</p>
+<p>Global pairwise Needleman–Wunsch alignments computed in this investigation place<br />
+<code>rdgBbeta</code> firmly in the <strong>Class II</strong> clade: <strong>61.6% identity to human PITPNC1<br />
+(Class II)</strong> versus only <strong>42.7% identity to human PITPNA (Class I)</strong>. This<br />
+~19-point identity gap is a clear orthology signal — <code>rdgBbeta</code> is the fly<br />
+ortholog of the mammalian "vibrator"/RdgBβ protein PITPNC1, not of the<br />
+PC-competent Class I PITPs.</p>
+<p>The single-domain Class II identity is confirmed in the review literature:<br />
+"Three members of the PITP family (PITPα, PITPβ, and RdgBβ (retinal degeneration<br />
+type B) alt. name PITPNC1) are present as single domain proteins"<br />
+(<a href="https://pubmed.ncbi.nlm.nih.gov/23086419/">PMID: 23086419</a>). Critically, the<br />
+current UniProt GO annotation for Q9U9P7 already reflects the correct<br />
+biochemistry: <strong>phosphatidylinositol binding (GO:0035091, IBA)</strong> and<br />
+<strong>phosphatidylinositol transfer activity (GO:0008526, ISS)</strong> — and <strong>no<br />
+GO:0008525</strong> is present. The predicted PC-transporter term would therefore be an<br />
+<em>addition</em> that contradicts the existing, more accurate PI-transfer annotation.</p>
+<h3 id="finding-3-go0008525-has-direct-evidence-only-for-class-i-multidomain-pitp-paralogs-never-for-the-class-ii-pitpnc1rdgbbeta-clade">Finding 3 — GO:0008525 has direct evidence only for Class I / multidomain PITP paralogs, never for the Class II PITPNC1/rdgBbeta clade</h3>
+<p>A systematic QuickGO/GOA enumeration of <strong>GO:0008525 (phosphatidylcholine<br />
+transporter activity)</strong> across human, mouse, rat, fly, and yeast PITP-family<br />
+proteins reveals a sharp phylogenetic pattern. Direct experimental (<strong>IDA</strong>)<br />
+support for the PC-transporter term exists only for the PC-competent branches:</p>
+<ul>
+<li><strong>Class I PITPs</strong>: human PITPNA (Q00169) and PITPNB (P48739) and their rodent<br />
+  orthologs;</li>
+<li><strong>Drosophila multidomain rdgB</strong> (P43125, IDA);</li>
+<li><strong>Yeast SEC14</strong> (P24280, IDA) — the founding dual PI/PC transfer protein, whose<br />
+  in vitro exchange of PI <em>or</em> PC is textbook (<a href="https://pubmed.ncbi.nlm.nih.gov/15299870/">PMID: 15299870</a>).</li>
+</ul>
+<p>By contrast, the <strong>entire Class II clade</strong> carries <strong>a single</strong> GO:0008525<br />
+annotation — rat Pitpnc1 (A0A8I6A182), and that annotation is <strong>ISO only</strong><br />
+(inferred electronically from an ortholog), with <strong>no IDA/EXP support anywhere</strong><br />
+in the clade. Drosophila <code>rdgBbeta</code> (Q9U9P7) carries <strong>no GO:0008525 annotation<br />
+at all</strong>. Within <em>Drosophila</em> specifically, PC-transporter activity is annotated<br />
+to the paralogs <strong>rdgB (IDA)</strong> and <strong>vib/vibrator (IBA)</strong> — not to <code>rdgBbeta</code>.</p>
+<p>This is the fingerprint of paralog over-annotation. The one Class II GO:0008525<br />
+record in existence is itself a non-experimental electronic inference that most<br />
+plausibly originated by carry-over from a Class I / multidomain paralog. A model<br />
+trained on such annotation landscapes can readily reproduce the same<br />
+misassignment for <code>rdgBbeta</code>. <em>(Provenance: computed enumeration saved to<br />
+<code>/tmp/go0008525_pitp_family.csv</code>.)</em></p>
+<hr />
+<h2 id="mechanistic-model-interpretation">Mechanistic Model / Interpretation</h2>
+<p>The PITP family splits into functionally distinct branches, and the seed<br />
+hypothesis fails because it ignores that split. The molecular function under test<br />
+is monomeric, headgroup-specific lipid transfer by a soluble PITP-domain protein:<br />
+extract a lipid, shield its headgroup inside a hydrophobic cavity, and deposit it<br />
+at an acceptor membrane. The discriminating variable is <strong>headgroup specificity<br />
+(PC vs PI/PA)</strong>.</p>
+<h3 id="pitp-family-map-and-pc-transfer-competence">PITP family map and PC-transfer competence</h3>
+<table>
+<thead>
+<tr>
+<th>Branch</th>
+<th>Representative proteins</th>
+<th>Domain architecture</th>
+<th>PI transfer</th>
+<th>PC transfer</th>
+<th>GO:0008525 evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Class I</strong></td>
+<td>PITPα/PITPNA, PITPβ/PITPNB</td>
+<td>Single PITP domain</td>
+<td>Yes</td>
+<td><strong>Yes</strong> (dual specificity)</td>
+<td><strong>IDA</strong> (direct)</td>
+</tr>
+<tr>
+<td><strong>Multidomain RdgBα / Sec14</strong></td>
+<td>Drosophila rdgB, yeast SEC14, Nir2</td>
+<td>PITP + FFAT/DDHD/LNS2</td>
+<td>Yes</td>
+<td><strong>Yes</strong></td>
+<td><strong>IDA</strong> (direct)</td>
+</tr>
+<tr>
+<td><strong>Class II (target clade)</strong></td>
+<td><strong>rdgBbeta/PITPNC1</strong>, vibrator</td>
+<td>Single PITP domain</td>
+<td>Yes</td>
+<td><strong>No / "hardly"</strong></td>
+<td>none direct; 1 ISO record only</td>
+</tr>
+</tbody>
+</table>
+<div class="codehilite"><pre><span></span><code><span class="w">         </span><span class="n">PITP</span><span class="w"> </span><span class="n">superfamily</span>
+<span class="w">               </span><span class="o">|</span>
+<span class="c1">-----------------------------------------------</span>
+<span class="o">|</span><span class="w">                      </span><span class="o">|</span><span class="w">                        </span><span class="o">|</span>
+<span class="w">   </span><span class="k">Class</span><span class="w"> </span><span class="n">I</span><span class="w"> </span><span class="n">PITPα</span><span class="o">/</span><span class="n">β</span><span class="w">     </span><span class="n">Multidomain</span><span class="w"> </span><span class="n">RdgBα</span><span class="w">         </span><span class="k">Class</span><span class="w"> </span><span class="n">II</span><span class="w">  </span><span class="o">&lt;</span><span class="c1">-- rdgBbeta (Q9U9P7)</span>
+<span class="w">   </span><span class="n">PITPNA</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">PITPNB</span><span class="w">     </span><span class="n">rdgB</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">SEC14</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">Nir2</span><span class="w">       </span><span class="n">PITPNC1</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">vibrator</span>
+<span class="o">|</span><span class="w">                      </span><span class="o">|</span><span class="w">                        </span><span class="o">|</span>
+<span class="w">   </span><span class="nf">PI</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="n">PC</span><span class="w"> </span><span class="n">transfer</span><span class="w">     </span><span class="nf">PI</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="n">PC</span><span class="w"> </span><span class="n">transfer</span><span class="w">          </span><span class="nf">PI</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="n">PA</span><span class="w"> </span><span class="n">transfer</span>
+<span class="w">   </span><span class="k">GO</span><span class="err">:</span><span class="mi">0008525</span><span class="w"> </span><span class="p">(</span><span class="n">IDA</span><span class="p">)</span><span class="w">     </span><span class="k">GO</span><span class="err">:</span><span class="mi">0008525</span><span class="w"> </span><span class="p">(</span><span class="n">IDA</span><span class="p">)</span><span class="w">          </span><span class="ss">&quot;hardly binds PC&quot;</span>
+<span class="w">                                  </span><span class="k">GO</span><span class="err">:</span><span class="mi">0008526</span><span class="w"> </span><span class="p">(</span><span class="nf">PI</span><span class="w"> </span><span class="n">transfer</span><span class="p">)</span>
+<span class="w">                                  </span><span class="o">&lt;&lt;</span><span class="w"> </span><span class="k">NO</span><span class="w"> </span><span class="k">GO</span><span class="err">:</span><span class="mi">0008525</span><span class="w"> </span><span class="o">&gt;&gt;</span>
+
+<span class="w">   </span><span class="n">Prediction</span><span class="w"> </span><span class="k">path</span><span class="w"> </span><span class="p">(</span><span class="n">WRONG</span><span class="p">)</span><span class="err">:</span><span class="w">  </span><span class="k">Class</span><span class="w"> </span><span class="n">I</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="n">multidomain</span><span class="w"> </span><span class="n">PC</span><span class="o">-</span><span class="n">transfer</span><span class="w"> </span><span class="n">trait</span>
+<span class="w">             </span><span class="err">─────</span><span class="n">propagated</span><span class="w"> </span><span class="n">across</span><span class="w"> </span><span class="n">paralogs</span><span class="err">────►</span><span class="w">  </span><span class="n">rdgBbeta</span>
+</code></pre></div>
+
+<p><strong>Immediate molecular function.</strong> The evidence indicates the direct molecular<br />
+activity of Q9U9P7 is <strong>PI transfer</strong> (GO:0008526) and, by clade analogy with<br />
+PITPNC1, <strong>PA binding/transfer</strong> — with PC essentially excluded from the binding<br />
+pocket. PC transfer is therefore not this gene product's activity; it is the<br />
+activity of sister paralogs. Downstream roles of PITPs (phosphoinositide<br />
+signaling, photoreceptor/neural signal transduction) are pathway consequences,<br />
+not the primary molecular activity, and do not implicate PC transport.</p>
+<p><strong>Why the model likely erred.</strong> Three compounding factors: (1) <em>frequency /<br />
+paralog bias</em> — most experimentally characterized PITPs (Class I, SEC14) are<br />
+PC-competent, so "PC transporter" is the family-common label; (2) <em>shared PITP<br />
+domain</em> — the single conserved fold (PF02121) is common to PC-competent and<br />
+PC-incompetent members, so domain-level features do not discriminate; (3)<br />
+<em>annotation carry-over</em> — the one existing Class II GO:0008525 record is an ISO<br />
+electronic inference, providing a spurious training signal. None of these reflect<br />
+the measured biochemistry of the Class II clade.</p>
+<hr />
+<h2 id="evidence-base-evidence-matrix">Evidence Base / Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Direction</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence &amp; limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/22822086/">PMID: 22822086</a></td>
+<td>Direct assay (in vitro binding/transfer)</td>
+<td><strong>Refutes</strong></td>
+<td>Does RdgBβ/PITPNC1 transfer PC?</td>
+<td>Binds/transfers PI and PA; "hardly binds phosphatidylcholine"; preloaded with PA/PG</td>
+<td>Recombinant mammalian PITPNC1</td>
+<td>High; mammalian ortholog, not fly protein directly</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/12562526/">PMID: 12562526</a></td>
+<td>Direct assay (recombinant binding)</td>
+<td><strong>Refutes</strong></td>
+<td>PC binding by a Class II RdgBβ ortholog</td>
+<td>mM-rdgBβ1 binds PI "but not to other phospholipids"</td>
+<td>Recombinant mouse Class II PITP</td>
+<td>Moderate–high; splice variant; qualitative</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/10358925/">PMID: 10358925</a></td>
+<td>Review of direct assays</td>
+<td><strong>Qualifies / competing</strong></td>
+<td>Which PITPs bind PC?</td>
+<td>PI <em>or</em> PC can occupy the Class I PITP site</td>
+<td>Mammalian Class I PITPα/β</td>
+<td>High; establishes PC transfer as Class I trait</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/3651458/">PMID: 3651458</a></td>
+<td>Direct assay (affinity/kinetics)</td>
+<td><strong>Qualifies / competing</strong></td>
+<td>Magnitude of PC vs PI transfer</td>
+<td>~16-fold PI-over-PC preference; measurable PC transfer</td>
+<td>Bovine brain PI-TP (Class I-like)</td>
+<td>High; PC transfer is a Class I quantitative property</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/15299870/">PMID: 15299870</a></td>
+<td>Structural/biochemical</td>
+<td><strong>Competing</strong></td>
+<td>Dual PI/PC specificity origin</td>
+<td>SEC14 exchanges PI <em>or</em> PC in vitro</td>
+<td>Yeast Sec14p</td>
+<td>High; multidomain/Sec14 branch, not Class II</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/23086419/">PMID: 23086419</a></td>
+<td>Structural/evolutionary review</td>
+<td><strong>Supports (classification)</strong></td>
+<td>Is RdgBβ/PITPNC1 a single-domain Class II PITP?</td>
+<td>Confirms RdgBβ = PITPNC1, single-domain, distinct branch</td>
+<td>Family-wide</td>
+<td>High</td>
+</tr>
+<tr>
+<td>UniProt Q9U9P7 + Pfam/InterPro/PANTHER; NW identity (61.6% vs PITPNC1; 42.7% vs PITPNA)</td>
+<td>Computational (sequence/domain/orthology)</td>
+<td><strong>Supports (classification)</strong></td>
+<td>Is fly rdgBbeta a Class II PITPNC1 ortholog?</td>
+<td>Single PITP domain; closest to PITPNC1 by identity</td>
+<td>Bioinformatic</td>
+<td>High; standard alignment/domain evidence</td>
+</tr>
+<tr>
+<td>QuickGO/GOA enumeration of GO:0008525</td>
+<td>Database landscape (computed)</td>
+<td><strong>Refutes (over-annotation pattern)</strong></td>
+<td>Who has direct PC-transporter evidence?</td>
+<td>IDA only in Class I / multidomain / SEC14; Class II has 1 ISO record; rdgBbeta has none</td>
+<td>Human/mouse/rat/fly/yeast</td>
+<td>High for the annotation pattern</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/17543578/">PMID: 17543578</a></td>
+<td>Review</td>
+<td>Orientation</td>
+<td>RdgB family function</td>
+<td>RdgB proteins are PITP-domain lipid-transfer proteins</td>
+<td>Family review</td>
+<td>Moderate; review-level</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/9216063/">PMID: 9216063</a></td>
+<td>Molecular characterization</td>
+<td>Orientation</td>
+<td>rdgB family homology</td>
+<td>Human rdgB N-terminus homologous to PITPα/β</td>
+<td>Rat/human retina</td>
+<td>Moderate; supports family placement</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="go-curation-implications">GO Curation Implications</h2>
+<p><strong>Leads (require curator verification):</strong></p>
+<ol>
+<li>
+<p><strong>Do NOT add GO:0008525 (phosphatidylcholine transporter activity)</strong> to<br />
+<code>rdgBbeta</code> (Q9U9P7). The computational prediction is contradicted by direct<br />
+   assays on the clade ("hardly binds phosphatidylcholine",<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22822086/">PMID: 22822086</a>) and by the absence<br />
+   of any experimental PC-transporter evidence in the entire Class II clade.<br />
+   Recommend <strong>reject</strong> the prediction.</p>
+</li>
+<li>
+<p><strong>Retain the existing, more accurate MF annotations</strong>:</p>
+</li>
+<li><strong>GO:0008526 — phosphatidylinositol transfer activity</strong> (currently ISS): the<br />
+     correct, clade-consistent molecular function and core MF.</li>
+<li>
+<p><strong>GO:0035091 — phosphatidylinositol binding</strong> (currently IBA): consistent<br />
+     with clade biochemistry.</p>
+</li>
+<li>
+<p><strong>Consider (lead) a phosphatidic-acid–related MF</strong> as a more informative<br />
+   activity than PC transfer, given that PITPNC1 binds/transfers PA<br />
+   (<a href="https://pubmed.ncbi.nlm.nih.gov/22822086/">PMID: 22822086</a>). Any such term<br />
+   should be applied only with an ISS/ISO evidence code from PITPNC1 and flagged,<br />
+   since the direct PA assay was on the mammalian ortholog; Drosophila-specific<br />
+   evidence is lacking, so treat as non-core for DROME for now.</p>
+</li>
+<li>
+<p><strong>Treat GO:0008525 as non-core</strong> for this gene and flag the single existing<br />
+   Class II ISO GO:0008525 record (rat Pitpnc1) as a candidate paralog-carry-over<br />
+   error.</p>
+</li>
+</ol>
+<p>The evidence supports an <strong>MF</strong> decision (lipid-transfer specificity), not a BP or<br />
+CC change. "Protein binding" is explicitly <strong>not</strong> recommended — the informative<br />
+term (PI transfer, GO:0008526) is already supported.</p>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p>The immediate function tested is <strong>headgroup-specific monomeric lipid transfer</strong>.<br />
+The seed prediction (PC transporter) conflates the Class II RdgBβ pocket<br />
+specificity (PI/PA) with the Class I PITPα/β dual PI/PC specificity. Everything<br />
+downstream — phosphoinositide signaling, secretory/Golgi function attributed to<br />
+some RdgB proteins, photoreceptor/neural signal transduction — is a pathway or<br />
+developmental consequence, not the primary molecular activity, and none of it<br />
+implicates PC transport by <code>rdgBbeta</code>. Importantly, <code>rdgBbeta</code> (small, cytosolic,<br />
+PITPNC1-type) must not be confused with <code>rdgB</code>-alpha (large multidomain<br />
+PITPNM/Nir-type); they are distinct paralogs with distinct biology, and it is the<br />
+alpha/multidomain and Class I paralogs — not <code>rdgBbeta</code> — that carry the direct<br />
+PC-transfer evidence.</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ul>
+<li><strong>Paralog confusion (primary alternative and likely source of the prediction).</strong><br />
+  PC-transporter activity is genuine for Class I PITPα/β<br />
+  (<a href="https://pubmed.ncbi.nlm.nih.gov/10358925/">PMID: 10358925</a>), for multidomain<br />
+  Drosophila <code>rdgB</code> (IDA), and for yeast SEC14<br />
+  (<a href="https://pubmed.ncbi.nlm.nih.gov/15299870/">PMID: 15299870</a>). These are<br />
+<em>paralogs</em> of <code>rdgBbeta</code>, not <code>rdgBbeta</code> itself. The model most plausibly<br />
+  generalized a family-common PC-transfer trait onto a Class II member that lacks<br />
+  it.</li>
+<li><strong>Isoform / organism-specific gaps.</strong> The strongest "no PC" assay<br />
+  (<a href="https://pubmed.ncbi.nlm.nih.gov/22822086/">PMID: 22822086</a>) used mammalian<br />
+  PITPNC1; the mouse Class II assay (<a href="https://pubmed.ncbi.nlm.nih.gov/12562526/">PMID: 12562526</a>)<br />
+  used mM-rdgBβ1. No published in vitro PC-transfer assay on the Drosophila Q9U9P7<br />
+  protein itself was located. The refutation rests on strong orthology plus<br />
+  concordant clade biochemistry rather than a fly-specific assay.</li>
+<li><strong>Quantitative "hardly" vs absolute exclusion.</strong> "Hardly binds PC" is a low but<br />
+  non-zero statement; under artificial vesicle conditions trace PC association is<br />
+  conceivable. This does not justify a core PC-<strong>transporter</strong> MF annotation,<br />
+  which implies a physiological transport function.</li>
+<li><strong>Database carry-over.</strong> The single Class II GO:0008525 record (rat Pitpnc1,<br />
+  ISO) is electronic and unverified; it should not be treated as independent<br />
+  support and may share the same error origin as the prediction.</li>
+</ul>
+<hr />
+<h2 id="limitations-and-knowledge-gaps">Limitations and Knowledge Gaps</h2>
+<ol>
+<li><strong>No Drosophila-protein-specific PC-transfer assay or functional phenotype<br />
+   paper.</strong> <em>Checked:</em> PubMed for CG17818/rdgBbeta biochemistry and<br />
+   photoreceptor/PLC function; GOA. <em>Why it matters:</em> specificity is inferred from<br />
+   the mammalian ortholog. <em>Resolver:</em> in vitro PI/PC/PA transfer assay with<br />
+   purified recombinant Drosophila <code>rdgBbeta</code>. (No experimental PDB exists for<br />
+   Q9U9P7, but a high-confidence AlphaFold model is available, global pLDDT ≈ 91.5,<br />
+   so structural pocket analysis is immediately feasible.)</li>
+<li><strong>PA-transfer relevance for the fly protein is inferred, not measured.</strong><br />
+<em>Checked:</em> PMID 22822086 (PITPNC1). <em>Why it matters:</em> a PA-related MF would be<br />
+   the most informative substitute for the rejected PC term. <em>Resolver:</em> PA<br />
+   binding/transfer assay on Q9U9P7 or structural pocket analysis.</li>
+<li><strong>Provenance of the single Class II ISO GO:0008525 record.</strong> <em>Checked:</em><br />
+   QuickGO/GOA enumeration. <em>Why it matters:</em> if it seeded the prediction, it is a<br />
+   correctable pipeline artifact. <em>Resolver:</em> trace the ISO "with/from" source<br />
+   protein.</li>
+<li><strong>Provenance of the BioReason-Pro prediction</strong> (whether it used Class I<br />
+   features) is unverified; matters for judging systematic paralog bias.</li>
+</ol>
+<hr />
+<h2 id="discriminating-tests-proposed-follow-up-experiments">Discriminating Tests / Proposed Follow-up Experiments</h2>
+<ol>
+<li><strong>In vitro fluorescent-lipid transfer assay</strong> (pyrene-PI vs pyrene-PC vs<br />
+   NBD-PA) with purified recombinant DROME <code>rdgBbeta</code> — the single most decisive<br />
+   experiment. Expectation if refuted: robust PI (and PA) transfer, negligible PC<br />
+   transfer, mirroring <a href="https://pubmed.ncbi.nlm.nih.gov/22822086/">PMID: 22822086</a>.</li>
+<li><strong>Mass-spectrometric lipidomics of the co-purified ligand</strong> (as done for<br />
+   PITPNC1, which co-purified PA/PG). Absence of PC in the bound pool directly<br />
+   counters the prediction.</li>
+<li><strong>Structural pocket comparison</strong> (AlphaFold model of Q9U9P7 vs Class I PITPα<br />
+   holo-structures vs PITPNC1): identify headgroup-coordinating residues and test<br />
+   whether the pocket can accommodate the PC choline headgroup.</li>
+<li><strong>Rescue/complementation:</strong> does <code>rdgBbeta</code> substitute for Class I PITP<br />
+   PC-dependent functions? A negative result supports non-PC specificity.</li>
+<li><strong>Annotation-provenance audit:</strong> trace the rat Pitpnc1 ISO GO:0008525 record's<br />
+   source and any BioReason-Pro training exposure to Class I / multidomain PITP<br />
+   PC-transporter annotations, to confirm the paralog-carry-over mechanism.</li>
+</ol>
+<hr />
+<h2 id="curation-leads-require-curator-verification">Curation Leads (require curator verification)</h2>
+<ul>
+<li><strong>Action change:</strong> Reject/omit <strong>GO:0008525</strong> for <code>rdgBbeta</code>; do not import the<br />
+  BioReason-Pro SFT prediction.</li>
+<li><strong>Retain:</strong> <strong>GO:0008526</strong> (phosphatidylinositol transfer activity, ISS) and<br />
+<strong>GO:0035091</strong> (phosphatidylinositol binding, IBA) as the accurate MF core.</li>
+<li><strong>Candidate new/replacement term (lead):</strong> a <strong>phosphatidic-acid<br />
+  binding/transfer</strong> MF term supported by ISS/ISO from PITPNC1<br />
+  (<a href="https://pubmed.ncbi.nlm.nih.gov/22822086/">PMID: 22822086</a>), clearly flagged<br />
+  as ortholog-inferred and non-core for DROME.</li>
+<li><strong>Candidate reference + snippet to verify:</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/22822086/">PMID: 22822086</a><br />
+  — <em>"besides PI, RdgBβ binds and transfers phosphatidic acid (PA) but hardly binds<br />
+  phosphatidylcholine."</em></li>
+<li><strong>Candidate reference + snippet to verify:</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/12562526/">PMID: 12562526</a><br />
+  — <em>"The recombinant mM-rdgBbeta1 protein shows the specific binding activity to<br />
+  phosphatidylinositol but not to other phospholipids."</em></li>
+<li><strong>Paralog-source reference:</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/10358925/">PMID: 10358925</a><br />
+  — <em>"The preferred lipid that can occupy the site can be either phosphatidylinositol<br />
+  (PI) or phosphatidylcholine (PC)"</em> (establishes PC transfer as a Class I trait).</li>
+<li><strong>Suggested curator question:</strong> Was GO:0008525 propagated from Class I /<br />
+  multidomain PITP paralogs (rdgB, vib, PITPNA/B), and should the single Class II<br />
+  ISO record (rat Pitpnc1) also be flagged?</li>
+<li><strong>Suggested experiment:</strong> direct DROME <code>rdgBbeta</code> PI/PC/PA transfer assay.</li>
+</ul>
+<hr />
+<h2 id="conclusion">Conclusion</h2>
+<p>The prediction of <strong>phosphatidylcholine transporter activity (GO:0008525)</strong> for<br />
+Drosophila <code>rdgBbeta</code> (Q9U9P7) is <strong>REFUTED</strong>. <code>rdgBbeta</code> is a single-domain<br />
+<strong>Class II PITP</strong> orthologous to human PITPNC1 (61.6% identity vs 42.7% to Class I<br />
+PITPNA). Direct biochemical characterization of this clade shows it binds and<br />
+transfers <strong>phosphatidylinositol and phosphatidic acid</strong> but <strong>"hardly binds<br />
+phosphatidylcholine"</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/22822086/">PMID: 22822086</a>);<br />
+PC transfer is a Class I / multidomain (Sec14-type) property. The prediction is a<br />
+<strong>paralog / substrate misassignment</strong>, reinforced by the fact that GO:0008525 has<br />
+direct (IDA) support only in Class I and multidomain paralogs and none in the<br />
+Class II clade. Curators should reject GO:0008525 and retain the more accurate<br />
+<strong>phosphatidylinositol transfer activity (GO:0008526)</strong>.</p>
+<hr />
+<p><em>Provenance:</em> UniProt Q9U9P7 JSON parse and Needleman–Wunsch identity computation<br />
+were executed in this investigation (rdgBbeta vs human PITPNC1 = 61.6%; vs PITPNA<br />
+= 42.7%). GO:0008525 family enumeration saved to <code>/tmp/go0008525_pitp_family.csv</code>.<br />
+Literature retrieved via PubMed.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="rdgBbeta-hypotheses/prediction-pc-transporter/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="rdgBbeta-hypotheses/prediction-pc-transporter/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/ECOLI/DnaJ/DnaJ-ai-review.html
+++ b/genes/ECOLI/DnaJ/DnaJ-ai-review.html
@@ -5697,6 +5697,305 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(DnaJ-hypotheses/prediction-disulfide-isomerase/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P08622" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">AIGR Gene Hypothesis Deep Research — *E. coli* DnaJ (P08622): Disulfide Isomerase Prediction</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+                    <span class="report-badge">3 citations</span>
+
+
+                    <span class="report-badge">3 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-09T13:41:32.975804</span>
+
+
+
+                    <a href="DnaJ-hypotheses/prediction-disulfide-isomerase/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="DnaJ-hypotheses/prediction-disulfide-isomerase/openscientist_artifacts/DnaJ_GO_decision_table.csv" class="term-link">OpenScientist DnaJ GO decision table</a>
+                        <span>(text/csv)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="DnaJ-hypotheses/prediction-disulfide-isomerase/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="DnaJ-hypotheses/prediction-disulfide-isomerase/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="aigr-gene-hypothesis-deep-research-e-coli-dnaj-p08622-disulfide-isomerase-prediction">AIGR Gene Hypothesis Deep Research — <em>E. coli</em> DnaJ (P08622): Disulfide Isomerase Prediction</h1>
+<p><strong>Target:</strong> DnaJ / P08622 — <em>Escherichia coli</em> (strain K12) (NCBITaxon:83333)<br />
+<strong>Focus type:</strong> computational_prediction<br />
+<strong>Hypothesis slug:</strong> prediction-disulfide-isomerase<br />
+<strong>Terms under review:</strong> GO:0003756 (protein disulfide isomerase activity); GO:0015035 (protein-disulfide reductase activity)<br />
+<strong>Prediction source:</strong> BioReason-Pro SFT<br />
+<strong>Reference context:</strong> doi:10.64898/2026.03.19.712954</p>
+<hr />
+<h2 id="summary">Summary</h2>
+<p>The BioReason-Pro SFT model predicts that <em>E. coli</em> DnaJ (P08622) possesses <strong>protein disulfide isomerase activity (GO:0003756)</strong> and <strong>protein-disulfide reductase activity (GO:0015035)</strong>. Independent evaluation of the structural, biochemical, and database evidence <strong>refutes the isomerase prediction and finds the reductase prediction to be, at most, an in-vitro-only over-annotation</strong>. DnaJ is the archetypal cytoplasmic <strong>Hsp40/J-domain co-chaperone</strong> of DnaK (Hsp70). Its diagnostic architecture is a J-domain (with the HPD motif near residue 33) → glycine/phenylalanine-rich linker → <strong>cysteine-rich zinc-finger domain</strong> → C-terminal substrate-binding/dimerization domain. There is no thioredoxin fold and no redox-active, solvent-exposed CXXC catalytic center of the kind found in DsbA, DsbC, or thioredoxin.</p>
+<p>The seed hypothesis poses exactly the right discriminating question — thioredoxin-fold redox CXXC versus structural zinc-finger CXXCXGXG — and the answer is unambiguous. Eight of DnaJ's ten cysteines cluster in the central cysteine-rich region as four <strong>CXXCXGXG</strong> motifs that tetrahedrally coordinate <strong>two structural Zn(II) ions</strong> (C4-type zinc fingers), demonstrated directly by EXAFS/atomic absorption spectroscopy and by cysteine-assignment biochemistry. These cysteines are consumed as metal ligands, a state chemically incompatible with simultaneous service as a catalytically cycling redox couple. The decisive point is that the single primary study underlying both GO annotations — Tang &amp; Wang 2001 (<a href="https://pubmed.ncbi.nlm.nih.gov/11732919/">PMID: 11732919</a>) — explicitly reports that "<strong>DnaJ shows reductase activity and oxidase activity but little, if any, isomerase activity</strong>." The paper that generated the GO:0003756 IDA annotation is, in effect, a negative result for isomerase activity.</p>
+<p>A pivotal contextual discovery is that <strong>both focus terms already exist on the P08622 record as legacy IDA annotations</strong>, both traceable to that same in-vitro paper. The BioReason-Pro "prediction" therefore recapitulates a pre-existing over-annotation rather than proposing a genuinely novel function. The recommended curation action is to <strong>reassess and remove GO:0003756</strong>, to <strong>demote GO:0015035 to a non-core, in-vitro-only caveat</strong> (or remove it), and to anchor the review on DnaJ's genuinely supported functions: <strong>zinc ion binding, DnaK/Hsp70 co-chaperone activity, and protein folding/refolding</strong> in the cytoplasm.</p>
+<hr />
+<h2 id="executive-judgment">Executive Judgment</h2>
+<p><strong>Verdict: REFUTED for GO:0003756 (protein disulfide isomerase activity); OVER-ANNOTATED / weakly-supported-in-vitro-only for GO:0015035 (protein-disulfide reductase activity).</strong></p>
+<p>Reasoning: Every independent line of evidence — sequence/motif analysis, direct metal-coordination spectroscopy, direct enzymatic assay, and database domain annotation — converges on DnaJ being a zinc-finger Hsp40 co-chaperone, not a thiol-disulfide oxidoreductase. The isomerase term is contradicted by its own source paper. The reductase term rests on a single in-vitro, zinc-dependent observation with no genetic or physiological corroboration, in a cytoplasmic compartment where disulfide isomerization is not the relevant chemistry (the periplasmic Dsb system and cytoplasmic thioredoxin/glutaredoxin systems handle disulfides in <em>E. coli</em>).</p>
+<p>Most important caveats: (1) the reductase activity reported by Tang &amp; Wang is real in vitro and should not be denied outright — it is simply non-core and likely an incidental property of one CXXC motif; (2) both terms are already annotated (IDA) on P08622, so the practical action is annotation reassessment rather than rejection of a fresh prediction; (3) the "no thioredoxin fold" conclusion rests on domain architecture and metal-coordination data rather than a fresh atomic-resolution fold superposition, which is recommended as a confirming test.</p>
+<hr />
+<h2 id="key-findings">Key Findings</h2>
+<h3 id="finding-1-dnajs-cysteines-form-two-structural-zinc-fingers-cxxcxgxg-not-a-thioredoxin-redox-fold">Finding 1 — DnaJ's cysteines form two structural zinc fingers (CXXCXGXG), not a thioredoxin redox fold</h3>
+<p>Sequence analysis of P08622 (376 aa) identifies 10 cysteines, of which 8 cluster in the central cysteine-rich domain (approximately residues 131–209) as four <strong>CXXCXGXG</strong> motifs: C144DVCHGSG, C161PTCHGSG, C183PHCQGRG, and C197NKCHGHG. This is the diagnostic signature of the DnaJ/Hsp40 zinc-binding domain (Pfam PF00684, DnaJ_CXXCXGXG), not the signature of a thioredoxin fold. A genuine thiol-disulfide oxidoreductase presents a <strong>single redox-active CXXC</strong> (e.g., the WCGPC motif of thioredoxin, or the CPHC of DsbA) embedded in a βαβαβαββα thioredoxin fold; DnaJ has no such fold, and only one J-domain HPD motif (near position 33) marking it as an Hsp40 co-chaperone.</p>
+<p>The metal architecture is established directly. EXAFS and atomic-absorption spectroscopy showed that "the 90 amino acid cysteine-rich region of DnaJ contains two Zn atoms tetrahedrally coordinated to four cysteine residues, resembling their arrangement in the C4 Zn binding domains of certain DNA binding proteins" (<a href="https://pubmed.ncbi.nlm.nih.gov/8617216/">PMID: 8617216</a>). Tang &amp; Wang assigned the exact coordinating residues: "two Zn(II) ions, which have been identified to form two zinc fingers, C(144)DVC(147)Zn(II)C(197)NKC(200) (Zn1) and C(161)PTC(164)Zn(II)C(183)PHC(186) (Zn2)" (<a href="https://pubmed.ncbi.nlm.nih.gov/11732919/">PMID: 11732919</a>). The interleaved topology — Zn1 uses motifs 1 and 4, Zn2 uses motifs 2 and 3 — is architecturally incompatible with a solvent-exposed, freely cycling redox CXXC. The full domain organization (J-domain + G/F linker + Zn-finger CRD + C-terminal domain) corresponds to the canonical DnaJ/Hsp40 family, mapping to Pfam PF00226 (J-domain) and PF00684 (CXXCXGXG zinc finger).</p>
+<h3 id="finding-2-dnaj-has-littleno-disulfide-isomerase-activity-only-in-vitro-zinc-dependent-reductaseoxidase-reported">Finding 2 — DnaJ has little/no disulfide isomerase activity; only in-vitro zinc-dependent reductase/oxidase reported</h3>
+<p>The single study that directly assayed DnaJ's redox chemistry is explicit: "<strong>DnaJ shows reductase activity and oxidase activity but little, if any, isomerase activity</strong>" (<a href="https://pubmed.ncbi.nlm.nih.gov/11732919/">PMID: 11732919</a>). This is a direct enzymatic assay on purified protein and constitutes a <strong>negative result for the very activity (GO:0003756) that the model predicts</strong>. The reductase/oxidase activities that were observed are <strong>zinc-dependent</strong> (reversibly inhibited by EDTA) and were localized to only the C183PHC186 motif of the Zn2 site acting as the putative active site. This is best read as a low-level side reaction of thiol chemistry rather than evidence of a dedicated oxidoreductase catalytic apparatus.</p>
+<p>The physiological role of DnaJ's cysteine-rich domain is substrate recognition, not redox catalysis. Nelson and colleagues demonstrated that "this Zn finger-like domain is required for the DnaJ molecular chaperone to specifically recognize and bind to proteins in their denatured state" (<a href="https://pubmed.ncbi.nlm.nih.gov/8617216/">PMID: 8617216</a>). DnaJ's established cellular function is to stimulate the ATPase activity of DnaK (Hsp70) via its J-domain and to deliver unfolded, aggregation-prone substrates — a co-chaperone role, not an oxidative-folding role.</p>
+<h3 id="finding-3-uniprotinterpro-confirm-a-cytoplasmic-j-domain-co-chaperone-with-a-cr-type-zinc-finger-no-thioredoxin-fold">Finding 3 — UniProt/InterPro confirm a cytoplasmic J-domain co-chaperone with a CR-type zinc finger; no thioredoxin fold</h3>
+<p>The UniProt record for P08622 annotates a <strong>J domain (residues 3–72)</strong> and a <strong>CR-type zinc finger (131–209)</strong> with eight metal-binding sites at C144, C147, C161, C164, C183, C186, C197, and C200; the subcellular location is <strong>cytoplasm</strong>. The domain signatures are Pfam PF00226 (J-domain), PF00684 (DnaJ_CXXCXGXG), and PF01556 (DnaJ_C); InterPro IPR001305/IPR036410 (HSP DnaJ cysteine-rich domain) and IPR001623 (J domain); SUPFAM SSF57938 (DnaJ/Hsp40 cysteine-rich domain) and SSF46565 (chaperone J-domain); and PROSITE PS51188 (ZF_CR). A programmatic check of the full record found the string "thioredoxin" <strong>absent</strong> — no thioredoxin, DsbA, DsbC, or PDI domain is annotated anywhere. Solved structures exist (e.g., PDB 1EXK for the zinc-finger/CRD, plus 5NRO). This aligns the localization and fold evidence: a cytoplasmic zinc-finger co-chaperone is the wrong compartment and wrong fold to be a protein disulfide isomerase, which in bacteria act in the oxidizing periplasm.</p>
+<h3 id="finding-4-go0003756-and-go0015035-already-exist-as-ida-annotations-both-tracing-to-the-single-in-vitro-study">Finding 4 — GO:0003756 and GO:0015035 already exist as IDA annotations, both tracing to the single in-vitro study</h3>
+<p>A QuickGO query of P08622 confirms that <strong>GO:0003756</strong> and <strong>GO:0015035</strong> are already present, both with <strong>IDA (Inferred from Direct Assay)</strong> evidence, and both derived from Tang &amp; Wang 2001 (<a href="https://pubmed.ncbi.nlm.nih.gov/11732919/">PMID: 11732919</a>). This reframes the "prediction" entirely: BioReason-Pro SFT is largely <strong>recapitulating a pre-existing legacy annotation</strong> — and one that over-interprets an essentially negative in-vitro result. Because the source paper itself states DnaJ has "little, if any, isomerase activity," the GO:0003756 IDA is an over-annotation at the source. The same query returns the genuinely well-supported functions: GO:0008270 zinc ion binding (IDA/IMP/IEA), GO:0051087 protein-folding chaperone binding (IPI), GO:0042803 protein homodimerization activity (IDA), GO:0006457 protein folding (IDA), GO:0042026 protein refolding (IDA/IBA), GO:0009408 response to heat, and GO:0005737 cytoplasm. These represent DnaJ's primary biology.</p>
+<hr />
+<h2 id="mechanistic-model-interpretation">Mechanistic Model / Interpretation</h2>
+<p>The seed hypothesis frames a clean either/or: is DnaJ a thioredoxin-fold oxidoreductase (redox-active CXXC) or an Hsp40 co-chaperone with a structural zinc finger (CXXCXGXG)? Every line of evidence points to the second answer.</p>
+<div class="codehilite"><pre><span></span><code><span class="w">   </span><span class="nx">E</span><span class="p">.</span><span class="w"> </span><span class="nx">coli</span><span class="w"> </span><span class="nx">DnaJ</span><span class="w"> </span><span class="p">(</span><span class="nx">P08622</span><span class="p">,</span><span class="w"> </span><span class="mi">376</span><span class="w"> </span><span class="nx">aa</span><span class="p">)</span><span class="w">  </span><span class="err">—</span><span class="w"> </span><span class="nx">Hsp40</span><span class="o">/</span><span class="nx">J</span><span class="o">-</span><span class="nx">domain</span><span class="w"> </span><span class="nx">co</span><span class="o">-</span><span class="nx">chaperone</span>
+<span class="w">   </span><span class="err">┌───────────┬───────────┬──────────────────────────┬────────────────────┐</span>
+<span class="w">   </span><span class="err">│</span><span class="w"> </span><span class="nx">J</span><span class="o">-</span><span class="nx">domain</span><span class="w">  </span><span class="err">│</span><span class="w">  </span><span class="nx">G</span><span class="o">/</span><span class="nx">F</span><span class="w"> </span><span class="nx">rich</span><span class="w"> </span><span class="err">│</span><span class="w">  </span><span class="nx">Cysteine</span><span class="o">-</span><span class="nx">rich</span><span class="w"> </span><span class="nx">domain</span><span class="w">    </span><span class="err">│</span><span class="w">  </span><span class="nx">C</span><span class="o">-</span><span class="nx">terminal</span><span class="w"> </span><span class="nx">domain</span><span class="w"> </span><span class="err">│</span>
+<span class="w">   </span><span class="err">│</span><span class="w">  </span><span class="mi">3</span><span class="err">–</span><span class="mi">72</span><span class="w">     </span><span class="err">│</span><span class="w">  </span><span class="nx">linker</span><span class="w">   </span><span class="err">│</span><span class="w">  </span><span class="p">(</span><span class="nx">Zn</span><span class="o">-</span><span class="nx">finger</span><span class="w"> </span><span class="nx">CRD</span><span class="p">,</span><span class="w"> </span><span class="mi">131</span><span class="err">–</span><span class="mi">209</span><span class="p">)</span><span class="err">│</span><span class="w">  </span><span class="nx">substrate</span><span class="w"> </span><span class="nx">binding</span><span class="w"> </span><span class="err">│</span>
+<span class="w">   </span><span class="err">│</span><span class="w">  </span><span class="nx">HPD</span><span class="w"> </span><span class="o">~</span><span class="mi">33</span><span class="w">  </span><span class="err">│</span><span class="w">           </span><span class="err">│</span><span class="w">  </span><span class="mi">4</span><span class="nx">x</span><span class="w"> </span><span class="nx">CXXCXGXG</span><span class="w">             </span><span class="err">│</span><span class="w">  </span><span class="o">+</span><span class="w"> </span><span class="nx">dimerization</span><span class="w">    </span><span class="err">│</span>
+<span class="w">   </span><span class="err">└───────────┴───────────┴──────────────────────────┴────────────────────┘</span>
+<span class="w">                     </span><span class="err">│</span>
+<span class="w">        </span><span class="mi">8</span><span class="w"> </span><span class="nx">Cys</span><span class="w"> </span><span class="nx">coordinate</span><span class="w"> </span><span class="mi">2</span><span class="w"> </span><span class="nx">structural</span><span class="w"> </span><span class="nx">Zn</span><span class="p">(</span><span class="nx">II</span><span class="p">):</span>
+<span class="w">        </span><span class="nx">Zn1</span><span class="w"> </span><span class="p">=</span><span class="w"> </span><span class="nx">C144</span><span class="o">/</span><span class="nx">C147</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="nx">C197</span><span class="o">/</span><span class="nx">C200</span><span class="w">  </span><span class="p">(</span><span class="nx">motifs</span><span class="w"> </span><span class="mi">1</span><span class="o">+</span><span class="mi">4</span><span class="p">)</span>
+<span class="w">        </span><span class="nx">Zn2</span><span class="w"> </span><span class="p">=</span><span class="w"> </span><span class="nx">C161</span><span class="o">/</span><span class="nx">C164</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="nx">C183</span><span class="o">/</span><span class="nx">C186</span><span class="w">  </span><span class="p">(</span><span class="nx">motifs</span><span class="w"> </span><span class="mi">2</span><span class="o">+</span><span class="mi">3</span><span class="p">)</span>
+<span class="w">        </span><span class="err">→</span><span class="w"> </span><span class="nx">C4</span><span class="o">-</span><span class="k">type</span><span class="w"> </span><span class="nx">zinc</span><span class="w"> </span><span class="nx">finger</span><span class="w"> </span><span class="p">(</span><span class="nx">EXAFS</span><span class="p">,</span><span class="w"> </span><span class="nx">PMID</span><span class="w"> </span><span class="mi">8617216</span><span class="p">)</span>
+
+<span class="w">   </span><span class="nx">Contrast</span><span class="w"> </span><span class="err">—</span><span class="w"> </span><span class="nx">a</span><span class="w"> </span><span class="nx">real</span><span class="w"> </span><span class="nx">thiol</span><span class="o">-</span><span class="nx">disulfide</span><span class="w"> </span><span class="nx">oxidoreductase</span><span class="w"> </span><span class="p">(</span><span class="nx">thioredoxin</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="nx">DsbA</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="nx">PDI</span><span class="p">):</span>
+<span class="w">   </span><span class="err">┌──────────────────────────────────────────┐</span>
+<span class="w">   </span><span class="err">│</span><span class="w">        </span><span class="nx">Thioredoxin</span><span class="w"> </span><span class="nx">fold</span><span class="w"> </span><span class="p">(</span><span class="nx">βαβαβαββα</span><span class="p">)</span><span class="w">       </span><span class="err">│</span>
+<span class="w">   </span><span class="err">│</span><span class="w">        </span><span class="nx">single</span><span class="w"> </span><span class="nx">redox</span><span class="o">-</span><span class="nx">active</span><span class="w"> </span><span class="nx">CXXC</span><span class="w">            </span><span class="err">│</span>
+<span class="w">   </span><span class="err">│</span><span class="w">        </span><span class="nx">e</span><span class="p">.</span><span class="nx">g</span><span class="p">.</span><span class="w"> </span><span class="nx">W</span><span class="o">-</span><span class="nx">C</span><span class="o">-</span><span class="nx">G</span><span class="o">-</span><span class="nx">P</span><span class="o">-</span><span class="nx">C</span><span class="w">  </span><span class="p">(</span><span class="nx">solvent</span><span class="o">-</span><span class="nx">exposed</span><span class="p">)</span><span class="w">   </span><span class="err">│</span>
+<span class="w">   </span><span class="err">└──────────────────────────────────────────┘</span>
+</code></pre></div>
+
+<p>The functional logic: in DnaJ, the cysteines are <strong>spent building two metal sites</strong> with an interleaved topology. A redox-active CXXC must be free to cycle between reduced dithiol and oxidized disulfide states while transferring electrons to substrate disulfides; cysteines locked into tetrahedral Zn coordination cannot perform that cycle. The in-vitro reductase/oxidase activity detected by Tang &amp; Wang is a low-level side reaction of one motif (C183PHC186) and is itself zinc-dependent — the opposite of what one expects from a dedicated oxidoreductase, whose active site should not require a structural metal.</p>
+<p>Compartment and pathway context reinforce the conclusion. Bacterial oxidative protein folding is carried out by DsbA/DsbB (oxidation) and DsbC/DsbD (isomerization) in the oxidizing <strong>periplasm</strong>. DnaJ is <strong>cytoplasmic</strong>, where the thioredoxin/glutaredoxin systems keep the environment reducing and stable disulfides do not normally form. A cytoplasmic protein is mechanistically and topologically the wrong place for a disulfide isomerase. DnaJ's real job here is to bind unfolded substrates via its zinc-finger and C-terminal domains and hand them to DnaK, stimulating DnaK's ATPase through the J-domain HPD motif.</p>
+<p>A likely source of the misassignment is the <strong>C183PHC186 (CPHC) motif</strong>, which is identical to the DsbA active-site CPHC. This surface-level residue similarity — not fold-level homology — is the most plausible driver of the machine prediction (motif/frequency bias / paralog-style over-annotation). In DnaJ, that CPHC is a zinc-knuckle whose cysteines ligate Zn2, so the resemblance is coincidental.</p>
+<hr />
+<h2 id="evidence-base">Evidence Base</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Stance</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence / limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/11732919/">PMID: 11732919</a> (Tang &amp; Wang 2001)</td>
+<td>Direct enzymatic assay + Zn-finger mapping</td>
+<td>Refutes isomerase; qualifies reductase</td>
+<td>Does DnaJ act as PDI / disulfide reductase?</td>
+<td>"DnaJ shows reductase activity and oxidase activity but <strong>little, if any, isomerase activity</strong>"; two zinc fingers Zn1 (C144/C147+C197/C200), Zn2 (C161/C164+C183/C186); Zn-dependent (EDTA-inhibited); active site limited to C183PHC186</td>
+<td>Purified <em>E. coli</em> DnaJ, in vitro</td>
+<td>Isomerase refutation high; reductase is single in-vitro report with no in-vivo validation. <strong>Source of both GO IDA annotations.</strong></td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/8617216/">PMID: 8617216</a> (Nelson et al.)</td>
+<td>Structural/biophysical (EXAFS, atomic absorption) + mutant</td>
+<td>Refutes thioredoxin fold; supports zinc finger</td>
+<td>Are DnaJ cysteines a redox center or structural Zn ligands?</td>
+<td>"two Zn atoms tetrahedrally coordinated to four cysteine residues…C4 Zn binding domains"; Zn-finger domain "required…to specifically recognize and bind to proteins in their denatured state"</td>
+<td><em>E. coli</em> DnaJ CRD, in vitro</td>
+<td>High; gold-standard metal-coordination evidence, assigns physiological role to substrate binding</td>
+</tr>
+<tr>
+<td>UniProt/InterPro P08622 (QuickGO, this run)</td>
+<td>Structural / database</td>
+<td>Refutes oxidoreductase assignment</td>
+<td>Fold class and localization</td>
+<td>J domain (3–72) + CR-type zinc finger (131–209), 8 Zn-binding Cys; cytoplasm; PF00226/PF00684/PF01556; <strong>no thioredoxin/DsbA/PDI domain</strong></td>
+<td><em>E. coli</em> K12 reference proteome</td>
+<td>High for architecture/localization; database-level orientation</td>
+</tr>
+<tr>
+<td>QuickGO annotations for P08622 (this run)</td>
+<td>Database</td>
+<td>Qualifies / competing</td>
+<td>What GO terms already annotate DnaJ?</td>
+<td>GO:0003756 and GO:0015035 present as IDA from PMID 11732919; core terms GO:0008270, GO:0051087, GO:0042803, GO:0006457, GO:0042026, GO:0005737 well-supported</td>
+<td><em>E. coli</em> K12</td>
+<td>High; documents the legacy annotation the model reproduces</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/11257542/">PMID: 11257542</a> (immunological dissection)</td>
+<td>Domain dissection / functional</td>
+<td>Supports co-chaperone role</td>
+<td>Physiological role of Zn-finger domain</td>
+<td>DnaJ = hsp40 with J-, G/F-, Zn-finger, C-terminal domains; J-, G/F- and Zn-finger domains protect luciferase from heat inactivation</td>
+<td><em>E. coli</em> chaperone assays</td>
+<td>Moderate; supports chaperone (not redox) function of the Zn-finger domain</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="go-curation-implications">GO Curation Implications</h2>
+<p><strong>Pivotal context (QuickGO, this run):</strong> Both focus terms are <strong>already present</strong> on P08622 as <strong>IDA</strong> annotations, both traceable to the single in-vitro study PMID 11732919. The BioReason-Pro prediction is therefore not novel; it recapitulates legacy IDA annotations. The curation task is to reassess existing annotations.</p>
+<table>
+<thead>
+<tr>
+<th>GO term</th>
+<th>Aspect</th>
+<th>Current state</th>
+<th>Recommended action (lead — verify)</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0003756 protein disulfide isomerase activity</td>
+<td>MF</td>
+<td>Present as IDA (PMID 11732919)</td>
+<td><strong>Remove / NOT-qualify</strong></td>
+<td>Source paper explicitly reports "little, if any, isomerase activity." The IDA over-interprets a negative result. This is the single most important action.</td>
+</tr>
+<tr>
+<td>GO:0015035 protein-disulfide reductase activity</td>
+<td>MF</td>
+<td>Present as IDA (PMID 11732919)</td>
+<td><strong>Demote to non-core / in-vitro caveat, or remove</strong></td>
+<td>Observed only in vitro, zinc-dependent, no physiological role; likely a side reaction of the CPHC zinc-knuckle.</td>
+</tr>
+<tr>
+<td>GO:0008270 zinc ion binding</td>
+<td>MF</td>
+<td>Present (IDA/IMP/IEA)</td>
+<td><strong>Retain (core)</strong></td>
+<td>Directly supported by EXAFS/AAS; two structural Zn(II) ions.</td>
+</tr>
+<tr>
+<td>GO:0051087 chaperone binding (DnaK/Hsp70 co-chaperone)</td>
+<td>MF</td>
+<td>Present (IPI)</td>
+<td><strong>Retain (core)</strong></td>
+<td>Established DnaK co-chaperone; the primary molecular function.</td>
+</tr>
+<tr>
+<td>GO:0051082 unfolded protein binding</td>
+<td>MF</td>
+<td>(recommend)</td>
+<td><strong>Add/retain (core)</strong></td>
+<td>Zn-finger domain binds denatured substrates (PMID 8617216).</td>
+</tr>
+<tr>
+<td>GO:0006457 / GO:0042026 protein folding / refolding</td>
+<td>BP</td>
+<td>Present (IDA/IBA)</td>
+<td><strong>Retain (core)</strong></td>
+<td>Established chaperone process.</td>
+</tr>
+<tr>
+<td>GO:0005737 cytoplasm</td>
+<td>CC</td>
+<td>Present</td>
+<td><strong>Retain (core)</strong></td>
+<td>Cytoplasmic localization; incompatible with periplasmic disulfide-isomerase role.</td>
+</tr>
+</tbody>
+</table>
+<p>The evidence supports MF terms centered on <strong>zinc ion binding, unfolded protein binding, and Hsp70 co-chaperone activity</strong>, BP terms for <strong>protein folding/refolding</strong>, and CC <strong>cytoplasm</strong> — not oxidoreductase MF terms. "Protein binding" is deliberately not offered as a final recommendation; more informative supported terms are available.</p>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p>The immediate molecular function being tested is <strong>thiol-disulfide oxidoreductase/isomerase catalysis</strong> — reducing, oxidizing, or shuffling substrate disulfides via a redox-active dithiol. The directly supported gene-product activity is instead <strong>structural zinc coordination and denatured-substrate binding</strong> by the cysteine-rich domain, plus <strong>J-domain-mediated stimulation of DnaK ATPase</strong>.</p>
+<p>Separated from the tested activity:<br />
+- <strong>Downstream phenotypes:</strong> protection of substrates (e.g., luciferase) from heat inactivation is a chaperoning outcome, not evidence of redox catalysis.<br />
+- <strong>Pathway consequences:</strong> disulfide-bond formation/isomerization in exported proteins is a separate Dsb pathway in the periplasm; DnaJ operates in the DnaK–DnaJ–GrpE cytoplasmic chaperone cycle.<br />
+- <strong>Inference from cysteine content:</strong> abundant cysteines and CXXC-containing motifs are sequence features that can mislead motif/frequency-based predictors; here those cysteines are demonstrably structural (zinc-coordinating), not catalytic-redox.</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ol>
+<li><strong>Legacy database carry-over (primary conflict).</strong> Both redox GO terms already exist as IDA annotations from a single paper whose own text undercuts the isomerase term. A predictor trained on GO annotations would learn and reproduce this over-annotation — a self-reinforcing artifact rather than independent evidence.</li>
+<li><strong>The CPHC motif.</strong> DnaJ's C183PHC186 is identical to the DsbA active-site CPHC and reminiscent of thioredoxin-family motifs. This surface similarity is the most likely driver of the prediction. In DnaJ, however, both CPHC cysteines ligate Zn2, so the resemblance is coincidental at the residue level, not homologous fold-level redox chemistry.</li>
+<li><strong>In-vitro-only activity.</strong> The reductase/oxidase activity is real but observed only under purified in-vitro conditions and is zinc-dependent; there is no mutant phenotype, genetic epistasis, or in-vivo demonstration tying DnaJ to disulfide processing in the cell.</li>
+<li><strong>Compartment/pathway mismatch.</strong> Genuine bacterial disulfide isomerases (DsbC/DsbG) and oxidases (DsbA) operate in the oxidizing periplasm; DnaJ is cytoplasmic and reducing-environment resident. No paralog confusion with Dsb proteins is warranted at the sequence/domain level (no thioredoxin fold present).</li>
+</ol>
+<p>No credible alternative interpretation elevates the redox prediction to a core function.</p>
+<hr />
+<h2 id="limitations-and-knowledge-gaps">Limitations and Knowledge Gaps</h2>
+<ol>
+<li><strong>Physiological relevance of the in-vitro reductase activity.</strong> Checked: only one in-vitro paper (PMID 11732919). Matters because a non-physiological activity should not become a core MF annotation. Resolve with: a <em>dnaJ</em> cysteine/CPHC-mutant phenotype in disulfide-stress or oxidative assays, or in-vivo redox-state trapping of substrates.</li>
+<li><strong>Atomic-resolution confirmation of no thioredoxin fold.</strong> Checked: EXAFS + cysteine mapping (PMIDs 8617216, 11732919) and Pfam architecture (PF00226 + PF00684) indicate a zinc-finger CRD; a fresh full-length fold superposition was not performed here. Matters for definitively excluding a redox fold. Resolve with: the deposited NMR structure of the DnaJ zinc-binding domain (PDB 1EXK) or an AlphaFold model of P08622 checked for βαβαβαββα thioredoxin topology.</li>
+<li><strong>Propagation of the redox annotations to orthologs/paralogs.</strong> Checked: QuickGO confirms IDA on P08622 from one paper; a cross-species audit of GO:0003756/GO:0015035 on DnaJ orthologs was not performed. Matters because over-annotation may have spread by IEA/ISS. Resolve with a QuickGO/GOA cross-species query.</li>
+<li><strong>Model prediction provenance is opaque.</strong> We cannot directly see why BioReason-Pro SFT emitted these terms; the parsimonious explanation is recapitulation of existing IDA annotations plus CPHC/cysteine features. Resolve by inspecting model feature attributions if available.</li>
+</ol>
+<hr />
+<h2 id="proposed-follow-up-experiments-actions">Proposed Follow-up Experiments / Actions</h2>
+<ol>
+<li><strong>Fold check (fast, computational):</strong> Superpose the DnaJ cysteine-rich domain (PDB 1EXK) or an AlphaFold model against thioredoxin (2TRX) and DsbA/DsbC using TM-align/DALI. Prediction: no thioredoxin fold; instead two zinc-knuckle modules — refutes the redox assignment.</li>
+<li><strong>Zinc-occupancy vs redox mutual exclusivity:</strong> Confirm computationally that both cysteines of each CXXC ligate Zn (EXAFS/site mapping already show this). A pair fully engaged in metal coordination cannot simultaneously serve as a physiological redox-active dithiol.</li>
+<li><strong>Cross-species annotation audit:</strong> QuickGO/GOA query for GO:0003756 and GO:0015035 across DnaJ/Hsp40 orthologs to quantify any over-annotation spread and flag for correction.</li>
+<li><strong>Genetic test (definitive, wet-lab):</strong> Construct chromosomal <em>dnaJ</em> Cys→Ser (or CPHC→APHA) mutants; assay disulfide-processing phenotypes (e.g., alkaline phosphatase folding, motility disulfide reporters) versus chaperone phenotypes (thermotolerance, λ replication, DnaK cycle). Prediction: chaperone/Zn-binding phenotypes, not disulfide-processing phenotypes.</li>
+<li><strong>Controlled in-vitro re-assay:</strong> Compare DnaJ to DsbC/PDI in scrambled-RNase A or insulin reduction assays with and without zinc/EDTA; expect negligible isomerase activity, consistent with PMID 11732919, and quantify an upper bound on any activity.</li>
+</ol>
+<p><strong>Curation actions (leads — require curator verification):</strong> Remove/NOT-qualify GO:0003756; demote or remove GO:0015035 as a non-core in-vitro caveat; retain and emphasize GO:0008270, GO:0051087, GO:0051082, GO:0006457/GO:0042026, and GO:0005737.</p>
+<p><strong>References with exact snippets to verify:</strong><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/11732919/">PMID: 11732919</a>: <em>"DnaJ shows reductase activity and oxidase activity but little, if any, isomerase activity"</em> and <em>"two zinc fingers, C(144)DVC(147)Zn(II)C(197)NKC(200) (Zn1) and C(161)PTC(164)Zn(II)C(183)PHC(186) (Zn2)."</em><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/8617216/">PMID: 8617216</a>: <em>"the 90 amino acid cysteine-rich region of DnaJ contains two Zn atoms tetrahedrally coordinated to four cysteine residues"</em> and <em>"this Zn finger-like domain is required for the DnaJ molecular chaperone to specifically recognize and bind to proteins in their denatured state."</em></p>
+<hr />
+<h2 id="provenance">Provenance</h2>
+<p>Computed motif analysis (this run) on P08622 (376 aa): 10 Cys total (positions 144, 147, 161, 164, 183, 186, 197, 200, and two additional outside the CRD); four central CXXCXGXG motifs — C144DVCHGSG, C161PTCHGSG, C183PHCQGRG, C197NKCHGHG; single J-domain HPD at position 33. Consistent with Pfam PF00226 (J-domain) + PF00684 (DnaJ central CXXCXGXG zinc finger). QuickGO annotation retrieval (this run) confirmed pre-existing GO:0003756 (IDA) and GO:0015035 (IDA) annotations traceable to PMID 11732919, alongside well-supported GO:0008270, GO:0051087, GO:0042803, GO:0006457, GO:0042026, GO:0009408, and GO:0005737.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="DnaJ-hypotheses/prediction-disulfide-isomerase/openscientist_artifacts/DnaJ_GO_decision_table.csv">OpenScientist DnaJ GO decision table</a></li>
+<li><a href="DnaJ-hypotheses/prediction-disulfide-isomerase/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="DnaJ-hypotheses/prediction-disulfide-isomerase/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/ECOLI/DnaK/DnaK-ai-review.html
+++ b/genes/ECOLI/DnaK/DnaK-ai-review.html
@@ -6630,6 +6630,255 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(DnaK-hypotheses/prediction-zinc-binding/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P0A6Y8" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">DnaK (P0A6Y8) Zinc-Ion-Binding Prediction — Focused Curation Report</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+                    <span class="report-badge">4 citations</span>
+
+
+                    <span class="report-badge">4 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-10T03:28:43.768333</span>
+
+
+
+                    <a href="DnaK-hypotheses/prediction-zinc-binding/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="DnaK-hypotheses/prediction-zinc-binding/openscientist_artifacts/artifacts_evidence_matrix.csv" class="term-link">OpenScientist evidence matrix</a>
+                        <span>(text/csv)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="DnaK-hypotheses/prediction-zinc-binding/openscientist_artifacts/artifacts_hsp70_cysteine_census.csv" class="term-link">OpenScientist hsp70 cysteine census</a>
+                        <span>(text/csv)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="DnaK-hypotheses/prediction-zinc-binding/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="DnaK-hypotheses/prediction-zinc-binding/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="dnak-p0a6y8-zinc-ion-binding-prediction-focused-curation-report">DnaK (P0A6Y8) Zinc-Ion-Binding Prediction — Focused Curation Report</h1>
+<p><strong>Gene:</strong> DnaK (Hsp70 chaperone) · <em>Escherichia coli</em> K-12 · UniProt <strong>P0A6Y8</strong><br />
+<strong>Prediction under review:</strong> BioReason-Pro SFT → <strong>zinc ion binding (GO:0008270)</strong><br />
+<strong>Focus type:</strong> computational_prediction · <strong>Slug:</strong> prediction-zinc-binding<br />
+<strong>Reference context:</strong> doi:10.64898/2026.03.19.712954</p>
+<hr />
+<h2 id="executive-judgment">Executive Judgment</h2>
+<p><strong>Verdict: Over-annotated / weakly supported — treat as a non-core, likely artifactual assignment (effectively refuted as a molecular function).</strong></p>
+<p>DnaK does not possess a bona fide zinc-coordinating center. The prediction is not wholly baseless — there is a single existing IDA GO annotation (GO:0008270) on DnaK — but that annotation rests entirely on <strong>one low-specificity, abundance-biased proteomic Zn-blot screen (PMID:11985624)</strong> and is contradicted by DnaK's sequence and structure:</p>
+<ul>
+<li>DnaK has <strong>only one cysteine (Cys15)</strong> in 638 residues and <strong>no CXXC / C4 zinc-finger motif</strong> — it is structurally incapable of forming a classical cysteine-based zinc site.</li>
+<li><strong>0 of 63 DnaK PDB entries</strong> contain a bound zinc ion, despite extensive structural characterization of both the NBD and SBD.</li>
+<li>The <strong>genuine zinc-binding component of the DnaK/DnaJ/GrpE system is the co-chaperone DnaJ</strong> (P08622), which has a CR-type zinc finger coordinating 2 Zn²⁺ via 8 cysteines. The prediction is best explained as <strong>paralog/system confusion plus database carry-over</strong>.</li>
+</ul>
+<p>Recommended lead: <strong>do not curate GO:0008270 as a DnaK function</strong>; if retained at all, downgrade to a low-confidence, in-vitro-only/adventitious note, not a mechanistic MF.</p>
+<p><strong>Most important caveat:</strong> an existing curated IDA annotation does exist (EcoliWiki, PMID:11985624), so this is a case of challenging a weak legacy annotation rather than a term with zero support. The judgment rests on the low specificity of that assay and the absence of any structural/sequence basis.</p>
+<hr />
+<h2 id="evidence-matrix">Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Stance</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence / limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>UniProt P0A6Y8 (computed here)</td>
+<td>Sequence/computational</td>
+<td><strong>Refutes</strong></td>
+<td>DnaK has a Cys-based zinc motif</td>
+<td>Only 1 Cys (Cys15); 0 CXXC motifs; no Metal-binding/Zinc-finger feature</td>
+<td><em>E. coli</em> DnaK, 638 aa</td>
+<td>High; sequence is definitive that no canonical C4/C2H2 Zn finger exists</td>
+</tr>
+<tr>
+<td>RCSB (63 entries, queried here)</td>
+<td>Structural</td>
+<td><strong>Refutes</strong></td>
+<td>Zinc is present in DnaK structures</td>
+<td>0/63 DnaK PDB entries contain a ZN ligand</td>
+<td>NBD + SBD crystal/NMR structures</td>
+<td>High; large structural sample, all zinc-free</td>
+</tr>
+<tr>
+<td>PMID:11985624 (Katayama 2002)</td>
+<td>Direct assay (proteomic ⁶⁵Zn-blot)</td>
+<td><strong>Qualifies (sole support)</strong></td>
+<td>DnaK binds Zn²⁺ in vitro</td>
+<td>DnaK "newly identified" among 9 hits alongside AckA, GlyA, TktA/B, Tsf, ribosomal proteins</td>
+<td>2D-gel Zn-blot of total <em>E. coli</em> lysate</td>
+<td>Low specificity; abundance-biased; many hits lack Zn-finger motifs</td>
+</tr>
+<tr>
+<td>QuickGO annotation record (queried here)</td>
+<td>Database</td>
+<td><strong>Qualifies</strong></td>
+<td>Provenance of DnaK Zn annotation</td>
+<td>Only GO:0008270 on DnaK = IDA/EcoliWiki/PMID:11985624; identical ref also used for DnaJ</td>
+<td>Annotation metadata</td>
+<td>High; shows single-source, carry-over pattern</td>
+</tr>
+<tr>
+<td>PMID:15683252 (Shi 2005)</td>
+<td>Structural/biochemical</td>
+<td><strong>Competing (DnaJ)</strong></td>
+<td>Which system member binds Zn</td>
+<td>DnaJ has two C4-type zinc fingers (C144/147/161/164/183/186/197/200) binding 2 Zn²⁺</td>
+<td><em>E. coli</em> DnaJ</td>
+<td>High; localizes zinc function to DnaJ, not DnaK</td>
+</tr>
+<tr>
+<td>PMID:8662861 (Banecki 1996)</td>
+<td>Direct assay (AAS/HgS titration)</td>
+<td><strong>Competing (DnaJ)</strong></td>
+<td>DnaJ zinc stoichiometry</td>
+<td>Two Zn²⁺ per DnaJ monomer</td>
+<td><em>E. coli</em> DnaJ</td>
+<td>High; establishes DnaJ as the zinc-binding partner</td>
+</tr>
+<tr>
+<td>PMID:23708608 (Qi 2013); 34453889; 33950017</td>
+<td>Structural</td>
+<td><strong>Refutes (by omission)</strong></td>
+<td>DnaK core MF is Zn-dependent</td>
+<td>Full-length ATP-bound and domain structures: ATPase NBD + peptide SBD; no zinc site</td>
+<td><em>E. coli</em> DnaK</td>
+<td>High; mechanism is ATP/Mg²⁺/K⁺- and peptide-driven, not zinc</td>
+</tr>
+<tr>
+<td>InterPro (queried Iter 2)</td>
+<td>Structural/evolutionary</td>
+<td><strong>Refutes</strong></td>
+<td>DnaK has a zinc-finger domain</td>
+<td>Only Hsp70 domains (IPR012725, PF00012, NBD/SBD/PBD); no zinc-finger/metal domain</td>
+<td><em>E. coli</em> DnaK</td>
+<td>High; comprehensive signature database</td>
+</tr>
+<tr>
+<td>Ortholog Cys census (queried Iter 2)</td>
+<td>Evolutionary</td>
+<td><strong>Refutes</strong></td>
+<td>Zinc binding conserved in Hsp70</td>
+<td>DnaK orthologs carry 0–5 Cys, 0 CXXC; <em>M. tuberculosis</em> DnaK has <strong>0 cysteines</strong></td>
+<td>Hsp70 family (bacteria/yeast/human)</td>
+<td>High; a zero-Cys ortholog cannot form a Cys zinc site</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="go-curation-implications">GO Curation Implications</h2>
+<ul>
+<li><strong>GO:0008270 (zinc ion binding, MF):</strong> Lead — <strong>do not propagate / recommend removal or NOT-qualifier consideration</strong> for DnaK. The single IDA source is a low-specificity proteomic screen; there is no motif, no structural zinc, and no mechanistic role. If curator policy forbids removing an IDA, at minimum it should <strong>not</strong> be treated as a core molecular function and should carry an explicit caveat that it derives from a whole-proteome Zn-blot with probable non-specific binding.</li>
+<li><strong>Do not</strong> substitute a vaguer term (e.g., "metal ion binding" or "protein binding") — no informative metal-binding term is supported.</li>
+<li><strong>Well-supported core MF terms to prefer/retain instead:</strong> ATP binding (GO:0005524), ATP hydrolysis activity (GO:0016887), ADP binding (GO:0043531), unfolded protein binding (GO:0051082), ATP-dependent protein folding chaperone (GO:0140662). These reflect DnaK's actual activities.</li>
+<li><strong>Paralog note for curators:</strong> the zinc-ion-binding annotation is biologically correct <strong>for DnaJ (P08622)</strong>, and the shared PMID:11985624 reference suggests the DnaK entry is a co-annotation carry-over.</li>
+</ul>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p>The immediate molecular function being tested is <strong>direct coordination of a Zn²⁺ ion by DnaK</strong>. DnaK's actual direct activities are: (i) ATP binding and hydrolysis in the N-terminal nucleotide-binding domain (actin/hexokinase fold; uses Mg²⁺ and K⁺, not Zn²⁺), and (ii) binding of exposed hydrophobic segments of unfolded clients in the C-terminal substrate-binding domain, allosterically coupled to the nucleotide state. No step of this cycle requires or involves a structural zinc. Any zinc signal observed in a lysate blot is a <strong>downstream in vitro observation</strong> on an abundant protein, not a mechanistic feature of the chaperone cycle.</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ul>
+<li><strong>Paralog confusion (most likely):</strong> DnaJ, the obligate co-chaperone in the DnaK/DnaJ/GrpE system, genuinely binds 2 Zn²⁺ via a CR-type zinc finger. Zinc binding is a real property of the <em>system</em> but resides in DnaJ.</li>
+<li><strong>Database carry-over / frequency bias:</strong> the same reference (PMID:11985624) underlies the IDA on both DnaK and DnaJ; a model trained on such annotations would plausibly transfer "zinc ion binding" onto the more famous/abundant DnaK.</li>
+<li><strong>Assay artifact:</strong> ⁶⁵Zn-blotting of 2D gels captures many abundant, acidic, or surface-exposed proteins non-specifically; the paper's own hit list (kinases, transketolase, ribosomal proteins, EF-Ts) is enriched for proteins with no canonical zinc-finger, signaling low specificity.</li>
+<li><strong>No organism/isoform escape hatch:</strong> DnaK is a single-copy, well-conserved bacterial Hsp70; no isoform harbors extra cysteines that could form a zinc site.</li>
+<li><strong>Negative literature check (Iter 3):</strong> targeted PubMed searches for a <em>functional</em> DnaK zinc/metal-binding site or a copper/zinc redox role returned no primary evidence (the only zinc-finger chaperone hit was thioredoxin-2, unrelated to DnaK). No study proposes zinc as mechanistically required for DnaK. The UniProt BP term "stress response to copper ion" (GO:1990169) reflects a physiological stress response, not direct metal coordination by DnaK.</li>
+</ul>
+<hr />
+<h2 id="knowledge-gaps">Knowledge Gaps</h2>
+<ol>
+<li><strong>Is the Katayama Zn signal specific or adventitious?</strong> Checked: sequence (1 Cys), structure (0/63 PDB), and hit-list composition all argue non-specific. Matters because it is the sole primary support. Resolve with: purified DnaK ICP-MS/atomic-absorption zinc stoichiometry and competition/specificity controls (as were done for DnaJ).</li>
+<li><strong>Does any DnaK conformer transiently bind Zn functionally?</strong> Checked: allosteric-cycle structures show no zinc site. Matters only if a regulatory zinc were proposed. Resolve with: metal-content analysis across ADP/ATP states.</li>
+<li><strong>What exactly does EcoliWiki's IDA claim?</strong> Checked provenance (PMID:11985624 only). Matters for whether removal vs. caveat is appropriate. Resolve with: read full Katayama methods to confirm DnaK's measured affinity/specificity class.</li>
+</ol>
+<hr />
+<h2 id="discriminating-tests">Discriminating Tests</h2>
+<ul>
+<li><strong>ICP-MS / atomic absorption on purified recombinant DnaK</strong> (apo vs. Zn-loaded) — quantify Zn:protein stoichiometry; expect ~0 for a genuine non-binder, ~2 for DnaJ control.</li>
+<li><strong>Cys15→Ser mutant + metal blot</strong> — a genuine Cys-based site would lose signal; a non-specific surface interaction would not.</li>
+<li><strong>Side-by-side ⁶⁵Zn-blot of DnaK vs DnaJ vs a bona fide C4 zinc-finger control</strong> with EDTA/competitor titration to grade specificity.</li>
+<li><strong>AlphaFold3/metal-aware docking or MIB/CHED metal-site prediction</strong> on P0A6Y8 — expect no high-confidence zinc site (bioinformatic corroboration).</li>
+</ul>
+<hr />
+<h2 id="curation-leads-require-curator-verification">Curation Leads (require curator verification)</h2>
+<ul>
+<li><strong>Action change:</strong> Flag GO:0008270 on DnaK as <strong>not a core function</strong>; propose removal or downgrade with an explicit provenance caveat. Do <strong>not</strong> replace with "metal ion binding" or "protein binding."</li>
+<li><strong>Candidate references to verify (exact snippets):</strong></li>
+<li>PMID:11985624 — <em>"nine zinc-binding proteins were newly identified including: acetate kinase (AckA), DnaK, serine hydroxymethyltransferase (GlyA)…"</em> (verify this is the sole basis and note low specificity).</li>
+<li>PMID:15683252 — <em>"which coordinate with two Zn(II) ions to form an unusual topology of two C4-type zinc fingers…"</em> (confirms zinc role belongs to DnaJ).</li>
+<li>PMID:8662861 — <em>"two Zn(II) ions interact with each monomer of DnaJ."</em> (DnaJ stoichiometry).</li>
+<li><strong>Suggested curator questions:</strong> (1) Is a single whole-proteome Zn-blot sufficient IDA support for a core MF given contradicting sequence/structure? (2) Should the DnaK/DnaJ shared reference trigger a carry-over review?</li>
+<li><strong>Suggested experiment:</strong> purified-DnaK ICP-MS zinc stoichiometry with Cys15 mutant control.</li>
+<li><strong>Positive terms to keep:</strong> ATP binding, ATP hydrolysis activity, unfolded protein binding, ATP-dependent protein folding chaperone.</li>
+</ul>
+<hr />
+<p><em>Artifacts (computed provenance):</em> <code>artifacts/evidence_matrix.csv</code>, <code>artifacts/hsp70_cysteine_census.csv</code>.</p>
+<p><em>Provenance:</em> All computed results (UniProt feature/GO parse, cysteine census, RCSB zinc-ligand query returning 0/63, QuickGO annotation provenance) were generated by executed code in Iteration 1; primary literature accessed via PubMed. No results were fabricated; the RCSB query returned HTTP 204 (empty) for DnaK-with-zinc.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="DnaK-hypotheses/prediction-zinc-binding/openscientist_artifacts/artifacts_evidence_matrix.csv">OpenScientist evidence matrix</a></li>
+<li><a href="DnaK-hypotheses/prediction-zinc-binding/openscientist_artifacts/artifacts_hsp70_cysteine_census.csv">OpenScientist hsp70 cysteine census</a></li>
+<li><a href="DnaK-hypotheses/prediction-zinc-binding/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="DnaK-hypotheses/prediction-zinc-binding/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/SCHPO/SPAC8E11.10/SPAC8E11.10-ai-review.html
+++ b/genes/SCHPO/SPAC8E11.10/SPAC8E11.10-ai-review.html
@@ -2669,6 +2669,422 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9Y6Z9" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">AIGR Deep Research — sou1 / SPAC8E11.10 (Q9Y6Z9)</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+
+                    <span class="report-badge">6 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-10T03:42:37.002322</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/provenance_sou1_GO_decision_table.json" class="term-link">OpenScientist sou1 GO decision table</a>
+                        <span>(application/json)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/provenance_sou1_GO_decision_table.png" class="term-link">OpenScientist sou1 GO decision table</a>
+                        <span>(image/png)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/provenance_sou1_evidence_matrix.json" class="term-link">OpenScientist sou1 evidence matrix</a>
+                        <span>(application/json)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/provenance_sou1_evidence_matrix.png" class="term-link">OpenScientist sou1 evidence matrix</a>
+                        <span>(image/png)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="aigr-deep-research-sou1-spac8e1110-q9y6z9">AIGR Deep Research — sou1 / SPAC8E11.10 (Q9Y6Z9)</h1>
+<h2 id="hypothesis-nadp-dependent-arabitol-polyol-dehydrogenase-go0008106-arabitol-metabolic-process">Hypothesis: NADP+-dependent arabitol (polyol) dehydrogenase (GO:0008106 + arabitol metabolic process)</h2>
+<p><strong>Organism:</strong> <em>Schizosaccharomyces pombe</em> 972h- · <strong>UniProt:</strong> Q9Y6Z9 · <strong>Gene:</strong> sou1 (SPAC8E11.10)<br />
+<strong>Focus type:</strong> computational_prediction (BioReason-Pro SFT)<br />
+<strong>Seed reference:</strong> doi:10.64898/2026.03.19.712954</p>
+<hr />
+<h2 id="executive-judgment">Executive Judgment</h2>
+<p><strong>Verdict: PARTIALLY SUPPORTED at the activity-class level / OVER-ANNOTATED at the substrate level.</strong></p>
+<p>The prediction decomposes into three claims that must be judged separately:</p>
+<ol>
+<li><strong>SDR-family NADP+-dependent CH–OH oxidoreductase</strong> → <strong>SUPPORTED.</strong> Fold/family, the SDR<br />
+   glycine coenzyme fingerprint (TGGSGGIG), the catalytic Tyr-x-x-x-Lys tetrad (YHATK), and the<br />
+   cofactor-discriminating residues (basic cluster R42/K44/K45, no acidic Asp discriminator) all<br />
+   independently indicate a functional NADP-preferring SDR reductase. UniProt keyword <em>NADP</em> and the<br />
+   NADPH-dependent characterized ortholog agree.</li>
+<li><strong>"Alcohol dehydrogenase (NADP+) activity" (GO:0008106)</strong> → <strong>WEAKLY / PARTIALLY SUPPORTED.</strong><br />
+   Defensible as a broad activity class, but it is <em>less informative and less precise</em> than the terms<br />
+   PomBase already carries (GO:0016616 CH–OH oxidoreductase; specific sugar/polyol reductase terms),<br />
+   and it remains experimentally unverified. Not the best available MF term.</li>
+<li><strong>Arabitol substrate / "arabitol metabolic process"</strong> → <strong>REFUTED / UNSUPPORTED and technically<br />
+   defective.</strong> No assay links SPAC8E11.10 to arabitol; the closest characterized ortholog acts on<br />
+   L-sorbose/fructose; and the proposed BP is a GO housekeeping problem: the seed cites <strong>GO:0019677,<br />
+   which is actually "NAD+ catabolic process," not arabitol</strong>, while the genuine "arabitol metabolic<br />
+   process" term (GO:0051161) is <strong>OBSOLETE</strong>. The arabitol call is best read as a paralog/substrate<br />
+   misassignment.</li>
+</ol>
+<p><strong>Most important caveat:</strong> the enzyme is officially <em>"conserved unknown"</em> (uncharacterized). No S. pombe<br />
+enzymatic assay exists, so every substrate assignment — sorbose, mannitol, xylulose, <strong>or arabitol</strong> —<br />
+is inference. The prediction is not "correct"; at best it names a plausible-but-unproven pentitol within<br />
+the right chemical class, wrapped in an obsolete/mis-cited GO term.</p>
+<hr />
+<h2 id="evidence-matrix">Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Supports/Refutes/Qualifies</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence &amp; limits</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>UniProt Q9Y6Z9 (database)</td>
+<td>Structural/evolutionary</td>
+<td>Qualifies</td>
+<td>Fold/family</td>
+<td>SDR family; InterPro IPR002347, Pfam PF13561, CDD cd05352, Rossmann Gene3D 3.40.50.720; kw <strong>NADP</strong>; EC 1.1.1.-</td>
+<td>S. pombe protein record</td>
+<td>High for family; cofactor kw is inferred</td>
+</tr>
+<tr>
+<td>2</td>
+<td>This analysis (computational, sequence)</td>
+<td>Computational</td>
+<td>Supports (NADP), Confirms (SDR)</td>
+<td>Motifs/cofactor residues</td>
+<td>Glycine fingerprint <strong>TGGSGGIG</strong> (res 11–22); catalytic <strong>YHATK</strong> (res 163–167); βB region res 33–46 has basic <strong>R42/K44/K45</strong>, <strong>no acidic Asp</strong> → NADP signature</td>
+<td>255-aa sequence</td>
+<td>Fingerprint heuristic, not a solved holo-structure</td>
+</tr>
+<tr>
+<td>3</td>
+<td>PMID 16134116 (primary)</td>
+<td>Direct assay (ortholog)</td>
+<td>Qualifies / Competing</td>
+<td>Substrate &amp; cofactor of ortholog</td>
+<td><em>C. albicans</em> SOU1 (P87219) is an <strong>NADPH sorbose reductase</strong>: L-sorbose→D-sorbitol; also fructose→mannitol; <strong>not arabitol</strong></td>
+<td>Purified FLAG-Sou1p, C. albicans</td>
+<td>High for ortholog; specificity may not transfer</td>
+</tr>
+<tr>
+<td>4</td>
+<td>UniProt CAUTION, ECO:0000269 <strong>PMID 31132130</strong></td>
+<td>Mutant/physiology (species trait)</td>
+<td>Refutes</td>
+<td>Sorbose reductase function in S. pombe</td>
+<td>S. pombe <strong>cannot assimilate L-sorbose</strong> → sorbose-reductase role rejected</td>
+<td>Fission-yeast carbon-assimilation physiology</td>
+<td>Species-level physiology, not a direct enzyme assay of Q9Y6Z9</td>
+</tr>
+<tr>
+<td>5</td>
+<td>PomBase SPAC8E11.10 (database)</td>
+<td>Review/database</td>
+<td>Qualifies</td>
+<td>Current curation state</td>
+<td>Product = "<strong>mitochondrial</strong> oxidoreductase … CH–OH … NAD or NADP acceptor, implicated in carbohydrate assimilation"; <strong>characterisation_status = conserved unknown</strong>; MF GO:0016616, GO:0050085 (mannitol 2-DH NADP+), GO:0032115 (sorbose reductase); CC GO:0005739</td>
+<td>S. pombe curation</td>
+<td>Predicted (ISS/IEA); no experimental MF</td>
+</tr>
+<tr>
+<td>6</td>
+<td>PANTHER PTHR43008:SF13 (database)</td>
+<td>Computational</td>
+<td>Competing (alt. substrate)</td>
+<td>Substrate class</td>
+<td>Nearest subfamily = "<strong>L-xylulose reductase-related</strong>" (dicarbonyl/xylulose→xylitol, NADPH)</td>
+<td>Family classification</td>
+<td>Suggests pentose/pentitol/dicarbonyl class, not specifically arabitol</td>
+</tr>
+<tr>
+<td>6a</td>
+<td>PMID 11882650 (primary)</td>
+<td>Direct assay (subfamily)</td>
+<td>Competing / Supports (NADP)</td>
+<td>Subfamily substrate &amp; cofactor</td>
+<td>DCXR = <strong>NADPH</strong>-linked homotetramer, oxidoreduces <strong>xylitol⇌L-xylulose</strong> and α-dicarbonyls</td>
+<td>Mammalian recombinant DCXR</td>
+<td>High for subfamily; substrate specificity may differ in fission yeast</td>
+</tr>
+<tr>
+<td>6b</td>
+<td>PMID 23661708 (primary)</td>
+<td>Direct assay (subfamily)</td>
+<td>Competing</td>
+<td>Subfamily substrate</td>
+<td>Human DCXR reduces α-dicarbonyls and L-xylulose (SDR superfamily)</td>
+<td>Recombinant human DCXR</td>
+<td>Confirms non-arabitol substrate space</td>
+</tr>
+<tr>
+<td>7</td>
+<td>QuickGO/GO (database)</td>
+<td>Database</td>
+<td>Refutes term validity</td>
+<td>Arabitol BP term</td>
+<td>Seed's <strong>GO:0019677 = "NAD+ catabolic process"</strong> (mis-cited); real "arabitol metabolic process" <strong>GO:0051161 is OBSOLETE</strong> (also GO:0051162/0051163)</td>
+<td>GO ontology</td>
+<td>Definitive term-level defect</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="go-curation-implications-leads-require-curator-verification">GO Curation Implications (leads — require curator verification)</h2>
+<ul>
+<li><strong>GO:0008106 "alcohol dehydrogenase (NADP+) activity" (MF):</strong> Do <strong>not</strong> add as a specific<br />
+  experimental call. If any MF is asserted computationally, prefer the more accurate, already-present<br />
+<strong>GO:0016616</strong> ("oxidoreductase activity, acting on the CH–OH group of donors, NAD or NADP as<br />
+  acceptor") with an ISS/IEA evidence code and a "conserved unknown" caveat. GO:0008106 is an<br />
+  acceptable-but-suboptimal generalization; it is neither wrong nor the most informative supported term.</li>
+<li><strong>Arabitol metabolic process (BP):</strong> <strong>Reject.</strong> The cited GO:0019677 is the wrong term (NAD+<br />
+  catabolism) and the intended arabitol term (GO:0051161) is obsolete. There is no substrate-level<br />
+  evidence. Do not annotate an arabitol BP.</li>
+<li><strong>Sorbose reductase (GO:0032115) / mannitol 2-dehydrogenase NADP+ (GO:0050085):</strong> These orthology-<br />
+  transferred terms should be retained only as low-confidence predictions with the existing CAUTION;<br />
+  the sorbose role is explicitly disfavored at species level.</li>
+<li><strong>Recommended framing:</strong> Retain the gene as an uncharacterized NADP-preferring SDR CH–OH<br />
+  oxidoreductase (carbohydrate assimilation, mitochondrion). The BioReason arabitol/NADP-ADH output<br />
+  should <strong>not</strong> upgrade the annotation beyond the current predicted state.</li>
+</ul>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p>Immediate molecular function under test = a single-domain, cytosolic/mitochondrial <strong>NADP(H)-dependent<br />
+short-chain oxidoreductase</strong> that reversibly interconverts a sugar/polyol CH–OH group with the<br />
+corresponding carbonyl (ketose ⇌ polyol), using the Tyr/Lys catalytic couple and an NADP cofactor.<br />
+This is a <em>direct</em> enzymatic activity claim. "Arabitol metabolic process" and "carbohydrate<br />
+assimilation" are <em>pathway/physiology-level</em> consequences that would follow only if the true substrate<br />
+were arabitol/a pentitol — which is not established. No loss-of-function phenotype, localization-driven,<br />
+or developmental inference is invoked by the prediction; the CC (mitochondrion) is itself predicted.</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ul>
+<li><strong>Paralog/ortholog substrate transfer:</strong> The "sou1" name and arabitol/sorbose reasoning derive from<br />
+<em>C. albicans</em> SOU1, whose measured activity is sorbose/fructose (not arabitol). Transferring a<br />
+  substrate across ~1 billion years of fungal divergence is unreliable, and UniProt already flags this.</li>
+<li><strong>Competing subfamily assignment:</strong> PANTHER places the protein closest to <strong>L-xylulose reductase /<br />
+  DCXR</strong> (PMID 11882650, 23661708, 21300042), an NADPH-dependent pentose/pentitol/α-dicarbonyl reductase<br />
+  (xylitol⇌L-xylulose). This is a different (though chemically adjacent) substrate space than arabitol,<br />
+  and — together with the Candida SOU1 sorbose/fructose data — gives <strong>two independent comparators that<br />
+  are NADPH-dependent but not arabitol-specific</strong>.</li>
+<li><strong>Species physiology:</strong> S. pombe does not use L-sorbose, directly conflicting with a sorbose-reductase<br />
+  reading and casting doubt on naive polyol-substrate transfers generally.</li>
+<li><strong>Cofactor caveat:</strong> The NADP signature is a sequence heuristic; some SDRs with basic βB residues<br />
+  retain measurable NAD activity. Without a holoenzyme structure or kinetics, NAD+ cannot be fully<br />
+  excluded, though NADP+ is the better-supported call.</li>
+</ul>
+<hr />
+<h2 id="knowledge-gaps">Knowledge Gaps</h2>
+<table>
+<thead>
+<tr>
+<th>Gap</th>
+<th>What was checked</th>
+<th>Why it matters</th>
+<th>What would resolve it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>True physiological substrate</td>
+<td>Orthology (sorbose/fructose), PANTHER (L-xylulose), UniProt/PomBase (unknown)</td>
+<td>Determines whether <em>any</em> specific MF/BP is annotatable</td>
+<td>Purified-enzyme substrate screen across polyols/ketoses (arabitol, sorbose, xylulose, mannitol, fructose)</td>
+</tr>
+<tr>
+<td>NAD vs NADP kinetics</td>
+<td>Sequence fingerprint + kw + ortholog</td>
+<td>Distinguishes GO:0008106 (NADP+) from an NAD+ term</td>
+<td>Cofactor-titration kinetics on recombinant Q9Y6Z9</td>
+</tr>
+<tr>
+<td>Subcellular location</td>
+<td>PomBase CC=mitochondrion (predicted)</td>
+<td>Affects CC annotation and pathway context</td>
+<td>Fluorescent-tag / fractionation localization</td>
+</tr>
+<tr>
+<td>Arabitol relevance in S. pombe</td>
+<td>GO term status (obsolete), literature (none found)</td>
+<td>If S. pombe lacks arabitol metabolism, BP is moot</td>
+<td>Metabolomic/growth assay on arabitol as C source</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="discriminating-tests">Discriminating Tests</h2>
+<ol>
+<li><strong>Recombinant enzyme substrate panel</strong> (most decisive): assay purified Q9Y6Z9 for reductase activity<br />
+   on D-/L-arabitol-linked ketoses (D-xylulose, L-xylulose, ribulose), L-sorbose, D-fructose, and<br />
+   corresponding polyol oxidation, with NADPH and NADH side-by-side. Directly separates arabitol vs<br />
+   sorbose vs xylulose specificity and NAD vs NADP.</li>
+<li><strong>AlphaFold holo-modeling + docking</strong> of NADP vs NAD and candidate polyols into the active site to<br />
+   corroborate the cofactor fingerprint and rank substrates.</li>
+<li><strong>Δsou1 growth phenotyping</strong> on arabitol, sorbose, xylitol, mannitol as sole carbon sources.</li>
+<li><strong>Phylogenetic reconciliation</strong> of the fission-yeast SDR clade vs Candida SOU1 vs DCXR/L-xylulose<br />
+   reductase to test whether "sou1" orthology actually implies sorbose/arabitol substrate.</li>
+</ol>
+<hr />
+<h2 id="curation-leads-require-curator-verification">Curation Leads (require curator verification)</h2>
+<ul>
+<li><strong>Action change:</strong> Do not adopt the BioReason arabitol/NADP-ADH prediction as a specific annotation.<br />
+  Keep gene as uncharacterized NADP-preferring SDR CH–OH oxidoreductase.</li>
+<li><strong>Candidate MF (if any):</strong> GO:0016616 (ISS/IEA) preferred over GO:0008106; both experimentally unproven.</li>
+<li><strong>Reject BP:</strong> arabitol metabolic process — wrong/obsolete GO ID (GO:0019677 = NAD+ catabolic;<br />
+  GO:0051161 obsolete).</li>
+<li><strong>Candidate references to verify:</strong> PMID 16134116 (ortholog assay); PMID 31132130 (species carbon<br />
+  physiology, basis of UniProt CAUTION); UniProt Q9Y6Z9; PomBase SPAC8E11.10; PANTHER PTHR43008:SF13.</li>
+<li><strong>Suggested question for curators:</strong> Is there any S. pombe experimental evidence (kinetics,<br />
+  phenotype, metabolomics) for arabitol metabolism at all? If not, the BP prediction cannot stand.</li>
+<li><strong>Suggested experiment:</strong> recombinant substrate/cofactor panel (Discriminating Test 1).</li>
+</ul>
+<hr />
+<p><em>Provenance artifacts:</em> <code>sou1_evidence_matrix.png</code> (computed SDR motif / cofactor-residue analysis and<br />
+evidence table) and <code>sou1_GO_decision_table.png</code> / <code>sou1_GO_decision_table.csv</code> (per-term curation<br />
+decision table). All computational results above are sequence/database-derived inference, explicitly<br />
+distinguished from direct assays (PMID 16134116 on the <em>C. albicans</em> ortholog and PMID 11882650/23661708<br />
+on the DCXR/L-xylulose reductase subfamily — none performed on Q9Y6Z9 itself, which remains<br />
+enzymatically uncharacterized).</p>
+<h3 id="go-decision-table-leads-curator-verification-required">GO Decision Table (leads — curator verification required)</h3>
+<table>
+<thead>
+<tr>
+<th>GO term</th>
+<th>Aspect</th>
+<th>Source</th>
+<th>Verdict</th>
+<th>Curation action</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0008106 alcohol dehydrogenase (NADP+) activity</td>
+<td>MF</td>
+<td>BioReason</td>
+<td>Weakly/partially supported</td>
+<td>Generalize / keep only as low-conf ISS</td>
+<td>Fold+NADP signature fit broad class; no assay; less precise than GO:0016616</td>
+</tr>
+<tr>
+<td>"arabitol metabolic process" (seed cited GO:0019677 = <em>NAD+ catabolic process</em>)</td>
+<td>BP</td>
+<td>BioReason</td>
+<td>Refuted / defective</td>
+<td><strong>Do NOT add</strong></td>
+<td>No substrate evidence; comparators = sorbose/fructose &amp; xylulose/xylitol; GO:0051161 obsolete; GO ID mis-cited</td>
+</tr>
+<tr>
+<td>GO:0016616 oxidoreductase, CH-OH donor, NAD/NADP acceptor</td>
+<td>MF</td>
+<td>PomBase ISS/IEA</td>
+<td>Retain</td>
+<td>Keep as best-supported MF</td>
+<td>Matches fold+cofactor; conservative</td>
+</tr>
+<tr>
+<td>GO:0032115 sorbose reductase activity</td>
+<td>MF</td>
+<td>PomBase ISS(ortholog)</td>
+<td>Disfavored</td>
+<td>Retain only with CAUTION</td>
+<td>S. pombe cannot assimilate L-sorbose (PMID 31132130)</td>
+</tr>
+<tr>
+<td>GO:0050085 mannitol 2-dehydrogenase (NADP+) activity</td>
+<td>MF</td>
+<td>PomBase ISS</td>
+<td>Uncertain</td>
+<td>Keep as low-conf prediction</td>
+<td>Ortholog fructose→mannitol side-activity; unproven</td>
+</tr>
+<tr>
+<td>GO:0005739 mitochondrion</td>
+<td>CC</td>
+<td>PomBase predicted</td>
+<td>Uncertain</td>
+<td>Keep as predicted</td>
+<td>Localization not experimentally confirmed</td>
+</tr>
+</tbody>
+</table>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+<li><a href="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/provenance_sou1_GO_decision_table.json">OpenScientist sou1 GO decision table</a><br />
+<img alt="OpenScientist sou1 GO decision table" src="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/provenance_sou1_GO_decision_table.png" /></li>
+<li><a href="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/provenance_sou1_evidence_matrix.json">OpenScientist sou1 evidence matrix</a><br />
+<img alt="OpenScientist sou1 evidence matrix" src="SPAC8E11.10-hypotheses/prediction-nadp-arabitol-dehydrogenase/openscientist_artifacts/provenance_sou1_evidence_matrix.png" /></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/SCHPO/SPBC3H7.04/SPBC3H7.04-ai-review.html
+++ b/genes/SCHPO/SPBC3H7.04/SPBC3H7.04-ai-review.html
@@ -1,0 +1,3236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SPBC3H7.04 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SPBC3H7.04</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O74379" target="_blank" class="term-link">
+                        O74379
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "SPBC3H7.04";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O74379" data-a="DESCRIPTION: SPBC3H7.04 (mS42; also referred to as bot1 in earl..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>SPBC3H7.04 (mS42; also referred to as bot1 in early functional studies) is a 220 aa mitochondrion-specific small ribosomal subunit protein of the fission yeast Schizosaccharomyces pombe. It is a structural component of the 37S mitochondrial small ribosomal subunit (mt-SSU), forming a dimer with mS43 that builds a large protuberance adjacent to the mRNA channel exit; the S. cerevisiae ortholog (Rsm26p / mS42; MrpS35p family) is visualized in this location in cryo-EM structures of the yeast mitoribosome. Its role is thus one of the many mitochondrion-specific ribosomal proteins that are required for mitochondrial translation of the respiratory-chain subunits encoded on mtDNA. Although the protein carries an Iron/manganese superoxide dismutase C-terminal fold (IPR019832 / Pfam PF02777 / SUPFAM SSF54719 / Gene3D 3.55.40.20), this is fold-only ancestry (the mitochondrial ribosome inherited the mS42/mS43 protein pair from the bacterial ancestor of mitochondria) and the protein is not a superoxide dismutase — no PROSITE Mn/Fe-SOD active-site signature matches, no metal-coordinating catalytic residues have been demonstrated, and the PANTHER subfamily assignment (PTHR43595:SF2) is the mitoribosomal branch, not the SOD branch. bot1 is essential for viability and its depletion causes defective mitochondrial protein synthesis, loss of mitochondrial network integrity, reduced respiration, and altered cell morphology (Wiley et al. 2008, PMID:18245278).</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA &#34;cytoplasm&#34; propagated from PANTHER family PTHR43595 (Iron/Manganese Superoxide Dismutase). The WITH/FROM list is dominated by canonical Fe/Mn-SOD paralogs (e.g. SGD:S000002755 = SOD2, UniProtKB:P00448 = SodA), which are legitimately cytoplasmic / mitochondrial-matrix SODs. The mS42/mS43 mitoribosomal branch of PTHR43595 is a separate subfamily (PTHR43595:SF2 = SMALL RIBOSOMAL SUBUNIT PROTEIN MS42) whose members reside in the mitochondrial small ribosomal subunit — mitochondrion is not a child of cytoplasm in the GO CC hierarchy, so `cytoplasm` is not just non-specific but sub-cellularly wrong for this protein. The correct specific location is already independently supported by NAS/ISO/IEA annotations to mitochondrion / mitochondrial small ribosomal subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA over-propagation from the SOD side of a family that also contains the mitoribosomal mS42 subfamily; the correct sub-cellular location (mitochondrial small ribosomal subunit) is already captured by NAS (PMID:18245278) and ISO (from SGD:S000003862) annotations, so no information is lost.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">SIMILARITY: Belongs to the mitochondrion-specific ribosomal protein mS42 family.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004784" target="_blank" class="term-link">
+                                    GO:0004784
+                                </a>
+                            </span>
+                            <span class="term-label">superoxide dismutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0004784" data-r="GO_REF:0000002" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO annotation from IPR019832 (Iron/manganese superoxide dismutase, C-terminal domain). IPR019832 is a fold/superfamily entry — matching it means the protein has the Fe/Mn-SOD C-terminal *fold*, not necessarily the catalytic activity. SPBC3H7.04 is the mS42 mitoribosomal small-subunit protein: it retains the SOD fold by ancestry (mitochondria are of bacterial origin, and the mitoribosome inherited multiple protein pairs that co-opted enzyme folds as purely structural components), but it does not match any PROSITE Mn/Fe-SOD active-site pattern, has no biochemical evidence of dismutase activity, and is classified by PANTHER&#39;s subfamily model (PTHR43595:SF2) as a mitoribosomal protein, not a SOD. Val Wood&#39;s upstream flag (geneontology/go-annotation#6474) explicitly diagnoses this as a fold-reuse pseudo-SOD — the same annotation-error class as the Cu/Zn-SOD pseudoenzymes documented in `projects/PSEUDOENZYMES.md`.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Fold-only InterPro2GO match; the protein is a mitoribosomal structural component, not a superoxide dismutase. Removing the SOD MF also removes the incorrect logical-inference chain that generated GO:0019430 (removal of superoxide radicals). This is the exact class of over-annotation the INTERPRO project targets.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">RecName: Full=Small ribosomal subunit protein mS42</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">SIMILARITY: Belongs to the mitochondrion-specific ribosomal protein mS42 family.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/SPBC3H7.04/SPBC3H7.04-notes.md
+
+                                </span>
+
+                                <div class="support-text">structurally classified in the SOD superfamily</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation mapped from the UniProt &#34;SUBCELLULAR LOCATION: Mitochondrion&#34; statement (Swiss-Prot SL-0173). The mitochondrial localization is supported by the by-similarity call to the yeast ortholog (UniProtKB:P10662) and by ComplexPortal membership in the 37S mt-SSU (CPX-10315). Cellular-component annotation should ideally be at the more specific `GO:0005763 mitochondrial small ribosomal subunit` child (already present via ISO and NAS), but this parent term is not wrong.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but generic location; the specific `mitochondrial small ribosomal subunit` term (already present via ISO/NAS) is the core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006801" target="_blank" class="term-link">
+                                    GO:0006801
+                                </a>
+                            </span>
+                            <span class="term-label">superoxide metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0006801" data-r="GO_REF:0000002" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO annotation from IPR019832 (Fe/Mn SOD C-terminal domain fold). Same fold-match rationale as the MF SOD-activity annotation: the protein does not perform superoxide-related chemistry — it is a structural component of the mt-SSU. The BP term is a direct downstream consequence of assuming SOD activity and is not supported by any independent evidence for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Downstream over-annotation of the pseudo-SOD IEA chain; no independent biological evidence links mS42 to superoxide metabolism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">RecName: Full=Small ribosomal subunit protein mS42</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/SPBC3H7.04/SPBC3H7.04-notes.md
+
+                                </span>
+
+                                <div class="support-text">`IEA with IPR019832 → GO:0004784 superoxide dismutase activity`</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019430" target="_blank" class="term-link">
+                                    GO:0019430
+                                </a>
+                            </span>
+                            <span class="term-label">removal of superoxide radicals</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0019430" data-r="GO_REF:0000108" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated inter-ontology inference (GO_REF:0000108) from GO:0004784 (SOD activity). Because the parent MF annotation is a fold-only over-annotation (see above), the derived BP annotation inherits the same defect: mS42 does not remove superoxide radicals — it is a structural mitoribosomal protein. Removing the parent MF resolves this without any biological information loss.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Logical-inference product of the incorrect SOD-activity IEA; falls away when the MF is removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">RecName: Full=Small ribosomal subunit protein mS42</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO annotation from IPR019832 (Fe/Mn SOD C-terminal domain fold). The metal-ion-binding MF term is only appropriate for members of the family that coordinate an Mn or Fe catalytic ion; the mS42 mitoribosomal subfamily has no evidence of metal coordination and no PROSITE Mn/Fe-SOD active-site match. There is no independent evidence that mS42 binds a catalytically relevant metal ion in vivo.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Fold-only over-annotation; no evidence of metal binding in the mitoribosomal mS42 subfamily.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">RecName: Full=Small ribosomal subunit protein mS42</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/SPBC3H7.04/SPBC3H7.04-notes.md
+
+                                </span>
+
+                                <div class="support-text">the metal-coordinating catalytic residues</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005763" target="_blank" class="term-link">
+                                    GO:0005763
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial small ribosomal subunit</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18245278" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18245278
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Bot1p is required for mitochondrial translation, respiratory...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0005763" data-r="PMID:18245278" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal-assigned NAS annotation citing Wiley et al. 2008: the paper shows the S. pombe protein Bot1p (identified as the S. pombe counterpart of the S. cerevisiae MrpS35p / Rsm26p family) localizes to mitochondria and cofractionates with purified mitochondrial ribosomes. ComplexPortal has SPBC3H7.04 as a component of the 37S mt-SSU (CPX-10315). This is the correct, core cellular-component annotation for the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by primary literature (cofractionation with mitoribosomes) and by ComplexPortal complex membership; the correct core CC annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18245278" target="_blank" class="term-link">
+                                        PMID:18245278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Bot1p localizes to the mitochondria in live cells and cofractionates with purified mitochondrial ribosomes.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">SUBUNIT: Component of the mitochondrial small ribosomal subunit (mt-SSU).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032543" target="_blank" class="term-link">
+                                    GO:0032543
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial translation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18245278" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18245278
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Bot1p is required for mitochondrial translation, respiratory...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0032543" data-r="PMID:18245278" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal-assigned NAS annotation citing Wiley et al. 2008: bot1 is required for mitochondrial protein synthesis, and its depletion causes decreased mitochondrial translation with a corresponding drop in cell respiration. Core biological-process annotation for a mitoribosomal structural subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by primary literature (loss-of-function phenotype is decreased mitochondrial protein translation); the correct core BP annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18245278" target="_blank" class="term-link">
+                                        PMID:18245278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Reduced levels of Bot1p lead to mitochondrial fragmentation, decreased mitochondrial protein translation, and a corresponding decrease in cell respiration.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0005739" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation from the S. cerevisiae ortholog UniProtKB:P10662, redundant with the UniProt SubCell-derived IEA above. Correct location call; already captured at the more specific `mt-SSU` child.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but redundant with the more specific mt-SSU annotations; the core location is `GO:0005763 mitochondrial small ribosomal subunit`.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003735" target="_blank" class="term-link">
+                                    GO:0003735
+                                </a>
+                            </span>
+                            <span class="term-label">structural constituent of ribosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0003735" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISO annotation transferred by PomBase from the S. cerevisiae ortholog SGD:S000003862 (Rsm26p / mS42). This is the correct core molecular function for a mitoribosomal structural subunit — the protein&#39;s contribution to the mitoribosome is structural (part of the mS42/mS43 protuberance adjacent to the mRNA channel exit), not catalytic. This annotation should stand in place of the incorrect SOD-activity IEA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core MF; supported by the ortholog&#39;s characterization and by the mS42-mS43 dimer&#39;s structural role in the mt-SSU.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">mS43 forms a dimer with mS42, building a large protuberance adjacent to the mRNA channel exit in the mt-SSU body.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005763" target="_blank" class="term-link">
+                                    GO:0005763
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial small ribosomal subunit</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0005763" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISO annotation from S. cerevisiae SGD:S000003862 (Rsm26p) — independent orthology-based support for the same conclusion as the NAS annotation above.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC; corroborates the NAS annotation and matches the UniProt/ComplexPortal-curated complex membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:O74379
+
+                                </span>
+
+                                <div class="support-text">SUBUNIT: Component of the mitochondrial small ribosomal subunit (mt-SSU).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032543" target="_blank" class="term-link">
+                                    GO:0032543
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial translation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISO</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O74379" data-a="GO:0032543" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISO annotation from S. cerevisiae SGD:S000003862 (Rsm26p) — independent orthology-based support for the same conclusion as the NAS annotation above.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP; corroborates the NAS annotation and is consistent with the loss-of-function phenotype reported in PMID:18245278.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18245278" target="_blank" class="term-link">
+                                        PMID:18245278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Reduced levels of Bot1p lead to mitochondrial fragmentation, decreased mitochondrial protein translation, and a corresponding decrease in cell respiration.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Structural component of the mitochondrial small ribosomal subunit (mt-SSU). mS42 and its dimer partner mS43 build a large protuberance adjacent to the mRNA channel exit in the mt-SSU body, where they contribute to the architecture of the mitoribosome; the mitoribosome is required for translation of the mtDNA-encoded respiratory-chain subunits. This is an inherently non-catalytic role: mS42 provides structural constituent activity to the ribonucleoprotein complex, not an enzymatic activity, despite matching an SOD fold at the domain level.</h3>
+                <span class="vote-buttons" data-g="O74379" data-a="FUNCTION: Structural component of the mitochondrial small ri..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003735" target="_blank" class="term-link">
+                            structural constituent of ribosome
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032543" target="_blank" class="term-link">
+                                mitochondrial translation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                mitochondrion
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005763" target="_blank" class="term-link">
+                            mitochondrial small ribosomal subunit
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:O74379
+
+                        </span>
+
+                        <div class="finding-text">SUBUNIT: Component of the mitochondrial small ribosomal subunit (mt-SSU) ... mS43 forms a dimer with mS42, building a large protuberance adjacent to the mRNA channel exit in the mt-SSU body.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18245278" target="_blank" class="term-link">
+                                PMID:18245278
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Bot1p localizes to the mitochondria in live cells and cofractionates with purified mitochondrial ribosomes.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18245278" target="_blank" class="term-link">
+                                PMID:18245278
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Reduced levels of Bot1p lead to mitochondrial fragmentation, decreased mitochondrial protein translation, and a corresponding decrease in cell respiration.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18245278" target="_blank" class="term-link">
+                            PMID:18245278
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Bot1p is required for mitochondrial translation, respiratory function, and normal cell morphology in the fission yeast Schizosaccharomyces pombe.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Bot1p is a novel S. pombe protein related to the S. cerevisiae mitoribosomal small-subunit protein MrpS35p (Rsm26p / mS42 family); it localizes to the mitochondria in live cells and cofractionates with purified mitochondrial ribosomes, establishing membership in the mitochondrial small ribosomal subunit.</div>
+
+                        <div class="finding-text">"Bot1p localizes to the mitochondria in live cells and cofractionates with purified mitochondrial ribosomes."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">bot1 is essential for viability; reduced Bot1p levels cause decreased mitochondrial protein translation and correspondingly decreased cell respiration, establishing a required role in mitochondrial translation.</div>
+
+                        <div class="finding-text">"Reduced levels of Bot1p lead to mitochondrial fragmentation, decreased mitochondrial protein translation, and a corresponding decrease in cell respiration."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        UniProt:O74379
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry O74379 (RT26_SCHPO) — Small ribosomal subunit protein mS42</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt classifies the protein as &#34;Small ribosomal subunit protein mS42&#34; belonging to the &#34;mitochondrion-specific ribosomal protein mS42 family&#34;, localized to the mitochondrion, forming a dimer with mS43 at the mRNA channel exit in the mt-SSU body. No superoxide dismutase / oxidoreductase / metal-binding functional annotation is claimed at the protein level; only fold-level InterPro / SUPFAM / Gene3D matches to the Fe/Mn-SOD structural superfamily are recorded.</div>
+
+                        <div class="finding-text">"RecName: Full=Small ribosomal subunit protein mS42 ... FUNCTION: Component of the mitochondrial ribosome (mitoribosome), a dedicated translation machinery responsible for the synthesis of mitochondrial genome-encoded proteins ... SUBUNIT: Component of the mitochondrial small ribosomal subunit (mt-SSU) ... mS43 forms a dimer with mS42, building a large protuberance adjacent to the mRNA channel exit in the mt-SSU body ... SIMILARITY: Belongs to the mitochondrion-specific ribosomal protein mS42 family ... KW Mitochondrion; Reference proteome; Ribonucleoprotein; Ribosomal protein."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:SCHPO/SPBC3H7.04/SPBC3H7.04-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SPBC3H7.04 (mS42 / bot1) — S. pombe mitoribosomal small subunit protein</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">RSM26/mS42 (SPBC3H7.04) is structurally classified in the SOD superfamily but does not have SOD activity — a fold-reuse situation driven by the bacterial ancestry of the mitochondrion. The upstream curator issue (geneontology/go-annotation#6474) diagnoses this as the reason IPR019832 should not blanket-propagate SOD activity terms; the mitoribosomal subfamily is a documented exception. Notes file reproduces the ValWood quote verbatim and contextualizes it against UniProt and PANTHER subfamily evidence.</div>
+
+                        <div class="finding-text">"structurally classified in the SOD superfamily"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does S. pombe mS42 (SPBC3H7.04) retain any residual metal-binding or superoxide-related activity, or is the SOD-fold reuse purely structural? A cryo-EM structure of the S. pombe mt-SSU (or a targeted structural prediction) at the mS42 position, together with an in-vitro superoxide-dismutase assay on the recombinant protein, would resolve whether the annotation should be `REMOVE` (as done here) or `MODIFY` to a residual/regulatory metal-binding term.</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74379" data-a="Q: Does S. pombe mS42 (SPBC3H7.04) retain any residua..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How many other members of the IPR019832 InterPro entry are mitoribosomal mS42-family proteins rather than SODs? A cross-taxonomic scan of PTHR43595:SF2 subfamily members would let InterPro consider adding a subfamily-level `NOT` annotation for the SOD MF/BP terms, or down-scoping the InterPro2GO mapping.</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74379" data-a="Q: How many other members of the IPR019832 InterPro e..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Recombinant expression of SPBC3H7.04 in E. coli followed by a standard xanthine/xanthine-oxidase or pyrogallol autoxidation SOD activity assay, with human SOD2 and E. coli SodA as positive controls. A negative result would give direct biochemical confirmation of the pseudoenzyme classification and support the `REMOVE` action for the SOD-activity IEA.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O74379" data-a="EXPERIMENT: Recombinant expression of SPBC3H7.04 in E. coli fo..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Ribosome-profiling / polysome-fractionation of a conditional depletion of SPBC3H7.04 (extending Wiley et al. 2008 to sub-cellular resolution) to quantify the specific mitochondrial-translation defect at the level of individual mtDNA-encoded transcripts. This would strengthen the mitochondrial-translation involvement annotation beyond NAS/ISO evidence.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="O74379" data-a="EXPERIMENT: Ribosome-profiling / polysome-fractionation of a c..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SPBC3H7.04-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O74379" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="spbc3h704-ms42-bot1-s-pombe-mitoribosomal-small-subunit-protein">SPBC3H7.04 (mS42 / bot1) — S. pombe mitoribosomal small subunit protein</h1>
+<h2 id="identity">Identity</h2>
+<ul>
+<li><strong>UniProt</strong>: O74379 (RT26_SCHPO), 220 aa</li>
+<li><strong>UniProt name</strong>: Small ribosomal subunit protein mS42; AltName: 37S ribosomal<br />
+  protein S26B, mitochondrial</li>
+<li><strong>PomBase</strong>: SPBC3H7.04 — "mitochondrial ribosomal protein subunit S43a"<br />
+  (characterisation_status: biological role inferred; no gene symbol assigned)</li>
+<li><strong>PANTHER</strong>: PTHR43595 (37S RIBOSOMAL PROTEIN S26, MITOCHONDRIAL);<br />
+  subfamily PTHR43595:SF2 = SMALL RIBOSOMAL SUBUNIT PROTEIN MS42</li>
+<li><strong>S. cerevisiae ortholog</strong>: SGD:S000003862 (Rsm26p / MrpS35p family)</li>
+</ul>
+<p>The S43a / mS42 dual naming reflects historical nomenclature: the<br />
+Amunts et al. 2014 cryo-EM structure of the S. cerevisiae mitoribosome named<br />
+this component mS42; some earlier annotations refer to it as mtSSU S43. Both<br />
+refer to the same protein — a mitochondrion-specific small ribosomal subunit<br />
+protein with no bacterial small-subunit homolog.</p>
+<h2 id="why-this-gene-matters-context-geneontologygo-annotation6474">Why this gene matters (context — geneontology/go-annotation#6474)</h2>
+<p>ValWood (2026-07-11, <code>geneontology/go-annotation#6474</code>) flagged <strong>IPR019832</strong><br />
+(Iron/manganese superoxide dismutase, C-terminal domain) as producing incorrect<br />
+InterPro2GO annotations on <strong>RSM26/mS42</strong> — the mitoribosomal small-subunit<br />
+protein. She writes:</p>
+<blockquote>
+<p>RSM26 (mS42) is structurally classified in the SOD superfamily — but doesn't<br />
+have SOD activity. This is a fold-reuse situation, not an enzyme. The<br />
+Fe/Mn-SOD fold is an ancient bacterial structural scaffold. Because<br />
+mitochondria are derived from bacteria, several mitoribosomal proteins retain<br />
+this fold by ancestry but have been repurposed over evolution purely as<br />
+ribosomal structural components — the metal-coordinating catalytic residues<br />
+needed for actual dismutase chemistry aren't necessarily intact or<br />
+functional.</p>
+</blockquote>
+<p>The specific problematic chain in GOA is:</p>
+<ul>
+<li><code>IEA with IPR019832 → GO:0004784 superoxide dismutase activity</code> (MF)</li>
+<li><code>IEA with IPR019832 → GO:0006801 superoxide metabolic process</code> (BP)</li>
+<li><code>IEA with IPR019832 → GO:0046872 metal ion binding</code> (MF)</li>
+<li>and, by inter-ontology logical inference from <code>GO:0004784</code>:<br />
+<code>IEA GO_REF:0000108 → GO:0019430 removal of superoxide radicals</code> (BP)</li>
+</ul>
+<p>All four are incorrect for the pombe protein: it is a mitoribosomal structural<br />
+subunit, not a superoxide dismutase.</p>
+<h2 id="evidence-that-ms42-is-a-mitoribosome-component-not-a-sod">Evidence that mS42 is a mitoribosome component, not a SOD</h2>
+<h3 id="from-uniprot-o74379">From UniProt (O74379)</h3>
+<ul>
+<li><strong>FUNCTION</strong> (<code>ECO:0000250|UniProtKB:P10662</code>, i.e. by-similarity to the<br />
+  S. cerevisiae ortholog): <em>"Component of the mitochondrial ribosome<br />
+  (mitoribosome), a dedicated translation machinery responsible for the<br />
+  synthesis of mitochondrial genome-encoded proteins... The mitoribosomes are<br />
+  attached to the mitochondrial inner membrane and translation products are<br />
+  cotranslationally integrated into the membrane."</em></li>
+<li><strong>SUBUNIT</strong> (<code>ECO:0000250|UniProtKB:P10662</code>): <em>"Component of the mitochondrial<br />
+  small ribosomal subunit (mt-SSU). Mature yeast 74S mitochondrial ribosomes<br />
+  consist of a small (37S) and a large (54S) subunit... mS43 forms a dimer with<br />
+  mS42, building a large protuberance adjacent to the mRNA channel exit in the<br />
+  mt-SSU body."</em></li>
+<li><strong>SUBCELLULAR LOCATION</strong> (<code>ECO:0000250|UniProtKB:P10662</code>): <em>"Mitochondrion."</em></li>
+<li><strong>SIMILARITY</strong> (<code>ECO:0000305</code>): <em>"Belongs to the mitochondrion-specific<br />
+  ribosomal protein mS42 family."</em></li>
+<li><strong>KEYWORDS</strong>: <code>Mitochondrion; Reference proteome; Ribonucleoprotein;
+  Ribosomal protein.</code> — importantly, <strong>no</strong> <code>Cytoplasm</code> / <code>Superoxide dismutase</code><br />
+  / <code>Metal-binding</code> / <code>Oxidoreductase</code> keywords, consistent with the manually<br />
+  curated view that this protein is a structural ribosomal component and not<br />
+  a metalloenzyme.</li>
+</ul>
+<h3 id="from-the-interpro-domain-signatures-via-uniprot-cross-references">From the InterPro / domain signatures (via UniProt cross-references)</h3>
+<p>Only <em>SOD-fold</em> signatures match — no SOD-<em>catalytic-site</em> signatures:</p>
+<ul>
+<li><code>Gene3D 3.55.40.20</code> — Iron/manganese SOD C-terminal domain <em>fold</em>.</li>
+<li><code>SUPFAM SSF54719 / SSF46609</code> — Fe,Mn SOD C-/N-terminal domain <em>structural</em><br />
+  superfamily.</li>
+<li><code>InterPro IPR019832 (Mn/Fe_SOD_C)</code>, <code>IPR036324</code>, <code>IPR036314</code> — all<br />
+  homologous-superfamily / structural-fold entries.</li>
+<li><code>Pfam PF02777 (Sod_Fe_C)</code> — the SOD C-terminal Pfam.</li>
+</ul>
+<p>There is <strong>no</strong> match to a PROSITE Mn/Fe-SOD active-site pattern (PS00088 —<br />
+Mn/Fe superoxide dismutase signature). PROSITE patterns require the canonical<br />
+catalytic residues <strong>and</strong> their flanking context to be preserved; failing the<br />
+pattern while matching the fold is the classic pseudoenzyme signature (see<br />
+<code>projects/PSEUDOENZYMES.md</code>, Pattern 2 and Pattern 6). This mirrors the<br />
+Cu/Zn-SOD pseudoenzyme detections in <code>projects/PSEUDOENZYMES.md</code> and in<br />
+<code>genes/RAMVA/RvY_13070/</code> (RvSOD15) — SOD fold present, SOD activity absent.</p>
+<p>The PANTHER subfamily assignment resolves the ambiguity: <strong>PTHR43595:SF2 —<br />
+SMALL RIBOSOMAL SUBUNIT PROTEIN MS42.</strong> IEA-via-PANTHER goes to a subfamily and<br />
+correctly does not propagate any SOD MF/BP terms. The InterPro2GO mapping fails<br />
+because InterPro2GO is a per-entry blanket rule with no subfamily resolution<br />
+(see <code>projects/INTERPRO.md</code> — "no subfamily resolution" failure mode).</p>
+<h3 id="from-experimental-manual-curation">From experimental / manual curation</h3>
+<ul>
+<li><strong>PMID:18245278</strong> (Wiley et al. 2008, <em>Eukaryot Cell</em>) — characterizes the<br />
+  S. pombe protein Bot1p (identified in the paper as related to<br />
+  S. cerevisiae MrpS35p, a mitoribosomal component). The paper shows Bot1p<br />
+<em>"localizes to the mitochondria in live cells and cofractionates with<br />
+  purified mitochondrial ribosomes"</em> and <em>"is required for mitochondrial<br />
+  protein synthesis."</em> ComplexPortal (CPX-10315, 37S mitochondrial small<br />
+  ribosomal subunit) has curated SPBC3H7.04 into this complex and cites this<br />
+  paper as NAS for <code>GO:0005763 mitochondrial small ribosomal subunit</code> and<br />
+<code>GO:0032543 mitochondrial translation</code>. The Bot1p / SPBC3H7.04 identity is<br />
+  supported by the paper's characterization of Bot1p as the S. pombe<br />
+  MrpS35p-family mitoribosomal protein — the same functional group as mS42.</li>
+<li><strong>PomBase HDA</strong> (in <code>SPBC3H7.04-uniprot.txt</code>): <code>GO:0005634 nucleus</code>,<br />
+<code>GO:0005737 cytoplasm</code>, <code>GO:0005829 cytosol</code> — these are high-throughput<br />
+  direct-assay localizations (mass-spec / imaging screens) that often pick up<br />
+  mitochondrial matrix proteins as "cytoplasmic". They are consistent with<br />
+  the mitochondrial matrix localization: mitoribosomal proteins are inside the<br />
+  mitochondrion but topologically the matrix is (loosely) a cytoplasmic<br />
+  compartment, and whole-cell / soluble-fraction mass-spec screens frequently<br />
+  pick them up. These HDA localizations do not appear in the QuickGO/GOA<br />
+  download used as this review's baseline; they are recorded in UniProt<br />
+  cross-references only and are not part of the twelve <code>existing_annotations</code><br />
+  under review.</li>
+<li><strong>ComplexPortal CPX-10315</strong> — the 37S mitochondrial small ribosomal subunit —<br />
+  includes SPBC3H7.04 as a subunit.</li>
+</ul>
+<h3 id="the-iba-go0005737-cytoplasm-annotation">The IBA <code>GO:0005737 cytoplasm</code> annotation</h3>
+<p>The IBA <code>cytoplasm</code> annotation propagates from the PANTHER family<br />
+PTHR43595 (Iron/Manganese Superoxide Dismutase). The <code>with_from</code> list is<br />
+telling — it includes canonical Fe/Mn-SOD paralogs (<code>SGD:S000002755</code> = SOD2 in<br />
+yeast, <code>UniProtKB:P00448</code> = SodA in <em>E. coli</em>). The family has both bona fide<br />
+SODs and the mitochondrion-specific mS42/mS43 mitoribosomal branch; IBA<br />
+propagates <code>cytoplasm</code> from the SOD side. For the mitoribosomal branch, the<br />
+specific location is <code>mitochondrial small ribosomal subunit</code>, not generic<br />
+cytoplasm, and mitochondrion is <strong>not</strong> a child of cytoplasm in the GO<br />
+cell-component hierarchy — so the IBA <code>cytoplasm</code> here is a taxonomically<br />
+plausible but sub-cellularly wrong annotation.</p>
+<h2 id="summary-review-actions">Summary — review actions</h2>
+<p>The IEA InterPro2GO / logical-inference chain<br />
+(SOD activity, superoxide metabolic process, removal of superoxide radicals,<br />
+metal ion binding) is a <strong>paradigmatic fold-reuse pseudo-SOD over-annotation</strong><br />
+of the mitoribosomal mS42/mS43 branch — the same annotation-error class as<br />
+Cu/Zn-SOD pseudoenzymes documented in <code>projects/PSEUDOENZYMES.md</code>. It should be<br />
+<code>REMOVE</code>d (all four terms).</p>
+<p>The IBA <code>cytoplasm</code> is family-level noise from the SOD paralogs in PTHR43595;<br />
+<code>REMOVE</code> with a proposed replacement of the mitochondrial-ribosome location<br />
+that is already independently supported by NAS/ISO.</p>
+<p>The NAS (PMID:18245278) and ISO annotations to<br />
+<code>GO:0005763 mitochondrial small ribosomal subunit</code>,<br />
+<code>GO:0032543 mitochondrial translation</code>,<br />
+<code>GO:0003735 structural constituent of ribosome</code>, and <code>GO:0005739 mitochondrion</code><br />
+are <strong>the correct, core-function annotations</strong> and should be <code>ACCEPT</code>ed.</p>
+<h2 id="cross-references-within-this-repo">Cross-references within this repo</h2>
+<ul>
+<li><code>projects/PSEUDOENZYMES.md</code> — pseudoenzymes framework; this case adds a new<br />
+  category: <strong>mitoribosomal fold-reuse of an ancestral bacterial enzyme fold</strong><br />
+  (mitochondria are of bacterial origin, so mitoribosomal proteins that<br />
+  co-opted enzyme folds are a systematic source of pseudoenzyme<br />
+  over-annotations).</li>
+<li><code>projects/INTERPRO.md</code> — IPR019832 appears in the per-entry priority table<br />
+  (7 reviewed / 5 suspect verdicts). Every existing verdict was on a real Fe/Mn<br />
+  SOD (MISSI/MnSOD, PSEPK/sodB, RAMVA/RvY_01767, yeast/SOD2); this review adds<br />
+  the first <strong>exception member</strong> for the entry — a protein whose SOD IEAs are<br />
+  not just non-core but outright incorrect. This shifts the entry from<br />
+  "SOD activity terms are broadly true but over-broad" toward "SOD activity<br />
+  terms are wrong for the mitoribosomal subfamily and should be demoted at the<br />
+  entry level with a <code>skos:broadMatch</code> (or an exact-match + <code>predicate_modifier:
+  Not</code>) predicate in <code>INTERPRO/interpro2go.sssom.yaml</code>."</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O74379
+gene_symbol: SPBC3H7.04
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:284812
+  label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
+description: &gt;-
+  SPBC3H7.04 (mS42; also referred to as bot1 in early functional studies)
+  is a 220 aa mitochondrion-specific small ribosomal subunit protein of the
+  fission yeast Schizosaccharomyces pombe. It is a structural component of
+  the 37S mitochondrial small ribosomal subunit (mt-SSU), forming a dimer
+  with mS43 that builds a large protuberance adjacent to the mRNA channel
+  exit; the S. cerevisiae ortholog (Rsm26p / mS42; MrpS35p family) is
+  visualized in this location in cryo-EM structures of the yeast
+  mitoribosome. Its role is thus one of the many mitochondrion-specific
+  ribosomal proteins that are required for mitochondrial translation of the
+  respiratory-chain subunits encoded on mtDNA. Although the protein
+  carries an Iron/manganese superoxide dismutase C-terminal fold
+  (IPR019832 / Pfam PF02777 / SUPFAM SSF54719 / Gene3D 3.55.40.20),
+  this is fold-only ancestry (the mitochondrial ribosome inherited the
+  mS42/mS43 protein pair from the bacterial ancestor of mitochondria) and
+  the protein is not a superoxide dismutase — no PROSITE Mn/Fe-SOD active-site
+  signature matches, no metal-coordinating catalytic residues have been
+  demonstrated, and the PANTHER subfamily assignment (PTHR43595:SF2) is the
+  mitoribosomal branch, not the SOD branch. bot1 is essential for viability
+  and its depletion causes defective mitochondrial protein synthesis, loss
+  of mitochondrial network integrity, reduced respiration, and altered cell
+  morphology (Wiley et al. 2008, PMID:18245278).
+references:
+- id: PMID:18245278
+  title: &gt;-
+    Bot1p is required for mitochondrial translation, respiratory function,
+    and normal cell morphology in the fission yeast Schizosaccharomyces
+    pombe.
+  findings:
+  - statement: &gt;-
+      Bot1p is a novel S. pombe protein related to the S. cerevisiae
+      mitoribosomal small-subunit protein MrpS35p (Rsm26p / mS42 family);
+      it localizes to the mitochondria in live cells and cofractionates
+      with purified mitochondrial ribosomes, establishing membership in
+      the mitochondrial small ribosomal subunit.
+    supporting_text: &gt;-
+      Bot1p localizes to the mitochondria in live cells and cofractionates
+      with purified mitochondrial ribosomes.
+  - statement: &gt;-
+      bot1 is essential for viability; reduced Bot1p levels cause
+      decreased mitochondrial protein translation and correspondingly
+      decreased cell respiration, establishing a required role in
+      mitochondrial translation.
+    supporting_text: &gt;-
+      Reduced levels of Bot1p lead to mitochondrial fragmentation,
+      decreased mitochondrial protein translation, and a corresponding
+      decrease in cell respiration.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; primary characterization paper for the S. pombe
+      mS42 mitoribosomal protein (named Bot1p in the paper). Establishes
+      the mitochondrial-ribosome localization and the mitochondrial
+      translation role, and is the ComplexPortal-cited NAS reference for
+      the mt-SSU annotations under review.
+- id: GO_REF:0000002
+  title: &gt;-
+    Gene Ontology annotation through association of InterPro records with
+    GO terms
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Standard InterPro2GO reference. For SPBC3H7.04 the InterPro entry
+      driving three of the IEA annotations (SOD activity, superoxide
+      metabolic process, metal ion binding) is IPR019832 (Iron/manganese
+      superoxide dismutase, C-terminal domain), a fold/superfamily match
+      only — see geneontology/go-annotation#6474.
+- id: GO_REF:0000024
+  title: &gt;-
+    Manual transfer of experimentally-verified manual GO annotation data
+    to orthologs by curator judgment of sequence similarity
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      ISS/ISO annotations transferred from the S. cerevisiae ortholog
+      SGD:S000003862 (Rsm26p) and via UniProtKB:P10662; these correctly
+      capture the mt-SSU membership, structural-constituent-of-ribosome
+      MF, and mitochondrial-translation BP.
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: MISCITED
+    review_notes: &gt;-
+      IBA `cytoplasm` propagated from PANTHER family PTHR43595, whose
+      characterized members are cytoplasmic/matrix Fe/Mn-SODs (SOD2,
+      SodA). The mitoribosomal mS42 branch is inside the mitochondrion,
+      not in the cytoplasm — the phylogenetic annotation applies to the
+      SOD side of the family and mis-propagates onto the mitoribosomal
+      subfamily.
+- id: GO_REF:0000044
+  title: &gt;-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular
+    Location vocabulary mapping, accompanied by conservative changes to
+    GO terms applied by UniProt
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Mapping of the UniProt &#34;SUBCELLULAR LOCATION: Mitochondrion&#34;
+      statement (SL-0173) to GO:0005739; correct location call.
+- id: GO_REF:0000108
+  title: &gt;-
+    Automatic assignment of GO terms using logical inference, based on
+    inter-ontology links
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Inter-ontology inference from GO:0004784 (SOD activity) →
+      GO:0019430 (removal of superoxide radicals). The inference chain
+      is mechanically correct but its input premise (SOD activity for
+      SPBC3H7.04) is wrong, so the derived BP annotation is also wrong
+      and inherits the same fate as the parent IEA.
+- id: UniProt:O74379
+  title: UniProtKB entry O74379 (RT26_SCHPO) — Small ribosomal subunit protein mS42
+  findings:
+  - statement: &gt;-
+      UniProt classifies the protein as &#34;Small ribosomal subunit protein
+      mS42&#34; belonging to the &#34;mitochondrion-specific ribosomal protein
+      mS42 family&#34;, localized to the mitochondrion, forming a dimer with
+      mS43 at the mRNA channel exit in the mt-SSU body. No superoxide
+      dismutase / oxidoreductase / metal-binding functional annotation is
+      claimed at the protein level; only fold-level InterPro / SUPFAM /
+      Gene3D matches to the Fe/Mn-SOD structural superfamily are recorded.
+    supporting_text: &gt;-
+      RecName: Full=Small ribosomal subunit protein mS42 ... FUNCTION:
+      Component of the mitochondrial ribosome (mitoribosome), a dedicated
+      translation machinery responsible for the synthesis of mitochondrial
+      genome-encoded proteins ... SUBUNIT: Component of the mitochondrial
+      small ribosomal subunit (mt-SSU) ... mS43 forms a dimer with mS42,
+      building a large protuberance adjacent to the mRNA channel exit in
+      the mt-SSU body ... SIMILARITY: Belongs to the mitochondrion-specific
+      ribosomal protein mS42 family ... KW Mitochondrion; Reference proteome;
+      Ribonucleoprotein; Ribosomal protein.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Authoritative UniProt curation of the protein as a mitoribosomal
+      mS42 family member, not a SOD; primary evidence anchor for this
+      review&#39;s core-function assignment.
+- id: file:SCHPO/SPBC3H7.04/SPBC3H7.04-notes.md
+  title: &gt;-
+    SPBC3H7.04 (mS42 / bot1) — S. pombe mitoribosomal small subunit protein
+  findings:
+  - statement: &gt;-
+      RSM26/mS42 (SPBC3H7.04) is structurally classified in the SOD
+      superfamily but does not have SOD activity — a fold-reuse situation
+      driven by the bacterial ancestry of the mitochondrion. The upstream
+      curator issue (geneontology/go-annotation#6474) diagnoses this as
+      the reason IPR019832 should not blanket-propagate SOD activity
+      terms; the mitoribosomal subfamily is a documented exception. Notes
+      file reproduces the ValWood quote verbatim and contextualizes it
+      against UniProt and PANTHER subfamily evidence.
+    supporting_text: &gt;-
+      structurally classified in the SOD superfamily
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Local reviewer notes file which reproduces the upstream go-annotation
+      curator issue (geneontology/go-annotation#6474) and integrates it
+      with the UniProt-level and PANTHER subfamily evidence and with the
+      pseudoenzyme detection pattern used elsewhere in this repo (Cu/Zn-SOD
+      fold-match without PROSITE PS00087 active-site match; see
+      projects/PSEUDOENZYMES.md).
+existing_annotations:
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      IBA &#34;cytoplasm&#34; propagated from PANTHER family PTHR43595 (Iron/Manganese
+      Superoxide Dismutase). The WITH/FROM list is dominated by canonical
+      Fe/Mn-SOD paralogs (e.g. SGD:S000002755 = SOD2, UniProtKB:P00448 = SodA),
+      which are legitimately cytoplasmic / mitochondrial-matrix SODs. The
+      mS42/mS43 mitoribosomal branch of PTHR43595 is a separate subfamily
+      (PTHR43595:SF2 = SMALL RIBOSOMAL SUBUNIT PROTEIN MS42) whose members
+      reside in the mitochondrial small ribosomal subunit — mitochondrion is
+      not a child of cytoplasm in the GO CC hierarchy, so `cytoplasm` is not
+      just non-specific but sub-cellularly wrong for this protein. The correct
+      specific location is already independently supported by NAS/ISO/IEA
+      annotations to mitochondrion / mitochondrial small ribosomal subunit.
+    action: REMOVE
+    reason: &gt;-
+      IBA over-propagation from the SOD side of a family that also contains
+      the mitoribosomal mS42 subfamily; the correct sub-cellular location
+      (mitochondrial small ribosomal subunit) is already captured by NAS
+      (PMID:18245278) and ISO (from SGD:S000003862) annotations, so no
+      information is lost.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+    supported_by:
+    - reference_id: UniProt:O74379
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion&#34;
+    - reference_id: UniProt:O74379
+      supporting_text: &gt;-
+        SIMILARITY: Belongs to the mitochondrion-specific ribosomal protein
+        mS42 family.
+- term:
+    id: GO:0004784
+    label: superoxide dismutase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO annotation from IPR019832 (Iron/manganese superoxide
+      dismutase, C-terminal domain). IPR019832 is a fold/superfamily entry —
+      matching it means the protein has the Fe/Mn-SOD C-terminal *fold*, not
+      necessarily the catalytic activity. SPBC3H7.04 is the mS42
+      mitoribosomal small-subunit protein: it retains the SOD fold by
+      ancestry (mitochondria are of bacterial origin, and the mitoribosome
+      inherited multiple protein pairs that co-opted enzyme folds as purely
+      structural components), but it does not match any PROSITE Mn/Fe-SOD
+      active-site pattern, has no biochemical evidence of dismutase activity,
+      and is classified by PANTHER&#39;s subfamily model (PTHR43595:SF2) as a
+      mitoribosomal protein, not a SOD. Val Wood&#39;s upstream flag
+      (geneontology/go-annotation#6474) explicitly diagnoses this as a
+      fold-reuse pseudo-SOD — the same annotation-error class as the Cu/Zn-SOD
+      pseudoenzymes documented in `projects/PSEUDOENZYMES.md`.
+    action: REMOVE
+    reason: &gt;-
+      Fold-only InterPro2GO match; the protein is a mitoribosomal structural
+      component, not a superoxide dismutase. Removing the SOD MF also removes
+      the incorrect logical-inference chain that generated GO:0019430
+      (removal of superoxide radicals). This is the exact class of
+      over-annotation the INTERPRO project targets.
+    supported_by:
+    - reference_id: UniProt:O74379
+      supporting_text: &#34;RecName: Full=Small ribosomal subunit protein mS42&#34;
+    - reference_id: UniProt:O74379
+      supporting_text: &gt;-
+        SIMILARITY: Belongs to the mitochondrion-specific ribosomal protein
+        mS42 family.
+    - reference_id: file:SCHPO/SPBC3H7.04/SPBC3H7.04-notes.md
+      supporting_text: &gt;-
+        structurally classified in the SOD superfamily
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation mapped from the UniProt &#34;SUBCELLULAR LOCATION:
+      Mitochondrion&#34; statement (Swiss-Prot SL-0173). The mitochondrial
+      localization is supported by the by-similarity call to the yeast
+      ortholog (UniProtKB:P10662) and by ComplexPortal membership in the 37S
+      mt-SSU (CPX-10315). Cellular-component annotation should ideally be at
+      the more specific `GO:0005763 mitochondrial small ribosomal subunit`
+      child (already present via ISO and NAS), but this parent term is not
+      wrong.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but generic location; the specific `mitochondrial small
+      ribosomal subunit` term (already present via ISO/NAS) is the core
+      location.
+    supported_by:
+    - reference_id: UniProt:O74379
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion&#34;
+- term:
+    id: GO:0006801
+    label: superoxide metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO annotation from IPR019832 (Fe/Mn SOD C-terminal domain
+      fold). Same fold-match rationale as the MF SOD-activity annotation:
+      the protein does not perform superoxide-related chemistry — it is a
+      structural component of the mt-SSU. The BP term is a direct downstream
+      consequence of assuming SOD activity and is not supported by any
+      independent evidence for this gene.
+    action: REMOVE
+    reason: &gt;-
+      Downstream over-annotation of the pseudo-SOD IEA chain; no independent
+      biological evidence links mS42 to superoxide metabolism.
+    supported_by:
+    - reference_id: UniProt:O74379
+      supporting_text: &#34;RecName: Full=Small ribosomal subunit protein mS42&#34;
+    - reference_id: file:SCHPO/SPBC3H7.04/SPBC3H7.04-notes.md
+      supporting_text: &gt;-
+        `IEA with IPR019832 → GO:0004784 superoxide dismutase activity`
+- term:
+    id: GO:0019430
+    label: removal of superoxide radicals
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Automated inter-ontology inference (GO_REF:0000108) from GO:0004784
+      (SOD activity). Because the parent MF annotation is a fold-only
+      over-annotation (see above), the derived BP annotation inherits the
+      same defect: mS42 does not remove superoxide radicals — it is a
+      structural mitoribosomal protein. Removing the parent MF resolves
+      this without any biological information loss.
+    action: REMOVE
+    reason: &gt;-
+      Logical-inference product of the incorrect SOD-activity IEA; falls
+      away when the MF is removed.
+    supported_by:
+    - reference_id: UniProt:O74379
+      supporting_text: &#34;RecName: Full=Small ribosomal subunit protein mS42&#34;
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO annotation from IPR019832 (Fe/Mn SOD C-terminal domain
+      fold). The metal-ion-binding MF term is only appropriate for members
+      of the family that coordinate an Mn or Fe catalytic ion; the mS42
+      mitoribosomal subfamily has no evidence of metal coordination and no
+      PROSITE Mn/Fe-SOD active-site match. There is no independent
+      evidence that mS42 binds a catalytically relevant metal ion in vivo.
+    action: REMOVE
+    reason: &gt;-
+      Fold-only over-annotation; no evidence of metal binding in the
+      mitoribosomal mS42 subfamily.
+    supported_by:
+    - reference_id: UniProt:O74379
+      supporting_text: &#34;RecName: Full=Small ribosomal subunit protein mS42&#34;
+    - reference_id: file:SCHPO/SPBC3H7.04/SPBC3H7.04-notes.md
+      supporting_text: &gt;-
+        the metal-coordinating catalytic residues
+- term:
+    id: GO:0005763
+    label: mitochondrial small ribosomal subunit
+  evidence_type: NAS
+  original_reference_id: PMID:18245278
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ComplexPortal-assigned NAS annotation citing Wiley et al. 2008: the
+      paper shows the S. pombe protein Bot1p (identified as the S. pombe
+      counterpart of the S. cerevisiae MrpS35p / Rsm26p family) localizes
+      to mitochondria and cofractionates with purified mitochondrial
+      ribosomes. ComplexPortal has SPBC3H7.04 as a component of the 37S
+      mt-SSU (CPX-10315). This is the correct, core cellular-component
+      annotation for the gene.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by primary literature (cofractionation with
+      mitoribosomes) and by ComplexPortal complex membership; the correct
+      core CC annotation.
+    supported_by:
+    - reference_id: PMID:18245278
+      supporting_text: &gt;-
+        Bot1p localizes to the mitochondria in live cells and cofractionates
+        with purified mitochondrial ribosomes.
+    - reference_id: UniProt:O74379
+      supporting_text: &gt;-
+        SUBUNIT: Component of the mitochondrial small ribosomal subunit (mt-SSU).
+- term:
+    id: GO:0032543
+    label: mitochondrial translation
+  evidence_type: NAS
+  original_reference_id: PMID:18245278
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal-assigned NAS annotation citing Wiley et al. 2008: bot1
+      is required for mitochondrial protein synthesis, and its depletion
+      causes decreased mitochondrial translation with a corresponding drop
+      in cell respiration. Core biological-process annotation for a
+      mitoribosomal structural subunit.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by primary literature (loss-of-function phenotype
+      is decreased mitochondrial protein translation); the correct core
+      BP annotation.
+    supported_by:
+    - reference_id: PMID:18245278
+      supporting_text: &gt;-
+        Reduced levels of Bot1p lead to mitochondrial fragmentation,
+        decreased mitochondrial protein translation, and a corresponding
+        decrease in cell respiration.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ISS annotation from the S. cerevisiae ortholog UniProtKB:P10662,
+      redundant with the UniProt SubCell-derived IEA above. Correct
+      location call; already captured at the more specific `mt-SSU` child.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but redundant with the more specific mt-SSU annotations; the
+      core location is `GO:0005763 mitochondrial small ribosomal subunit`.
+    supported_by:
+    - reference_id: UniProt:O74379
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion&#34;
+- term:
+    id: GO:0003735
+    label: structural constituent of ribosome
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ISO annotation transferred by PomBase from the S. cerevisiae ortholog
+      SGD:S000003862 (Rsm26p / mS42). This is the correct core molecular
+      function for a mitoribosomal structural subunit — the protein&#39;s
+      contribution to the mitoribosome is structural (part of the
+      mS42/mS43 protuberance adjacent to the mRNA channel exit), not
+      catalytic. This annotation should stand in place of the incorrect
+      SOD-activity IEA.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core MF; supported by the ortholog&#39;s characterization and by
+      the mS42-mS43 dimer&#39;s structural role in the mt-SSU.
+    supported_by:
+    - reference_id: UniProt:O74379
+      supporting_text: &gt;-
+        mS43 forms a dimer with mS42, building a large protuberance
+        adjacent to the mRNA channel exit in the mt-SSU body.
+- term:
+    id: GO:0005763
+    label: mitochondrial small ribosomal subunit
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ISO annotation from S. cerevisiae SGD:S000003862 (Rsm26p) —
+      independent orthology-based support for the same conclusion as the
+      NAS annotation above.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core CC; corroborates the NAS annotation and matches the
+      UniProt/ComplexPortal-curated complex membership.
+    supported_by:
+    - reference_id: UniProt:O74379
+      supporting_text: &gt;-
+        SUBUNIT: Component of the mitochondrial small ribosomal subunit (mt-SSU).
+- term:
+    id: GO:0032543
+    label: mitochondrial translation
+  evidence_type: ISO
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ISO annotation from S. cerevisiae SGD:S000003862 (Rsm26p) —
+      independent orthology-based support for the same conclusion as the
+      NAS annotation above.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP; corroborates the NAS annotation and is consistent
+      with the loss-of-function phenotype reported in PMID:18245278.
+    supported_by:
+    - reference_id: PMID:18245278
+      supporting_text: &gt;-
+        Reduced levels of Bot1p lead to mitochondrial fragmentation,
+        decreased mitochondrial protein translation, and a corresponding
+        decrease in cell respiration.
+core_functions:
+- description: &gt;-
+    Structural component of the mitochondrial small ribosomal subunit
+    (mt-SSU). mS42 and its dimer partner mS43 build a large protuberance
+    adjacent to the mRNA channel exit in the mt-SSU body, where they
+    contribute to the architecture of the mitoribosome; the mitoribosome
+    is required for translation of the mtDNA-encoded respiratory-chain
+    subunits. This is an inherently non-catalytic role: mS42 provides
+    structural constituent activity to the ribonucleoprotein complex, not
+    an enzymatic activity, despite matching an SOD fold at the domain
+    level.
+  molecular_function:
+    id: GO:0003735
+    label: structural constituent of ribosome
+  directly_involved_in:
+  - id: GO:0032543
+    label: mitochondrial translation
+  locations:
+  - id: GO:0005739
+    label: mitochondrion
+  in_complex:
+    id: GO:0005763
+    label: mitochondrial small ribosomal subunit
+  supported_by:
+  - reference_id: UniProt:O74379
+    supporting_text: &gt;-
+      SUBUNIT: Component of the mitochondrial small ribosomal subunit
+      (mt-SSU) ... mS43 forms a dimer with mS42, building a large
+      protuberance adjacent to the mRNA channel exit in the mt-SSU body.
+  - reference_id: PMID:18245278
+    supporting_text: &gt;-
+      Bot1p localizes to the mitochondria in live cells and cofractionates
+      with purified mitochondrial ribosomes.
+  - reference_id: PMID:18245278
+    supporting_text: &gt;-
+      Reduced levels of Bot1p lead to mitochondrial fragmentation,
+      decreased mitochondrial protein translation, and a corresponding
+      decrease in cell respiration.
+suggested_questions:
+- question: &gt;-
+    Does S. pombe mS42 (SPBC3H7.04) retain any residual metal-binding or
+    superoxide-related activity, or is the SOD-fold reuse purely structural?
+    A cryo-EM structure of the S. pombe mt-SSU (or a targeted structural
+    prediction) at the mS42 position, together with an in-vitro
+    superoxide-dismutase assay on the recombinant protein, would resolve
+    whether the annotation should be `REMOVE` (as done here) or `MODIFY`
+    to a residual/regulatory metal-binding term.
+- question: &gt;-
+    How many other members of the IPR019832 InterPro entry are mitoribosomal
+    mS42-family proteins rather than SODs? A cross-taxonomic scan of
+    PTHR43595:SF2 subfamily members would let InterPro consider adding a
+    subfamily-level `NOT` annotation for the SOD MF/BP terms, or
+    down-scoping the InterPro2GO mapping.
+suggested_experiments:
+- description: &gt;-
+    Recombinant expression of SPBC3H7.04 in E. coli followed by a
+    standard xanthine/xanthine-oxidase or pyrogallol autoxidation SOD
+    activity assay, with human SOD2 and E. coli SodA as positive controls.
+    A negative result would give direct biochemical confirmation of the
+    pseudoenzyme classification and support the `REMOVE` action for the
+    SOD-activity IEA.
+- description: &gt;-
+    Ribosome-profiling / polysome-fractionation of a conditional
+    depletion of SPBC3H7.04 (extending Wiley et al. 2008 to sub-cellular
+    resolution) to quantify the specific mitochondrial-translation defect
+    at the level of individual mtDNA-encoded transcripts. This would
+    strengthen the mitochondrial-translation involvement annotation
+    beyond NAS/ISO evidence.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/SCHPO/alo1/alo1-ai-review.html
+++ b/genes/SCHPO/alo1/alo1-ai-review.html
@@ -2621,6 +2621,348 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9HDX8" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">AIGR Deep Research — S. pombe *alo1* (Q9HDX8): L-gulonolactone oxidase prediction</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+                    <span class="report-badge">3 citations</span>
+
+
+                    <span class="report-badge">5 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-09T13:56:14.266516</span>
+
+
+
+                    <a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist_artifacts/provenance_evidence_matrix.csv" class="term-link">OpenScientist evidence matrix</a>
+                        <span>(text/csv)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist_artifacts/provenance_go_decision_table.csv" class="term-link">OpenScientist go decision table</a>
+                        <span>(text/csv)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist_artifacts/provenance_sequence_identity_matrix.csv" class="term-link">OpenScientist sequence identity matrix</a>
+                        <span>(text/csv)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="aigr-deep-research-s-pombe-alo1-q9hdx8-l-gulonolactone-oxidase-prediction">AIGR Deep Research — S. pombe <em>alo1</em> (Q9HDX8): L-gulonolactone oxidase prediction</h1>
+<p><strong>Hypothesis slug:</strong> prediction-gulonolactone-oxidase<br />
+<strong>Focus type:</strong> computational_prediction<br />
+<strong>Term under test:</strong> GO:0050105 L-gulonolactone oxidase activity (+ GO:0019853 L-ascorbic acid biosynthetic process)<br />
+<strong>Model source of prediction:</strong> BioReason-Pro SFT (ref doi:10.64898/2026.03.19.712954)</p>
+<hr />
+<h2 id="executive-judgment">Executive Judgment</h2>
+<p><strong>Verdict: REFUTED (over-annotated — paralog/substrate misassignment).</strong></p>
+<p>The BioReason-Pro predictions of <strong>L-gulonolactone oxidase activity (GO:0050105)</strong> and<br />
+<strong>L-ascorbic acid biosynthetic process (GO:0019853)</strong> for <em>S. pombe</em> alo1 (Q9HDX8) are<br />
+<strong>not supported</strong> and should not enter the review as-is. Multiple independent lines of<br />
+evidence identify alo1 as <strong>D-arabinono-1,4-lactone oxidase (EC 1.1.3.37)</strong>, the terminal<br />
+enzyme of the <strong>fungal D-erythroascorbate</strong> pathway — a distinct-substrate, distinct-product<br />
+paralog within the same ALO/GULO/GLDH aldonolactone-oxidoreductase (FAD, vanillyl-alcohol-oxidase)<br />
+superfamily:</p>
+<ul>
+<li>UniProtKB Q9HDX8 curated recommended name = <em>D-arabinono-1,4-lactone oxidase</em>, EC 1.1.3.37;<br />
+  curated reaction produces <strong>dehydro-D-arabinono-1,4-lactone + H₂O₂</strong>, and the assigned pathway<br />
+  is <strong>D-erythroascorbate biosynthesis (step 2/2)</strong> — not L-ascorbate.</li>
+<li>PomBase/GO_Central assigns MF <strong>GO:0003885 (D-arabinono-1,4-lactone oxidase activity, IBA)</strong>;<br />
+  GO:0050105 is <strong>absent</strong>.</li>
+<li>The mislabel is explainable: the enzyme sits in <strong>PANTHER family PTHR43762</strong>, whose <em>family-level</em><br />
+  name is "L-gulonolactone oxidase," while alo1 maps to <strong>subfamily SF1 = D-arabinono-1,4-lactone oxidase</strong>.<br />
+  A model keying on the family name (frequency/name bias) will over-call GULO.</li>
+<li>Biochemistry of orthologs confirms the fungal substrate/product: <em>S. cerevisiae</em> ALO1 was <strong>purified</strong><br />
+  as D-arabinono-1,4-lactone oxidase making D-erythroascorbate and shares only <strong>32 % identity with rat GULO</strong><br />
+  (PMID:10094636); <em>C. albicans</em> ALO1 null mutants lose the activity and D-erythroascorbate (PMID:11349062, 18282465).</li>
+</ul>
+<p><strong>Most important caveat:</strong> Members of this family have measurable <em>in vitro</em> promiscuity toward related<br />
+aldonolactones (the Q9HDX8 alt-name "L-galactono-γ-lactone oxidase" reflects this), so a weak <em>in vitro</em><br />
+turnover of L-gulono-1,4-lactone cannot be excluded. That would still not justify a GULO/L-ascorbate<br />
+annotation, because the physiological substrate and product are D-arabinono-lactone → D-erythroascorbate.</p>
+<hr />
+<h2 id="evidence-matrix">Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Direction</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>UniProtKB Q9HDX8 (ALO_SCHPO)</td>
+<td>database/curated</td>
+<td>Refutes seed</td>
+<td>Is alo1 a GULO making L-ascorbate?</td>
+<td>Rec. name D-arabinono-1,4-lactone oxidase EC 1.1.3.37; rxn → dehydro-D-arabinono-1,4-lactone + H₂O₂; pathway = D-erythroascorbate biosynthesis step 2/2</td>
+<td><em>S. pombe</em> alo1</td>
+<td>High (ECO:0000250)</td>
+</tr>
+<tr>
+<td>PomBase GO:0003885 (IBA)</td>
+<td>database/phylogenetic</td>
+<td>Refutes / true MF</td>
+<td>Correct MF term</td>
+<td>D-arabinono-1,4-lactone oxidase activity; <strong>no</strong> GO:0050105</td>
+<td><em>S. pombe</em> alo1</td>
+<td>High</td>
+</tr>
+<tr>
+<td>PANTHER PTHR43762:SF1</td>
+<td>computational/orthology</td>
+<td>Qualifies</td>
+<td>Source of mislabel</td>
+<td>Subfamily SF1 = D-arabinono-lactone oxidase; parent family named "L-gulonolactone oxidase" → name carryover</td>
+<td>protein family</td>
+<td>Med-High</td>
+</tr>
+<tr>
+<td>PMID:10094636</td>
+<td>direct assay + sequence</td>
+<td>Refutes</td>
+<td>Fungal enzyme identity / GULO homology</td>
+<td><em>S. cerevisiae</em> ALO1 purified as D-arabinono-1,4-lactone oxidase (final step of D-erythroascorbate synth); 32 % id to rat GULO</td>
+<td><em>S. cerevisiae</em></td>
+<td>High</td>
+</tr>
+<tr>
+<td>PMID:11349062</td>
+<td>mutant phenotype + cloning</td>
+<td>Refutes</td>
+<td>Gene product &amp; pathway</td>
+<td><em>C. albicans</em> ALO1 = D-arabinono-1,4-lactone oxidase; alo1 null loses activity + D-erythroascorbate; antioxidant/virulence</td>
+<td><em>C. albicans</em></td>
+<td>High</td>
+</tr>
+<tr>
+<td>PMID:18282465</td>
+<td>mutant phenotype</td>
+<td>Qualifies</td>
+<td>Pathway product</td>
+<td>alo1/alo1 mutant lacks ALO; D-erythroascorbate (EASC) is the product regulating alternative-oxidase respiration</td>
+<td><em>C. albicans</em></td>
+<td>Med</td>
+</tr>
+<tr>
+<td>This run (computed)</td>
+<td>structural/evolutionary</td>
+<td>Qualifies</td>
+<td>Does global %id discriminate ALO vs GULO?</td>
+<td>Gotoh/BLOSUM62 global identity: alo1 vs ScALO1 = <strong>30.5%</strong>, alo1 vs rat GULO = <strong>31.0%</strong>, alo1 vs plant GLDH = 19.9%. Twilight-zone, ~tie with GULO. Four-point test weakly groups (alo1,ScALO1)</td>
+<td>(GULO,GLDH), margin 0.8</td>
+<td>Q9HDX8/P54783/P10867/Q9SU56</td>
+</tr>
+<tr>
+<td>QuickGO (this run)</td>
+<td>database (verification)</td>
+<td>Refutes seed</td>
+<td>Are the predicted terms in the curated set?</td>
+<td>Q9HDX8 curated set: MF <strong>GO:0003885</strong> (IGC), BP <strong>GO:0070485</strong> dehydro-D-arabinono-1,4-lactone biosynthetic process (IGC), CC mitochondrion/outer membrane. <strong>GO:0050105 and GO:0019853 both ABSENT</strong> (verified present=False)</td>
+<td><em>S. pombe</em> alo1, PomBase</td>
+<td>High</td>
+</tr>
+</tbody>
+</table>
+<p><em>(Provenance: <code>provenance/evidence_matrix.csv</code>, <code>provenance/go_decision_table.csv</code>, <code>provenance/sequence_identity_matrix.csv</code>; UniProt fetch + alignment executed via MCP execute_code.)</em></p>
+<p><strong>Computed identity note (this run):</strong> A Gotoh global alignment (BLOSUM62) shows alo1 is essentially<br />
+equidistant from the fungal ALO (S. cerevisiae ALO1, 30.5 %) and the mammalian GULO (rat, 31.0 %) —<br />
+both in the ~30 % alignment "twilight zone". Global % identity therefore <strong>does not</strong> discriminate the two<br />
+functions and marginally favors GULO, which is exactly why a homology/embedding-based model can<br />
+over-predict L-gulonolactone oxidase. Discrimination instead rests on the PANTHER subfamily assignment<br />
+(PTHR43762:SF1 = D-arabinono-lactone oxidase), the curated EC 1.1.3.37 / D-erythroascorbate pathway, and<br />
+fungal-clade biology — all of which point to ALO, not GULO. This nuance strengthens, rather than weakens,<br />
+the refuted verdict.</p>
+<hr />
+<h2 id="go-curation-implications-leads-require-curator-verification">GO Curation Implications <em>(leads — require curator verification)</em></h2>
+<p>Verified against the live QuickGO annotation set for Q9HDX8 (13 annotations). <strong>Both model-predicted<br />
+terms are absent from the curated set</strong>, and the curated terms are already correct and <em>more specific</em>:</p>
+<table>
+<thead>
+<tr>
+<th>GO term</th>
+<th>Aspect</th>
+<th>Curated status</th>
+<th>Recommended action</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>GO:0050105</strong> L-gulonolactone oxidase activity</td>
+<td>MF</td>
+<td><strong>Absent</strong> (predicted only)</td>
+<td><strong>REMOVE / do not add</strong></td>
+<td>Wrong substrate; curated enzyme is EC 1.1.3.37</td>
+</tr>
+<tr>
+<td><strong>GO:0019853</strong> L-ascorbic acid biosynthetic process</td>
+<td>BP</td>
+<td><strong>Absent</strong> (predicted only)</td>
+<td><strong>REMOVE / replace with GO:0070485</strong></td>
+<td>Fungi make D-erythroascorbate, not L-ascorbate</td>
+</tr>
+<tr>
+<td><strong>GO:0003885</strong> D-arabinono-1,4-lactone oxidase activity</td>
+<td>MF</td>
+<td><strong>Present</strong> (IGC/IBA, PomBase)</td>
+<td><strong>RETAIN (core)</strong></td>
+<td>Correct curated MF, EC 1.1.3.37</td>
+</tr>
+<tr>
+<td><strong>GO:0070485</strong> dehydro-D-arabinono-1,4-lactone biosynthetic process</td>
+<td>BP</td>
+<td><strong>Present</strong> (IGC, PomBase)</td>
+<td><strong>RETAIN (core)</strong></td>
+<td>Direct product of the alo1 reaction; the correct specific BP that supersedes GO:0019853</td>
+</tr>
+<tr>
+<td><strong>GO:0005741</strong> mitochondrial outer membrane / <strong>GO:0005739</strong> mitochondrion</td>
+<td>CC</td>
+<td><strong>Present</strong> (ISO / HDA-IBA)</td>
+<td><strong>RETAIN</strong></td>
+<td>Consistent with ALO-family localization</td>
+</tr>
+</tbody>
+</table>
+<p>Core function is fully captured by the curated MF (GO:0003885) plus the specific product BP (GO:0070485);<br />
+"protein binding" is neither needed nor recommended. The model prediction is strictly <em>less accurate</em> than<br />
+existing curation — a textbook paralog/substrate over-annotation.</p>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p>Direct molecular function tested: a mitochondrial-membrane, covalent-FAD flavoprotein oxidase that<br />
+oxidizes an aldono-1,4-lactone using O₂, releasing H₂O₂. The <em>specific, physiological</em> reaction for<br />
+alo1 is <strong>D-arabinono-1,4-lactone → dehydro-D-arabinono-1,4-lactone</strong>, the last step yielding<br />
+<strong>D-erythroascorbate</strong> (a 5-carbon L-ascorbate analog). Downstream/pleiotropic effects (oxidative-stress<br />
+resistance, virulence, alternative-oxidase induction seen in <em>Candida</em>) are pathway consequences of the<br />
+D-erythroascorbate product, <strong>not</strong> the enzyme's direct activity, and must not be conflated with the MF term.<br />
+The seed's GULO/L-ascorbate claim describes a <strong>different substrate (L-gulono-1,4-lactone) and different product<br />
+(L-ascorbate)</strong> belonging to the mammalian pathway.</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ul>
+<li><strong>Paralog confusion (primary conflict):</strong> GULO (mammals), GLDH/L-galactono-lactone dehydrogenase (plants),<br />
+  and ALO (fungi) are homologous but substrate-distinct. ~32 % identity between fungal ALO1 and rat GULO<br />
+  (PMID:10094636) is exactly the zone where automated methods over-transfer the better-known family label.</li>
+<li><strong>Family-name bias:</strong> PANTHER PTHR43762 carries the name "L-gulonolactone oxidase" at family level; the<br />
+  correct assignment is subfamily SF1 (D-arabinono-lactone oxidase).</li>
+<li><strong>In-vitro promiscuity:</strong> The UniProt alt-name "L-galactono-γ-lactone oxidase" and known broad aldonolactone<br />
+  activity mean a low-level <em>in vitro</em> L-gulonolactone turnover is possible; this is an artifact-level caveat,<br />
+  not physiological evidence for L-ascorbate biosynthesis in <em>S. pombe</em>.</li>
+</ul>
+<hr />
+<h2 id="knowledge-gaps">Knowledge Gaps</h2>
+<ol>
+<li><strong>No S. pombe-specific enzymatic assay was located.</strong> Checked PubMed (no <em>S. pombe</em> ALO papers returned);<br />
+   the <em>S. pombe</em> assignment rests on curated by-similarity + IBA. Matters because direct <em>S. pombe</em> kinetics<br />
+   would definitively fix substrate preference. Resolve with: in-vitro substrate-panel kinetics on recombinant Q9HDX8.</li>
+<li><strong>Exact GO BP ID for D-erythroascorbate biosynthesis</strong> not confirmed here — curator should map the UniProt<br />
+   pathway string to the current ontology term.</li>
+<li><strong>Whether <em>S. pombe</em> actually accumulates D-erythroascorbate</strong> (vs. only enzyme presence) — resolve by<br />
+   metabolite LC-MS of wild-type vs. alo1Δ.</li>
+</ol>
+<hr />
+<h2 id="discriminating-tests">Discriminating Tests</h2>
+<ul>
+<li><strong>Substrate-panel oxidase assay</strong> on recombinant Q9HDX8: compare V/Km for D-arabinono-1,4-lactone,<br />
+  L-gulono-1,4-lactone, and L-galactono-1,4-lactone (O₂ consumption / H₂O₂ release). Physiological substrate<br />
+  should dominate.</li>
+<li><strong>Metabolomics of alo1Δ <em>S. pombe</em>:</strong> loss of D-erythroascorbate (not L-ascorbate) confirms pathway identity.</li>
+<li><strong>Phylogenetic placement / reciprocal-best-hit</strong> of Q9HDX8 vs. GULO (rat), GLDH (plant), ALO1 (Sc/Ca):<br />
+  expect clustering with fungal ALO subfamily, away from GULO.</li>
+</ul>
+<hr />
+<h2 id="curation-leads-require-curator-verification">Curation Leads (require curator verification)</h2>
+<ul>
+<li><strong>Action change:</strong> reject BioReason-Pro GO:0050105 and GO:0019853 for alo1; keep GO:0003885; consider adding<br />
+  the D-erythroascorbate biosynthetic-process BP term.</li>
+<li><strong>Candidate references / snippets to verify:</strong></li>
+<li>PMID:11349062 — "ALO1, the gene encoding D-arabinono-1,4-lactone oxidase, which catalyzes the final step of D-erythroascorbic acid biosynthesis."</li>
+<li>PMID:10094636 — "shared 32% … identity with … L-gulono-1,4-lactone oxidase from rat," establishing paralogy, not identity.</li>
+<li>UniProtKB Q9HDX8 — EC 1.1.3.37; pathway "D-erythroascorbate biosynthesis; step 2/2."</li>
+<li><strong>Suggested question for curator:</strong> Is a fungal-ascorbate-analog BP term already applied? If not, add and<br />
+  remove the L-ascorbate BP.</li>
+<li><strong>Suggested experiment:</strong> recombinant-enzyme substrate panel + alo1Δ metabolomics (above).</li>
+</ul>
+<hr />
+<h2 id="limitations">Limitations</h2>
+<p>Evidence is predominantly curated-database and ortholog-biochemistry; no <em>S. pombe</em>-specific assay was found in<br />
+the literature search. Network access limited the run to UniProt REST + PubMed; a direct sequence/phylogeny<br />
+computation was not executed. The conclusion (paralog misassignment) is nonetheless robust because it is<br />
+concordant across UniProt curation, GO_Central phylogenetics, PANTHER subfamily mapping, and ortholog<br />
+biochemistry.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+<li><a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist_artifacts/provenance_evidence_matrix.csv">OpenScientist evidence matrix</a></li>
+<li><a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist_artifacts/provenance_go_decision_table.csv">OpenScientist go decision table</a></li>
+<li><a href="alo1-hypotheses/prediction-gulonolactone-oxidase/openscientist_artifacts/provenance_sequence_identity_matrix.csv">OpenScientist sequence identity matrix</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/SCHPO/pmp20/pmp20-ai-review.html
+++ b/genes/SCHPO/pmp20/pmp20-ai-review.html
@@ -3975,6 +3975,367 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(pmp20-hypotheses/prediction-peroxiredoxin-activity/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O14313" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">AIGR Gene Hypothesis Deep Research — Final Report</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+                    <span class="report-badge">3 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-09T12:55:00.276609</span>
+
+
+
+                    <a href="pmp20-hypotheses/prediction-peroxiredoxin-activity/openscientist.md.citations.md" class="term-link">citations file</a>
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="pmp20-hypotheses/prediction-peroxiredoxin-activity/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="pmp20-hypotheses/prediction-peroxiredoxin-activity/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="aigr-gene-hypothesis-deep-research-final-report">AIGR Gene Hypothesis Deep Research — Final Report</h1>
+<h2 id="target-pmp20-o14313-schizosaccharomyces-pombe-peroxiredoxin-activity-prediction">Target: <em>pmp20</em> (O14313), <em>Schizosaccharomyces pombe</em> — Peroxiredoxin Activity Prediction</h2>
+<p><strong>Focus type:</strong> computational_prediction<br />
+<strong>Hypothesis slug:</strong> prediction-peroxiredoxin-activity<br />
+<strong>Terms under evaluation:</strong> peroxiredoxin activity (GO:0051920), peroxidase activity (GO:0004601), hydrogen peroxide catabolic process (GO:0042744)</p>
+<hr />
+<h2 id="executive-judgment">Executive Judgment</h2>
+<p><strong>Verdict: PARTIALLY SUPPORTED — the pseudoenzyme/"lost resolving cysteine" alternative is REFUTED, but direct catalytic activity in <em>S. pombe</em> remains unproven.</strong></p>
+<p>The BioReason-Pro SFT prediction that pmp20 is a peroxiredoxin/peroxidase is grounded in real, intact catalytic machinery — not a degenerate over-annotation. The seed hypothesis raised a specific, testable structural concern: that pmp20 might have lost the resolving cysteine (Cr) or otherwise degenerated its active site, which would make the peroxiredoxin predictions a pseudoenzyme artifact. That specific concern is <strong>incorrect on its premise</strong>. pmp20 is a <strong>1-Cys peroxiredoxin</strong> — a legitimate, well-characterized structural subclass of the peroxiredoxin family (PMP20/PRDX6 type) that normally has no resolving cysteine at all. The absence of a second cysteine is therefore not degeneration; it is the expected, catalytically competent architecture. Structural analysis confirms that the peroxidatic active site is fully intact and correctly assembled.</p>
+<p>However, the prediction cannot be scored as fully "supported" because the single direct enzymatic assay performed on <em>S. pombe</em> PMP20 failed to detect thioredoxin-dependent peroxidase activity, and the authors instead proposed a molecular chaperone role (<a href="https://pubmed.ncbi.nlm.nih.gov/20356456/">PMID: 20356456</a>). Family-level evidence (orthologs in <em>Hansenula polymorpha</em>, human, and mouse) strongly supports antioxidant/peroxiredoxin function, but 1-Cys peroxiredoxins typically use physiological reductants other than thioredoxin (e.g., glutathione, ascorbate, or protein partners), so a negative thioredoxin assay does not by itself rule out peroxidase activity. The net result for a curator: the molecular machinery justifies retaining GO:0051920 and GO:0042744 as <strong>conservation/family-supported leads</strong>, but the species-specific claim of <em>thioredoxin</em> peroxidase activity (GO:0008379) is not supported and should be generalized or dropped for this organism.</p>
+<p>The most important caveat is the tension between <strong>structural competence</strong> (strongly in favor of peroxidase function) and <strong>the one direct functional assay</strong> (which was negative for the thioredoxin-coupled reaction). This is a classic 1-Cys peroxiredoxin situation where the correct reductant/partner matters, and it is exactly the kind of nuance a curator should preserve rather than flatten into a single yes/no annotation.</p>
+<hr />
+<h2 id="key-findings">Key Findings</h2>
+<h3 id="finding-1-pmp20-retains-an-intact-peroxidatic-cysteine-motif-but-is-a-1-cys-peroxiredoxin-no-resolving-cys">Finding 1 — pmp20 retains an intact peroxidatic cysteine motif but is a 1-Cys peroxiredoxin (no resolving Cys)</h3>
+<p>UniProt O14313 encodes a 156-amino-acid protein containing <strong>exactly one cysteine, Cys43</strong>, which UniProt annotates as the active-site residue forming a "Cysteine sulfenic acid (–SOH) intermediate." This is the diagnostic signature of the peroxidatic cysteine (Cp) of a peroxiredoxin: during catalysis, Cp attacks the peroxide substrate and is oxidized to a sulfenic acid intermediate.</p>
+<p>Critically, Cys43 sits within an <strong>intact peroxiredoxin peroxidatic motif</strong>: the local sequence P36-G-A-F-T40-P-P-C43 matches the canonical <strong>P-x-x-x-(T/S)-x-x-C</strong> signature exactly. Position 1 is proline (P36), position 5 is the conserved threonine (T40), and position 8 is the peroxidatic cysteine (C43). All three invariant anchor residues of the motif are satisfied.</p>
+<p>Because the entire 156-residue sequence contains <strong>no second cysteine anywhere</strong>, there is <strong>no resolving cysteine (Cr)</strong>. This is the defining feature of the <strong>1-Cys peroxiredoxin</strong> subclass. In 2-Cys peroxiredoxins, Cr forms a disulfide with the oxidized Cp to complete the catalytic cycle; in 1-Cys peroxiredoxins, that role is filled instead by an external low-molecular-weight thiol or a protein partner. The seed hypothesis framed the absence of a resolving cysteine as possible "degeneration" indicative of a pseudoenzyme — but for the PMP20/PRDX6 family, the lack of Cr is the <strong>normal, catalytically legitimate architecture</strong>, not a loss.</p>
+<p>Domain and family classifications corroborate the assignment: InterPro places pmp20 in the <strong>PRX5-like</strong> superfamily (IPR037944) with a thioredoxin-like fold, and PANTHER assigns it to <strong>PTHR10430 PEROXIREDOXIN:SF39 (PMP20)</strong>. Both are canonical peroxiredoxin family memberships, not degenerate outliers.</p>
+<h3 id="finding-2-the-pmp20-family-is-a-genuine-antioxidant-peroxiredoxin-but-s-pombe-pmp20-showed-no-thioredoxin-dependent-peroxidase-activity-in-vitro">Finding 2 — The PMP20 family is a genuine antioxidant peroxiredoxin, but <em>S. pombe</em> pmp20 showed no thioredoxin-dependent peroxidase activity in vitro</h3>
+<p>Family-level functional evidence is consistent and strong:</p>
+<ul>
+<li>In the methylotrophic yeast <em>Hansenula polymorpha</em>, deletion of the peroxisomal peroxiredoxin (pmp20Δ) produces a methanol-dependent growth defect, elevated reactive oxygen species, lipid peroxidation, loss of peroxisome membrane integrity, and necrotic cell death (<a href="https://pubmed.ncbi.nlm.nih.gov/18694816/">PMID: 18694816</a>). This is a direct loss-of-function demonstration that a PMP20-family peroxiredoxin protects against oxidative damage.</li>
+<li>Human and murine PMP20 orthologs "exhibit antioxidant activity in vitro" and share high sequence similarity to thiol-specific antioxidant proteins (<a href="https://pubmed.ncbi.nlm.nih.gov/10514471/">PMID: 10514471</a>).</li>
+</ul>
+<p>However, the <strong>species-specific</strong> evidence for <em>S. pombe</em> introduces an important qualification. In a direct comparative study of fission yeast peroxiredoxin isozymes and glutathione peroxidase, recombinant <em>S. pombe</em> PMP20 showed <strong>no thioredoxin-dependent peroxidase activity</strong>, in contrast to the TPx, BCP, and GPx enzymes that were assayed in parallel. The authors explicitly stated that "peroxidase activity was not observed for PMP20 (peroxisomal membrane protein 20)" and proposed that "the fission yeast PMP20 without thioredoxin-dependent peroxidase activity may act as a molecular chaperone" (<a href="https://pubmed.ncbi.nlm.nih.gov/20356456/">PMID: 20356456</a>).</p>
+<p>Two interpretations are compatible with this negative result, and a curator should hold both:</p>
+<ol>
+<li><strong>Wrong reductant.</strong> 1-Cys peroxiredoxins characteristically do <em>not</em> use thioredoxin as their recycling partner; they typically depend on glutathione, ascorbate, or specific protein partners. A negative thioredoxin-coupled assay is therefore weak evidence against peroxidase activity per se — it may simply reflect the wrong electron donor in the in vitro reconstitution.</li>
+<li><strong>Genuinely divergent function.</strong> Alternatively, <em>S. pombe</em> pmp20 may have shifted toward a chaperone-dominant role, as the authors suggest, even while retaining the structural active site.</li>
+</ol>
+<p>The evidence does not currently discriminate cleanly between these, which is precisely why the prediction lands at "partially supported."</p>
+<h3 id="finding-3-alphafold-model-shows-a-fully-assembled-peroxiredoxin-catalytic-tetrad-pro36thr40cys43arg122">Finding 3 — AlphaFold model shows a fully assembled peroxiredoxin catalytic tetrad (Pro36–Thr40–Cys43–Arg122)</h3>
+<p>The high-confidence AlphaFold model <strong>AF-O14313-F1-v6</strong> (overall mean pLDDT 95.4; active-site residues pLDDT 93.9–97.9) directly refutes the "degenerate active site" premise of the seed hypothesis. Measured geometry of the modeled active site shows the conserved catalytic residues correctly positioned around the peroxidatic cysteine:</p>
+<table>
+<thead>
+<tr>
+<th>Interaction</th>
+<th>Measured distance</th>
+<th>Interpretation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Cys43(SG) – Thr40(OG1)</td>
+<td>3.00 Å</td>
+<td>Hydrogen-bonding distance; Thr correctly poised to stabilize the Cp thiolate/transition state</td>
+</tr>
+<tr>
+<td>Cys43(SG) – Arg122(guanidinium CZ)</td>
+<td>3.86 Å</td>
+<td>Conserved catalytic Arg correctly positioned to lower Cp pKa and stabilize the sulfenate</td>
+</tr>
+<tr>
+<td>Pro36</td>
+<td>Present, high confidence</td>
+<td>Completes the canonical Pro–Thr–Cys–Arg tetrad</td>
+</tr>
+</tbody>
+</table>
+<p>The <strong>Pro36–Thr40–Cys43–Arg122 catalytic tetrad</strong> — the universally conserved active-site constellation of functional peroxiredoxins — is therefore fully assembled at high modeling confidence. There is no second cysteine anywhere in the structure, confirming the 1-Cys architecture at the structural level and matching the sequence analysis. Structurally, pmp20 is an <strong>active-site-competent peroxiredoxin</strong>, not a degenerate pseudoenzyme.</p>
+<hr />
+<h2 id="mechanistic-model-interpretation">Mechanistic Model / Interpretation</h2>
+<p>The three findings converge on a coherent picture. pmp20 is a <strong>structurally intact 1-Cys peroxiredoxin</strong> whose catalytic machinery is fully present, but whose recycling chemistry in <em>S. pombe</em> is unresolved.</p>
+<div class="codehilite"><pre><span></span><code><span class="nx">PEROXIREDOXIN</span><span class="w"> </span><span class="nx">CATALYTIC</span><span class="w"> </span><span class="nx">CYCLE</span><span class="w"> </span><span class="p">(</span><span class="mi">1</span><span class="o">-</span><span class="nx">Cys</span><span class="w"> </span><span class="k">type</span><span class="p">)</span>
+
+<span class="w">   </span><span class="nx">ROOH</span><span class="w"> </span><span class="p">(</span><span class="nx">H2O2</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="nx">lipid</span><span class="w"> </span><span class="nx">peroxide</span><span class="p">)</span>
+<span class="o">|</span>
+<span class="nx">v</span>
+<span class="w">   </span><span class="nx">Cp</span><span class="o">-</span><span class="nx">SH</span><span class="w">  </span><span class="o">--</span><span class="p">(</span><span class="nx">peroxidatic</span><span class="w"> </span><span class="nx">Cys43</span><span class="w"> </span><span class="nx">attacks</span><span class="w"> </span><span class="nx">peroxide</span><span class="p">)</span><span class="o">--</span><span class="p">&gt;</span><span class="w">  </span><span class="nx">Cp</span><span class="o">-</span><span class="nx">SOH</span><span class="w">  </span><span class="o">+</span><span class="w"> </span><span class="nx">ROH</span>
+<span class="w">   </span><span class="p">(</span><span class="nx">thiolate</span><span class="w">                                          </span><span class="p">(</span><span class="nx">sulfenic</span><span class="w"> </span><span class="nx">acid</span>
+<span class="w">    </span><span class="nx">stabilized</span><span class="w"> </span><span class="nx">by</span><span class="w">                                      </span><span class="nx">intermediate</span><span class="p">;</span>
+<span class="w">    </span><span class="nx">Thr40</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="nx">Arg122</span><span class="p">)</span><span class="w">                                    </span><span class="nx">UniProt</span><span class="o">-</span><span class="nx">annotated</span><span class="p">)</span>
+<span class="o">^</span><span class="w">                                                  </span><span class="o">|</span>
+<span class="o">|</span><span class="w">                                                  </span><span class="nx">v</span>
+<span class="o">|</span><span class="w">                              </span><span class="nx">Resolution</span><span class="w"> </span><span class="nx">step</span><span class="w"> </span><span class="nx">requires</span><span class="w"> </span><span class="nx">an</span><span class="w"> </span><span class="nx">EXTERNAL</span><span class="w"> </span><span class="nx">reductant</span>
+<span class="o">|</span><span class="w">                              </span><span class="p">(</span><span class="mi">1</span><span class="o">-</span><span class="nx">Cys</span><span class="w"> </span><span class="nx">Prx</span><span class="w"> </span><span class="nx">has</span><span class="w"> </span><span class="nx">NO</span><span class="w"> </span><span class="nx">resolving</span><span class="w"> </span><span class="nx">Cys</span><span class="w"> </span><span class="nx">of</span><span class="w"> </span><span class="nx">its</span><span class="w"> </span><span class="nx">own</span><span class="p">)</span>
+<span class="o">|</span><span class="w">                                                  </span><span class="o">|</span>
+<span class="o">+----</span><span class="w"> </span><span class="nx">reduced</span><span class="w"> </span><span class="nx">by</span><span class="p">:</span><span class="w"> </span><span class="nx">glutathione</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="nx">ascorbate</span><span class="w"> </span><span class="o">/</span><span class="w"> </span><span class="o">-------+</span>
+<span class="w">      </span><span class="nx">protein</span><span class="w"> </span><span class="nx">partner</span><span class="w">  </span><span class="p">(</span><span class="nx">NOT</span><span class="w"> </span><span class="nx">thioredoxin</span><span class="w"> </span><span class="k">in</span><span class="w"> </span><span class="nx">vitro</span><span class="w"> </span><span class="err">—</span><span class="w"> </span><span class="nx">PMID</span><span class="w"> </span><span class="mi">20356456</span><span class="p">)</span>
+
+<span class="w">   </span><span class="nx">Catalytic</span><span class="w"> </span><span class="nx">tetrad</span><span class="w"> </span><span class="p">(</span><span class="nx">AlphaFold</span><span class="w"> </span><span class="nx">AF</span><span class="o">-</span><span class="nx">O14313</span><span class="o">-</span><span class="nx">F1</span><span class="o">-</span><span class="nx">v6</span><span class="p">,</span><span class="w"> </span><span class="nx">pLDDT</span><span class="w"> </span><span class="o">~</span><span class="mi">95</span><span class="p">):</span>
+<span class="w">       </span><span class="nx">Pro36</span><span class="w"> </span><span class="o">---</span><span class="w"> </span><span class="nx">Thr40</span><span class="w"> </span><span class="p">(</span><span class="m m-Double">3.0</span><span class="w"> </span><span class="nx">Å</span><span class="w"> </span><span class="nx">to</span><span class="w"> </span><span class="nx">Cp</span><span class="p">)</span><span class="w"> </span><span class="o">---</span><span class="w"> </span><span class="nx">Cys43</span><span class="p">(</span><span class="nx">Cp</span><span class="p">)</span><span class="w"> </span><span class="o">---</span><span class="w"> </span><span class="nx">Arg122</span><span class="w"> </span><span class="p">(</span><span class="m m-Double">3.9</span><span class="w"> </span><span class="nx">Å</span><span class="w"> </span><span class="nx">to</span><span class="w"> </span><span class="nx">Cp</span><span class="p">)</span>
+<span class="w">       </span><span class="nx">ALL</span><span class="w"> </span><span class="nx">PRESENT</span><span class="w"> </span><span class="nx">AND</span><span class="w"> </span><span class="nx">CORRECTLY</span><span class="w"> </span><span class="nx">POSITIONED</span>
+</code></pre></div>
+
+<p><strong>What the machinery tells us (strongly supported):</strong> The peroxidatic half-reaction — the step that actually defines "peroxidase/peroxiredoxin activity" — has an intact, correctly geometried active site. Sequence (P-x-x-x-T-x-x-C motif), family classification (PRX5-like, PANTHER PMP20), and structure (assembled Pro/Thr/Cys/Arg tetrad) all agree. The seed's pseudoenzyme hypothesis is refuted.</p>
+<p><strong>What remains uncertain (the resolution half-reaction):</strong> The absence of a resolving cysteine is normal for this subclass, but it means the enzyme depends on an external reductant. The only direct <em>S. pombe</em> assay used thioredoxin and was negative — an expected outcome if pmp20 is a glutathione- or ascorbate-dependent 1-Cys enzyme, but also consistent with a functional shift toward chaperone activity. The negative thioredoxin result should therefore <strong>not</strong> be read as "no peroxidase activity," only as "no <em>thioredoxin-dependent</em> peroxidase activity."</p>
+<p>The correct mechanistic scope for curation is: pmp20's <strong>immediate molecular function</strong> is thiol-based peroxide reduction via a sulfenic-acid intermediate on Cys43. Downstream/pleiotropic consequences at the family level (peroxisome membrane protection, prevention of lipid peroxidation and necrotic death in orthologs) are real but should not be conflated with the direct MF term.</p>
+<hr />
+<h2 id="evidence-matrix">Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Supports / Refutes / Qualifies</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence &amp; limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>UniProt O14313 (database record)</td>
+<td>Structural/evolutionary; database</td>
+<td>Refutes pseudoenzyme; supports Prx MF</td>
+<td>Does pmp20 retain the Cp motif and a resolving Cys?</td>
+<td>Single Cys (C43) in intact P36-x-x-x-T40-x-x-C43 motif; annotated Cys-sulfenic-acid intermediate; 1-Cys architecture (no Cr)</td>
+<td><em>S. pombe</em>, sequence-level</td>
+<td>High for sequence facts; annotation is inference-based</td>
+</tr>
+<tr>
+<td>InterPro IPR037944 / PANTHER PTHR10430:SF39 (database)</td>
+<td>Computational/family</td>
+<td>Supports Prx family membership</td>
+<td>Is pmp20 a bona fide peroxiredoxin family member?</td>
+<td>PRX5-like, thioredoxin-like fold; PANTHER PMP20 subfamily</td>
+<td><em>S. pombe</em></td>
+<td>High for classification; does not prove activity</td>
+</tr>
+<tr>
+<td>AlphaFold AF-O14313-F1-v6 (structural model)</td>
+<td>Structural (predicted)</td>
+<td>Refutes degenerate active site</td>
+<td>Is the catalytic tetrad assembled?</td>
+<td>Pro36–Thr40–Cys43–Arg122 tetrad intact; Cp–Thr 3.0 Å, Cp–Arg 3.9 Å; pLDDT ~95</td>
+<td><em>S. pombe</em>, in silico</td>
+<td>High model confidence; predicted not experimental structure</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/20356456/">PMID: 20356456</a></td>
+<td>Direct in vitro assay</td>
+<td>Qualifies / partially refutes</td>
+<td>Does <em>S. pombe</em> PMP20 have Trx-dependent peroxidase activity?</td>
+<td>No thioredoxin-dependent peroxidase activity observed; proposed chaperone role</td>
+<td><em>S. pombe</em> recombinant protein</td>
+<td>High for the negative Trx result; wrong reductant is a strong confound for 1-Cys Prx</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/18694816/">PMID: 18694816</a></td>
+<td>Mutant phenotype (loss-of-function)</td>
+<td>Supports (family level)</td>
+<td>Does a PMP20-family Prx protect against oxidative damage?</td>
+<td>pmp20Δ → ROS, lipid peroxidation, membrane leakage, necrotic death</td>
+<td><em>Hansenula polymorpha</em></td>
+<td>High for ortholog; not <em>S. pombe</em>; phenotype is downstream of MF</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/10514471/">PMID: 10514471</a></td>
+<td>Direct assay (ortholog)</td>
+<td>Supports (family level)</td>
+<td>Do PMP20 orthologs have antioxidant activity?</td>
+<td>Human/murine PMP20 show antioxidant activity in vitro; similar to thiol-specific antioxidants</td>
+<td>Human, mouse</td>
+<td>Moderate-high for orthologs; species transfer inference</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="go-curation-implications">GO Curation Implications</h2>
+<p><strong>Lead requiring curator verification.</strong> The molecular and structural evidence justifies treating the peroxiredoxin function as real but not fully experimentally nailed down in <em>S. pombe</em>.</p>
+<table>
+<thead>
+<tr>
+<th>GO term</th>
+<th>Aspect</th>
+<th>Recommended action (lead)</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0051920 peroxiredoxin activity</td>
+<td>MF</td>
+<td><strong>Retain as conservation/family-supported lead</strong> (evidence code ISS/IBA-type reasoning)</td>
+<td>Intact Cp motif + assembled catalytic tetrad + family membership strongly support the MF; direct <em>S. pombe</em> kinetics not demonstrated</td>
+</tr>
+<tr>
+<td>GO:0004601 peroxidase activity</td>
+<td>MF</td>
+<td><strong>Retain as the broader parent lead</strong></td>
+<td>Supported by same structural/family evidence; more general and safer than the thioredoxin-specific child</td>
+</tr>
+<tr>
+<td>GO:0042744 hydrogen peroxide catabolic process</td>
+<td>BP</td>
+<td><strong>Retain as family-supported lead</strong></td>
+<td>Consistent with peroxiredoxin MF and ortholog oxidative-stress phenotypes</td>
+</tr>
+<tr>
+<td>GO:0008379 thioredoxin peroxidase activity</td>
+<td>MF</td>
+<td><strong>Do NOT assign / generalize</strong> for <em>S. pombe</em></td>
+<td>Directly contradicted by the one in vitro assay (<a href="https://pubmed.ncbi.nlm.nih.gov/20356456/">PMID: 20356456</a>); 1-Cys Prx generally are not thioredoxin-coupled</td>
+</tr>
+<tr>
+<td>Chaperone activity (e.g., unfolded protein binding / chaperone)</td>
+<td>MF</td>
+<td><strong>Flag as a competing/complementary lead</strong></td>
+<td>Proposed by <a href="https://pubmed.ncbi.nlm.nih.gov/20356456/">PMID: 20356456</a>; needs curator judgement on whether experimentally established</td>
+</tr>
+</tbody>
+</table>
+<p>The evidence supports an <strong>MF</strong> (peroxiredoxin/peroxidase) and an associated <strong>BP</strong> (H2O2 catabolism), with the peroxisomal <strong>CC</strong> context suggested by family membership (PMP20 = peroxisomal membrane protein 20). "Protein binding" is not an appropriate final term here; the informative MF is peroxiredoxin/peroxidase activity. The key curator decision is whether to attach these as computationally/conservation-supported (ISS/IBA) rather than experimentally supported (IDA), given the absence of a positive direct assay in this species.</p>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<ul>
+<li><strong>Direct gene-product activity (what is being tested):</strong> Thiol-based reduction of peroxide substrate via nucleophilic attack by the peroxidatic Cys43, forming a Cys-sulfenic-acid intermediate stabilized by Thr40 and Arg122. This is the immediate molecular function.</li>
+<li><strong>Resolution chemistry:</strong> As a 1-Cys peroxiredoxin, pmp20 lacks an internal resolving cysteine and must be recycled by an external reductant (glutathione/ascorbate/protein partner), not by an intramolecular disulfide.</li>
+<li><strong>Downstream / not to be conflated with MF:</strong> Peroxisome membrane integrity, protection from lipid peroxidation, prevention of necrotic death (ortholog phenotypes) — these are pathway-level consequences of the antioxidant function, valuable as BP context but not direct MF evidence.</li>
+<li><strong>Competing direct function:</strong> Possible molecular chaperone activity, proposed on the basis of the absent thioredoxin-dependent peroxidase activity in <em>S. pombe</em>.</li>
+</ul>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ol>
+<li><strong>Structural competence vs. negative functional assay.</strong> The dominant conflict: sequence + AlphaFold say "fully competent active site," while the one direct <em>S. pombe</em> assay says "no thioredoxin-dependent peroxidase activity." The most parsimonious reconciliation is that the assay used the wrong reductant for a 1-Cys enzyme, not that the enzyme is inactive.</li>
+<li><strong>Chaperone reassignment.</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/20356456/">PMID: 20356456</a> proposes a molecular chaperone role. This is a genuine alternative primary function that a curator should weigh; peroxiredoxins are known to moonlight as chaperones, so the two are not mutually exclusive.</li>
+<li><strong>Ortholog/paralog transfer risk.</strong> The strongest positive functional data come from <em>H. polymorpha</em>, human, and mouse orthologs, not <em>S. pombe</em> itself. Cross-species function transfer is reasonable for a conserved family but is inference, not direct evidence.</li>
+<li><strong>"Lost resolving cysteine = pseudoenzyme" is a category error.</strong> The seed hypothesis implicitly treats a missing Cr as pathological. For the PMP20/PRDX6 1-Cys subclass this is the normal architecture, so the pseudoenzyme framing does not apply.</li>
+</ol>
+<hr />
+<h2 id="limitations-and-knowledge-gaps">Limitations and Knowledge Gaps</h2>
+<table>
+<thead>
+<tr>
+<th>Gap</th>
+<th>What was checked</th>
+<th>Why it matters</th>
+<th>What would resolve it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>No positive direct peroxidase assay in <em>S. pombe</em></td>
+<td>Literature; found only a negative thioredoxin-coupled assay</td>
+<td>Determines whether MF should be IDA vs ISS/IBA</td>
+<td>Peroxide-reduction assay with glutathione/ascorbate or candidate protein reductants</td>
+</tr>
+<tr>
+<td>Physiological reductant unknown</td>
+<td>Sequence shows 1-Cys architecture (needs external reductant)</td>
+<td>1-Cys Prx recycling partner defines its true activity</td>
+<td>Reconstitution with GSH/glutaredoxin, ascorbate, and protein-partner screens</td>
+</tr>
+<tr>
+<td>Chaperone vs peroxidase primacy unresolved</td>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/20356456/">PMID: 20356456</a> proposes chaperone</td>
+<td>Affects which MF is "core"</td>
+<td>Side-by-side chaperone and peroxidase assays; in vivo H2O2 sensitivity of pmp20Δ</td>
+</tr>
+<tr>
+<td>Subcellular localization not independently verified here</td>
+<td>Family name implies peroxisomal (PMP20)</td>
+<td>CC term assignment</td>
+<td>GFP localization / peroxisome fractionation in <em>S. pombe</em></td>
+</tr>
+<tr>
+<td>AlphaFold is a model, not experimental structure</td>
+<td>pLDDT ~95 gives high confidence</td>
+<td>Geometry-based active-site claims rest on a prediction</td>
+<td>Experimental crystal/cryo-EM structure</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="discriminating-tests">Discriminating Tests</h2>
+<ol>
+<li><strong>Reductant-swap peroxidase assay.</strong> Repeat the peroxide-reduction assay using <strong>glutathione (± glutaredoxin) and ascorbate</strong> as reductants rather than thioredoxin. A positive result would convert the annotation from a conservation lead to a direct (IDA) peroxiredoxin annotation and explain the negative thioredoxin result.</li>
+<li><strong>Cys43-to-Ser active-site mutant.</strong> Test whether C43S abolishes any detected peroxidase (and/or chaperone) activity — establishes that the annotated Cp is the catalytic residue.</li>
+<li><strong>In vivo oxidative-stress phenotyping.</strong> Compare <em>S. pombe</em> wild-type vs pmp20Δ (and C43S knock-in) under H2O2 and organic-peroxide challenge; scored ROS, lipid peroxidation, and viability — mirrors the informative <em>H. polymorpha</em> experiment.</li>
+<li><strong>Chaperone activity assay.</strong> Aggregation-prevention (e.g., citrate synthase/insulin turbidity) to test the chaperone hypothesis directly and determine whether it is redox-state dependent.</li>
+<li><strong>Localization confirmation.</strong> Fluorescent tagging / peroxisome co-localization to justify a peroxisomal CC term.</li>
+</ol>
+<hr />
+<h2 id="curation-leads">Curation Leads</h2>
+<p><strong>All items below are leads requiring curator verification.</strong></p>
+<p><strong>Candidate references with exact snippets to verify:</strong><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/20356456/">PMID: 20356456</a> — verify snippet: <em>"peroxidase activity was not observed for PMP20 (peroxisomal membrane protein 20)"</em> and <em>"The fission yeast PMP20 without thioredoxin-dependent peroxidase activity may act as a molecular chaperone."</em> → supports NOT assigning GO:0008379 and flags a competing chaperone MF.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/18694816/">PMID: 18694816</a> — verify snippet: <em>"absence of the peroxisomal peroxiredoxin leads to loss of peroxisome membrane integrity and necrotic cell death"</em> → family-level antioxidant/peroxidase support (ortholog).<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/10514471/">PMID: 10514471</a> — verify PMP20 orthologs <em>"exhibit antioxidant activity in vitro"</em> → family-level support.</p>
+<p><strong>Candidate GO actions:</strong><br />
+- Retain <strong>GO:0051920 peroxiredoxin activity</strong> and <strong>GO:0004601 peroxidase activity</strong> as conservation/family-supported (ISS/IBA) leads, not IDA.<br />
+- Retain <strong>GO:0042744 hydrogen peroxide catabolic process</strong> as a supporting BP lead.<br />
+- Do <strong>not</strong> assign <strong>GO:0008379 thioredoxin peroxidase activity</strong> for <em>S. pombe</em>; generalize to the parent peroxidase term.<br />
+- Consider a peroxisomal <strong>CC</strong> term consistent with PMP20 family identity (verify by localization).<br />
+- Consider flagging a <strong>chaperone</strong> MF as an alternative/complementary function pending direct evidence.</p>
+<p><strong>Suggested curator questions:</strong><br />
+- Is there any positive peroxidase assay for <em>S. pombe</em> pmp20 with a non-thioredoxin reductant?<br />
+- Should the record carry both a peroxiredoxin MF (conservation-based) and a chaperone MF (experiment-based proposal)?</p>
+<p><strong>Suggested experiments:</strong> the five discriminating tests above, prioritizing the glutathione/ascorbate-coupled peroxidase assay and the C43S mutant.</p>
+<hr />
+<h2 id="bottom-line">Bottom Line</h2>
+<p>pmp20 is a structurally intact <strong>1-Cys peroxiredoxin</strong> with a complete, correctly assembled Pro36–Thr40–Cys43–Arg122 catalytic tetrad. The seed's "lost resolving cysteine / pseudoenzyme over-annotation" hypothesis is <strong>refuted</strong> — the missing resolving cysteine is the normal architecture of this subclass, not degeneration. The BioReason-Pro peroxiredoxin/peroxidase/H2O2-catabolism predictions are therefore <strong>partially supported</strong>: justified as conservation/family-based leads (retain GO:0051920, GO:0004601, GO:0042744), but not upgraded to direct-experimental confidence because the only direct <em>S. pombe</em> assay found no thioredoxin-dependent peroxidase activity (GO:0008379 should be generalized/dropped for this organism), and a competing chaperone role remains on the table.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="pmp20-hypotheses/prediction-peroxiredoxin-activity/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="pmp20-hypotheses/prediction-peroxiredoxin-activity/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/genes/human/GPAA1/GPAA1-ai-review.html
+++ b/genes/human/GPAA1/GPAA1-ai-review.html
@@ -1,0 +1,6829 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GPAA1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>GPAA1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O43292" target="_blank" class="term-link">
+                        O43292
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "GPAA1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O43292" data-a="DESCRIPTION: GPAA1 (GAA1; glycosylphosphatidylinositol anchor a..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>GPAA1 (GAA1; glycosylphosphatidylinositol anchor attachment 1 protein) is a multi-pass endoplasmic reticulum membrane protein and one of the five subunits of the GPI-anchor transamidase (GPI-T) complex (with PIGK, PIGT, PIGS and PIGU). This complex catalyses the last step of GPI-anchored protein biosynthesis: in the ER lumen it removes the C-terminal GPI-attachment signal peptide of precursor proteins and, through a transamidation reaction, replaces it with a pre-assembled GPI anchor at the new C-terminus. The catalytic cysteine-protease chemistry that cleaves the signal peptide and forms the acyl(carbonyl)-enzyme intermediate resides in the PIGK subunit; GPAA1, which adopts an M28 peptidase-like fold, is a required accessory subunit that binds the GPI lipid substrate and coordinates its three ethanolamine-phosphate arms, positioning the bridging ethanolamine-phosphate for amide-bond formation with the substrate omega-site. GPAA1 is passively retained in the ER, and its large luminal loop mediates assembly with the other subunits. Biallelic loss-of-function variants in GPAA1 cause an inherited GPI-deficiency disorder (GPI biosynthesis defect 15; GPIBD15) presenting with developmental delay, hypotonia, early-onset seizures, cerebellar atrophy and osteopenia, and reduced cell-surface levels of GPI-anchored proteins.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred core biological process. GPAA1 orthologs across eukaryotes (yeast Gaa1p, Drosophila) are components of the GPI transamidase that attaches GPI to precursor proteins. Well supported by direct experimental evidence in human (see IDA/EXP annotations).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct, appropriately specific core BP; matches direct experimental annotations and the phylogenetic consensus.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase mediates GPI anchoring in the endoplasmic reticulum, by replacing a protein&#39;s C-terminal GPI attachment signal peptide with a pre-assembled GPI.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred complex membership. GPAA1 is a conserved subunit of the GPI-anchor transamidase complex; this is confirmed by direct co-purification, mutagenesis and cryo-EM structures of the human complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, correct complex-membership assignment consistent with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation from the UniProt subcellular-location vocabulary. GPAA1 is a multi-pass ER membrane protein; supported directly by experimental localization studies.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization; consistent with experimental and structural evidence that GPAA1 is a multi-pass ER membrane protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GPAA1/GPAA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation to the generic &#39;membrane&#39; term. True but uninformative: the specific and correct location is the ER membrane (GO:0005789), which is separately annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant, low-information parent of the more specific ER membrane annotation; retained but flagged as over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GPAA1/GPAA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation (IPR007246, Gaa1) to the transamidase complex. Correct complex membership, confirmed experimentally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership term; consistent with experimental and structural data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10793132
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Gaa1p and gpi8p are components of a glycosylphosphatidylinos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005515" data-r="PMID:10793132" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct/UniProt binary interaction with PIGK (Q92643), the catalytic subunit of the same complex. The interaction is real but the bare &#39;protein binding&#39; term is uninformative; the biologically meaningful relationship is captured by GPI-anchor transamidase complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-informative molecular-function term (bare protein binding); the underlying PIGK interaction is already represented by complex membership. Per curation policy this IPI is not removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link">
+                                        PMID:10793132
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Gaa1p and Gpi8p are associated with each other.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005515" data-r="PMID:11483512" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct/UniProt interaction (with PIGK Q92643) supporting GPI-T complex assembly. Bare &#39;protein binding&#39; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-informative MF term; the relevant biology (co-complex with the other GPI-T subunits) is captured by GO:0042765. Not removed per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-T maintains the complex by stabilizing the expression of GAA1 and GPI8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005515" data-r="PMID:12802054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct/UniProt interaction (with PIGK Q92643) within the GPI transamidase complex, which PMID:12802054 shows is a five-subunit assembly. Bare &#39;protein binding&#39; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-informative MF term; complex membership is the meaningful annotation. Not removed per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mammalian GPI transamidase is a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput AP-MS interactome (BioPlex 2.0) binary interactions (PIGK Q92643, PIGT Q969N2, MOXD1 Q6UVY6). Bare &#39;protein binding&#39; is uninformative and derives from a proteome-scale screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-informative MF term from a large-scale interactome study; complex membership already captures the relevant partners. Not removed per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                                        PMID:28514442
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the largest such network so far</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput AP-MS interactome (BioPlex 3.0) interactions. Bare &#39;protein binding&#39; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-informative MF term from a proteome-scale interactome; not removed per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we have created two proteome-scale, cell-line-specific</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput multimodal cell-map interactome (PIGK Q92643, PIGT Q969N2). Bare &#39;protein binding&#39; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-informative MF term from a proteome-scale mapping study; not removed per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                                        PMID:40205054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Multimodal cell maps as a foundation for structural and functional genomics</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000041
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0006506" data-r="GO_REF:0000041" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniPathway-based electronic annotation to the parent GPI-anchor biosynthesis process. GPAA1 acts in the terminal transamidation step of this pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct parent BP for GPAA1&#39;s role in GPI-anchored protein biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GPAA1/GPAA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PATHWAY: Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor biosynthesis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005789" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (NAS) assignment of the GPI-anchor transamidase complex to the ER membrane. Consistent with direct experimental localization of GPAA1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization; corroborated by experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                                        PMID:12582175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI transamidase is localized in the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (NAS) assignment of the transamidase complex process to GPAA1. Correct core BP, confirmed by experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP; consistent with the direct experimental annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI transamidase that attaches GPI-anchors to proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Affinity-purification evidence that GPAA1 is part of the GPI transamidase complex; this paper established PIG-U as the fifth subunit alongside GAA1, GPI8, PIG-S and PIG-T.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation, experimentally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase complex affinity-purified from cells expressing epitope-tagged-GPI8 contained PIG-U and four other known components.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005783" data-r="GO_REF:0000052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Human Protein Atlas immunofluorescence localizes GPAA1 to the endoplasmic reticulum. Consistent with its role as an ER-membrane transamidase subunit; the ER membrane (GO:0005789) is the more precise location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization to the ER (parent of ER membrane); consistent with all other localization data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GPAA1/GPAA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">GO:0005783; C:endoplasmic reticulum; IDA:HPA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005789" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental localization of the GAA1-containing transamidase to the ER membrane, where it mediates GPI anchoring.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization, directly supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase mediates GPI anchoring in the endoplasmic reticulum</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0180046" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cryo-EM structure of the human GPI transamidase (PIGK/PIGU/PIGT/PIGS/GPAA1) demonstrating its role in maturation of GPI-anchored proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, directly supported by the structural characterization of the complex containing GPAA1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0180046" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cryo-EM structure of the human GPI-T heteropentamer including GPAA1, illuminating GPI-anchored protein biogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP; directly supported by structural data on the GPAA1- containing complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-T at a global 2.53-Å resolution, revealing an equimolar</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29100095" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29100095
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in GPAA1, Encoding a GPI Transamidase Complex Prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:29100095" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Functional evidence that GPAA1 is essential for attaching GPI to precursor proteins: patient cells with biallelic GPAA1 variants show reduced surface levels of GPI-anchored proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, supported by loss-of-function disease evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29100095" target="_blank" class="term-link">
+                                        PMID:29100095
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This complex orchestrates the attachment of the GPI anchor to the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9468317" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9468317
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning of human homolog of yeast GAA1 which is re...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:9468317" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Original cloning of human GAA1; antisense knockdown reduced production of a reporter GPI-anchored protein, implicating GPAA1 in GPI attachment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP; supported by functional knockdown evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9468317" target="_blank" class="term-link">
+                                        PMID:9468317
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Overexpression of antisense hGAA1 in human K562 cells significantly reduced the production of a reporter GPI-anchored protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9468317" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9468317
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning of human homolog of yeast GAA1 which is re...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:9468317" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GPAA1 identified as a component of the putative transamidase machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9468317" target="_blank" class="term-link">
+                                        PMID:9468317
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We have isolated a component of the putative transamidase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29100095" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29100095
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in GPAA1, Encoding a GPI Transamidase Complex Prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0180046" data-r="PMID:29100095" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GPAA1 as an essential component of the transamidase complex in GPI-anchored protein biosynthesis; loss of function reduces surface GPI-APs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, supported by disease/functional evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29100095" target="_blank" class="term-link">
+                                        PMID:29100095
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-anchored proteins had decreased cell-surface abundance in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0180046" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutational screen of GPI-TA subunits confirming GPAA1 function in GPI anchoring (GPAA1 D250A reduces activity).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, directly supported by functional mutagenesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The D250A construct reduced GPI-TA activity without changing the protein stability</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0180046" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Liganded GPI-T structures showing GPAA1 within the complex engaged in GPI-anchored protein biogenesis (GPI substrate bound).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, directly supported by structural data on the substrate- and product-bound complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">EtNP2 is fixed by GPAA1 Gln355 and Ser51</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9468317" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9468317
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning of human homolog of yeast GAA1 which is re...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0180046" data-r="PMID:9468317" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GPAA1 functionally implicated in production of GPI-anchored proteins via antisense knockdown.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP; functional knockdown evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9468317" target="_blank" class="term-link">
+                                        PMID:9468317
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Overexpression of antisense hGAA1 in human K562 cells significantly reduced the production of a reporter GPI-anchored protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034235" target="_blank" class="term-link">
+                                    GO:0034235
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0034235" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Liganded cryo-EM structures directly show GPAA1 binding the GPI lipid substrate: GPAA1 residues coordinate the three ethanolamine-phosphate arms of GPI (EtNP1-His354 via Mg2+, EtNP2-Gln355/Ser51, EtNP3-Ser51/Asn53). This is GPAA1&#39;s specific molecular function within the complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported, informative core molecular function (GPI lipid-substrate binding), established by liganded structures.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">EtNP1 interacts with GPAA1 His354 through metal coordination (modeled as Mg2+)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Finally, EtNP3 interacts with GPAA1 Ser51 and Asn53</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence for the transamidase complex (containing GAA1) attaching GPI anchors to proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, experimentally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI transamidase that attaches GPI-anchors to proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Functional analysis of GPI-TA subunits including GPAA1, confirming its role in GPI attachment; GPAA1 is proposed to catalyse formation of the amide bond between the substrate omega-site and the bridging EtNP.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, supported by mutagenesis and functional rescue assays.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPAA1 is proposed to catalyze the formation of an amide bond between the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Substrate/product-bound GPI-T structures directly visualise the attachment reaction, with GPAA1 binding the GPI substrate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, directly supported by structural data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">EtNP2 is fixed by GPAA1 Gln355 and Ser51</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cryo-EM structures of the GPI-T complex including GPAA1 (light blue subunit) with PIGK, PIGT, PIGS and PIGU.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation, structurally confirmed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a Interactions between the product ULBP2* and GPI-T (GPAA1, light blue; PIGK, marine blue; PIGT, purple; PGIS, cyan).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cryo-EM structure of the human GPI transamidase catalysing GPI attachment to proteins in the ER.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, structurally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cryo-EM structure of the human GPI-T heteropentamer engaged in the removal of the signal peptide and covalent attachment of GPI.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, structurally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">covalent attachment of GPI at the new carboxyl terminus</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cryo-EM structure demonstrating GPAA1 as one of the five subunits of the human GPI transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation, structurally confirmed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cryo-EM structure of the equimolar heteropentameric GPI-T complex including GPAA1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation, structurally confirmed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-T at a global 2.53-Å resolution, revealing an equimolar</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12582175
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Two subunits of glycosylphosphatidylinositol transamidase, G...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:12582175" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Biochemical evidence that the human GPI transamidase is a multimeric complex of five components (including GAA1) sufficient to hold the substrate protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                                        PMID:12582175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indicating that these five components are sufficient to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Purified human GPI-TA containing GPAA1 with the four other subunits.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation, experimentally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14660601" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14660601
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A conserved proline in the last transmembrane segment of Gaa...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:14660601" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutation of a conserved proline in the last TM segment of GAA1 abolishes GPI recognition/binding by the transamidase, impairing GPI attachment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, supported by mutational (IMP) evidence linking GAA1 to the attachment reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14660601" target="_blank" class="term-link">
+                                        PMID:14660601
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">required for glycosylphosphatidylinositol (GPI) recognition by GPI transamidase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Affinity-purified GPI transamidase complex containing GAA1 and the four other subunits.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase complex affinity-purified from cells expressing epitope-tagged-GPI8 contained PIG-U and four other known components.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GAA1 shown to form a protein complex with GPI8, PIG-S and PIG-T.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation, experimentally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14660601" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14660601
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A conserved proline in the last transmembrane segment of Gaa...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:14660601" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GAA1 shown to be part of the multisubunit human GPI transamidase (Gaa1, Gpi8, PIG-S, PIG-T, PIG-U).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14660601" target="_blank" class="term-link">
+                                        PMID:14660601
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human GPIT is a multisubunit membrane-bound protein complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mass-spectrometry identification of GPAA1 in an NK-cell membrane proteome. Generic &#39;membrane&#39; term; the specific location is the ER membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative parent term from a proteome-scale membrane fractionation; the specific ER membrane location is annotated separately.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">define the composition of the membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162836
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005789" data-r="Reactome:R-HSA-162836" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable assignment of GPAA1 (as part of the GPI transamidase reaction) to the ER membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization, consistent with all other evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GPAA1/GPAA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034235" target="_blank" class="term-link">
+                                    GO:0034235
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14660601" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14660601
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A conserved proline in the last transmembrane segment of Gaa...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0034235" data-r="PMID:14660601" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Truncation of GAA1&#39;s C-terminal TM span, or mutation of a conserved proline within it, prevents the transamidase complex from co-immunoprecipitating GPI while leaving assembly intact - showing GAA1 contributes to GPI binding by the complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct, informative core molecular function; the contributes_to qualifier appropriately captures that GPI binding is a property of the complex to which GAA1 contributes.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14660601" target="_blank" class="term-link">
+                                        PMID:14660601
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">abrogate the ability of the resulting GPIT complex to co-immunoprecipitate GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006621" target="_blank" class="term-link">
+                                    GO:0006621
+                                </a>
+                            </span>
+                            <span class="term-label">protein retention in ER lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12052837" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12052837
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural requirements for the recruitment of Gaa1 into a f...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0006621" data-r="PMID:12052837" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The cited paper describes how GAA1 itself is retained in the ER (a signalless, passive mechanism) and how its cytoplasmic N terminus may act as a membrane-sorting determinant for GAA1 and associated GPIT subunits. It does not show that GPAA1 retains other proteins in the ER lumen, and GPAA1 is not a KDEL-receptor-type lumenal-retention factor. The GO term &#39;protein retention in ER lumen&#39; is therefore a poor fit for GPAA1&#39;s biology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Term/paper mismatch: PMID:12052837 concerns retention of GAA1 (and its own complex) in the ER membrane, not retention of substrate proteins in the ER lumen. NAS evidence; not experimentally supported for this process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12052837" target="_blank" class="term-link">
+                                        PMID:12052837
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cytoplasmic N terminus of Gaa1 is not required for formation of a functional GPIT complex but may act as a membrane-sorting determinant directing Gaa1 and associated GPIT subunits to an endoplasmic reticulum membrane domain.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable assertion that the GAA1-containing transamidase attaches GPI to the C-terminus of precursor proteins in the ER.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP, consistent with all experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase mediates GPI anchoring in the endoplasmic reticulum, by replacing a protein&#39;s C-terminal GPI attachment signal peptide with a pre-assembled GPI.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9468317" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9468317
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning of human homolog of yeast GAA1 which is re...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0016255" data-r="PMID:9468317" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable assertion that human GAA1 is required for attachment of GPI to proteins (original cloning paper).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP; corroborated by later direct experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9468317" target="_blank" class="term-link">
+                                        PMID:9468317
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">required for attachment of glycosylphosphatidylinositols to proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15713669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Endoplasmic reticulum localization of Gaa1 and PIG-T, subuni...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0005515" data-r="PMID:15713669" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct/UniProt interaction (with PIGT Q969N2) within the ER-localized GPI transamidase complex. Bare &#39;protein binding&#39; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-informative MF term; the PIGT interaction is captured by complex membership (GO:0042765). Not removed per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link">
+                                        PMID:15713669
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">human Gaa1 and PIG-T, two of the five subunits</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15713669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Endoplasmic reticulum localization of Gaa1 and PIG-T, subuni...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43292" data-a="GO:0042765" data-r="PMID:15713669" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable assertion that GAA1 is one of the five subunits of the ER-localized GPI transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex-membership annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link">
+                                        PMID:15713669
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">human Gaa1 and PIG-T, two of the five subunits</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Binds the pre-assembled GPI lipid substrate as an accessory subunit of the ER-membrane GPI-anchor transamidase complex, coordinating the ethanolamine- phosphate arms of GPI (via residues including Ser51, His354 and Gln355) to position the bridging ethanolamine-phosphate for amide-bond formation during transfer of the GPI anchor to the substrate protein&#39;s C-terminal omega-site. Catalytic cleavage of the GPI-attachment signal peptide is performed by the PIGK subunit, not GPAA1.</h3>
+                <span class="vote-buttons" data-g="O43292" data-a="FUNCTION: Binds the pre-assembled GPI lipid substrate as an ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034235" target="_blank" class="term-link">
+                            GPI anchor binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                            GPI-anchor transamidase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000041.md" target="_blank" class="term-link">
+                            GO_REF:0000041
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniPathway vocabulary mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/GPAA1/GPAA1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry O43292 (GPAA1_HUMAN)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link">
+                            PMID:10793132
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gaa1p and gpi8p are components of a glycosylphosphatidylinositol (GPI) transamidase that mediates attachment of GPI to proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                            PMID:11483512
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a complex with GAA1 and GPI8.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12052837" target="_blank" class="term-link">
+                            PMID:12052837
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural requirements for the recruitment of Gaa1 into a functional glycosylphosphatidylinositol transamidase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                            PMID:12582175
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Two subunits of glycosylphosphatidylinositol transamidase, GPI8 and PIG-T, form a functionally important intermolecular disulfide bridge.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                            PMID:12802054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human PIG-U and yeast Cdc91p are the fifth subunit of GPI transamidase that attaches GPI-anchors to proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14660601" target="_blank" class="term-link">
+                            PMID:14660601
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A conserved proline in the last transmembrane segment of Gaa1 is required for glycosylphosphatidylinositol (GPI) recognition by GPI transamidase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link">
+                            PMID:15713669
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Endoplasmic reticulum localization of Gaa1 and PIG-T, subunits of the glycosylphosphatidylinositol transamidase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29100095" target="_blank" class="term-link">
+                            PMID:29100095
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in GPAA1, Encoding a GPI Transamidase Complex Protein, Cause Developmental Delay, Epilepsy, Cerebellar Atrophy, and Osteopenia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                            PMID:34576938
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional Analysis of the GPI Transamidase Complex by Screening for Amino Acid Mutations in Each Subunit.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                            PMID:35165458
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of human glycosylphosphatidylinositol transamidase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                            PMID:35551457
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular insights into biogenesis of glycosylphosphatidylinositol anchor proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                            PMID:37684232
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structures of liganded glycosylphosphatidylinositol transamidase illuminate GPI-AP biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9468317" target="_blank" class="term-link">
+                            PMID:9468317
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular cloning of human homolog of yeast GAA1 which is required for attachment of glycosylphosphatidylinositols to proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162836
+
+                    </span>
+                </div>
+
+                <div class="reference-title">uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + uPAR propeptide</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(GPAA1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O43292" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="gpaa1-gaa1-review-notes">GPAA1 (GAA1) review notes</h1>
+<p>UniProtKB: O43292; HGNC:4446; human; 621 aa; MANE NM_003801.4.<br />
+Deep research: falcon OUT OF CREDITS (HTTP 402) so no <code>-deep-research-falcon.md</code>. Review grounded in<br />
+<code>GPAA1-uniprot.txt</code>, seeded <code>GPAA1-goa.tsv</code>, and cached <code>publications/PMID_*.md</code> (all 17 cited PMIDs cached).</p>
+<h2 id="core-biology-verified-from-cited-literature-uniprot">Core biology (verified from cited literature + UniProt)</h2>
+<p>GPAA1 is a non-catalytic (accessory) subunit of the eukaryotic <strong>GPI-anchor transamidase (GPI-T / GPI-TA)<br />
+complex</strong>, an ER-membrane heteropentamer of PIGK, GPAA1, PIGT, PIGS, PIGU<br />
+[PMID:35551457 "an equimolar heteropentameric assembly"; PMID:34576938 "GPI-TA consists of five subunits:<br />
+PIGK, GPAA1, PIGT, PIGS, and PIGU"]. GPI-T removes the C-terminal GPI-attachment signal peptide of<br />
+precursor proteins in the ER and replaces it with a pre-assembled GPI anchor via a transamidation reaction<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11483512" title="GPI transamidase mediates GPI anchoring in the endoplasmic reticulum, by replacing a protein's C-terminal GPI attachment signal peptide with a pre-assembled GPI">PMID:11483512</a>.</p>
+<ul>
+<li><strong>Catalytic cysteine-protease chemistry resides in PIGK (Gpi8p)</strong>, not GPAA1<br />
+  [PMID:10793132 "Gpi8p is a catalytic component that cleaves the GPI attachment signal peptide";<br />
+  PMID:34576938 "PIGK is the catalytic subunit of GPI-TA"].</li>
+<li><strong>GPAA1 role</strong>: M28-family peptidase-like fold; proposed to mediate the second half-reaction — formation of<br />
+  the amide bond between the substrate ω-site carbonyl (acyl-enzyme intermediate on PIGK Cys) and the bridging<br />
+  ethanolamine-phosphate (EtNP) of GPI [PMID:34576938 "This reaction may be mediated by GPAA1, which is<br />
+  structurally similar to M28-type aminopeptidase"; PMID:34576938 "GPAA1 is proposed to catalyze the<br />
+  formation of an amide bond between the ω-site and the bridging EtNP on the GPI complete precursor"].<br />
+  GPAA1 Asp250 is functionally important (D250A reduces GPI-T activity)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/34576938" title="The D250A construct reduced GPI-TA activity without changing the protein stability">PMID:34576938</a>.</li>
+<li><strong>GPI (lipid substrate) binding / positioning is a GPAA1 function.</strong> Structures with liganded GPI-T show<br />
+  GPAA1 residues coordinate the three EtNP arms of GPI: EtNP1–His354(+Mg2+), EtNP2–Gln355/Ser51,<br />
+  EtNP3–Ser51/Asn53 <a href="https://pubmed.ncbi.nlm.nih.gov/37684232">PMID:37684232</a>. Truncating GPAA1's C-terminal TM span or mutating a conserved Pro in it<br />
+  abolishes GPI co-IP without disrupting assembly <a href="https://pubmed.ncbi.nlm.nih.gov/14660601" title="cannot co-immunoprecipitate GPI">PMID:14660601</a>.<br />
+  UniProt annotates GPAA1 GPI-anchor BINDING at residues 49/51/354/355/356 (ChEBI:144080) from PMID:37684232.</li>
+<li><strong>Complex assembly / stability</strong>: PIG-T stabilises GAA1+GPI8 expression <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" title="PIG-T maintains the   complex by stabilizing the expression of GAA1 and GPI8">PMID:11483512</a>; GAA1's large luminal loop mediates subunit<br />
+  interaction <a href="https://pubmed.ncbi.nlm.nih.gov/12052837">PMID:12052837</a>.</li>
+<li><strong>Localization</strong>: ER membrane, multi-pass; GAA1 is passively retained in the ER by a signalless mechanism<br />
+  [PMID:15713669 "Gaa1 is passively retained in the ER by a signalless mechanism"; UniProt SUBCELL<br />
+  Endoplasmic reticulum membrane, Multi-pass].</li>
+<li><strong>Disease</strong>: biallelic GPAA1 variants cause GPI biosynthesis defect 15 (GPIBD15; MIM:617810) — developmental<br />
+  delay, hypotonia, early-onset seizures, cerebellar atrophy, osteopenia; patient cells show reduced<br />
+  cell-surface GPI-anchored proteins <a href="https://pubmed.ncbi.nlm.nih.gov/29100095">PMID:29100095</a>.</li>
+</ul>
+<h2 id="annotation-action-rationale">Annotation-action rationale</h2>
+<ul>
+<li><strong>attachment of GPI anchor to protein (GO:0016255)</strong> and <strong>GPI anchored protein biosynthesis (GO:0180046)</strong><br />
+  and <strong>GPI-anchor transamidase complex (GO:0042765)</strong> and <strong>GPI anchor binding (GO:0034235)</strong> — well<br />
+  supported by IDA/IMP/EXP + IBA; ACCEPT (core).</li>
+<li><strong>GPI anchor biosynthetic process (GO:0006506)</strong> IEA(UniPathway) — parent BP, consistent; ACCEPT.</li>
+<li><strong>endoplasmic reticulum membrane (GO:0005789)</strong> (EXP/NAS/TAS/IEA) and <strong>endoplasmic reticulum (GO:0005783)</strong><br />
+  (IDA/HPA) — ACCEPT (ER membrane is core location; ER is the parent).</li>
+<li><strong>membrane (GO:0016020)</strong> IEA/HDA — true but uninformative parent of ER membrane; MARK_AS_OVER_ANNOTATED.</li>
+<li><strong>protein binding (GO:0005515)</strong> IPI ×8 — all resolve to complex partners (PIGK Q92643, PIGT Q969N2,<br />
+  MOXD1 Q6UVY6) or HT interactome studies; uninformative bare term per curation policy;<br />
+  MARK_AS_OVER_ANNOTATED (do NOT REMOVE per policy). The real MF is captured by GPI anchor binding +<br />
+  transamidase-complex membership.</li>
+<li><strong>protein retention in ER lumen (GO:0006621)</strong> NAS PMID:12052837 — the cited paper describes GAA1's own ER<br />
+  retention (a signalless mechanism), not GPAA1 causing retention of other lumenal proteins; the term is a<br />
+  mis-fit (GPAA1 is not a KDEL-receptor-like retention factor and the abstract does not support retaining<br />
+  other proteins in the ER lumen). NAS + demonstrably poor term/paper fit → MARK_AS_OVER_ANNOTATED.</li>
+</ul>
+<h2 id="core_functions-mf-chosen">core_functions MF chosen</h2>
+<p>GOA carries NO transamidase catalytic-activity MF term for GPAA1 (catalysis attributed to PIGK). The only MF<br />
+in GOA is GO:0005515 (bare protein binding, dropped) and <strong>GO:0034235 GPI anchor binding</strong> (IDA, PMID:37684232;<br />
+IMP contributes_to, PMID:14660601). Per instructions, use the exact GOA MF present → <strong>GO:0034235 GPI anchor<br />
+binding</strong> as the core molecular_function. Do NOT invent an independent transamidase catalytic activity.<br />
+</content></p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O43292
+gene_symbol: GPAA1
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  GPAA1 (GAA1; glycosylphosphatidylinositol anchor attachment 1 protein) is a
+  multi-pass endoplasmic reticulum membrane protein and one of the five subunits
+  of the GPI-anchor transamidase (GPI-T) complex (with PIGK, PIGT, PIGS and PIGU).
+  This complex catalyses the last step of GPI-anchored protein biosynthesis:
+  in the ER lumen it removes the C-terminal GPI-attachment signal peptide of
+  precursor proteins and, through a transamidation reaction, replaces it with a
+  pre-assembled GPI anchor at the new C-terminus. The catalytic cysteine-protease
+  chemistry that cleaves the signal peptide and forms the acyl(carbonyl)-enzyme
+  intermediate resides in the PIGK subunit; GPAA1, which adopts an M28
+  peptidase-like fold, is a required accessory subunit that binds the GPI lipid
+  substrate and coordinates its three ethanolamine-phosphate arms, positioning
+  the bridging ethanolamine-phosphate for amide-bond formation with the substrate
+  omega-site. GPAA1 is passively retained in the ER, and its large luminal loop
+  mediates assembly with the other subunits. Biallelic loss-of-function variants
+  in GPAA1 cause an inherited GPI-deficiency disorder (GPI biosynthesis defect 15;
+  GPIBD15) presenting with developmental delay, hypotonia, early-onset seizures,
+  cerebellar atrophy and osteopenia, and reduced cell-surface levels of
+  GPI-anchored proteins.
+alternative_products:
+- name: &#39;1&#39;
+  id: O43292-1
+- name: &#39;2&#39;
+  id: O43292-2
+  sequence_note: VSP_009542
+existing_annotations:
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred core biological process. GPAA1 orthologs across
+      eukaryotes (yeast Gaa1p, Drosophila) are components of the GPI transamidase
+      that attaches GPI to precursor proteins. Well supported by direct
+      experimental evidence in human (see IDA/EXP annotations).
+    action: ACCEPT
+    reason: &gt;-
+      Correct, appropriately specific core BP; matches direct experimental
+      annotations and the phylogenetic consensus.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: &gt;-
+        The GPI transamidase mediates GPI anchoring in the endoplasmic
+        reticulum, by replacing a protein&#39;s C-terminal GPI attachment signal
+        peptide with a pre-assembled GPI.
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Phylogenetically inferred complex membership. GPAA1 is a conserved subunit
+      of the GPI-anchor transamidase complex; this is confirmed by direct
+      co-purification, mutagenesis and cryo-EM structures of the human complex.
+    action: ACCEPT
+    reason: &gt;-
+      Core, correct complex-membership assignment consistent with experimental
+      evidence.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation from the UniProt subcellular-location vocabulary.
+      GPAA1 is a multi-pass ER membrane protein; supported directly by
+      experimental localization studies.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization; consistent with experimental and structural
+      evidence that GPAA1 is a multi-pass ER membrane protein.
+    supported_by:
+    - reference_id: file:human/GPAA1/GPAA1-uniprot.txt
+      supporting_text: &gt;-
+        SUBCELLULAR LOCATION: Endoplasmic reticulum membrane
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation to the generic &#39;membrane&#39; term. True but
+      uninformative: the specific and correct location is the ER membrane
+      (GO:0005789), which is separately annotated.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Redundant, low-information parent of the more specific ER membrane
+      annotation; retained but flagged as over-annotated.
+    supported_by:
+    - reference_id: file:human/GPAA1/GPAA1-uniprot.txt
+      supporting_text: &gt;-
+        SUBCELLULAR LOCATION: Endoplasmic reticulum membrane
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation (IPR007246, Gaa1) to the transamidase
+      complex. Correct complex membership, confirmed experimentally.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership term; consistent with experimental and
+      structural data.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:10793132
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct/UniProt binary interaction with PIGK (Q92643), the catalytic
+      subunit of the same complex. The interaction is real but the bare
+      &#39;protein binding&#39; term is uninformative; the biologically meaningful
+      relationship is captured by GPI-anchor transamidase complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Non-informative molecular-function term (bare protein binding); the
+      underlying PIGK interaction is already represented by complex membership.
+      Per curation policy this IPI is not removed.
+    supported_by:
+    - reference_id: PMID:10793132
+      supporting_text: &gt;-
+        Gaa1p and Gpi8p are associated with each other.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:11483512
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct/UniProt interaction (with PIGK Q92643) supporting GPI-T complex
+      assembly. Bare &#39;protein binding&#39; is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Non-informative MF term; the relevant biology (co-complex with the other
+      GPI-T subunits) is captured by GO:0042765. Not removed per policy.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: &gt;-
+        PIG-T maintains the complex by stabilizing the expression of GAA1 and GPI8
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12802054
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct/UniProt interaction (with PIGK Q92643) within the GPI transamidase
+      complex, which PMID:12802054 shows is a five-subunit assembly. Bare
+      &#39;protein binding&#39; is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Non-informative MF term; complex membership is the meaningful annotation.
+      Not removed per policy.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        The mammalian GPI transamidase is a
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: &gt;-
+      High-throughput AP-MS interactome (BioPlex 2.0) binary interactions
+      (PIGK Q92643, PIGT Q969N2, MOXD1 Q6UVY6). Bare &#39;protein binding&#39; is
+      uninformative and derives from a proteome-scale screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Non-informative MF term from a large-scale interactome study; complex
+      membership already captures the relevant partners. Not removed per policy.
+    supported_by:
+    - reference_id: PMID:28514442
+      supporting_text: &gt;-
+        the largest such network so far
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      High-throughput AP-MS interactome (BioPlex 3.0) interactions. Bare
+      &#39;protein binding&#39; is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Non-informative MF term from a proteome-scale interactome; not removed per
+      policy.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: &gt;-
+        we have created two proteome-scale, cell-line-specific
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: &gt;-
+      High-throughput multimodal cell-map interactome (PIGK Q92643, PIGT
+      Q969N2). Bare &#39;protein binding&#39; is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Non-informative MF term from a proteome-scale mapping study; not removed
+      per policy.
+    supported_by:
+    - reference_id: PMID:40205054
+      supporting_text: &gt;-
+        Multimodal cell maps as a foundation for structural and functional genomics
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000041
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      UniPathway-based electronic annotation to the parent GPI-anchor
+      biosynthesis process. GPAA1 acts in the terminal transamidation step of
+      this pathway.
+    action: ACCEPT
+    reason: &gt;-
+      Correct parent BP for GPAA1&#39;s role in GPI-anchored protein biosynthesis.
+    supported_by:
+    - reference_id: file:human/GPAA1/GPAA1-uniprot.txt
+      supporting_text: &gt;-
+        PATHWAY: Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor
+        biosynthesis.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:12802054
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ComplexPortal (NAS) assignment of the GPI-anchor transamidase complex to
+      the ER membrane. Consistent with direct experimental localization of GPAA1.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization; corroborated by experimental evidence.
+    supported_by:
+    - reference_id: PMID:12582175
+      supporting_text: &gt;-
+        GPI transamidase is localized in the
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: NAS
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal (NAS) assignment of the transamidase complex process to
+      GPAA1. Correct core BP, confirmed by experimental data.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP; consistent with the direct experimental annotations.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        GPI transamidase that attaches GPI-anchors to proteins
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IPI
+  original_reference_id: PMID:12802054
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Affinity-purification evidence that GPAA1 is part of the GPI transamidase
+      complex; this paper established PIG-U as the fifth subunit alongside GAA1,
+      GPI8, PIG-S and PIG-T.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation, experimentally supported.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        The GPI transamidase complex affinity-purified from cells expressing
+        epitope-tagged-GPI8 contained PIG-U and four other known components.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Human Protein Atlas immunofluorescence localizes GPAA1 to the endoplasmic
+      reticulum. Consistent with its role as an ER-membrane transamidase subunit;
+      the ER membrane (GO:0005789) is the more precise location.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localization to the ER (parent of ER membrane); consistent with all
+      other localization data.
+    supported_by:
+    - reference_id: file:human/GPAA1/GPAA1-uniprot.txt
+      supporting_text: &gt;-
+        GO:0005783; C:endoplasmic reticulum; IDA:HPA.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: EXP
+  original_reference_id: PMID:11483512
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental localization of the GAA1-containing transamidase to the ER
+      membrane, where it mediates GPI anchoring.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization, directly supported.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: &gt;-
+        The GPI transamidase mediates GPI anchoring in the endoplasmic
+        reticulum
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Cryo-EM structure of the human GPI transamidase (PIGK/PIGU/PIGT/PIGS/GPAA1)
+      demonstrating its role in maturation of GPI-anchored proteins.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, directly supported by the structural characterization of
+      the complex containing GPAA1.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: &gt;-
+        composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Cryo-EM structure of the human GPI-T heteropentamer including GPAA1,
+      illuminating GPI-anchored protein biogenesis.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP; directly supported by structural data on the GPAA1-
+      containing complex.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        GPI-T at a global 2.53-Å resolution, revealing an equimolar
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:29100095
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Functional evidence that GPAA1 is essential for attaching GPI to precursor
+      proteins: patient cells with biallelic GPAA1 variants show reduced surface
+      levels of GPI-anchored proteins.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, supported by loss-of-function disease evidence.
+    supported_by:
+    - reference_id: PMID:29100095
+      supporting_text: &gt;-
+        This complex orchestrates the attachment of the GPI anchor to the
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:9468317
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Original cloning of human GAA1; antisense knockdown reduced production of a
+      reporter GPI-anchored protein, implicating GPAA1 in GPI attachment.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP; supported by functional knockdown evidence.
+    supported_by:
+    - reference_id: PMID:9468317
+      supporting_text: &gt;-
+        Overexpression of antisense hGAA1 in human K562 cells significantly
+        reduced the production of a reporter GPI-anchored protein
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:9468317
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      GPAA1 identified as a component of the putative transamidase machinery.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation.
+    supported_by:
+    - reference_id: PMID:9468317
+      supporting_text: &gt;-
+        We have isolated a component of the putative transamidase
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:29100095
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      GPAA1 as an essential component of the transamidase complex in GPI-anchored
+      protein biosynthesis; loss of function reduces surface GPI-APs.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, supported by disease/functional evidence.
+    supported_by:
+    - reference_id: PMID:29100095
+      supporting_text: &gt;-
+        GPI-anchored proteins had decreased cell-surface abundance in
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mutational screen of GPI-TA subunits confirming GPAA1 function in GPI
+      anchoring (GPAA1 D250A reduces activity).
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, directly supported by functional mutagenesis.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        The D250A construct reduced GPI-TA activity without changing the protein
+        stability
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Liganded GPI-T structures showing GPAA1 within the complex engaged in
+      GPI-anchored protein biogenesis (GPI substrate bound).
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, directly supported by structural data on the substrate-
+      and product-bound complex.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: &gt;-
+        EtNP2 is fixed by GPAA1 Gln355 and Ser51
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:9468317
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      GPAA1 functionally implicated in production of GPI-anchored proteins via
+      antisense knockdown.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP; functional knockdown evidence.
+    supported_by:
+    - reference_id: PMID:9468317
+      supporting_text: &gt;-
+        Overexpression of antisense hGAA1 in human K562 cells significantly
+        reduced the production of a reporter GPI-anchored protein
+- term:
+    id: GO:0034235
+    label: GPI anchor binding
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Liganded cryo-EM structures directly show GPAA1 binding the GPI lipid
+      substrate: GPAA1 residues coordinate the three ethanolamine-phosphate arms
+      of GPI (EtNP1-His354 via Mg2+, EtNP2-Gln355/Ser51, EtNP3-Ser51/Asn53).
+      This is GPAA1&#39;s specific molecular function within the complex.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported, informative core molecular function (GPI lipid-substrate
+      binding), established by liganded structures.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: &gt;-
+        EtNP1 interacts with GPAA1 His354 through metal coordination (modeled as
+        Mg2+)
+    - reference_id: PMID:37684232
+      supporting_text: &gt;-
+        Finally, EtNP3 interacts with GPAA1 Ser51 and Asn53
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct evidence for the transamidase complex (containing GAA1) attaching
+      GPI anchors to proteins.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, experimentally supported.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        GPI transamidase that attaches GPI-anchors to proteins
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Functional analysis of GPI-TA subunits including GPAA1, confirming its role
+      in GPI attachment; GPAA1 is proposed to catalyse formation of the amide
+      bond between the substrate omega-site and the bridging EtNP.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, supported by mutagenesis and functional rescue assays.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        GPAA1 is proposed to catalyze the formation of an amide bond between the
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Substrate/product-bound GPI-T structures directly visualise the attachment
+      reaction, with GPAA1 binding the GPI substrate.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, directly supported by structural data.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: &gt;-
+        EtNP2 is fixed by GPAA1 Gln355 and Ser51
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Cryo-EM structures of the GPI-T complex including GPAA1 (light blue subunit)
+      with PIGK, PIGT, PIGS and PIGU.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation, structurally confirmed.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: &gt;-
+        a Interactions between the product ULBP2* and GPI-T (GPAA1, light blue;
+        PIGK, marine blue; PIGT, purple; PGIS, cyan).
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Cryo-EM structure of the human GPI transamidase catalysing GPI attachment
+      to proteins in the ER.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, structurally supported.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: &gt;-
+        composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Cryo-EM structure of the human GPI-T heteropentamer engaged in the removal
+      of the signal peptide and covalent attachment of GPI.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, structurally supported.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        covalent attachment of GPI at the new carboxyl terminus
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Cryo-EM structure demonstrating GPAA1 as one of the five subunits of the
+      human GPI transamidase complex.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation, structurally confirmed.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: &gt;-
+        composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Cryo-EM structure of the equimolar heteropentameric GPI-T complex including
+      GPAA1.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation, structurally confirmed.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        GPI-T at a global 2.53-Å resolution, revealing an equimolar
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12582175
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Biochemical evidence that the human GPI transamidase is a multimeric complex
+      of five components (including GAA1) sufficient to hold the substrate protein.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation.
+    supported_by:
+    - reference_id: PMID:12582175
+      supporting_text: &gt;-
+        indicating that these five components are sufficient to
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Purified human GPI-TA containing GPAA1 with the four other subunits.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation, experimentally supported.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IMP
+  original_reference_id: PMID:14660601
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mutation of a conserved proline in the last TM segment of GAA1 abolishes
+      GPI recognition/binding by the transamidase, impairing GPI attachment.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, supported by mutational (IMP) evidence linking GAA1 to
+      the attachment reaction.
+    supported_by:
+    - reference_id: PMID:14660601
+      supporting_text: &gt;-
+        required for glycosylphosphatidylinositol (GPI) recognition by GPI
+        transamidase
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12802054
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Affinity-purified GPI transamidase complex containing GAA1 and the four
+      other subunits.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        The GPI transamidase complex affinity-purified from cells expressing
+        epitope-tagged-GPI8 contained PIG-U and four other known components.
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:11483512
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      GAA1 shown to form a protein complex with GPI8, PIG-S and PIG-T.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation, experimentally supported.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: &gt;-
+        PIG-S and PIG-T form a protein complex with GAA1 and GPI8
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:14660601
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      GAA1 shown to be part of the multisubunit human GPI transamidase (Gaa1,
+      Gpi8, PIG-S, PIG-T, PIG-U).
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation.
+    supported_by:
+    - reference_id: PMID:14660601
+      supporting_text: &gt;-
+        Human GPIT is a multisubunit membrane-bound protein complex
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mass-spectrometry identification of GPAA1 in an NK-cell
+      membrane proteome. Generic &#39;membrane&#39; term; the specific location is the
+      ER membrane.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative parent term from a proteome-scale membrane fractionation;
+      the specific ER membrane location is annotated separately.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: &gt;-
+        define the composition of the membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162836
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome traceable assignment of GPAA1 (as part of the GPI transamidase
+      reaction) to the ER membrane.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization, consistent with all other evidence.
+    supported_by:
+    - reference_id: file:human/GPAA1/GPAA1-uniprot.txt
+      supporting_text: &gt;-
+        SUBCELLULAR LOCATION: Endoplasmic reticulum membrane
+- term:
+    id: GO:0034235
+    label: GPI anchor binding
+  evidence_type: IMP
+  original_reference_id: PMID:14660601
+  qualifier: contributes_to
+  review:
+    summary: &gt;-
+      Truncation of GAA1&#39;s C-terminal TM span, or mutation of a conserved proline
+      within it, prevents the transamidase complex from co-immunoprecipitating
+      GPI while leaving assembly intact - showing GAA1 contributes to GPI binding
+      by the complex.
+    action: ACCEPT
+    reason: &gt;-
+      Correct, informative core molecular function; the contributes_to qualifier
+      appropriately captures that GPI binding is a property of the complex to
+      which GAA1 contributes.
+    supported_by:
+    - reference_id: PMID:14660601
+      supporting_text: &gt;-
+        abrogate the ability of the resulting GPIT complex to co-immunoprecipitate
+        GPI
+- term:
+    id: GO:0006621
+    label: protein retention in ER lumen
+  evidence_type: NAS
+  original_reference_id: PMID:12052837
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The cited paper describes how GAA1 itself is retained in the ER (a
+      signalless, passive mechanism) and how its cytoplasmic N terminus may act
+      as a membrane-sorting determinant for GAA1 and associated GPIT subunits.
+      It does not show that GPAA1 retains other proteins in the ER lumen, and
+      GPAA1 is not a KDEL-receptor-type lumenal-retention factor. The GO term
+      &#39;protein retention in ER lumen&#39; is therefore a poor fit for GPAA1&#39;s biology.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Term/paper mismatch: PMID:12052837 concerns retention of GAA1 (and its own
+      complex) in the ER membrane, not retention of substrate proteins in the ER
+      lumen. NAS evidence; not experimentally supported for this process.
+    supported_by:
+    - reference_id: PMID:12052837
+      supporting_text: &gt;-
+        the cytoplasmic N terminus of Gaa1 is not required for formation of a
+        functional GPIT complex but may act as a membrane-sorting determinant
+        directing Gaa1 and associated GPIT subunits to an endoplasmic reticulum
+        membrane domain.
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: TAS
+  original_reference_id: PMID:11483512
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Traceable assertion that the GAA1-containing transamidase attaches GPI to
+      the C-terminus of precursor proteins in the ER.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP, consistent with all experimental evidence.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: &gt;-
+        The GPI transamidase mediates GPI anchoring in the endoplasmic
+        reticulum, by replacing a protein&#39;s C-terminal GPI attachment signal
+        peptide with a pre-assembled GPI.
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: NAS
+  original_reference_id: PMID:9468317
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Non-traceable assertion that human GAA1 is required for attachment of GPI
+      to proteins (original cloning paper).
+    action: ACCEPT
+    reason: &gt;-
+      Correct core BP; corroborated by later direct experimental evidence.
+    supported_by:
+    - reference_id: PMID:9468317
+      supporting_text: &gt;-
+        required for attachment of glycosylphosphatidylinositols to proteins
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:15713669
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct/UniProt interaction (with PIGT Q969N2) within the ER-localized GPI
+      transamidase complex. Bare &#39;protein binding&#39; is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Non-informative MF term; the PIGT interaction is captured by complex
+      membership (GO:0042765). Not removed per policy.
+    supported_by:
+    - reference_id: PMID:15713669
+      supporting_text: &gt;-
+        human Gaa1 and PIG-T, two of the five subunits
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: TAS
+  original_reference_id: PMID:15713669
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Traceable assertion that GAA1 is one of the five subunits of the
+      ER-localized GPI transamidase complex.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core complex-membership annotation.
+    supported_by:
+    - reference_id: PMID:15713669
+      supporting_text: &gt;-
+        human Gaa1 and PIG-T, two of the five subunits
+core_functions:
+- description: &gt;-
+    Binds the pre-assembled GPI lipid substrate as an accessory subunit of the
+    ER-membrane GPI-anchor transamidase complex, coordinating the ethanolamine-
+    phosphate arms of GPI (via residues including Ser51, His354 and Gln355) to
+    position the bridging ethanolamine-phosphate for amide-bond formation during
+    transfer of the GPI anchor to the substrate protein&#39;s C-terminal omega-site.
+    Catalytic cleavage of the GPI-attachment signal peptide is performed by the
+    PIGK subunit, not GPAA1.
+  molecular_function:
+    id: GO:0034235
+    label: GPI anchor binding
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000041
+  title: Gene Ontology annotation based on UniPathway vocabulary mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: file:human/GPAA1/GPAA1-uniprot.txt
+  title: UniProtKB entry O43292 (GPAA1_HUMAN)
+  findings: []
+- id: PMID:10793132
+  title: Gaa1p and gpi8p are components of a glycosylphosphatidylinositol (GPI) transamidase
+    that mediates attachment of GPI to proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes that GAA1 and GPI8 are the core transamidase components and that
+      GPI8 (PIGK) is the catalytic cysteine-protease subunit; GAA1 KO abolishes
+      carbonyl-intermediate formation. Abstract-only cache.
+- id: PMID:11483512
+  title: PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a
+    complex with GAA1 and GPI8.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Defines the GAA1/GPI8/PIG-S/PIG-T complex and its ER localization; source of
+      the direct protein-sequence and complex-assembly annotations. Abstract-only.
+- id: PMID:12052837
+  title: Structural requirements for the recruitment of Gaa1 into a functional glycosylphosphatidylinositol
+    transamidase complex.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: MISCITED
+    review_notes: &gt;-
+      Concerns ER retention/sorting of GAA1 itself and complex assembly via its
+      luminal domain; does NOT support &#39;protein retention in ER lumen&#39; (GO:0006621)
+      as a GPAA1 function acting on other proteins - that annotation is a term/paper
+      mismatch. Relevant for localization/assembly. Abstract-only.
+- id: PMID:12582175
+  title: Two subunits of glycosylphosphatidylinositol transamidase, GPI8 and PIG-T,
+    form a functionally important intermolecular disulfide bridge.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      GPI8-PIG-T disulfide bridge and confirmation the five-component complex holds
+      substrate; supports complex membership. Abstract-only.
+- id: PMID:12802054
+  title: Human PIG-U and yeast Cdc91p are the fifth subunit of GPI transamidase that
+    attaches GPI-anchors to proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes PIG-U as the fifth subunit alongside GAA1; affinity-purified
+      complex; supports complex membership and attachment BP. Abstract-only.
+- id: PMID:14660601
+  title: A conserved proline in the last transmembrane segment of Gaa1 is required
+    for glycosylphosphatidylinositol (GPI) recognition by GPI transamidase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Direct functional link between GAA1 and GPI recognition/binding by the
+      complex (co-IP of GPI abolished by GAA1 C-terminal TM mutation); basis of the
+      GPI anchor binding (contributes_to) IMP annotation. Abstract-only.
+- id: PMID:15713669
+  title: Endoplasmic reticulum localization of Gaa1 and PIG-T, subunits of the glycosylphosphatidylinositol
+    transamidase complex.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Shows GAA1 is passively retained in the ER by a signalless mechanism;
+      supports ER-membrane localization and complex membership. Abstract-only.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput membrane-proteome MS; only supports the generic &#39;membrane&#39;
+      HDA term, which is over-annotated relative to the specific ER membrane.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex 2.0 proteome-scale AP-MS; source of bare &#39;protein binding&#39; IPIs
+      (PIGK/PIGT/MOXD1). Interactions plausible but term uninformative.
+- id: PMID:29100095
+  title: Mutations in GPAA1, Encoding a GPI Transamidase Complex Protein, Cause Developmental
+    Delay, Epilepsy, Cerebellar Atrophy, and Osteopenia.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Defines GPIBD15 disease; biallelic GPAA1 variants reduce surface GPI-APs;
+      supports the attachment BP and disease context. Abstract-only.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex 3.0 proteome-scale AP-MS; bare &#39;protein binding&#39; IPI source.
+- id: PMID:34576938
+  title: Functional Analysis of the GPI Transamidase Complex by Screening for Amino
+    Acid Mutations in Each Subunit.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text cached; systematic mutagenesis of all five subunits. Confirms PIGK
+      is catalytic, GPAA1 has M28-peptidase-like fold, GPAA1 D250A reduces activity,
+      and GPAA1 proposed to form the amide bond with the bridging EtNP.
+- id: PMID:35165458
+  title: Structure of human glycosylphosphatidylinositol transamidase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Cryo-EM structure of the human GPI-T; PIGK C206-H164-N58 catalytic triad;
+      TM cleft as GPI substrate-binding site. Abstract-only cache.
+- id: PMID:35551457
+  title: Molecular insights into biogenesis of glycosylphosphatidylinositol anchor
+    proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      2.53-Å cryo-EM structure of the equimolar heteropentameric GPI-T; legumain-
+      like proprotein cleavage mechanism; GPAA1 His354 mutation reduces activity.
+      Abstract-only cache.
+- id: PMID:37684232
+  title: Structures of liganded glycosylphosphatidylinositol transamidase illuminate
+    GPI-AP biogenesis.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text cached; substrate/product-bound GPI-T structures. Directly shows
+      GPAA1 binding the GPI lipid (EtNP1-His354/Mg2+, EtNP2-Gln355/Ser51,
+      EtNP3-Ser51/Asn53); basis of the GPI anchor binding IDA and core MF.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale multimodal cell-map interactome; bare &#39;protein binding&#39; IPI
+      source (PIGK/PIGT).
+- id: PMID:9468317
+  title: Molecular cloning of human homolog of yeast GAA1 which is required for attachment
+    of glycosylphosphatidylinositols to proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Original cloning of human GAA1; antisense knockdown reduces reporter GPI-AP;
+      basis of the attachment BP and complex-component annotations. Abstract-only.
+- id: Reactome:R-HSA-162836
+  title: uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + uPAR propeptide
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PGAP1/PGAP1-ai-review.html
+++ b/genes/human/PGAP1/PGAP1-ai-review.html
@@ -1,0 +1,3215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PGAP1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PGAP1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q75T13" target="_blank" class="term-link">
+                        Q75T13
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PGAP1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q75T13" data-a="DESCRIPTION: PGAP1 (GPI inositol-deacylase; Post-GPI Attachment..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PGAP1 (GPI inositol-deacylase; Post-GPI Attachment to Proteins factor 1) is a multi-pass endoplasmic reticulum membrane protein with an alpha/beta-hydrolase (serine-hydrolase) fold. After a nascent protein has received its glycosylphosphatidylinositol (GPI) anchor from the GPI transamidase, PGAP1 removes the acyl chain that is linked to the 2-OH of the inositol ring of the anchor. This inositol-deacylation is the first, ER-resident step of the post-attachment GPI-anchor remodeling pathway and is required for efficient export of GPI-anchored proteins from the ER to the Golgi (via recognition of the remodeled anchor by p24-family cargo receptors that load GPI-anchored proteins into COPII vesicles). Biallelic loss-of-function variants cause an autosomal-recessive inherited GPI-deficiency disorder (GPI biosynthesis defect; NEDDSBA, MIM:615802) with global developmental delay, impaired intellectual development, hypotonia/spasticity, epilepsy and structural brain abnormalities; in this disorder cell-surface levels of GPI-anchored proteins are near-normal but the anchor fine structure is abnormal (PI-PLC-resistant), reflecting a remodeling rather than an attachment defect.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>GPI inositol-deacylase activity</h3>
+                <span class="vote-buttons" data-g="Q75T13" data-a="GPI inositol-deacylase activity" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> Catalysis of the hydrolytic removal of the acyl chain linked to the 2-position (2-O-acyl) of the inositol ring of a glycosylphosphatidylinositol (GPI) anchor of a GPI-anchored protein, releasing a fatty acid.</p>
+
+
+
+            <p><strong>Justification:</strong> PGAP1 (and its yeast ortholog Bst1) has a specific, well-characterized inositol-deacylase activity on GPI anchors that is currently only representable by the generic term GO:0160215 (deacylase activity) or its broad parent GO:0016788 (hydrolase activity, acting on ester bonds). A dedicated child term would capture the substrate specificity.</p>
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160215" target="_blank" class="term-link">
+                    deacylase activity
+                </a>
+            </p>
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0005783" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation placing PGAP1 activity in the endoplasmic reticulum. This is correct - PGAP1 is an ER-resident enzyme that acts on the GPI anchor immediately after attachment in the ER.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with experimental localization and function; PGAP1 acts on nascent GPI-anchored proteins in the ER. The more precise term ER membrane (GO:0005789) is also annotated and is captured in core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24784135" target="_blank" class="term-link">
+                                        PMID:24784135
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PGAP1 is a deacylase that removes an acyl-chain from the inositol of GPI anchors in the endoplasmic reticulum immediately after attachment of GPI to proteins.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                        PMID:38167496
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Residing in the ER membrane, PGAP1 removes the inositol-linked acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated forms.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160215" target="_blank" class="term-link">
+                                    GO:0160215
+                                </a>
+                            </span>
+                            <span class="term-label">deacylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0160215" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation of deacylase activity - the core molecular function of PGAP1 as a GPI inositol-deacylase. GO:0160215 (current label &#34;deacylase activity&#34;) is the most specific currently available GO molecular-function term for this activity; there is no dedicated &#34;GPI inositol-deacylase activity&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the defining, experimentally supported molecular function of PGAP1 (removal of the inositol-linked acyl chain of the GPI anchor). Retained as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                        PMID:38167496
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Residing in the ER membrane, PGAP1 removes the inositol-linked acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated forms.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24784135" target="_blank" class="term-link">
+                                        PMID:24784135
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PGAP1 is a deacylase that removes an acyl-chain from the inositol of GPI anchors in the endoplasmic reticulum immediately after attachment of GPI to proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation from the UniProt Subcellular Location vocabulary mapping placing PGAP1 in the ER membrane. PGAP1 is a multi-pass ER membrane protein, so this is correct and is the most precise localization term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization; PGAP1 is a multi-pass ER membrane protein acting on the luminal face of the anchor. Retained in core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP1/PGAP1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                        PMID:38167496
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Residing in the ER membrane, PGAP1 removes the inositol-linked acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated forms.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016788" target="_blank" class="term-link">
+                                    GO:0016788
+                                </a>
+                            </span>
+                            <span class="term-label">hydrolase activity, acting on ester bonds</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0016788" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-to-GO electronic annotation assigning ester-bond hydrolase activity based on the alpha/beta-hydrolase (PGAP1/BST1) domains. This is a correct but broad parent of the specific deacylase activity; PGAP1 hydrolyzes an ester bond to release the inositol-linked fatty acid.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biologically accurate broader classification (carboxylic-ester hydrolase; EC 3.1.-.-). It is a general parent of the more specific deacylase activity (GO:0160215) but is not wrong, so it is retained. The specific deacylase term is captured as the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                        PMID:38167496
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">serine hydrolase-type catalysis</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP1/PGAP1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SIMILARITY: Belongs to the GPI inositol-deacylase family.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162791
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0016255" data-r="Reactome:R-HSA-162791" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable annotation placing PGAP1 in the &#34;Attachment of GPI anchor to uPAR&#34; pathway. PGAP1 does not catalyze the transamidase attachment step; it acts immediately after attachment, deacylating the inositol of the already-transferred anchor as the first post-attachment remodeling step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The term overstates PGAP1&#39;s role. The transamidase (PIGK/GPAA1/PIGS/PIGT/PIGU) attaches the GPI anchor to the protein; PGAP1 acts downstream on the anchor that has already been attached. Reactome groups the deacylation reaction within the broader attachment pathway (so the annotation is not entirely wrong at the pathway level), but a GPI anchor biosynthetic/remodeling process term better reflects the direct role. The correct core BP (GPI anchor biosynthetic process, GO:0006506; the post-attachment remodeling step) is captured in core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24784135" target="_blank" class="term-link">
+                                        PMID:24784135
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PGAP1 is a deacylase that removes an acyl-chain from the inositol of GPI anchors in the endoplasmic reticulum immediately after attachment of GPI to proteins.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162791
+
+                                </span>
+
+                                <div class="support-text">In a second step, the GPI moiety is deacylated, yielding a uPAR-GPI conjugate that can be efficiently transported to the Golgi apparatus.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0005789" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation transferring ER membrane localization from the mouse ortholog (UniProtKB:Q765A7). Consistent with the multi-pass ER membrane topology of PGAP1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization, consistent with the SubCell-based IEA, the Reactome TAS, and the multi-pass membrane topology annotated in UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP1/PGAP1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                        PMID:38167496
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Residing in the ER membrane, PGAP1 removes the inositol-linked acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated forms.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160215" target="_blank" class="term-link">
+                                    GO:0160215
+                                </a>
+                            </span>
+                            <span class="term-label">deacylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24784135" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24784135
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Null mutation in PGAP1 impairing Gpi-anchor maturation in pa...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0160215" data-r="PMID:24784135" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (IDA) annotation of deacylase activity. In this study, the patient p.Leu197del null mutation abolished PGAP1 activity, rendering GPI-anchored proteins resistant to PI-PLC, and wild-type PGAP1 cDNA rescued PI-PLC sensitivity in PGAP1-deficient CHO cells - functionally demonstrating the inositol-deacylase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core molecular function (GPI inositol-deacylase); GO:0160215 is the most specific available term for this activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24784135" target="_blank" class="term-link">
+                                        PMID:24784135
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PGAP1 is a deacylase that removes an acyl-chain from the inositol of GPI anchors in the endoplasmic reticulum immediately after attachment of GPI to proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160215" target="_blank" class="term-link">
+                                    GO:0160215
+                                </a>
+                            </span>
+                            <span class="term-label">deacylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:38167496
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular basis of the inositol deacylase PGAP1 involved in ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0160215" data-r="PMID:38167496" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (IDA) annotation of deacylase activity from the structural/biochemical study, which developed a fluorescent GPI-AP substrate assay, kinetically characterized the enzyme, and showed a serine-hydrolase-type catalysis that removes the inositol-linked acyl chain from GPI-anchored proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core molecular function; the same activity as the other IDA annotation. Retained as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                        PMID:38167496
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Residing in the ER membrane, PGAP1 removes the inositol-linked acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated forms.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                        PMID:38167496
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">serine hydrolase-type catalysis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902953" target="_blank" class="term-link">
+                                    GO:1902953
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of ER to Golgi vesicle-mediated transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:1902953" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation (from mouse ortholog) capturing PGAP1&#39;s role in promoting ER-to-Golgi transport of GPI-anchored proteins. Inositol-deacylation by PGAP1 is required for efficient ER export of GPI-APs, mediated by binding of the remodeled anchor to p24-family cargo receptors that recruit GPI-APs into COPII vesicles.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported downstream biological consequence of PGAP1 deacylation, but it is a regulatory/trafficking process rather than the direct molecular role of the enzyme. Retained as non-core; the direct role (inositol-deacylation / GPI anchor remodeling) is the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                        PMID:38167496
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in mammalian cells, the deacylation by hPGAP1 is necessary for efficient ER export</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                        PMID:38167496
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the deacylation is required for binding with p24-family cargo receptors</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016788" target="_blank" class="term-link">
+                                    GO:0016788
+                                </a>
+                            </span>
+                            <span class="term-label">hydrolase activity, acting on ester bonds</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162729
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0016788" data-r="Reactome:R-HSA-162729" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable annotation of ester-bond hydrolase activity, based on the modeled reaction uPAR-acyl-GPI + H2O to uPAR + long-chain fatty acid in the ER. Correct broad classification of the deacylation (ester hydrolysis) reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate broader parent of the specific deacylase activity; the reaction is an ester hydrolysis releasing the inositol-linked fatty acid. Retained; the more specific deacylase term is the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162729
+
+                                </span>
+
+                                <div class="support-text">The fatty acid group added to inositol in the fourth step of GPI biosynthsis is removed from GPI-conjugated uPAR.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162729
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0005789" data-r="Reactome:R-HSA-162729" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable annotation placing the PGAP1 deacylation reaction at the ER membrane. Consistent with the SubCell IEA, ISS, and experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization; the deacylation reaction occurs in the ER.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162729
+
+                                </span>
+
+                                <div class="support-text">This hydrolysis event occurs in the endoplasmic reticulum</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                        PMID:38167496
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Residing in the ER membrane, PGAP1 removes the inositol-linked acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated forms.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q75T13" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GPI anchor biosynthetic process is the correct core biological process for PGAP1. PGAP1 performs the first, ER-resident step of the post-attachment GPI-anchor remodeling phase (inositol-deacylation). This term is present as an IBA:GO_Central annotation in the UniProt cross-reference block but was not in the seeded GOA TSV; it is added here as the appropriate replacement for the over-annotated GO:0016255 (attachment of GPI anchor to protein).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Captures PGAP1&#39;s direct role in GPI-anchor biosynthesis/remodeling more accurately than the transamidase-centric GO:0016255. Supported by the UniProt IBA annotation and the experimental literature.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP1/PGAP1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">GO:0006506; P:GPI anchor biosynthetic process; IBA:GO_Central.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24784135" target="_blank" class="term-link">
+                                        PMID:24784135
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PGAP1 is a deacylase that removes an acyl-chain from the inositol of GPI anchors in the endoplasmic reticulum immediately after attachment of GPI to proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>GPI inositol-deacylase that hydrolyzes and removes the acyl chain linked to the 2-OH of the inositol ring of the GPI anchor of a GPI-anchored protein in the ER, the first step of post-attachment GPI-anchor remodeling.</h3>
+                <span class="vote-buttons" data-g="Q75T13" data-a="FUNCTION: GPI inositol-deacylase that hydrolyzes and removes..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160215" target="_blank" class="term-link">
+                            deacylase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                PMID:38167496
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Residing in the ER membrane, PGAP1 removes the inositol-linked acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated forms.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24784135" target="_blank" class="term-link">
+                                PMID:24784135
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PGAP1 is a deacylase that removes an acyl-chain from the inositol of GPI anchors in the endoplasmic reticulum immediately after attachment of GPI to proteins.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>The inositol-deacylation performed by PGAP1 is required for efficient ER-to-Golgi transport of GPI-anchored proteins, enabling recognition of the remodeled anchor by p24-family cargo receptors that load GPI-APs into COPII vesicles.</h3>
+                <span class="vote-buttons" data-g="Q75T13" data-a="FUNCTION: The inositol-deacylation performed by PGAP1 is req..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160215" target="_blank" class="term-link">
+                            deacylase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902953" target="_blank" class="term-link">
+                                positive regulation of ER to Golgi vesicle-mediated transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                PMID:38167496
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">in mammalian cells, the deacylation by hPGAP1 is necessary for efficient ER export</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                                PMID:38167496
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the deacylation is required for binding with p24-family cargo receptors</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24784135" target="_blank" class="term-link">
+                            PMID:24784135
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Null mutation in PGAP1 impairing Gpi-anchor maturation in patients with intellectual disability and encephalopathy.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PGAP1 is the GPI inositol-deacylase that removes an acyl chain from the inositol of GPI anchors in the ER immediately after attachment of GPI to proteins; a homozygous null variant (p.Leu197del) causes autosomal-recessive intellectual disability and encephalopathy.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/38167496" target="_blank" class="term-link">
+                            PMID:38167496
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular basis of the inositol deacylase PGAP1 involved in quality control of GPI-AP biogenesis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PGAP1 resides in the ER membrane, initiates the post-attachment remodeling phase by removing the inositol-linked acyl chain of nascent GPI-anchored proteins via serine-hydrolase-type catalysis, and this deacylation is required for efficient ER-to-Golgi export via p24-family cargo receptors.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24482476" target="_blank" class="term-link">
+                            PMID:24482476
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Exome sequencing links corticospinal motor neuron disease to common neurodegenerative disorders.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Independent exome-sequencing evidence linking PGAP1 variants to the neurodevelopmental disorder (NEDDSBA); cited by UniProt for disease involvement.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162729
+
+                    </span>
+                </div>
+
+                <div class="reference-title">uPAR-acyl-GPI + H2O -&gt; uPAR + long-chain fatty acid</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Models the PGAP1-catalyzed removal of the inositol-linked fatty acid from GPI-conjugated uPAR in the ER, associated with efficient ER-to-Golgi transport.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162791
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Attachment of GPI anchor to uPAR</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Pathway in which the transferred GPI moiety is deacylated (by PGAP1), yielding a uPAR-GPI conjugate that can be efficiently transported to the Golgi.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PGAP1/PGAP1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q75T13 (PGAP1_HUMAN)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PGAP1 is a GPI inositol-deacylase, a multi-pass ER membrane protein belonging to the GPI inositol-deacylase family, with EC 3.1.-.- carboxylic-ester hydrolase activity; deficiency causes NEDDSBA (MIM:615802).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Beyond the inositol-deacylase activity, does human PGAP1 have direct roles in ER quality control / ERAD of misfolded GPI-anchored proteins that warrant separate GO annotation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q75T13" data-a="Q: Beyond the inositol-deacylase activity, does human..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Direct kinetic and substrate-specificity characterization of purified recombinant human PGAP1 on defined GPI-anchored protein substrates, to formally establish the human enzyme&#39;s inositol-deacylase activity (current human IDA annotations rely on cell-based PI-PLC-sensitivity rescue rather than in vitro enzymology).</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Human PGAP1 directly and specifically hydrolyzes the inositol-linked acyl chain of GPI-anchored protein substrates.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q75T13" data-a="EXPERIMENT: Direct kinetic and substrate-specificity character..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PGAP1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q75T13" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pgap1-q75t13-review-notes">PGAP1 (Q75T13) review notes</h1>
+<p>Human PGAP1 = <strong>GPI inositol-deacylase</strong> (Post-GPI Attachment to Proteins factor 1; hPGAP1).<br />
+922 aa, multi-pass ER membrane protein (10 TM in the fungal ortholog structure), alpha/beta-hydrolase<br />
+(serine-hydrolase) fold; catalytic Ser predicted at ~residue 174 (ACT_SITE by similarity to Q765A7).</p>
+<h2 id="core-biology-verified">Core biology (verified)</h2>
+<ul>
+<li>PGAP1 removes the <strong>acyl chain attached to the 2-OH of the inositol ring</strong> of the GPI anchor<br />
+<strong>after</strong> the GPI has been transferred en bloc to the protein by the transamidase — i.e. it acts in the<br />
+<strong>post-attachment remodeling</strong> phase of GPI-anchored-protein (GPI-AP) biogenesis, in the ER.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24784135" title="PGAP1 is a deacylase that removes an acyl-chain from the inositol of GPI anchors in the endoplasmic reticulum immediately after attachment of GPI to proteins">PMID:24784135</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38167496" title="Residing in the ER membrane, PGAP1 removes the inositol-linked acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated forms">PMID:38167496</a></li>
+<li>This is the acyl group that was added earlier (during GPI synthesis) by PIGW; PGAP1 initiates remodeling,<br />
+  MPPE1/PGAP5 then removes an EtN-P side chain, then Golgi remodeling by PGAP3/PGAP2.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24784135" title="This remodeling starts in the ER by eliminating the acyl-chain linked to the inositol in the GPI-anchor by PGAP1">PMID:24784135</a></li>
+<li>Deacylation is <strong>required for efficient ER-to-Golgi transport</strong> of GPI-APs (binding of the remodeled anchor<br />
+  to p24-family cargo receptors that load GPI-APs into COPII vesicles).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38167496" title="in mammalian cells, the deacylation by hPGAP1 is necessary for efficient ER export">PMID:38167496</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38167496" title="the deacylation is required for binding with p24-family cargo receptors">PMID:38167496</a></li>
+<li>Reactome models the exact reaction (uPAR-acyl-GPI + H2O -&gt; uPAR + long-chain fatty acid) in the ER and<br />
+  links it to efficient ER-&gt;Golgi transport [Reactome:R-HSA-162729; R-HSA-162791].</li>
+<li>Catalysis: serine-hydrolase-type mechanism (structural/biochemical study of fungal ortholog).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38167496" title="serine hydrolase-type catalysis">PMID:38167496</a></li>
+</ul>
+<h2 id="enzyme-classification-mf-term">Enzyme classification / MF term</h2>
+<ul>
+<li>GOA/UniProt MF term is <strong>GO:0160215 "deacylase activity"</strong> (current label is the generic "deacylase activity";<br />
+  definition: "hydrolysis of an acyl group or groups from a substrate molecule"). There is no dedicated<br />
+  "GPI inositol-deacylase activity" GO term (checked go.db; the closest specific term<br />
+  GO:0050185 phosphatidylinositol deacylase activity is a different substrate). So GO:0160215 is the correct,<br />
+  currently-available MF term and is used both in existing_annotations and core_functions.</li>
+<li>InterPro/Reactome also give the parent GO:0016788 "hydrolase activity, acting on ester bonds" — correct but<br />
+  less specific than GO:0160215; kept (ACCEPT) as a valid broader IEA/TAS.</li>
+<li>EC=3.1.-.- (carboxylic-ester hydrolase) per UniProt; RHEA:83663/83787 catalytic reactions.</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>ER / ER membrane; multi-pass membrane protein. GO:0005789 (ER membrane) supported by SubCell (IEA),<br />
+  ISS (from mouse Q765A7), and Reactome (TAS). GO:0005783 (ER) IBA also fine.<br />
+  [UniProt "SUBCELLULAR LOCATION: Endoplasmic reticulum membrane ... Multi-pass membrane protein"]</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>Biallelic loss-of-function causes an inherited GPI-deficiency / GPI-anchor biosynthesis defect (GPIBD):<br />
+  neurodevelopmental disorder with dysmorphic features, spasticity, and brain abnormalities (NEDDSBA,<br />
+  MIM:615802) — global developmental delay, impaired intellectual development, hypotonia/spasticity,<br />
+  epilepsy, brain atrophy. Distinctively, in PGAP1 deficiency the <em>surface levels</em> of GPI-APs are normal but<br />
+  the anchor <em>fine structure</em> is abnormal (PI-PLC-resistant), because remodeling — not attachment — is lost.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24784135" title="null mutations in PGAP1 lead to severe intellectual disability and encephalopathy">PMID:24784135</a><br />
+  [PMID:24482476 links PGAP1 to corticospinal motor neuron disease / NEDDSBA]</li>
+</ul>
+<h2 id="curation-decisions-goa-rows">Curation decisions (GOA rows)</h2>
+<ul>
+<li>GO:0160215 deacylase activity (IBA, 2x IDA) -&gt; ACCEPT (core MF; the two IDAs = 24784135, 38167496).</li>
+<li>GO:0016788 hydrolase acting on ester bonds (IEA InterPro, TAS Reactome) -&gt; ACCEPT (correct broader parent).</li>
+<li>GO:0005783 ER (IBA), GO:0005789 ER membrane (IEA SubCell, ISS, TAS) -&gt; ACCEPT (localization).</li>
+<li>GO:1902953 positive regulation of ER to Golgi vesicle-mediated transport (ISS) -&gt; KEEP_AS_NON_CORE<br />
+  (real, well-supported downstream consequence of deacylation, but a regulatory/phenotypic BP rather than<br />
+  the direct molecular role).</li>
+<li>GO:0016255 attachment of GPI anchor to protein (TAS Reactome) -&gt; MARK_AS_OVER_ANNOTATED. PGAP1 does NOT<br />
+  catalyze transamidase attachment; it acts <em>after</em> attachment on the anchor. The Reactome pathway groups the<br />
+  deacylation reaction within the "Attachment of GPI anchor to uPAR" pathway, so the term is not wrong at the<br />
+  pathway level, but it over-states PGAP1's role. Better BP = GPI anchor biosynthetic/metabolic process<br />
+  (GO:0006506), which UniProt also carries as IBA. Added as core BP via core_functions.</li>
+</ul>
+<h2 id="core_functions">core_functions</h2>
+<ul>
+<li>MF: GO:0160215 deacylase activity (GPI inositol-deacylase)</li>
+<li>BP: GO:0006506 GPI anchor biosynthetic process (post-attachment remodeling step)</li>
+<li>CC: GO:0005789 endoplasmic reticulum membrane</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q75T13
+gene_symbol: PGAP1
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PGAP1 (GPI inositol-deacylase; Post-GPI Attachment to Proteins factor
+  1) is a multi-pass endoplasmic reticulum membrane protein with an alpha/beta-hydrolase
+  (serine-hydrolase) fold. After a nascent protein has received its glycosylphosphatidylinositol
+  (GPI) anchor from the GPI transamidase, PGAP1 removes the acyl chain that is linked
+  to the 2-OH of the inositol ring of the anchor. This inositol-deacylation is the
+  first, ER-resident step of the post-attachment GPI-anchor remodeling pathway and
+  is required for efficient export of GPI-anchored proteins from the ER to the Golgi
+  (via recognition of the remodeled anchor by p24-family cargo receptors that load
+  GPI-anchored proteins into COPII vesicles). Biallelic loss-of-function variants
+  cause an autosomal-recessive inherited GPI-deficiency disorder (GPI biosynthesis
+  defect; NEDDSBA, MIM:615802) with global developmental delay, impaired intellectual
+  development, hypotonia/spasticity, epilepsy and structural brain abnormalities;
+  in this disorder cell-surface levels of GPI-anchored proteins are near-normal but
+  the anchor fine structure is abnormal (PI-PLC-resistant), reflecting a remodeling
+  rather than an attachment defect.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q75T13-1
+- name: &#39;2&#39;
+  id: Q75T13-2
+  sequence_note: VSP_023040
+- name: &#39;3&#39;
+  id: Q75T13-3
+  sequence_note: VSP_023042, VSP_023043
+- name: &#39;4&#39;
+  id: Q75T13-4
+  sequence_note: VSP_023041, VSP_023044
+existing_annotations:
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) annotation placing PGAP1 activity in the endoplasmic
+      reticulum. This is correct - PGAP1 is an ER-resident enzyme that acts on the
+      GPI anchor immediately after attachment in the ER.
+    action: ACCEPT
+    reason: Consistent with experimental localization and function; PGAP1 acts on
+      nascent GPI-anchored proteins in the ER. The more precise term ER membrane (GO:0005789)
+      is also annotated and is captured in core_functions.
+    supported_by:
+    - reference_id: PMID:24784135
+      supporting_text: PGAP1 is a deacylase that removes an acyl-chain from the inositol
+        of GPI anchors in the endoplasmic reticulum immediately after attachment of
+        GPI to proteins.
+    - reference_id: PMID:38167496
+      supporting_text: Residing in the ER membrane, PGAP1 removes the inositol-linked
+        acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated
+        forms.
+- term:
+    id: GO:0160215
+    label: deacylase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) annotation of deacylase activity - the core molecular
+      function of PGAP1 as a GPI inositol-deacylase. GO:0160215 (current label &#34;deacylase
+      activity&#34;) is the most specific currently available GO molecular-function term
+      for this activity; there is no dedicated &#34;GPI inositol-deacylase activity&#34; term.
+    action: ACCEPT
+    reason: This is the defining, experimentally supported molecular function of PGAP1
+      (removal of the inositol-linked acyl chain of the GPI anchor). Retained as a
+      core function.
+    supported_by:
+    - reference_id: PMID:38167496
+      supporting_text: Residing in the ER membrane, PGAP1 removes the inositol-linked
+        acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated
+        forms.
+    - reference_id: PMID:24784135
+      supporting_text: PGAP1 is a deacylase that removes an acyl-chain from the inositol
+        of GPI anchors in the endoplasmic reticulum immediately after attachment of
+        GPI to proteins.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic annotation from the UniProt Subcellular Location vocabulary
+      mapping placing PGAP1 in the ER membrane. PGAP1 is a multi-pass ER membrane
+      protein, so this is correct and is the most precise localization term.
+    action: ACCEPT
+    reason: Correct localization; PGAP1 is a multi-pass ER membrane protein acting
+      on the luminal face of the anchor. Retained in core_functions.
+    supported_by:
+    - reference_id: file:human/PGAP1/PGAP1-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+    - reference_id: PMID:38167496
+      supporting_text: Residing in the ER membrane, PGAP1 removes the inositol-linked
+        acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated
+        forms.
+- term:
+    id: GO:0016788
+    label: hydrolase activity, acting on ester bonds
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro-to-GO electronic annotation assigning ester-bond hydrolase activity
+      based on the alpha/beta-hydrolase (PGAP1/BST1) domains. This is a correct but
+      broad parent of the specific deacylase activity; PGAP1 hydrolyzes an ester bond
+      to release the inositol-linked fatty acid.
+    action: ACCEPT
+    reason: Biologically accurate broader classification (carboxylic-ester hydrolase;
+      EC 3.1.-.-). It is a general parent of the more specific deacylase activity
+      (GO:0160215) but is not wrong, so it is retained. The specific deacylase term
+      is captured as the core molecular function.
+    supported_by:
+    - reference_id: PMID:38167496
+      supporting_text: serine hydrolase-type catalysis
+    - reference_id: file:human/PGAP1/PGAP1-uniprot.txt
+      supporting_text: &#39;SIMILARITY: Belongs to the GPI inositol-deacylase family.&#39;
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162791
+  qualifier: involved_in
+  review:
+    summary: Reactome traceable annotation placing PGAP1 in the &#34;Attachment of GPI
+      anchor to uPAR&#34; pathway. PGAP1 does not catalyze the transamidase attachment
+      step; it acts immediately after attachment, deacylating the inositol of the
+      already-transferred anchor as the first post-attachment remodeling step.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The term overstates PGAP1&#39;s role. The transamidase (PIGK/GPAA1/PIGS/PIGT/PIGU)
+      attaches the GPI anchor to the protein; PGAP1 acts downstream on the anchor
+      that has already been attached. Reactome groups the deacylation reaction within
+      the broader attachment pathway (so the annotation is not entirely wrong at the
+      pathway level), but a GPI anchor biosynthetic/remodeling process term better
+      reflects the direct role. The correct core BP (GPI anchor biosynthetic process,
+      GO:0006506; the post-attachment remodeling step) is captured in core_functions.
+    supported_by:
+    - reference_id: PMID:24784135
+      supporting_text: PGAP1 is a deacylase that removes an acyl-chain from the inositol
+        of GPI anchors in the endoplasmic reticulum immediately after attachment of
+        GPI to proteins.
+    - reference_id: Reactome:R-HSA-162791
+      supporting_text: In a second step, the GPI moiety is deacylated, yielding a uPAR-GPI
+        conjugate that can be efficiently transported to the Golgi apparatus.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: ISS annotation transferring ER membrane localization from the mouse ortholog
+      (UniProtKB:Q765A7). Consistent with the multi-pass ER membrane topology of PGAP1.
+    action: ACCEPT
+    reason: Correct localization, consistent with the SubCell-based IEA, the Reactome
+      TAS, and the multi-pass membrane topology annotated in UniProt.
+    supported_by:
+    - reference_id: file:human/PGAP1/PGAP1-uniprot.txt
+      supporting_text: Multi-pass membrane protein
+    - reference_id: PMID:38167496
+      supporting_text: Residing in the ER membrane, PGAP1 removes the inositol-linked
+        acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated
+        forms.
+- term:
+    id: GO:0160215
+    label: deacylase activity
+  evidence_type: IDA
+  original_reference_id: PMID:24784135
+  qualifier: enables
+  review:
+    summary: Direct-assay (IDA) annotation of deacylase activity. In this study, the
+      patient p.Leu197del null mutation abolished PGAP1 activity, rendering GPI-anchored
+      proteins resistant to PI-PLC, and wild-type PGAP1 cDNA rescued PI-PLC sensitivity
+      in PGAP1-deficient CHO cells - functionally demonstrating the inositol-deacylase
+      activity.
+    action: ACCEPT
+    reason: Experimentally supported core molecular function (GPI inositol-deacylase);
+      GO:0160215 is the most specific available term for this activity.
+    supported_by:
+    - reference_id: PMID:24784135
+      supporting_text: PGAP1 is a deacylase that removes an acyl-chain from the inositol
+        of GPI anchors in the endoplasmic reticulum immediately after attachment of
+        GPI to proteins.
+- term:
+    id: GO:0160215
+    label: deacylase activity
+  evidence_type: IDA
+  original_reference_id: PMID:38167496
+  qualifier: enables
+  review:
+    summary: Direct-assay (IDA) annotation of deacylase activity from the structural/biochemical
+      study, which developed a fluorescent GPI-AP substrate assay, kinetically characterized
+      the enzyme, and showed a serine-hydrolase-type catalysis that removes the inositol-linked
+      acyl chain from GPI-anchored proteins.
+    action: ACCEPT
+    reason: Experimentally supported core molecular function; the same activity as
+      the other IDA annotation. Retained as core.
+    supported_by:
+    - reference_id: PMID:38167496
+      supporting_text: Residing in the ER membrane, PGAP1 removes the inositol-linked
+        acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated
+        forms.
+    - reference_id: PMID:38167496
+      supporting_text: serine hydrolase-type catalysis
+- term:
+    id: GO:1902953
+    label: positive regulation of ER to Golgi vesicle-mediated transport
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: ISS annotation (from mouse ortholog) capturing PGAP1&#39;s role in promoting
+      ER-to-Golgi transport of GPI-anchored proteins. Inositol-deacylation by PGAP1
+      is required for efficient ER export of GPI-APs, mediated by binding of the remodeled
+      anchor to p24-family cargo receptors that recruit GPI-APs into COPII vesicles.
+    action: KEEP_AS_NON_CORE
+    reason: Well-supported downstream biological consequence of PGAP1 deacylation,
+      but it is a regulatory/trafficking process rather than the direct molecular
+      role of the enzyme. Retained as non-core; the direct role (inositol-deacylation
+      / GPI anchor remodeling) is the core function.
+    supported_by:
+    - reference_id: PMID:38167496
+      supporting_text: in mammalian cells, the deacylation by hPGAP1 is necessary
+        for efficient ER export
+    - reference_id: PMID:38167496
+      supporting_text: the deacylation is required for binding with p24-family cargo
+        receptors
+- term:
+    id: GO:0016788
+    label: hydrolase activity, acting on ester bonds
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162729
+  qualifier: enables
+  review:
+    summary: Reactome traceable annotation of ester-bond hydrolase activity, based
+      on the modeled reaction uPAR-acyl-GPI + H2O to uPAR + long-chain fatty acid
+      in the ER. Correct broad classification of the deacylation (ester hydrolysis)
+      reaction.
+    action: ACCEPT
+    reason: Accurate broader parent of the specific deacylase activity; the reaction
+      is an ester hydrolysis releasing the inositol-linked fatty acid. Retained; the
+      more specific deacylase term is the core molecular function.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162729
+      supporting_text: The fatty acid group added to inositol in the fourth step of
+        GPI biosynthsis is removed from GPI-conjugated uPAR.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162729
+  qualifier: located_in
+  review:
+    summary: Reactome traceable annotation placing the PGAP1 deacylation reaction
+      at the ER membrane. Consistent with the SubCell IEA, ISS, and experimental data.
+    action: ACCEPT
+    reason: Correct localization; the deacylation reaction occurs in the ER.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162729
+      supporting_text: This hydrolysis event occurs in the endoplasmic reticulum
+    - reference_id: PMID:38167496
+      supporting_text: Residing in the ER membrane, PGAP1 removes the inositol-linked
+        acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated
+        forms.
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: GPI anchor biosynthetic process is the correct core biological process
+      for PGAP1. PGAP1 performs the first, ER-resident step of the post-attachment
+      GPI-anchor remodeling phase (inositol-deacylation). This term is present as an
+      IBA:GO_Central annotation in the UniProt cross-reference block but was not in
+      the seeded GOA TSV; it is added here as the appropriate replacement for the
+      over-annotated GO:0016255 (attachment of GPI anchor to protein).
+    action: NEW
+    reason: Captures PGAP1&#39;s direct role in GPI-anchor biosynthesis/remodeling more
+      accurately than the transamidase-centric GO:0016255. Supported by the UniProt
+      IBA annotation and the experimental literature.
+    supported_by:
+    - reference_id: file:human/PGAP1/PGAP1-uniprot.txt
+      supporting_text: &#39;GO:0006506; P:GPI anchor biosynthetic process; IBA:GO_Central.&#39;
+    - reference_id: PMID:24784135
+      supporting_text: PGAP1 is a deacylase that removes an acyl-chain from the inositol
+        of GPI anchors in the endoplasmic reticulum immediately after attachment of
+        GPI to proteins.
+core_functions:
+- description: GPI inositol-deacylase that hydrolyzes and removes the acyl chain linked
+    to the 2-OH of the inositol ring of the GPI anchor of a GPI-anchored protein in
+    the ER, the first step of post-attachment GPI-anchor remodeling.
+  molecular_function:
+    id: GO:0160215
+    label: deacylase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:38167496
+    supporting_text: Residing in the ER membrane, PGAP1 removes the inositol-linked
+      acyl chain from nascent triacylated GPI-APs (dubbed GPI-AP3) to form the diacylated
+      forms.
+  - reference_id: PMID:24784135
+    supporting_text: PGAP1 is a deacylase that removes an acyl-chain from the inositol
+      of GPI anchors in the endoplasmic reticulum immediately after attachment of
+      GPI to proteins.
+- description: The inositol-deacylation performed by PGAP1 is required for efficient
+    ER-to-Golgi transport of GPI-anchored proteins, enabling recognition of the remodeled
+    anchor by p24-family cargo receptors that load GPI-APs into COPII vesicles.
+  molecular_function:
+    id: GO:0160215
+    label: deacylase activity
+  directly_involved_in:
+  - id: GO:1902953
+    label: positive regulation of ER to Golgi vesicle-mediated transport
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:38167496
+    supporting_text: in mammalian cells, the deacylation by hPGAP1 is necessary for
+      efficient ER export
+  - reference_id: PMID:38167496
+    supporting_text: the deacylation is required for binding with p24-family cargo
+      receptors
+proposed_new_terms:
+- proposed_name: GPI inositol-deacylase activity
+  proposed_definition: Catalysis of the hydrolytic removal of the acyl chain linked
+    to the 2-position (2-O-acyl) of the inositol ring of a glycosylphosphatidylinositol
+    (GPI) anchor of a GPI-anchored protein, releasing a fatty acid.
+  justification: PGAP1 (and its yeast ortholog Bst1) has a specific, well-characterized
+    inositol-deacylase activity on GPI anchors that is currently only representable
+    by the generic term GO:0160215 (deacylase activity) or its broad parent GO:0016788
+    (hydrolase activity, acting on ester bonds). A dedicated child term would capture
+    the substrate specificity.
+  proposed_parent:
+    id: GO:0160215
+    label: deacylase activity
+suggested_questions:
+- question: Beyond the inositol-deacylase activity, does human PGAP1 have direct roles
+    in ER quality control / ERAD of misfolded GPI-anchored proteins that warrant separate
+    GO annotation?
+suggested_experiments:
+- description: Direct kinetic and substrate-specificity characterization of purified
+    recombinant human PGAP1 on defined GPI-anchored protein substrates, to formally
+    establish the human enzyme&#39;s inositol-deacylase activity (current human IDA annotations
+    rely on cell-based PI-PLC-sensitivity rescue rather than in vitro enzymology).
+  hypothesis: Human PGAP1 directly and specifically hydrolyzes the inositol-linked
+    acyl chain of GPI-anchored protein substrates.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:24784135
+  title: Null mutation in PGAP1 impairing Gpi-anchor maturation in patients with intellectual
+    disability and encephalopathy.
+  findings:
+  - statement: PGAP1 is the GPI inositol-deacylase that removes an acyl chain from
+      the inositol of GPI anchors in the ER immediately after attachment of GPI to
+      proteins; a homozygous null variant (p.Leu197del) causes autosomal-recessive
+      intellectual disability and encephalopathy.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Full text available and PubMed-verified; directly establishes PGAP1
+      function, its ER localization, the post-attachment inositol-deacylation, and
+      the human disease phenotype. Supporting quotes verified as verbatim substrings.
+- id: PMID:38167496
+  title: Molecular basis of the inositol deacylase PGAP1 involved in quality control
+    of GPI-AP biogenesis.
+  findings:
+  - statement: PGAP1 resides in the ER membrane, initiates the post-attachment remodeling
+      phase by removing the inositol-linked acyl chain of nascent GPI-anchored proteins
+      via serine-hydrolase-type catalysis, and this deacylation is required for efficient
+      ER-to-Golgi export via p24-family cargo receptors.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Full text available and PubMed-verified; structural/biochemical
+      study of the inositol-deacylase and its role in GPI-AP quality control and ER
+      export. Supporting quotes verified as verbatim substrings.
+- id: PMID:24482476
+  title: Exome sequencing links corticospinal motor neuron disease to common neurodegenerative
+    disorders.
+  findings:
+  - statement: Independent exome-sequencing evidence linking PGAP1 variants to the
+      neurodevelopmental disorder (NEDDSBA); cited by UniProt for disease involvement.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Cited by UniProt as a second reference implicating PGAP1 in the
+      inherited disorder; corroborates disease relevance rather than molecular function.
+- id: Reactome:R-HSA-162729
+  title: uPAR-acyl-GPI + H2O -&gt; uPAR + long-chain fatty acid
+  findings:
+  - statement: Models the PGAP1-catalyzed removal of the inositol-linked fatty acid
+      from GPI-conjugated uPAR in the ER, associated with efficient ER-to-Golgi transport.
+    reference_section_type: OTHER
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Reactome reaction directly representing PGAP1 deacylase activity;
+      title left exactly as fetched.
+- id: Reactome:R-HSA-162791
+  title: Attachment of GPI anchor to uPAR
+  findings:
+  - statement: Pathway in which the transferred GPI moiety is deacylated (by PGAP1),
+      yielding a uPAR-GPI conjugate that can be efficiently transported to the Golgi.
+    reference_section_type: OTHER
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Reactome pathway grouping the deacylation reaction under GPI attachment;
+      title left exactly as fetched.
+- id: file:human/PGAP1/PGAP1-uniprot.txt
+  title: UniProtKB entry Q75T13 (PGAP1_HUMAN)
+  findings:
+  - statement: PGAP1 is a GPI inositol-deacylase, a multi-pass ER membrane protein
+      belonging to the GPI inositol-deacylase family, with EC 3.1.-.- carboxylic-ester
+      hydrolase activity; deficiency causes NEDDSBA (MIM:615802).
+    reference_section_type: OTHER
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PGAP2/PGAP2-ai-review.html
+++ b/genes/human/PGAP2/PGAP2-ai-review.html
@@ -1,0 +1,3131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PGAP2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PGAP2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9UHJ9" target="_blank" class="term-link">
+                        Q9UHJ9
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PGAP2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9UHJ9" data-a="DESCRIPTION: PGAP2 (Post-GPI Attachment to Proteins Factor 2; a..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PGAP2 (Post-GPI Attachment to Proteins Factor 2; also FRAG1) is a multi-pass Golgi-membrane protein that carries out the second step of glycosylphosphatidylinositol (GPI) fatty-acid remodeling. GPI anchors are made in the endoplasmic reticulum and attached to nascent proteins, then remodeled during transport through the Golgi. In the Golgi, after PGAP3 removes the sn-2 unsaturated fatty acid, PGAP2 is required to reacylate the resulting lyso-GPI intermediate with a saturated (stearic) fatty acid at the sn-2 position; it is annotated as an acyltransferase (EC 2.3.-.-) by similarity, though whether it is the catalytic acyltransferase or an accessory factor required for reacylation is not firmly established. This fatty-acid remodeling generates the mature, detergent-resistant-membrane (lipid-raft)-associating GPI anchor and is required for stable cell-surface expression of GPI-anchored proteins such as DAF (CD55) and CD59. Biallelic hypomorphic PGAP2 variants cause hyperphosphatasia with impaired intellectual development syndrome 3 (HPMRS3), characterized by intellectual disability, hypotonia, and elevated serum alkaline phosphatase.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PGAP2 acts in the GPI-anchor pathway, carrying out (or being required for) the second fatty-acid remodeling step in which a lyso-GPI intermediate is reacylated with a saturated stearoyl chain. This phylogenetically-inferred BP annotation is the core biological process for the gene and is well supported by experimental and by-similarity evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, concordant with experimental (IDA/IMP) annotations and the UniProt-curated function. The more specific child term GO:0120574 (GPI anchor remodelling) is also present and captured below.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link">
+                                        PMID:29374258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3 removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation with stearic acid, a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ER-membrane localization inferred from the phylogenetic tree. GPI-anchor biosynthesis begins in the ER, so ER association is plausible, but the experimentally supported and functionally relevant location for PGAP2&#39;s fatty-acid remodeling step is the Golgi. Retained as a non-core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Plausible given the ER-to-Golgi span of the GPI pathway, but the mature remodeling function and experimental localization are Golgi; ER membrane is not the core site of action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP2/PGAP2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Golgi apparatus membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                    GO:0000139
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0000139" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Golgi membrane localization derived from InterPro/UniProt automated pipelines. This is the core, experimentally supported location where PGAP2 performs GPI fatty-acid remodeling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core cellular component; concordant with the EXP annotation (PMID:10585768) and UniProt subcellular location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP2/PGAP2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Golgi apparatus membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Binary protein-protein interaction (with KRTAP10-9, UniProtKB:P60411) recorded by a proteome-scale interactome screen. This uninformative protein-binding term does not convey PGAP2&#39;s molecular function and the partner is not part of the GPI remodeling machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding from a high-throughput binary interactome map is uninformative and does not describe PGAP2&#39;s function; retained per policy (do not REMOVE experimental IPIs) but flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                                        PMID:25416956
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a systematic map of ?14,000 high-quality human binary protein-protein interactions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26871637" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26871637
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Widespread Expansion of Protein Interaction Capabilities by ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0005515" data-r="PMID:26871637" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Binary protein-protein interaction (with CREB3L1, UniProtKB:Q96BA8) recorded by an alternative-splicing interactome screen. Uninformative protein-binding term that does not describe PGAP2&#39;s GPI-remodeling molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding from a high-throughput interactome map is uninformative; retained per policy but flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26871637" target="_blank" class="term-link">
+                                        PMID:26871637
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Alternatively-spliced isoforms of proteins exhibit strikingly different</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+                        <br>
+                        <span class="isoform-badge" title="This annotation was made on a specific isoform">
+                            <a href="https://www.uniprot.org/uniprotkb/Q9UHJ9-5" target="_blank" class="term-link" style="font-size: 0.7rem;">
+                                Q9UHJ9-5
+                            </a>
+                        </span>
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Multiple binary protein-protein interactions recorded for isoform 5 by the HuRI reference interactome (yeast two-hybrid). These are uninformative protein-binding annotations that do not describe PGAP2&#39;s molecular function; the isoform field records that isoform 5 was the tested clone, not an isoform-specific function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding from a systematic Y2H interactome map (HuRI) is uninformative for PGAP2&#39;s function; retained per policy but flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reference interactome map of human binary protein interactions, or &#39;HuRI&#39;</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120574" target="_blank" class="term-link">
+                                    GO:0120574
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor remodelling</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0120574" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GPI anchor remodelling captures PGAP2&#39;s specific role most accurately - the post-attachment Golgi fatty-acid remodeling in which the lyso-GPI intermediate is reacylated with a saturated stearoyl chain. Transferred by sequence similarity from the mouse ortholog (UniProtKB:Q2ABP3).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Most specific and accurate BP for PGAP2; consistent with UniProt function and the PMID:29374258 mechanistic description of PGAP2 reacylation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP2/PGAP2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">second step of the fatty acid remodeling, by reacylating a lyso-GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                    GO:0000139
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10585768" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10585768
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human FRAG1 encodes a novel membrane-spanning protein that l...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0000139" data-r="PMID:10585768" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported Golgi membrane localization for PGAP2/FRAG1, the core site where PGAP2 performs GPI fatty-acid remodeling. The original report characterized FRAG1 as an integral membrane protein with multiple membrane-spanning segments; the Golgi assignment reflects the full-text/curated localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular component; experimental annotation consistent with UniProt subcellular location (Golgi apparatus membrane, multi-pass).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10585768" target="_blank" class="term-link">
+                                        PMID:10585768
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hydropathy analysis predicted FRAG1 to encode an integral membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP2/PGAP2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Golgi apparatus membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23561846" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23561846
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hypomorphic mutations in PGAP2, encoding a GPI-anchor-remode...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0006506" data-r="PMID:23561846" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that PGAP2 is required for GPI-anchor maturation and surface expression of GPI-anchored proteins. Rescue of PGAP2-deficient CHO cells with wild-type versus HPMRS3-mutant PGAP2 showed reduced cell-surface DAF and CD59 with the mutants, demonstrating PGAP2&#39;s role in the GPI-anchor process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process supported by direct functional (rescue) experiments; also the basis for the HPMRS3 disease association.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23561846" target="_blank" class="term-link">
+                                        PMID:23561846
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">less expression of cell-surface GPI-anchored proteins DAF and CD59 than</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23561846" target="_blank" class="term-link">
+                                        PMID:23561846
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PGAP2 encodes a protein involved in remodeling the glycosylphosphatidylinositol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29374258
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of a Golgi GPI-N-acetylgalactosamine transfer...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0006506" data-r="PMID:29374258" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Although this paper primarily characterizes PGAP4, its full text places PGAP2 in the Golgi GPI fatty-acid remodeling pathway and uses PGAP2 in the GPI-remodeling context; the experimental (IMP) annotation to the GPI-anchor biosynthetic process is consistent with PGAP2&#39;s established role. Retained as core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental annotation for the core biological process; full text (available) explicitly assigns PGAP2 the reacylation step of Golgi fatty-acid remodeling. Defer to curator on the IMP evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link">
+                                        PMID:29374258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3 removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation with stearic acid, a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                    GO:0000139
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0000139" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Golgi membrane localization transferred by sequence similarity from the mouse ortholog (UniProtKB:Q2ABP3). Duplicates the experimentally supported Golgi membrane location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core location; concordant with the EXP and IEA Golgi annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP2/PGAP2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Golgi apparatus membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0005789" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ER-membrane localization transferred by sequence similarity from the mouse ortholog. As with the IBA ER annotation, this is plausible given the ER-to-Golgi span of the GPI pathway, but the core, experimentally supported location for PGAP2&#39;s remodeling function is the Golgi.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Plausible but non-core; PGAP2&#39;s fatty-acid remodeling step and its documented subcellular location are Golgi, not ER.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP2/PGAP2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Golgi apparatus membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10585768" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10585768
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human FRAG1 encodes a novel membrane-spanning protein that l...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHJ9" data-a="GO:0016020" data-r="PMID:10585768" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Original characterization of FRAG1/PGAP2 as an integral membrane protein with multiple membrane-spanning segments. The generic membrane term is correct but uninformative; PGAP2 is a multi-pass Golgi-membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic membrane term is too general; the specific location is the Golgi membrane, which is separately and experimentally annotated.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                    Golgi membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10585768" target="_blank" class="term-link">
+                                        PMID:10585768
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hydropathy analysis predicted FRAG1 to encode an integral membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP2/PGAP2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PGAP2 acts in the Golgi to carry out (or to be required for) the second step of GPI fatty-acid remodeling, reacylating the lyso-GPI intermediate with a saturated stearoyl chain after PGAP3 removes the sn-2 unsaturated fatty acid; this generates the mature, lipid-raft-associating GPI anchor needed for stable cell-surface expression of GPI-anchored proteins.</h3>
+                <span class="vote-buttons" data-g="Q9UHJ9" data-a="FUNCTION: PGAP2 acts in the Golgi to carry out (or to be req..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120574" target="_blank" class="term-link">
+                                GPI anchor remodelling
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                Golgi membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PGAP2/PGAP2-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">second step of the fatty acid remodeling, by reacylating a lyso-GPI</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link">
+                                PMID:29374258
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3 removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation with stearic acid, a</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PGAP2 is required for GPI-anchor biosynthesis/maturation; loss of function reduces cell-surface expression of GPI-anchored proteins (e.g. DAF/CD55, CD59), and hypomorphic variants cause HPMRS3.</h3>
+                <span class="vote-buttons" data-g="Q9UHJ9" data-a="FUNCTION: PGAP2 is required for GPI-anchor biosynthesis/matu..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                Golgi membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23561846" target="_blank" class="term-link">
+                                PMID:23561846
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">less expression of cell-surface GPI-anchored proteins DAF and CD59 than</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PGAP2/PGAP2-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q9UHJ9 (PGAP2_HUMAN)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10585768" target="_blank" class="term-link">
+                            PMID:10585768
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human FRAG1 encodes a novel membrane-spanning protein that localizes to chromosome 11p15.5, a region of frequent loss of heterozygosity in cancer.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23561846" target="_blank" class="term-link">
+                            PMID:23561846
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Hypomorphic mutations in PGAP2, encoding a GPI-anchor-remodeling protein, cause autosomal-recessive intellectual disability.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26871637" target="_blank" class="term-link">
+                            PMID:26871637
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Widespread Expansion of Protein Interaction Capabilities by Alternative Splicing.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link">
+                            PMID:29374258
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of a Golgi GPI-N-acetylgalactosamine transferase with tandem transmembrane regions in the catalytic domain.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is PGAP2 itself the sn-2 acyltransferase (EC 2.3.-.-) that reacylates lyso-GPI with stearoyl-CoA, or an accessory factor required for the reaction? The catalytic activity and EC number are currently assigned only by similarity.</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UHJ9" data-a="Q: Is PGAP2 itself the sn-2 acyltransferase (EC 2.3.-..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which residues constitute the catalytic/substrate-binding site, and do the HPMRS3 hypomorphic variants (e.g. Y99C, R177P, T160I) impair catalysis, substrate binding, or protein stability?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UHJ9" data-a="Q: Which residues constitute the catalytic/substrate-..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute the reacylation reaction in vitro with purified PGAP2, lyso-GPI substrate, and stearoyl-CoA to test whether PGAP2 has intrinsic acyltransferase activity.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UHJ9" data-a="EXPERIMENT: Reconstitute the reacylation reaction in vitro wit..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Mass-spectrometry lipidomics of GPI anchors from PGAP2-knockout versus rescued cells to confirm accumulation of lyso-GPI and loss of the stearoyl-remodeled species.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9UHJ9" data-a="EXPERIMENT: Mass-spectrometry lipidomics of GPI anchors from P..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PGAP2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9UHJ9" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pgap2-post-gpi-attachment-to-proteins-factor-2-curation-notes">PGAP2 (Post-GPI Attachment to Proteins Factor 2) — curation notes</h1>
+<p>UniProt: Q9UHJ9 (PGAP2_HUMAN), aka FRAG1 (FGF receptor-activating protein 1).<br />
+HGNC:17893. 254 aa (canonical isoform 2, Q9UHJ9-1). Multi-pass Golgi membrane protein.</p>
+<p>Deep research: falcon provider was out of credits (HTTP 402) at the time of review, so<br />
+no <code>-deep-research-falcon.md</code> was generated. Grounding is UniProt (Q9UHJ9), the seeded<br />
+GOA (<code>PGAP2-goa.tsv</code>), and cached publications in <code>publications/</code>.</p>
+<h2 id="function">Function</h2>
+<p>PGAP2 carries out the <strong>second step of GPI fatty-acid remodeling</strong> in the Golgi. GPI<br />
+anchors are synthesized in the ER, attached to nascent proteins, then remodeled during<br />
+transport to the plasma membrane. In the Golgi, PGAP3 first removes the sn-2 unsaturated<br />
+fatty acid to give a lyso-GPI intermediate; PGAP2 is then required to <strong>reacylate the<br />
+lyso-GPI with a saturated (stearic) fatty acid at sn-2</strong>. This fatty-acid remodeling<br />
+generates the mature, detergent-resistant-membrane (DRM/lipid-raft)-associating GPI anchor<br />
+and is required for stable cell-surface expression of GPI-anchored proteins (GPI-APs).</p>
+<p>Key verbatim quote (PMID:29374258, full text available):</p>
+<blockquote>
+<p>"In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3 removes an sn-2-linked<br />
+unsaturated fatty acid and PGAP2 is involved in reacylation with stearic acid, a<br />
+saturated fatty acid"</p>
+</blockquote>
+<p>UniProt CC FUNCTION (file:human/PGAP2/PGAP2-uniprot.txt):</p>
+<blockquote>
+<p>"Involved in the fatty acid remodeling steps of GPI-anchor maturation where the<br />
+unsaturated acyl chain at sn-2 of inositol phosphate is replaced by a saturated stearoyl<br />
+chain. May catalyze the second step of the fatty acid remodeling, by reacylating a<br />
+lyso-GPI intermediate at sn-2 of inositol phosphate by a saturated chain (By similarity).<br />
+The fatty acid remodeling steps is critical for the integration of GPI-APs into lipid<br />
+rafts (PubMed:23561846)."</p>
+</blockquote>
+<p>Catalytic role is debated: UniProt names it "Acyltransferase PGAP2" with EC=2.3.-.- and a<br />
+CATALYTIC ACTIVITY (Rhea:RHEA:83851, octadecanoyl-CoA + lysoGPI -&gt; acyl-GPI + CoA) but<br />
+both are annotated <strong>By similarity (ECO:0000250|UniProtKB:Q2ABP2)</strong> — i.e., inferred, not<br />
+demonstrated for the human protein. PGAP2 may be the acyltransferase itself, or required<br />
+for the reacylation (accessory). The GOA carries <strong>no catalytic MF</strong> (only <code>protein
+binding</code> IPI and a KW-derived <code>transferase activity</code> on the UniProt side that is NOT in<br />
+the GOA TSV), so no specific acyltransferase MF is asserted in <code>core_functions</code>.</p>
+<h2 id="localization">Localization</h2>
+<p>Golgi apparatus membrane, multi-pass (5 predicted TM helices per UniProt topology).<br />
+UniProt SUBCELLULAR LOCATION: "Golgi apparatus membrane" (ECO:0000269|PubMed:10585768).<br />
+GOA also carries ER-membrane (ISS/IBA) — consistent with GPI-anchor pathway spanning<br />
+ER-&gt;Golgi, though the mature remodeling function is Golgi-localized.</p>
+<h2 id="disease">Disease</h2>
+<p>Biallelic hypomorphic PGAP2 variants cause <strong>hyperphosphatasia with mental retardation<br />
+syndrome 3 / hyperphosphatasia with impaired intellectual development syndrome 3<br />
+(HPMRS3; MIM:614207)</strong> — intellectual disability, hypotonia, poor speech, elevated serum<br />
+alkaline phosphatase (a hallmark of GPI-anchor / inherited GPI deficiency, IGD).<br />
+[PMID:23561846; PMID:23561847]</p>
+<p>PMID:23561846 (Hansen et al. 2013, IDA for GPI anchor biosynthetic process): rescue<br />
+experiments in PGAP2-deficient CHO cells with mutant (p.Tyr99Cys, p.Arg177Pro) vs WT<br />
+PGAP2 showed "less expression of cell-surface GPI-anchored proteins DAF and CD59 than of<br />
+the wild-type protein" — functional demonstration that PGAP2 is required for surface<br />
+GPI-AP expression.</p>
+<h2 id="annotation-decisions-summary">Annotation decisions summary</h2>
+<ul>
+<li>GPI anchor biosynthetic process (GO:0006506): core BP. ACCEPT IBA/IDA. IMP<br />
+  (PMID:29374258) is a PGAP4 paper whose full text explicitly assays/uses PGAP2 context;<br />
+  ACCEPT (defer to curator, experimental).</li>
+<li>GPI anchor remodelling (GO:0120574, ISS): core BP, more specific/accurate; ACCEPT.</li>
+<li>Golgi membrane (GO:0000139) EXP/ISS/IEA: core location; ACCEPT (EXP), the ISS/IEA<br />
+  duplicates ACCEPT/KEEP_AS_NON_CORE.</li>
+<li>endoplasmic reticulum membrane (GO:0005789) IBA/ISS: KEEP_AS_NON_CORE — plausible<br />
+  (pathway spans ER-&gt;Golgi) but mature remodeling is Golgi; not the core location.</li>
+<li>membrane (GO:0016020) TAS: MODIFY -&gt; Golgi membrane (too general).</li>
+<li>protein binding (GO:0005515) IPI x3 refs: all from large-scale binary interactome /<br />
+  splicing PPI screens (HuRI, alt-splicing PPI, human interactome map). Uninformative;<br />
+  MARK_AS_OVER_ANNOTATED per curation policy (do not REMOVE experimental IPIs).</li>
+</ul>
+<h2 id="references-relevance">References (relevance)</h2>
+<ul>
+<li>PMID:29374258 — HIGH (best verbatim mechanistic description of PGAP2 reacylation step)</li>
+<li>PMID:23561846 — HIGH (function + disease; IDA)</li>
+<li>PMID:10585768 — MEDIUM (original cloning as FRAG1; membrane protein; Golgi from full text)</li>
+<li>PMID:25416956 / 26871637 / 32296183 — LOW (high-throughput PPI, uninformative for MF)</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9UHJ9
+gene_symbol: PGAP2
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PGAP2 (Post-GPI Attachment to Proteins Factor 2; also FRAG1) is a multi-pass
+  Golgi-membrane protein that carries out the second step of glycosylphosphatidylinositol
+  (GPI) fatty-acid remodeling. GPI anchors are made in the endoplasmic reticulum and
+  attached to nascent proteins, then remodeled during transport through the Golgi. In
+  the Golgi, after PGAP3 removes the sn-2 unsaturated fatty acid, PGAP2 is required to
+  reacylate the resulting lyso-GPI intermediate with a saturated (stearic) fatty acid
+  at the sn-2 position; it is annotated as an acyltransferase (EC 2.3.-.-) by similarity,
+  though whether it is the catalytic acyltransferase or an accessory factor required for
+  reacylation is not firmly established. This fatty-acid remodeling generates the mature,
+  detergent-resistant-membrane (lipid-raft)-associating GPI anchor and is required for
+  stable cell-surface expression of GPI-anchored proteins such as DAF (CD55) and CD59.
+  Biallelic hypomorphic PGAP2 variants cause hyperphosphatasia with impaired intellectual
+  development syndrome 3 (HPMRS3), characterized by intellectual disability, hypotonia,
+  and elevated serum alkaline phosphatase.
+alternative_products:
+- name: &#39;2&#39;
+  id: Q9UHJ9-1
+- name: &#39;1&#39;
+  id: Q9UHJ9-2
+  sequence_note: VSP_032550
+- name: &#39;3&#39;
+  id: Q9UHJ9-3
+  sequence_note: VSP_032551
+- name: &#39;4&#39;
+  id: Q9UHJ9-4
+  sequence_note: VSP_045984, VSP_045985
+- name: &#39;5&#39;
+  id: Q9UHJ9-5
+  sequence_note: VSP_053800, VSP_032551
+existing_annotations:
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: PGAP2 acts in the GPI-anchor pathway, carrying out (or being required for)
+      the second fatty-acid remodeling step in which a lyso-GPI intermediate is reacylated
+      with a saturated stearoyl chain. This phylogenetically-inferred BP annotation is
+      the core biological process for the gene and is well supported by experimental and
+      by-similarity evidence.
+    action: ACCEPT
+    reason: Core biological process, concordant with experimental (IDA/IMP) annotations
+      and the UniProt-curated function. The more specific child term GO:0120574 (GPI anchor
+      remodelling) is also present and captured below.
+    supported_by:
+    - reference_id: PMID:29374258
+      supporting_text: In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3
+        removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation
+        with stearic acid, a
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: ER-membrane localization inferred from the phylogenetic tree. GPI-anchor
+      biosynthesis begins in the ER, so ER association is plausible, but the experimentally
+      supported and functionally relevant location for PGAP2&#39;s fatty-acid remodeling step
+      is the Golgi. Retained as a non-core location.
+    action: KEEP_AS_NON_CORE
+    reason: Plausible given the ER-to-Golgi span of the GPI pathway, but the mature remodeling
+      function and experimental localization are Golgi; ER membrane is not the core site
+      of action.
+    supported_by:
+    - reference_id: file:human/PGAP2/PGAP2-uniprot.txt
+      supporting_text: Golgi apparatus membrane
+- term:
+    id: GO:0000139
+    label: Golgi membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Golgi membrane localization derived from InterPro/UniProt automated pipelines.
+      This is the core, experimentally supported location where PGAP2 performs GPI fatty-acid
+      remodeling.
+    action: ACCEPT
+    reason: Correct core cellular component; concordant with the EXP annotation (PMID:10585768)
+      and UniProt subcellular location.
+    supported_by:
+    - reference_id: file:human/PGAP2/PGAP2-uniprot.txt
+      supporting_text: Golgi apparatus membrane
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  qualifier: enables
+  review:
+    summary: Binary protein-protein interaction (with KRTAP10-9, UniProtKB:P60411) recorded
+      by a proteome-scale interactome screen. This uninformative protein-binding term
+      does not convey PGAP2&#39;s molecular function and the partner is not part of the GPI
+      remodeling machinery.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding from a high-throughput binary interactome map is
+      uninformative and does not describe PGAP2&#39;s function; retained per policy (do not
+      REMOVE experimental IPIs) but flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:25416956
+      supporting_text: a systematic map of ?14,000 high-quality human binary protein-protein
+        interactions
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26871637
+  qualifier: enables
+  review:
+    summary: Binary protein-protein interaction (with CREB3L1, UniProtKB:Q96BA8) recorded
+      by an alternative-splicing interactome screen. Uninformative protein-binding term
+      that does not describe PGAP2&#39;s GPI-remodeling molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding from a high-throughput interactome map is uninformative;
+      retained per policy but flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:26871637
+      supporting_text: Alternatively-spliced isoforms of proteins exhibit strikingly
+        different
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  isoform: Q9UHJ9-5
+  review:
+    summary: Multiple binary protein-protein interactions recorded for isoform 5 by the
+      HuRI reference interactome (yeast two-hybrid). These are uninformative protein-binding
+      annotations that do not describe PGAP2&#39;s molecular function; the isoform field
+      records that isoform 5 was the tested clone, not an isoform-specific function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding from a systematic Y2H interactome map (HuRI) is
+      uninformative for PGAP2&#39;s function; retained per policy but flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: reference interactome map of human binary protein interactions,
+        or &#39;HuRI&#39;
+- term:
+    id: GO:0120574
+    label: GPI anchor remodelling
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: GPI anchor remodelling captures PGAP2&#39;s specific role most accurately - the
+      post-attachment Golgi fatty-acid remodeling in which the lyso-GPI intermediate is
+      reacylated with a saturated stearoyl chain. Transferred by sequence similarity from
+      the mouse ortholog (UniProtKB:Q2ABP3).
+    action: ACCEPT
+    reason: Most specific and accurate BP for PGAP2; consistent with UniProt function and
+      the PMID:29374258 mechanistic description of PGAP2 reacylation.
+    supported_by:
+    - reference_id: file:human/PGAP2/PGAP2-uniprot.txt
+      supporting_text: second step of the fatty acid remodeling, by reacylating a lyso-GPI
+- term:
+    id: GO:0000139
+    label: Golgi membrane
+  evidence_type: EXP
+  original_reference_id: PMID:10585768
+  qualifier: located_in
+  review:
+    summary: Experimentally supported Golgi membrane localization for PGAP2/FRAG1, the
+      core site where PGAP2 performs GPI fatty-acid remodeling. The original report
+      characterized FRAG1 as an integral membrane protein with multiple membrane-spanning
+      segments; the Golgi assignment reflects the full-text/curated localization.
+    action: ACCEPT
+    reason: Core cellular component; experimental annotation consistent with UniProt
+      subcellular location (Golgi apparatus membrane, multi-pass).
+    supported_by:
+    - reference_id: PMID:10585768
+      supporting_text: hydropathy analysis predicted FRAG1 to encode an integral membrane
+    - reference_id: file:human/PGAP2/PGAP2-uniprot.txt
+      supporting_text: Golgi apparatus membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:23561846
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence that PGAP2 is required for GPI-anchor maturation
+      and surface expression of GPI-anchored proteins. Rescue of PGAP2-deficient CHO cells
+      with wild-type versus HPMRS3-mutant PGAP2 showed reduced cell-surface DAF and CD59
+      with the mutants, demonstrating PGAP2&#39;s role in the GPI-anchor process.
+    action: ACCEPT
+    reason: Core biological process supported by direct functional (rescue) experiments;
+      also the basis for the HPMRS3 disease association.
+    supported_by:
+    - reference_id: PMID:23561846
+      supporting_text: less expression of cell-surface GPI-anchored proteins DAF and CD59
+        than
+    - reference_id: PMID:23561846
+      supporting_text: PGAP2 encodes a protein involved in remodeling the
+        glycosylphosphatidylinositol
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:29374258
+  qualifier: involved_in
+  review:
+    summary: Although this paper primarily characterizes PGAP4, its full text places PGAP2
+      in the Golgi GPI fatty-acid remodeling pathway and uses PGAP2 in the GPI-remodeling
+      context; the experimental (IMP) annotation to the GPI-anchor biosynthetic process
+      is consistent with PGAP2&#39;s established role. Retained as core.
+    action: ACCEPT
+    reason: Experimental annotation for the core biological process; full text (available)
+      explicitly assigns PGAP2 the reacylation step of Golgi fatty-acid remodeling. Defer
+      to curator on the IMP evidence.
+    supported_by:
+    - reference_id: PMID:29374258
+      supporting_text: In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3
+        removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation
+        with stearic acid, a
+- term:
+    id: GO:0000139
+    label: Golgi membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: Golgi membrane localization transferred by sequence similarity from the mouse
+      ortholog (UniProtKB:Q2ABP3). Duplicates the experimentally supported Golgi membrane
+      location.
+    action: ACCEPT
+    reason: Correct core location; concordant with the EXP and IEA Golgi annotations.
+    supported_by:
+    - reference_id: file:human/PGAP2/PGAP2-uniprot.txt
+      supporting_text: Golgi apparatus membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: ER-membrane localization transferred by sequence similarity from the mouse
+      ortholog. As with the IBA ER annotation, this is plausible given the ER-to-Golgi
+      span of the GPI pathway, but the core, experimentally supported location for PGAP2&#39;s
+      remodeling function is the Golgi.
+    action: KEEP_AS_NON_CORE
+    reason: Plausible but non-core; PGAP2&#39;s fatty-acid remodeling step and its documented
+      subcellular location are Golgi, not ER.
+    supported_by:
+    - reference_id: file:human/PGAP2/PGAP2-uniprot.txt
+      supporting_text: Golgi apparatus membrane
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: TAS
+  original_reference_id: PMID:10585768
+  qualifier: located_in
+  review:
+    summary: Original characterization of FRAG1/PGAP2 as an integral membrane protein with
+      multiple membrane-spanning segments. The generic membrane term is correct but
+      uninformative; PGAP2 is a multi-pass Golgi-membrane protein.
+    action: MODIFY
+    reason: The generic membrane term is too general; the specific location is the Golgi
+      membrane, which is separately and experimentally annotated.
+    proposed_replacement_terms:
+    - id: GO:0000139
+      label: Golgi membrane
+    supported_by:
+    - reference_id: PMID:10585768
+      supporting_text: hydropathy analysis predicted FRAG1 to encode an integral membrane
+    - reference_id: file:human/PGAP2/PGAP2-uniprot.txt
+      supporting_text: Multi-pass membrane
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: file:human/PGAP2/PGAP2-uniprot.txt
+  title: UniProtKB entry Q9UHJ9 (PGAP2_HUMAN)
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Curated UniProt record; source of the fatty-acid remodeling function,
+      Golgi apparatus membrane localization, multi-pass topology, and HPMRS3 disease
+      association. Quotes verified as verbatim substrings.
+- id: PMID:10585768
+  title: Human FRAG1 encodes a novel membrane-spanning protein that localizes to chromosome
+    11p15.5, a region of frequent loss of heterozygosity in cancer.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Original cloning of FRAG1 (=PGAP2); establishes multi-pass membrane
+      topology and ubiquitous expression. Golgi assignment is from the full text / curated
+      record (abstract does not state Golgi). Basis for the EXP Golgi and TAS membrane
+      annotations.
+- id: PMID:23561846
+  title: Hypomorphic mutations in PGAP2, encoding a GPI-anchor-remodeling protein,
+    cause autosomal-recessive intellectual disability.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Direct functional evidence - CHO rescue with WT vs mutant PGAP2 alters
+      surface DAF/CD59; establishes HPMRS3. Basis for the IDA GPI-anchor annotation.
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput binary interactome map; source of a single uninformative
+      protein-binding IPI. Does not inform PGAP2&#39;s molecular function.
+- id: PMID:26871637
+  title: Widespread Expansion of Protein Interaction Capabilities by Alternative Splicing.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Alternative-splicing interactome screen; source of an uninformative
+      protein-binding IPI. Does not inform PGAP2&#39;s molecular function.
+- id: PMID:29374258
+  title: Identification of a Golgi GPI-N-acetylgalactosamine transferase with tandem
+    transmembrane regions in the catalytic domain.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Primarily a PGAP4 paper, but the full text gives the clearest verbatim
+      description of PGAP2&#39;s role (Golgi reacylation with stearic acid after PGAP3);
+      cited for the IMP GPI-anchor annotation.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: HuRI reference Y2H interactome; source of multiple uninformative
+      protein-binding IPIs on isoform 5. Does not inform PGAP2&#39;s molecular function.
+core_functions:
+- description: PGAP2 acts in the Golgi to carry out (or to be required for) the second
+    step of GPI fatty-acid remodeling, reacylating the lyso-GPI intermediate with a
+    saturated stearoyl chain after PGAP3 removes the sn-2 unsaturated fatty acid; this
+    generates the mature, lipid-raft-associating GPI anchor needed for stable cell-surface
+    expression of GPI-anchored proteins.
+  directly_involved_in:
+  - id: GO:0120574
+    label: GPI anchor remodelling
+  locations:
+  - id: GO:0000139
+    label: Golgi membrane
+  supported_by:
+  - reference_id: file:human/PGAP2/PGAP2-uniprot.txt
+    supporting_text: second step of the fatty acid remodeling, by reacylating a lyso-GPI
+  - reference_id: PMID:29374258
+    supporting_text: In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3
+      removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation
+      with stearic acid, a
+- description: PGAP2 is required for GPI-anchor biosynthesis/maturation; loss of function
+    reduces cell-surface expression of GPI-anchored proteins (e.g. DAF/CD55, CD59), and
+    hypomorphic variants cause HPMRS3.
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0000139
+    label: Golgi membrane
+  supported_by:
+  - reference_id: PMID:23561846
+    supporting_text: less expression of cell-surface GPI-anchored proteins DAF and CD59
+      than
+suggested_questions:
+- question: Is PGAP2 itself the sn-2 acyltransferase (EC 2.3.-.-) that reacylates lyso-GPI
+    with stearoyl-CoA, or an accessory factor required for the reaction? The catalytic
+    activity and EC number are currently assigned only by similarity.
+- question: Which residues constitute the catalytic/substrate-binding site, and do the
+    HPMRS3 hypomorphic variants (e.g. Y99C, R177P, T160I) impair catalysis, substrate
+    binding, or protein stability?
+suggested_experiments:
+- description: Reconstitute the reacylation reaction in vitro with purified PGAP2, lyso-GPI
+    substrate, and stearoyl-CoA to test whether PGAP2 has intrinsic acyltransferase
+    activity.
+- description: Mass-spectrometry lipidomics of GPI anchors from PGAP2-knockout versus
+    rescued cells to confirm accumulation of lyso-GPI and loss of the stearoyl-remodeled
+    species.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PGAP3/PGAP3-ai-review.html
+++ b/genes/human/PGAP3/PGAP3-ai-review.html
@@ -1,0 +1,3150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PGAP3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PGAP3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q96FM1" target="_blank" class="term-link">
+                        Q96FM1
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PGAP3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q96FM1" data-a="DESCRIPTION: PGAP3 (Post-GPI Attachment to Proteins factor 3; P..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PGAP3 (Post-GPI Attachment to Proteins factor 3; PERLD1; CAB2/hCOS16) is a Golgi multi-pass membrane protein that acts as a GPI-specific phospholipase A2 in the fatty-acid remodeling of glycosylphosphatidylinositol (GPI) anchors. It catalyzes the first remodeling step, removing the unsaturated (sn-2) fatty acyl chain from the inositol phospholipid of the mature GPI anchor to generate a lyso-GPI intermediate; PGAP2 then reacylates the anchor with a saturated (stearoyl) chain. This remodeling is required for GPI-anchored proteins to associate with membrane microdomains (lipid rafts) at the cell surface. PGAP3 is the functional ortholog of yeast Per1p. Loss of function causes hyperphosphatasia with impaired intellectual development syndrome 4 (HPMRS4 / Mabry syndrome), an autosomal recessive disorder with developmental delay, intellectual disability and elevated serum alkaline phosphatase (a GPI-anchored enzyme).</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0180046" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to the overall pathway of GPI-anchored protein biosynthesis. PGAP3 performs a Golgi lipid-remodeling step required for GPI-APs to reach a fully functional, raft-associated state, so involvement in this broad process is well supported. A more specific remodeling term is also annotated (GO:0120574).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the established role of PGAP3 in GPI-anchor maturation; IBA is at an appropriate pathway-level of specificity for this multi-step process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link">
+                                        PMID:29374258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3 removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation with stearic acid, a saturated fatty acid</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                    GO:0000139
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0000139" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) is_active_in Golgi membrane. This matches the experimentally determined steady-state localization of PGAP3 and the compartment where fatty-acid remodeling of GPI anchors occurs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The Golgi membrane is where PGAP3 carries out its remodeling activity; supported by IDA localization and by the known Golgi site of GPI fatty-acid remodeling.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP3/PGAP3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Golgi apparatus membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link">
+                                        PMID:29374258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3 removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation with stearic acid, a saturated fatty acid</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016788" target="_blank" class="term-link">
+                                    GO:0016788
+                                </a>
+                            </span>
+                            <span class="term-label">hydrolase activity, acting on ester bonds</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0016788" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) molecular-function annotation as an ester-bond hydrolase. PGAP3 is a GPI-specific phospholipase A2 (EC 3.1.1.-) that hydrolyzes the ester bond linking the sn-2 unsaturated fatty acid to the GPI inositol phospholipid, so ester-bond hydrolase activity is correct, if general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct at the family/phylogenetic level; the phospholipase A2 (acyl-ester hydrolase) activity of PGAP3 is a specialization of this ester-bond hydrolase term. A more specific phospholipase A2 term would be an appropriate refinement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP3/PGAP3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">May catalyze the first step of the fatty acid</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17021251" target="_blank" class="term-link">
+                                        PMID:17021251
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PER1 is required for the production of
+lyso-GPI, suggesting that Per1p possesses or regulates the GPI-phospholipase A2
+activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                    GO:0000139
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0000139" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt SubCell mapping SL-0134) annotation to Golgi membrane. Consistent with the experimentally supported Golgi localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the IDA and IBA Golgi membrane annotations and correctly derived from the curated UniProt subcellular location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP3/PGAP3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Golgi apparatus membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0006506" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro IPR007217, Per1-like) annotation to GPI anchor biosynthetic process. The Per1-like family carries out GPI-anchor lipid remodeling, part of the overall biosynthetic/maturation pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro-to-GO mapping is biologically appropriate for the PGAP3/Per1 family; PGAP3 acts in GPI-anchor maturation. Duplicated by experimental IMP annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24439110" target="_blank" class="term-link">
+                                        PMID:24439110
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">identified mutations in PGAP3, encoding a protein that is involved in GPI-anchor
+maturation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32814053
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactome Mapping Provides a Network of Neurodegenerative ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI &#39;protein binding&#39; from a large-scale neurodegenerative-disease interactome (yeast two-hybrid) reporting an interaction with GTF3C3 (Q9Y5Q9). This is an uninformative bare protein-binding term from a high-throughput screen with no established functional relationship to GPI remodeling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0005515 protein binding conveys no specific molecular function; the interactor (GTF3C3, a TFIIIC transcription-factor subunit) has no known connection to GPI-anchor biology, and the evidence is a single high-throughput Y2H hit. Retained (not removed) per policy on experimental IPI annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                                        PMID:32814053
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">candidate interactions and is generated by systematic yeast two-hybrid</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI &#39;protein binding&#39; from the BioPlex proteome-scale AP-MS interactome reporting an interaction with TBRG4 (Q969Z0). Bare protein-binding term from a high-throughput screen without an established functional link to PGAP3&#39;s remodeling role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0005515 protein binding is uninformative; the interactor (TBRG4, a mitochondrial RNA-processing protein) has no known relationship to Golgi GPI remodeling, and the evidence is a single proteome-scale AP-MS association. Retained (not removed) per policy on experimental IPI annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The first, BioPlex 3.0, results from affinity purification
+of 10,128 human proteins-half the proteome-in 293T cells and includes 118,162
+interactions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120574" target="_blank" class="term-link">
+                                    GO:0120574
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor remodelling</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17021251" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17021251
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PER1 is required for GPI-phospholipase A2 activity and invol...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0120574" data-r="PMID:17021251" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP to GPI anchor remodelling based on the yeast PER1 study, which established PER1 as required for GPI lipid remodeling (production of lyso-GPI / GPI-phospholipase A2 activity) and showed that human PERLD1 (PGAP3) is a functional homolog of PER1. This is the most specific and accurate BP term for PGAP3.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly captures the core evolved function of PGAP3 - remodeling of the GPI anchor after its attachment to protein - and is supported by cross-species complementation demonstrating conserved function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17021251" target="_blank" class="term-link">
+                                        PMID:17021251
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We also found that human PERLD1 is a functional homologue of PER1</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17021251" target="_blank" class="term-link">
+                                        PMID:17021251
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PER1 is required for the production of
+lyso-GPI, suggesting that Per1p possesses or regulates the GPI-phospholipase A2
+activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120574" target="_blank" class="term-link">
+                                    GO:0120574
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor remodelling</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24439110" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24439110
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in PGAP3 impair GPI-anchor maturation, causing a s...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0120574" data-r="PMID:24439110" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP to GPI anchor remodelling from the human genetics/functional study showing that biallelic PGAP3 loss-of-function variants impair GPI-anchor maturation, cause elevated surface expression of abnormally remodeled GPI-APs, and are validated in CHO functional assays. This is the core, most specific BP for PGAP3.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported experimental annotation to the specific remodeling process; patient variants and CHO cell functional studies demonstrate PGAP3&#39;s role in the later GPI-anchor remodeling steps.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24439110" target="_blank" class="term-link">
+                                        PMID:24439110
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the later
+GPI-anchor remodelling steps for normal neuronal development</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24439110" target="_blank" class="term-link">
+                                        PMID:24439110
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">functional studies on Chinese hamster ovary cell lines</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29374258
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of a Golgi GPI-N-acetylgalactosamine transfer...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0180046" data-r="PMID:29374258" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP to GPI anchored protein biosynthesis from the PGAP4 study, in which PGAP3-knockout cells were used and the Golgi fatty-acid remodeling role of PGAP3 (removal of the sn-2 unsaturated fatty acid, before PGAP2 reacylation) is directly described. Supports involvement in the broad GPI-AP biosynthesis/maturation pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PGAP3 performs an obligatory Golgi remodeling step in producing mature, functional GPI-anchored proteins; the annotation is at an appropriate pathway level and is duplicated by the IBA annotation to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link">
+                                        PMID:29374258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3 removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation with stearic acid, a saturated fatty acid</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                    GO:0000139
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24439110" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24439110
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in PGAP3 impair GPI-anchor maturation, causing a s...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0000139" data-r="PMID:24439110" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA localization to the Golgi membrane. The HPMRS4 study characterized wild-type and mutant PGAP3 localization, confirming Golgi apparatus residence of the wild-type protein (with ER retention of certain pathogenic mutants).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for the steady-state Golgi membrane localization where PGAP3 acts; the primary and most reliable localization annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAP3/PGAP3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Golgi apparatus membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031410" target="_blank" class="term-link">
+                                    GO:0031410
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasmic vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12460457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12460457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of the CAB2/hCOS16 gene required for the repa...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0031410" data-r="PMID:12460457" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA to cytoplasmic vesicle from the early CAB2/hCOS16 study, which reported that a CAB2 (PGAP3)-GFP fusion translocated into vesicles. This predates recognition of PGAP3 as a GPI-remodeling enzyme; the well-established, functionally relevant location is the Golgi.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Localization to vesicular structures is plausible for a secretory-pathway membrane protein but is peripheral to PGAP3&#39;s core Golgi remodeling function and derives from an overexpressed GFP-fusion in a study focused on chromosome 17q12 amplicon genes, not GPI biology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12460457" target="_blank" class="term-link">
+                                        PMID:12460457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CAB2 translocates into vesicles</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29374258
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of a Golgi GPI-N-acetylgalactosamine transfer...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0006506" data-r="PMID:29374258" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP to GPI anchor biosynthetic process (UniProt-assigned), supported by the same functional context in which PGAP3 performs the Golgi fatty-acid remodeling step of GPI-anchor maturation. Duplicates the InterPro IEA annotation to the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct pathway-level BP for PGAP3&#39;s role in producing mature GPI anchors; the remodeling activity is an integral part of GPI-anchor biosynthesis/maturation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link">
+                                        PMID:29374258
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3 removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation with stearic acid, a saturated fatty acid</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016788" target="_blank" class="term-link">
+                                    GO:0016788
+                                </a>
+                            </span>
+                            <span class="term-label">hydrolase activity, acting on ester bonds</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17021251" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17021251
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PER1 is required for GPI-phospholipase A2 activity and invol...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96FM1" data-a="GO:0016788" data-r="PMID:17021251" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP molecular-function annotation as an ester-bond hydrolase, based on the PER1 study demonstrating that PER1/PERLD1(PGAP3) is required for GPI-phospholipase A2 activity and lyso-GPI production. PGAP3 hydrolyzes the sn-2 acyl-ester bond of the GPI inositol phospholipid.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The phospholipase A2 (acyl-ester hydrolase) activity of PGAP3 is a specific instance of ester-bond hydrolase activity; a dedicated phospholipase A2 term would be an appropriate future refinement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17021251" target="_blank" class="term-link">
+                                        PMID:17021251
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PER1 is required for the production of
+lyso-GPI, suggesting that Per1p possesses or regulates the GPI-phospholipase A2
+activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>GPI-specific phospholipase A2 that hydrolyzes the ester bond linking the unsaturated (sn-2) fatty acyl chain to the inositol phospholipid of the mature GPI anchor, generating a lyso-GPI intermediate - the first step of Golgi GPI fatty-acid remodeling (before PGAP2 reacylation with a saturated stearoyl chain).</h3>
+                <span class="vote-buttons" data-g="Q96FM1" data-a="FUNCTION: GPI-specific phospholipase A2 that hydrolyzes the ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016788" target="_blank" class="term-link">
+                            hydrolase activity, acting on ester bonds
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120574" target="_blank" class="term-link">
+                                GPI anchor remodelling
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                Golgi membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PGAP3/PGAP3-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Involved in the fatty acid remodeling steps of GPI-anchor</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PGAP3/PGAP3-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">removing the unsaturated acyl chain at sn-2 of inositol</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PGAP3/PGAP3-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">generating a lyso-GPI intermediate</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17021251" target="_blank" class="term-link">
+                                PMID:17021251
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PER1 is required for the production of
+lyso-GPI, suggesting that Per1p possesses or regulates the GPI-phospholipase A2
+activity</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link">
+                                PMID:29374258
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3 removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation with stearic acid, a saturated fatty acid</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PGAP3/PGAP3-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q96FM1 (PGAP3_HUMAN)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12460457" target="_blank" class="term-link">
+                            PMID:12460457
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of the CAB2/hCOS16 gene required for the repair of DNA double-strand breaks on a core amplified region of the 17q12 locus in breast and gastric cancers.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17021251" target="_blank" class="term-link">
+                            PMID:17021251
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PER1 is required for GPI-phospholipase A2 activity and involved in lipid remodeling of GPI-anchored proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24439110" target="_blank" class="term-link">
+                            PMID:24439110
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in PGAP3 impair GPI-anchor maturation, causing a subtype of hyperphosphatasia with mental retardation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29374258" target="_blank" class="term-link">
+                            PMID:29374258
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of a Golgi GPI-N-acetylgalactosamine transferase with tandem transmembrane regions in the catalytic domain.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                            PMID:32814053
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PGAP3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q96FM1" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pgap3-q96fm1-review-notes">PGAP3 (Q96FM1) review notes</h1>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>Human PGAP3 = Post-GPI Attachment to Proteins factor 3 = PERLD1 = CAB2/hCOS16 = COS16 homolog.</li>
+<li>HGNC:23719; located 17q12 (within the PPP1R1B-STARD3-ERBB2-GRB7 amplicon).</li>
+<li>320 aa, multi-pass Golgi membrane protein (7 predicted TM helices), N-glycosylated at N40.</li>
+<li>Member of the PGAP3/PER1 (Per1-like, Pfam PF04080 / InterPro IPR007217) family.</li>
+</ul>
+<h2 id="core-biology-from-uniprot-q96fm1-cited-papers">Core biology (from UniProt Q96FM1 + cited papers)</h2>
+<ul>
+<li><strong>GPI-specific phospholipase A2</strong>. Carries out the <strong>first step of GPI fatty-acid remodeling</strong><br />
+  in the Golgi: removes the <strong>unsaturated acyl chain at sn-2 of the inositol phospholipid</strong><br />
+  (phosphatidylinositol) of the mature GPI anchor, generating a lyso-GPI intermediate.<br />
+  PGAP2 then reacylates with a saturated (stearic) chain. This remodeling is required for<br />
+  GPI-anchored proteins (GPI-APs) to associate with lipid rafts / detergent-resistant membranes.</li>
+<li>UniProt FUNCTION + CATALYTIC ACTIVITY (Rhea RHEA:83847), EC 3.1.1.-.</li>
+<li>[PMID:29374258 (PGAP4 paper) intro, "In the Golgi, GPI-APs undergo fatty acid remodeling where<br />
+    PGAP3 removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation with<br />
+    stearic acid, a saturated fatty acid"].</li>
+<li>Yeast PER1 is the ortholog; human PERLD1/PGAP3 functionally complements per1Δ<br />
+    [PMID:17021251 "human PERLD1 is a functional homologue of PER1"; "PER1 is required for the<br />
+    production of lyso-GPI, suggesting that Per1p possesses or regulates the GPI-phospholipase A2<br />
+    activity"].</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>Golgi apparatus membrane (GO:0000139): UniProt SUBCELLULAR LOCATION; IDA <a href="https://pubmed.ncbi.nlm.nih.gov/24439110">PMID:24439110</a>;<br />
+  IBA is_active_in; IEA (SubCell SL-0134). HPMRS4 P105R and D305G mutants are ER-retained.</li>
+<li>GO:0031410 cytoplasmic vesicle (IDA, PMID:12460457): from the CAB2/hCOS16 GFP-fusion study<br />
+  reporting translocation into vesicles. Peripheral/older assignment; the well-supported steady-state<br />
+  location is Golgi. Keep as non-core.</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>Hyperphosphatasia with impaired intellectual development syndrome 4 (HPMRS4 / Mabry syndrome),<br />
+  MIM 615716, autosomal recessive; elevated serum ALP (a GPI-anchored enzyme) <a href="https://pubmed.ncbi.nlm.nih.gov/24439110">PMID:24439110</a>.</li>
+</ul>
+<h2 id="interactions-go0005515-protein-binding-ipi">Interactions (GO:0005515 protein binding, IPI)</h2>
+<ul>
+<li>GTF3C3 (Q9Y5Q9) [PMID:32814053, ND interactome Y2H]; TBRG4 (Q969Z0) [PMID:33961781, BioPlex AP-MS].<br />
+  Both are large-scale high-throughput screens; neither has an established functional relationship<br />
+  to GPI remodeling. Uninformative bare <code>protein binding</code> -&gt; MARK_AS_OVER_ANNOTATED (do not REMOVE<br />
+  per policy).</li>
+</ul>
+<h2 id="goa-mf-term-used-for-core_functions">GOA MF term used for core_functions</h2>
+<ul>
+<li>GOA carries <strong>GO:0016788 "hydrolase activity, acting on ester bonds"</strong> (both the IBA and the<br />
+  IMP MF annotations). Per instructions, use this exact current GOA term as the core molecular_function.<br />
+  (A more specific phospholipase A2 term would be biologically apt, but the task requires the exact<br />
+  GOA-carried MF term.)</li>
+</ul>
+<h2 id="quote-verification-log-all-verbatim-substrings-confirmed-via-python-in-check-against-cached-files">Quote-verification log (all verbatim substrings confirmed via python <code>in</code> check against cached files)</h2>
+<ul>
+<li>PMID:29374258: "In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3 removes an<br />
+  sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation with stearic acid, a<br />
+  saturated fatty acid" (also PGAP3-KO used experimentally in that paper).</li>
+<li>PMID:17021251: wrapped substrings for lyso-GPI/phospholipase A2 and PERLD1 homologue.</li>
+<li>PMID:24439110: "identified mutations in PGAP3, encoding a protein that is involved in GPI-anchor \nmaturation";<br />
+  "elevated serum alkaline phosphatase (ALP), a GPI-anchored enzyme"; "functional studies on Chinese<br />
+  hamster ovary cell lines"; "the later \nGPI-anchor remodelling steps for normal neuronal development".</li>
+<li>PMID:12460457: "CAB2 translocates into vesicles".</li>
+<li>file:human/PGAP3/PGAP3-uniprot.txt used for FUNCTION/CATALYTIC ACTIVITY/SUBCELLULAR LOCATION quotes.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q96FM1
+gene_symbol: PGAP3
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PGAP3 (Post-GPI Attachment to Proteins factor 3; PERLD1; CAB2/hCOS16)
+  is a Golgi multi-pass membrane protein that acts as a GPI-specific phospholipase
+  A2 in the fatty-acid remodeling of glycosylphosphatidylinositol (GPI) anchors. It
+  catalyzes the first remodeling step, removing the unsaturated (sn-2) fatty acyl
+  chain from the inositol phospholipid of the mature GPI anchor to generate a lyso-GPI
+  intermediate; PGAP2 then reacylates the anchor with a saturated (stearoyl) chain.
+  This remodeling is required for GPI-anchored proteins to associate with membrane
+  microdomains (lipid rafts) at the cell surface. PGAP3 is the functional ortholog
+  of yeast Per1p. Loss of function causes hyperphosphatasia with impaired intellectual
+  development syndrome 4 (HPMRS4 / Mabry syndrome), an autosomal recessive disorder
+  with developmental delay, intellectual disability and elevated serum alkaline phosphatase
+  (a GPI-anchored enzyme).
+alternative_products:
+- name: &#39;1&#39;
+  id: Q96FM1-1
+- name: &#39;2&#39;
+  id: Q96FM1-2
+  sequence_note: VSP_034158
+- name: &#39;3&#39;
+  id: Q96FM1-3
+  sequence_note: VSP_057229
+existing_annotations:
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic (IBA) annotation to the overall pathway of GPI-anchored protein
+      biosynthesis. PGAP3 performs a Golgi lipid-remodeling step required for GPI-APs
+      to reach a fully functional, raft-associated state, so involvement in this broad
+      process is well supported. A more specific remodeling term is also annotated
+      (GO:0120574).
+    action: ACCEPT
+    reason: Consistent with the established role of PGAP3 in GPI-anchor maturation;
+      IBA is at an appropriate pathway-level of specificity for this multi-step process.
+    supported_by:
+    - reference_id: PMID:29374258
+      supporting_text: In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3
+        removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation
+        with stearic acid, a saturated fatty acid
+- term:
+    id: GO:0000139
+    label: Golgi membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) is_active_in Golgi membrane. This matches the experimentally
+      determined steady-state localization of PGAP3 and the compartment where fatty-acid
+      remodeling of GPI anchors occurs.
+    action: ACCEPT
+    reason: The Golgi membrane is where PGAP3 carries out its remodeling activity;
+      supported by IDA localization and by the known Golgi site of GPI fatty-acid remodeling.
+    supported_by:
+    - reference_id: file:human/PGAP3/PGAP3-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Golgi apparatus membrane&#39;
+    - reference_id: PMID:29374258
+      supporting_text: In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3
+        removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation
+        with stearic acid, a saturated fatty acid
+- term:
+    id: GO:0016788
+    label: hydrolase activity, acting on ester bonds
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) molecular-function annotation as an ester-bond hydrolase.
+      PGAP3 is a GPI-specific phospholipase A2 (EC 3.1.1.-) that hydrolyzes the ester
+      bond linking the sn-2 unsaturated fatty acid to the GPI inositol phospholipid,
+      so ester-bond hydrolase activity is correct, if general.
+    action: ACCEPT
+    reason: Correct at the family/phylogenetic level; the phospholipase A2 (acyl-ester
+      hydrolase) activity of PGAP3 is a specialization of this ester-bond hydrolase
+      term. A more specific phospholipase A2 term would be an appropriate refinement.
+    supported_by:
+    - reference_id: file:human/PGAP3/PGAP3-uniprot.txt
+      supporting_text: May catalyze the first step of the fatty acid
+    - reference_id: PMID:17021251
+      supporting_text: &#34;PER1 is required for the production of \nlyso-GPI, suggesting\
+        \ that Per1p possesses or regulates the GPI-phospholipase A2 \nactivity&#34;
+- term:
+    id: GO:0000139
+    label: Golgi membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic (UniProt SubCell mapping SL-0134) annotation to Golgi membrane.
+      Consistent with the experimentally supported Golgi localization.
+    action: ACCEPT
+    reason: Redundant with the IDA and IBA Golgi membrane annotations and correctly
+      derived from the curated UniProt subcellular location.
+    supported_by:
+    - reference_id: file:human/PGAP3/PGAP3-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Golgi apparatus membrane&#39;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: Electronic (InterPro IPR007217, Per1-like) annotation to GPI anchor biosynthetic
+      process. The Per1-like family carries out GPI-anchor lipid remodeling, part of
+      the overall biosynthetic/maturation pathway.
+    action: ACCEPT
+    reason: The InterPro-to-GO mapping is biologically appropriate for the PGAP3/Per1
+      family; PGAP3 acts in GPI-anchor maturation. Duplicated by experimental IMP annotations
+      to the same term.
+    supported_by:
+    - reference_id: PMID:24439110
+      supporting_text: &#34;identified mutations in PGAP3, encoding a protein that is involved\
+        \ in GPI-anchor \nmaturation&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  qualifier: enables
+  review:
+    summary: IPI &#39;protein binding&#39; from a large-scale neurodegenerative-disease interactome
+      (yeast two-hybrid) reporting an interaction with GTF3C3 (Q9Y5Q9). This is an
+      uninformative bare protein-binding term from a high-throughput screen with no
+      established functional relationship to GPI remodeling.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;GO:0005515 protein binding conveys no specific molecular function; the
+      interactor (GTF3C3, a TFIIIC transcription-factor subunit) has no known connection
+      to GPI-anchor biology, and the evidence is a single high-throughput Y2H hit.
+      Retained (not removed) per policy on experimental IPI annotations.&#39;
+    supported_by:
+    - reference_id: PMID:32814053
+      supporting_text: candidate interactions and is generated by systematic yeast
+        two-hybrid
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: IPI &#39;protein binding&#39; from the BioPlex proteome-scale AP-MS interactome
+      reporting an interaction with TBRG4 (Q969Z0). Bare protein-binding term from
+      a high-throughput screen without an established functional link to PGAP3&#39;s remodeling
+      role.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;GO:0005515 protein binding is uninformative; the interactor (TBRG4, a
+      mitochondrial RNA-processing protein) has no known relationship to Golgi GPI
+      remodeling, and the evidence is a single proteome-scale AP-MS association. Retained
+      (not removed) per policy on experimental IPI annotations.&#39;
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: &#34;The first, BioPlex 3.0, results from affinity purification \n\
+        of 10,128 human proteins-half the proteome-in 293T cells and includes 118,162\
+        \ \ninteractions&#34;
+- term:
+    id: GO:0120574
+    label: GPI anchor remodelling
+  evidence_type: IMP
+  original_reference_id: PMID:17021251
+  qualifier: involved_in
+  review:
+    summary: IMP to GPI anchor remodelling based on the yeast PER1 study, which established
+      PER1 as required for GPI lipid remodeling (production of lyso-GPI / GPI-phospholipase
+      A2 activity) and showed that human PERLD1 (PGAP3) is a functional homolog of
+      PER1. This is the most specific and accurate BP term for PGAP3.
+    action: ACCEPT
+    reason: Directly captures the core evolved function of PGAP3 - remodeling of the
+      GPI anchor after its attachment to protein - and is supported by cross-species
+      complementation demonstrating conserved function.
+    supported_by:
+    - reference_id: PMID:17021251
+      supporting_text: We also found that human PERLD1 is a functional homologue of
+        PER1
+    - reference_id: PMID:17021251
+      supporting_text: &#34;PER1 is required for the production of \nlyso-GPI, suggesting\
+        \ that Per1p possesses or regulates the GPI-phospholipase A2 \nactivity&#34;
+- term:
+    id: GO:0120574
+    label: GPI anchor remodelling
+  evidence_type: IMP
+  original_reference_id: PMID:24439110
+  qualifier: involved_in
+  review:
+    summary: IMP to GPI anchor remodelling from the human genetics/functional study
+      showing that biallelic PGAP3 loss-of-function variants impair GPI-anchor maturation,
+      cause elevated surface expression of abnormally remodeled GPI-APs, and are validated
+      in CHO functional assays. This is the core, most specific BP for PGAP3.
+    action: ACCEPT
+    reason: Well-supported experimental annotation to the specific remodeling process;
+      patient variants and CHO cell functional studies demonstrate PGAP3&#39;s role in
+      the later GPI-anchor remodeling steps.
+    supported_by:
+    - reference_id: PMID:24439110
+      supporting_text: &#34;the later \nGPI-anchor remodelling steps for normal neuronal\
+        \ development&#34;
+    - reference_id: PMID:24439110
+      supporting_text: functional studies on Chinese hamster ovary cell lines
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IMP
+  original_reference_id: PMID:29374258
+  qualifier: involved_in
+  review:
+    summary: IMP to GPI anchored protein biosynthesis from the PGAP4 study, in which
+      PGAP3-knockout cells were used and the Golgi fatty-acid remodeling role of PGAP3
+      (removal of the sn-2 unsaturated fatty acid, before PGAP2 reacylation) is directly
+      described. Supports involvement in the broad GPI-AP biosynthesis/maturation pathway.
+    action: ACCEPT
+    reason: PGAP3 performs an obligatory Golgi remodeling step in producing mature,
+      functional GPI-anchored proteins; the annotation is at an appropriate pathway
+      level and is duplicated by the IBA annotation to the same term.
+    supported_by:
+    - reference_id: PMID:29374258
+      supporting_text: In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3
+        removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation
+        with stearic acid, a saturated fatty acid
+- term:
+    id: GO:0000139
+    label: Golgi membrane
+  evidence_type: IDA
+  original_reference_id: PMID:24439110
+  qualifier: located_in
+  review:
+    summary: IDA localization to the Golgi membrane. The HPMRS4 study characterized
+      wild-type and mutant PGAP3 localization, confirming Golgi apparatus residence
+      of the wild-type protein (with ER retention of certain pathogenic mutants).
+    action: ACCEPT
+    reason: Direct experimental evidence for the steady-state Golgi membrane localization
+      where PGAP3 acts; the primary and most reliable localization annotation.
+    supported_by:
+    - reference_id: file:human/PGAP3/PGAP3-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Golgi apparatus membrane&#39;
+- term:
+    id: GO:0031410
+    label: cytoplasmic vesicle
+  evidence_type: IDA
+  original_reference_id: PMID:12460457
+  qualifier: located_in
+  review:
+    summary: IDA to cytoplasmic vesicle from the early CAB2/hCOS16 study, which reported
+      that a CAB2 (PGAP3)-GFP fusion translocated into vesicles. This predates recognition
+      of PGAP3 as a GPI-remodeling enzyme; the well-established, functionally relevant
+      location is the Golgi.
+    action: KEEP_AS_NON_CORE
+    reason: Localization to vesicular structures is plausible for a secretory-pathway
+      membrane protein but is peripheral to PGAP3&#39;s core Golgi remodeling function
+      and derives from an overexpressed GFP-fusion in a study focused on chromosome
+      17q12 amplicon genes, not GPI biology.
+    supported_by:
+    - reference_id: PMID:12460457
+      supporting_text: CAB2 translocates into vesicles
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:29374258
+  qualifier: involved_in
+  review:
+    summary: IMP to GPI anchor biosynthetic process (UniProt-assigned), supported by
+      the same functional context in which PGAP3 performs the Golgi fatty-acid remodeling
+      step of GPI-anchor maturation. Duplicates the InterPro IEA annotation to the
+      same term.
+    action: ACCEPT
+    reason: Correct pathway-level BP for PGAP3&#39;s role in producing mature GPI anchors;
+      the remodeling activity is an integral part of GPI-anchor biosynthesis/maturation.
+    supported_by:
+    - reference_id: PMID:29374258
+      supporting_text: In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3
+        removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation
+        with stearic acid, a saturated fatty acid
+- term:
+    id: GO:0016788
+    label: hydrolase activity, acting on ester bonds
+  evidence_type: IMP
+  original_reference_id: PMID:17021251
+  qualifier: enables
+  review:
+    summary: IMP molecular-function annotation as an ester-bond hydrolase, based on
+      the PER1 study demonstrating that PER1/PERLD1(PGAP3) is required for GPI-phospholipase
+      A2 activity and lyso-GPI production. PGAP3 hydrolyzes the sn-2 acyl-ester bond
+      of the GPI inositol phospholipid.
+    action: ACCEPT
+    reason: The phospholipase A2 (acyl-ester hydrolase) activity of PGAP3 is a specific
+      instance of ester-bond hydrolase activity; a dedicated phospholipase A2 term
+      would be an appropriate future refinement.
+    supported_by:
+    - reference_id: PMID:17021251
+      supporting_text: &#34;PER1 is required for the production of \nlyso-GPI, suggesting\
+        \ that Per1p possesses or regulates the GPI-phospholipase A2 \nactivity&#34;
+core_functions:
+- description: GPI-specific phospholipase A2 that hydrolyzes the ester bond linking
+    the unsaturated (sn-2) fatty acyl chain to the inositol phospholipid of the mature
+    GPI anchor, generating a lyso-GPI intermediate - the first step of Golgi GPI fatty-acid
+    remodeling (before PGAP2 reacylation with a saturated stearoyl chain).
+  molecular_function:
+    id: GO:0016788
+    label: hydrolase activity, acting on ester bonds
+  directly_involved_in:
+  - id: GO:0120574
+    label: GPI anchor remodelling
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0000139
+    label: Golgi membrane
+  supported_by:
+  - reference_id: file:human/PGAP3/PGAP3-uniprot.txt
+    supporting_text: Involved in the fatty acid remodeling steps of GPI-anchor
+  - reference_id: file:human/PGAP3/PGAP3-uniprot.txt
+    supporting_text: removing the unsaturated acyl chain at sn-2 of inositol
+  - reference_id: file:human/PGAP3/PGAP3-uniprot.txt
+    supporting_text: generating a lyso-GPI intermediate
+  - reference_id: PMID:17021251
+    supporting_text: &#34;PER1 is required for the production of \nlyso-GPI, suggesting\
+      \ that Per1p possesses or regulates the GPI-phospholipase A2 \nactivity&#34;
+  - reference_id: PMID:29374258
+    supporting_text: In the Golgi, GPI-APs undergo fatty acid remodeling where PGAP3
+      removes an sn-2-linked unsaturated fatty acid and PGAP2 is involved in reacylation
+      with stearic acid, a saturated fatty acid
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: file:human/PGAP3/PGAP3-uniprot.txt
+  title: UniProtKB entry Q96FM1 (PGAP3_HUMAN)
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Curated UniProt record; source for FUNCTION, CATALYTIC ACTIVITY (Rhea
+      RHEA:83847, EC 3.1.1.-), Golgi subcellular location, topology, and HPMRS4 disease
+      association.
+- id: PMID:12460457
+  title: Identification of the CAB2/hCOS16 gene required for the repair of DNA double-strand
+    breaks on a core amplified region of the 17q12 locus in breast and gastric cancers.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: First cloning of CAB2/hCOS16 (=PGAP3) as a 17q12 amplicon gene; reports
+      GFP-fusion translocation into vesicles. Predates the enzymatic characterization;
+      DNA-repair/Mn2+ framing is not related to PGAP3&#39;s GPI-remodeling function.
+- id: PMID:17021251
+  title: PER1 is required for GPI-phospholipase A2 activity and involved in lipid
+    remodeling of GPI-anchored proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Establishes the GPI-phospholipase A2 / lyso-GPI-forming activity of
+      the PER1 family and shows human PERLD1 (PGAP3) functionally complements yeast
+      per1; foundational for PGAP3&#39;s molecular function.
+- id: PMID:24439110
+  title: Mutations in PGAP3 impair GPI-anchor maturation, causing a subtype of hyperphosphatasia
+    with mental retardation.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Human genetics plus CHO functional studies defining HPMRS4 and confirming
+      PGAP3&#39;s role in GPI-anchor remodeling; source of Golgi IDA localization and disease
+      variants.
+- id: PMID:29374258
+  title: Identification of a Golgi GPI-N-acetylgalactosamine transferase with tandem
+    transmembrane regions in the catalytic domain.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: PGAP4 paper; used PGAP3-knockout cells and gives a clear verbatim
+      description of PGAP3 removing the sn-2 unsaturated fatty acid in Golgi GPI remodeling
+      (before PGAP2 reacylation).
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
+    and Uncovers Widespread Protein Aggregation in Affected Brains.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Large-scale Y2H neurodegenerative-disease interactome; source of the
+      GTF3C3 protein-binding IPI. High-throughput; no established functional link to
+      PGAP3&#39;s GPI-remodeling role.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: BioPlex proteome-scale AP-MS interactome; source of the TBRG4 protein-binding
+      IPI. High-throughput; no established functional link to PGAP3.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGK/PIGK-ai-review.html
+++ b/genes/human/PIGK/PIGK-ai-review.html
@@ -1,0 +1,6234 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGK - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGK</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q92643" target="_blank" class="term-link">
+                        Q92643
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGK";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q92643" data-a="DESCRIPTION: PIGK (also known as GPI8) is the catalytic subunit..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGK (also known as GPI8) is the catalytic subunit of the multi-subunit glycosylphosphatidylinositol-anchor transamidase (GPI-T) complex, an endoplasmic reticulum membrane enzyme that attaches preassembled GPI anchors to the C-terminus of GPI-anchored proteins. During maturation of GPI-anchored proteins in the ER lumen, GPI-T recognizes a diverse C-terminal GPI-attachment signal peptide (lacking a consensus sequence), cleaves it, and forms a new amide bond between the exposed C-terminal residue (omega-site) and the amino group of the bridging ethanolamine-phosphate of the preassembled GPI, i.e. a transamidation reaction. PIGK is a legumain/caspase-like cysteine protease of the peptidase C13 family: its catalytic residues (nucleophile Cys206 and proton donor His164, completed by Asn58) cleave the signal peptide and form a transient acyl(carbonyl)-enzyme thioester intermediate that is then resolved by attack of the GPI ethanolamine amine. PIGK is a single-pass type I ER membrane protein with its catalytic domain in the ER lumen; it assembles with GPAA1, PIGT, PIGS and PIGU into an equimolar heteropentamer, and a disulfide bond to PIGT contributes to full activity. Bi-allelic loss-of-function variants in PIGK cause an autosomal recessive inherited GPI-deficiency disorder (GPIBD), a neurodevelopmental disorder with hypotonia, cerebellar atrophy, and (in most patients) seizures.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to the core biological process of PIGK - attachment of GPI anchor to protein. This is well supported by direct evidence for human PIGK and is consistent across the GPI8/PIGK orthologue family.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation at an appropriate level of specificity. PIGK is the catalytic subunit of the GPI transamidase that replaces the C-terminal GPI-attachment signal peptide with a preassembled GPI anchor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recognizes and cleaves the C-terminal GPI attachment signal of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation placing PIGK as part of the GPI-anchor transamidase complex. This matches direct human evidence that PIGK assembles with GPAA1, PIGT, PIGS and PIGU into the GPI-T heteropentamer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation; PIGK is a constitutive subunit of the GPI-T complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003923" target="_blank" class="term-link">
+                                    GO:0003923
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0003923" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to the core molecular function - GPI-anchor transamidase activity. PIGK is the catalytic component that provides this activity within the GPI-T complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core MF term. This is the exact term carried by GOA and is the informative molecular function of PIGK, confirmed by direct experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">functions as the catalytic component</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003923" target="_blank" class="term-link">
+                                    GO:0003923
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0003923" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO (IPR028361, GPI_transamidase) electronic mapping to the core molecular function GPI-anchor transamidase activity. Fully consistent with the curated experimental annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and specific IEA mapping to the core MF term; the GPI_transamidase InterPro signature is diagnostic for this activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">functions as the catalytic component</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Subcellular-location IEA (UniProtKB-SubCell SL-0097) placing PIGK in the endoplasmic reticulum membrane. This is the experimentally established site of GPI-T action and is corroborated by an EXP annotation to the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC term; PIGK is an ER membrane protein whose catalytic domain faces the ER lumen where GPI anchoring occurs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">are catalyzed by an endoplasmic reticulum membrane GPI transamidase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006508" target="_blank" class="term-link">
+                                    GO:0006508
+                                </a>
+                            </span>
+                            <span class="term-label">proteolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0006508" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping from the Peptidase_C13 domain (IPR001096) to proteolysis. PIGK is genuinely a legumain-like cysteine protease that cleaves the C-terminal GPI-attachment signal peptide, so this is biologically accurate, but proteolysis is only one half of the transamidation reaction and is far less informative than GPI-anchor transamidase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not incorrect - the C13 peptidase activity underlies signal-peptide cleavage - but it captures only the cleavage step and does not describe the integrated transamidation function; retained as non-core context.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link">
+                                        PMID:10793132
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Gpi8p is a catalytic component that cleaves the GPI attachment signal peptide</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008233" target="_blank" class="term-link">
+                                    GO:0008233
+                                </a>
+                            </span>
+                            <span class="term-label">peptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0008233" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping from the Peptidase_C13 domain (IPR001096) to the general MF peptidase activity. PIGK is a cysteine protease of the C13/legumain family (MEROPS C13.005), so the domain-based inference is sound, but peptidase activity is a general parent that undersells the specific transamidase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate at the domain level (C13 cysteine protease) but too general to be a core term; the informative MF is GPI-anchor transamidase activity (GO:0003923).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGK/PIGK-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the peptidase C13 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Combined-automated-annotation (ARBA/InterPro) electronic annotation to the core BP attachment of GPI anchor to protein. Redundant with the IBA and IDA annotations to the same term and biologically correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation, consistent with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recognizes and cleaves the C-terminal GPI attachment signal of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Combined-automated-annotation (ARBA/InterPro) electronic annotation placing PIGK in the GPI-anchor transamidase complex. Redundant with, and consistent with, the curated IDA/IBA complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation; PIGK is a bona fide subunit of the GPI-T complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10793132
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Gaa1p and gpi8p are components of a glycosylphosphatidylinos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0005515" data-r="PMID:10793132" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct protein-protein interaction (PIGK with GPAA1, UniProtKB:O43292). This documents PIGK-GPAA1 association within the GPI-T complex, which is real, but the bare term protein binding is uninformative as a molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The interaction (PIGK-GPAA1) is genuine and biologically meaningful, but GO:0005515 protein binding is not an informative MF; the interaction is already captured by GPI-anchor transamidase complex membership (GO:0042765). Retained per curation policy rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link">
+                                        PMID:10793132
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Gaa1p and Gpi8p are associated with each other</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0005515" data-r="PMID:11483512" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct protein-protein interaction annotations (PIGK with GPAA1/PIGT/PIGS). These document GPI-T subunit associations but the bare protein binding term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine intra-complex interactions, but GO:0005515 is uninformative and redundant with the GPI-anchor transamidase complex CC annotation. Retained per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0005515" data-r="PMID:12802054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct protein-protein interaction annotations (PIGK with GPAA1/PIGT). Documents intra-complex associations of the GPI-T subunits.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real interaction but uninformative bare protein binding term; complex membership is already annotated (GO:0042765). Retained per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase complex affinity-purified from cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput interactome (BioPlex-type affinity-purification MS) protein binding annotation (PIGK with GPAA1/PIGT). Large-scale interaction screen capturing GPI-T subunit associations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare protein binding term from a high-throughput interactome; the biologically meaningful content (GPI-T subunit association) is already captured by complex membership. Retained per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput dual-proteome interactome protein binding annotation (PIGK with GPAA1/PIGT). Large-scale interaction screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare protein binding term from a high-throughput interactome; redundant with complex membership. Retained per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput multimodal cell-map interactome protein binding annotation (PIGK with GPAA1/PIGT). Large-scale interaction/proximity screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare protein binding term from a high-throughput interactome; redundant with complex membership. Retained per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162791
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="Reactome:R-HSA-162791" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable annotation for the GPI-T reaction attaching a GPI anchor to uPAR (a representative GPI-anchored substrate), mapped to attachment of GPI anchor to protein. Correctly represents the core BP.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation via a specific curated Reactome pathway event.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recognizes and cleaves the C-terminal GPI attachment signal of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000041
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0006506" data-r="GO_REF:0000041" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniPathway-based electronic annotation (UPA00196) to GPI anchor biosynthetic process. GPI-T catalyzes the terminal transamidation step of GPI-anchor biosynthesis, so this parent BP is accurate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP; the transamidation/attachment step is part of GPI-anchor biosynthesis. Consistent with the UniProt PATHWAY (glycosylphosphatidylinositol-anchor biosynthesis).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">are catalyzed by an endoplasmic reticulum membrane GPI transamidase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0005789" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-6503) non-traceable statement locating the GPI-T complex, including PIGK, at the ER membrane. Corroborated by an independent EXP annotation to the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC; PIGK/GPI-T resides in the ER membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">are catalyzed by an endoplasmic reticulum membrane GPI transamidase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal non-traceable statement annotating the GPI-T complex to attachment of GPI anchor to protein. Consistent with abundant direct evidence for PIGK.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recognizes and cleaves the C-terminal GPI attachment signal of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal-curated complex membership of PIGK in the GPI-anchor transamidase complex (CPX-6503). PMID:12802054 established PIG-U as the fifth subunit and confirmed the affinity-purified GPI8-containing complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation of PIGK as a subunit of the GPI-T complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase complex affinity-purified from cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0005789" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental evidence localizing PIGK/GPI8 (and the GPI-T complex) to the endoplasmic reticulum membrane. This is the definitive experimental support for the ER-membrane location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC term, directly supported by experiment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase mediates GPI anchoring</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003923" target="_blank" class="term-link">
+                                    GO:0003923
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0003923" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (cryo-EM structure plus structure-based mutagenesis of the reconstituted human GPI-T) for GPI-anchor transamidase activity, with PIGK as the catalytic subunit. This is the primary core MF annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core MF term with strong direct experimental support; matches the exact GOA term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">suggests a legumain-like</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0180046" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (structure and functional analysis of human GPI-T) that PIGK participates in GPI anchored protein biosynthesis. GO:0180046 is the current specific BP for the GPI-AP maturation process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP; PIGK is essential for GPI-anchored protein biosynthesis (maturation), as shown by the catalytic dyad requirement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which is essential for</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0180046" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that PIGK/GPI-T is required for GPI anchored protein biosynthesis, from the cryo-EM structure and functional mutagenesis of the human complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation, redundant with and consistent with the other IDA to GO:0180046.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">important step towards the mechanistic understanding of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003923" target="_blank" class="term-link">
+                                    GO:0003923
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0003923" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence for GPI-anchor transamidase activity from substrate- and product-bound cryo-EM structures of human GPI-T, defining a caspase-like catalytic mechanism with PIGK as the catalytic subunit (Cys206 nucleophile / His164 proton donor).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core MF term with strong structural/mechanistic support.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">inform a caspase-like catalytic mechanism</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that PIGK/GPI-T is required for attachment of GPI anchor to protein. Class-U (PIG-U-deficient) cells lacking a functional GPI-T could not cleave the GPI attachment signal peptide.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation supported by loss-of-function cell evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">had no ability to cleave the GPI attachment signal peptide</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (subunit mutagenesis affecting GPI-anchor attachment to protein) that PIGK is required for attachment of GPI anchor to protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation; mutagenesis of PIGK catalytic residues (e.g. His164, Cys206) abolishes GPI-anchor attachment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recognizes and cleaves the C-terminal GPI attachment signal of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence from substrate/product-bound GPI-T structures that PIGK mediates attachment of GPI anchor to protein via the transamidation reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation with mechanistic structural support.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">replaces it with GPI via a transamida</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (cryo-EM) evidence identifying PIGK as a subunit of the GPI-anchor transamidase complex, resolved together with GPAA1, PIGS, PIGT and PIGU.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation with direct structural support.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The transmembrane complex GPI-T</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (human GPI-T structure and mutagenesis of the C206-H164-N58 catalytic triad) that PIGK mediates attachment of GPI anchor to protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation with strong structural/functional support.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed by</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (2.53-A cryo-EM structure and structure-based mutagenesis) that PIGK/GPI-T mediates attachment of GPI anchor to protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation, redundant with and consistent with other IDAs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">covalent attachment of GPI at the new carboxyl terminus</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (cryo-EM) identification of PIGK as the catalytic subunit of the GPI-anchor transamidase complex, resolved with the four other subunits.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation with direct structural support.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The PIGK subunit</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (cryo-EM) evidence resolving PIGK within the equimolar heteropentameric GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation with direct structural support.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">revealing an equimolar</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10793132
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Gaa1p and gpi8p are components of a glycosylphosphatidylinos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="PMID:10793132" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that GPI8/PIGK is required for GPI attachment; conserved cysteine and histidine residues essential for the carbonyl intermediate identify PIGK as the catalytic component that cleaves the GPI signal peptide.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation, supported by mutagenesis of catalytic residues.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link">
+                                        PMID:10793132
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Gpi8p is a catalytic component that cleaves the GPI attachment signal peptide</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9356492" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9356492
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The affected gene underlying the class K glycosylphosphatidy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="PMID:9356492" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence identifying hGPI8/PIGK as the gene defective in the class-K GPI-deficient mutant; reconstitution with hGPI8 restored C-terminal processing of GPI-anchored proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Foundational functional evidence for the core BP; PIGK loss abolishes, and its restoration rescues, GPI anchor attachment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9356492" target="_blank" class="term-link">
+                                        PMID:9356492
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">restores the ability</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12582175
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Two subunits of glycosylphosphatidylinositol transamidase, G...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="PMID:12582175" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that GPI8/PIGK is a subunit of the multimeric mammalian GPI transamidase and forms a functionally important disulfide bond with PIG-T within the complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation; PIGK-PIGT disulfide within the GPI-T complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                                        PMID:12582175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is a multimeric complex consisting of at least five subunits</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (purification and functional analysis of the five-subunit human GPI-TA) confirming PIGK as a subunit of the GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that the GPI8/PIGK-containing GPI transamidase complex affinity-purified from cells contains PIG-U and four other components, confirming PIGK complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase complex affinity-purified from cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003923" target="_blank" class="term-link">
+                                    GO:0003923
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162836
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0003923" data-r="Reactome:R-HSA-162836" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable annotation for the GPI-T-catalyzed reaction (uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + propeptide), mapped to GPI-anchor transamidase activity - the exact GOA core MF term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core MF annotation via a curated Reactome reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">functions as the catalytic component</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that PIG-S and PIG-T form a complex with GAA1 and GPI8/PIGK, establishing PIGK membership in the GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mass-spectrometry detection of PIGK in an NK-cell membrane proteome. Consistent with PIGK being membrane-associated but the generic term membrane is far less informative than the established ER membrane location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not incorrect (PIGK is a membrane protein) but GO:0016020 membrane is uninformatively general and is superseded by the specific ER membrane (GO:0005789) annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">define the composition of the membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162836
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0005789" data-r="Reactome:R-HSA-162836" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable annotation placing the GPI transamidase (including PIGK) at the ER membrane, consistent with the experimental EXP annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">are catalyzed by an endoplasmic reticulum membrane GPI transamidase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034235" target="_blank" class="term-link">
+                                    GO:0034235
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10793132
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Gaa1p and gpi8p are components of a glycosylphosphatidylinos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0034235" data-r="PMID:10793132" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable annotation that PIGK contributes_to GPI anchor binding. The GPI-T complex binds the preassembled GPI lipid substrate (a composite GPI-binding cavity is resolved in structures), and PIGK contributes to this binding as the catalytic subunit acting on the GPI ethanolamine.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biologically reasonable with the contributes_to qualifier: GPI binding is a complex-level property to which PIGK contributes, not an independent PIGK activity. Retained as non-core supporting MF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an endogenous GPI in the structure defines a composite cavity for the lipid</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0016255" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable annotation that PIGK/GPI-T mediates GPI anchor attachment to proteins in the ER by replacing the C-terminal GPI-attachment signal peptide.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core BP annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase mediates GPI anchoring</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003923" target="_blank" class="term-link">
+                                    GO:0003923
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10793132
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Gaa1p and gpi8p are components of a glycosylphosphatidylinos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0003923" data-r="PMID:10793132" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutational evidence that conserved catalytic cysteine/histidine residues of GPI8/PIGK are essential for the carbonyl intermediate, i.e. for GPI-anchor transamidase activity. Catalytic-residue mutants abolish activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core MF term with genetic/mutational support (loss of transamidase activity on mutating catalytic residues).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link">
+                                        PMID:10793132
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">essential for generation of a carbonyl intermediate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10793132
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Gaa1p and gpi8p are components of a glycosylphosphatidylinos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92643" data-a="GO:0042765" data-r="PMID:10793132" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Evidence that Gaa1p and Gpi8p/PIGK associate as components of the GPI transamidase, placing PIGK in the GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core CC annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link">
+                                        PMID:10793132
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Gaa1p and Gpi8p are associated with each other</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalytic (cysteine-protease-like) subunit of the ER-membrane GPI-anchor transamidase (GPI-T) complex that attaches preassembled GPI anchors to proteins. PIGK cleaves the C-terminal GPI-attachment signal peptide of nascent proproteins (nucleophile Cys206, proton donor His164) forming an acyl(carbonyl)-enzyme thioester intermediate, then transfers the GPI anchor onto the newly exposed omega-site via a transamidation reaction.</h3>
+                <span class="vote-buttons" data-g="Q92643" data-a="FUNCTION: Catalytic (cysteine-protease-like) subunit of the ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003923" target="_blank" class="term-link">
+                            GPI-anchor transamidase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                attachment of GPI anchor to protein
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                GPI anchored protein biosynthesis
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                            GPI-anchor transamidase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                PMID:35165458
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The PIGK subunit</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link">
+                                PMID:10793132
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Gpi8p is a catalytic component that cleaves the GPI attachment signal peptide</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGK/PIGK-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Catalytic subunit of the glycosylphosphatidylinositol-anchor</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000041.md" target="_blank" class="term-link">
+                            GO_REF:0000041
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniPathway vocabulary mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" target="_blank" class="term-link">
+                            PMID:10793132
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gaa1p and gpi8p are components of a glycosylphosphatidylinositol (GPI) transamidase that mediates attachment of GPI to proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                            PMID:11483512
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a complex with GAA1 and GPI8.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                            PMID:12582175
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Two subunits of glycosylphosphatidylinositol transamidase, GPI8 and PIG-T, form a functionally important intermolecular disulfide bridge.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                            PMID:12802054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human PIG-U and yeast Cdc91p are the fifth subunit of GPI transamidase that attaches GPI-anchors to proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                            PMID:34576938
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional Analysis of the GPI Transamidase Complex by Screening for Amino Acid Mutations in Each Subunit.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                            PMID:35165458
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of human glycosylphosphatidylinositol transamidase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                            PMID:35551457
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular insights into biogenesis of glycosylphosphatidylinositol anchor proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                            PMID:37684232
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structures of liganded glycosylphosphatidylinositol transamidase illuminate GPI-AP biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9356492" target="_blank" class="term-link">
+                            PMID:9356492
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The affected gene underlying the class K glycosylphosphatidylinositol (GPI) surface protein defect codes for the GPI transamidase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162791
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Attachment of GPI anchor to uPAR</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162836
+
+                    </span>
+                </div>
+
+                <div class="reference-title">uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + uPAR propeptide</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGK/PIGK-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q92643 (GPI8_HUMAN)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGK-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q92643" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigk-gpi8_human-q92643-review-notes">PIGK (GPI8_HUMAN, Q92643) review notes</h1>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>HGNC:8965; synonym GPI8. UniProt RecName "GPI-anchor transamidase", AltName "component PIGK, catalytic subunit"; EC 2.6.1.- (transferase).</li>
+<li>395 aa precursor; signal peptide 1-27 (cleaved after Ala-27); chain 28-395. Single-pass type I ER membrane protein: lumenal 28-368, TM 369-385, cytoplasmic 386-395.</li>
+<li>Peptidase C13 family (legumain-like cysteine protease); MEROPS C13.005; Pfam PF01650 Peptidase_C13; InterPro IPR028361 (GPI_transamidase), IPR001096 (Peptidase_C13).</li>
+</ul>
+<h2 id="core-function-well-established">Core function (well established)</h2>
+<ul>
+<li>Catalytic subunit of the GPI-anchor transamidase (GPI-T) complex, an ER-membrane heteropentamer of PIGK, GPAA1, PIGT, PIGS, PIGU [PMID:35165458 "The GPIT complex is known to be composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1."; PMID:11483512; PMID:12802054].</li>
+<li>GPI-T removes the C-terminal GPI attachment signal peptide (CSP) of nascent proproteins and attaches a preassembled GPI anchor via transamidation, in the ER [PMID:10793132 abstract; PMID:35551457 "The removal of a hydrophobic signal peptide and covalent attachment of GPI at the new carboxyl terminus are catalyzed by an endoplasmic reticulum membrane GPI transamidase complex (GPI-T)"].</li>
+<li>PIGK is the catalytic component; conserved Cys/His residues of a cysteine-protease family generate the carbonyl (acyl-enzyme thioester) intermediate <a href="https://pubmed.ncbi.nlm.nih.gov/10793132" title="cysteine and histidine residues of Gpi8p, which are conserved in members of a cysteine protease family, are essential for generation of a carbonyl intermediate... Gpi8p is a catalytic component that cleaves the GPI attachment signal peptide">PMID:10793132</a>.</li>
+<li>Catalytic dyad/triad: Cys206 (nucleophile), His164 (proton donor); Asn58 completes a C206-H164-N58 triad <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" title="The PIGK subunit functions as the catalytic component, in which we identified a C206-H164-N58 triad that is critical for the transamination reaction.">PMID:35165458</a>. C206A and H164A abolish activity (UniProt MUTAGEN, PMID:10793132/35165458/35551457).</li>
+<li>Caspase/legumain-like two-phase mechanism; autoinhibitory loop (231-236) gates activity until proprotein binding [PMID:37684232 full text].</li>
+<li>Disulfide bond Cys92(PIGK)-Cys182(PIGT) is important (not essential) for full activity <a href="https://pubmed.ncbi.nlm.nih.gov/12582175">PMID:12582175</a>.</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>ER membrane [PMID:11483512 EXP; UniProt SUBCELLULAR LOCATION SL-0097]. Also detected generically in membrane fraction proteomics (NK-cell membrane proteome, PMID:19946888, HDA GO:0016020).</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>Bi-allelic PIGK variants cause NEDHCAS (neurodevelopmental disorder with hypotonia and cerebellar atrophy, with or without seizures), MIM:618879, autosomal recessive <a href="https://pubmed.ncbi.nlm.nih.gov/32220290">PMID:32220290</a>. An inherited GPI-deficiency disorder (GPIBD).</li>
+</ul>
+<h2 id="annotation-review-decisions-summary">Annotation review decisions (summary)</h2>
+<ul>
+<li>MF GPI-anchor transamidase activity (GO:0003923): the correct, current GOA MF term. Multiple IDA (PMID:35551457, 37684232), IMP (PMID:10793132), IBA, IEA, TAS -&gt; ACCEPT (core).</li>
+<li>BP attachment of GPI anchor to protein (GO:0016255) and GPI anchored protein biosynthesis (GO:0180046) and GPI anchor biosynthetic process (GO:0006506): ACCEPT (core BP). GO:0180046 is the newer specific BP; keep both.</li>
+<li>CC GPI-anchor transamidase complex (GO:0042765): ACCEPT (part_of complex; multiple IDA). ER membrane (GO:0005789): ACCEPT.</li>
+<li>CC membrane (GO:0016020) HDA: MARK_AS_OVER_ANNOTATED (too general, superseded by ER membrane).</li>
+<li>MF proteolysis (GO:0006508) / peptidase activity (GO:0008233) IEA from Peptidase_C13 domain: KEEP_AS_NON_CORE. PIGK IS a cysteine-protease-like enzyme that cleaves the CSP, so these are not wrong, but they capture only half the transamidation reaction; GPI-anchor transamidase activity is the informative core term.</li>
+<li>MF protein binding (GO:0005515) IPI (many, GPAA1/PIGT/PIGS): MARK_AS_OVER_ANNOTATED per policy (bare protein binding uninformative; captures GPI-T subunit interactions already covered by complex membership).</li>
+<li>MF GPI anchor binding (GO:0034235) contributes_to TAS PMID:10793132: ACCEPT/KEEP_AS_NON_CORE — GPI-T binds the GPI lipid substrate; supported by structure (composite GPI cavity).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q92643
+gene_symbol: PIGK
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PIGK (also known as GPI8) is the catalytic subunit of the multi-subunit
+  glycosylphosphatidylinositol-anchor transamidase (GPI-T) complex, an
+  endoplasmic reticulum membrane enzyme that attaches preassembled GPI anchors
+  to the C-terminus of GPI-anchored proteins. During maturation of GPI-anchored
+  proteins in the ER lumen, GPI-T recognizes a diverse C-terminal GPI-attachment
+  signal peptide (lacking a consensus sequence), cleaves it, and forms a new
+  amide bond between the exposed C-terminal residue (omega-site) and the amino
+  group of the bridging ethanolamine-phosphate of the preassembled GPI, i.e. a
+  transamidation reaction. PIGK is a legumain/caspase-like cysteine protease of
+  the peptidase C13 family: its catalytic residues (nucleophile Cys206 and
+  proton donor His164, completed by Asn58) cleave the signal peptide and form a
+  transient acyl(carbonyl)-enzyme thioester intermediate that is then resolved
+  by attack of the GPI ethanolamine amine. PIGK is a single-pass type I ER
+  membrane protein with its catalytic domain in the ER lumen; it assembles with
+  GPAA1, PIGT, PIGS and PIGU into an equimolar heteropentamer, and a disulfide
+  bond to PIGT contributes to full activity. Bi-allelic loss-of-function
+  variants in PIGK cause an autosomal recessive inherited GPI-deficiency
+  disorder (GPIBD), a neurodevelopmental disorder with hypotonia, cerebellar
+  atrophy, and (in most patients) seizures.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q92643-1
+- name: &#39;2&#39;
+  id: Q92643-2
+  sequence_note: VSP_056457
+existing_annotations:
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic (IBA) annotation to the core biological process of PIGK -
+      attachment of GPI anchor to protein. This is well supported by direct evidence
+      for human PIGK and is consistent across the GPI8/PIGK orthologue family.
+    action: ACCEPT
+    reason: Correct core BP annotation at an appropriate level of specificity. PIGK
+      is the catalytic subunit of the GPI transamidase that replaces the C-terminal
+      GPI-attachment signal peptide with a preassembled GPI anchor.
+    supported_by:
+      - reference_id: PMID:34576938
+        supporting_text: recognizes and cleaves the C-terminal GPI attachment signal
+          of
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: Phylogenetic (IBA) annotation placing PIGK as part of the GPI-anchor
+      transamidase complex. This matches direct human evidence that PIGK assembles
+      with GPAA1, PIGT, PIGS and PIGU into the GPI-T heteropentamer.
+    action: ACCEPT
+    reason: Correct core CC annotation; PIGK is a constitutive subunit of the GPI-T
+      complex.
+    supported_by:
+      - reference_id: PMID:34576938
+        supporting_text: &#39;GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS,
+          and&#39;
+- term:
+    id: GO:0003923
+    label: GPI-anchor transamidase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) annotation to the core molecular function - GPI-anchor
+      transamidase activity. PIGK is the catalytic component that provides this activity
+      within the GPI-T complex.
+    action: ACCEPT
+    reason: Correct core MF term. This is the exact term carried by GOA and is the
+      informative molecular function of PIGK, confirmed by direct experimental evidence.
+    supported_by:
+      - reference_id: PMID:35165458
+        supporting_text: functions as the catalytic component
+- term:
+    id: GO:0003923
+    label: GPI-anchor transamidase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO (IPR028361, GPI_transamidase) electronic mapping to the core
+      molecular function GPI-anchor transamidase activity. Fully consistent with the
+      curated experimental annotations.
+    action: ACCEPT
+    reason: Correct and specific IEA mapping to the core MF term; the GPI_transamidase
+      InterPro signature is diagnostic for this activity.
+    supported_by:
+      - reference_id: PMID:35165458
+        supporting_text: functions as the catalytic component
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Subcellular-location IEA (UniProtKB-SubCell SL-0097) placing PIGK in the
+      endoplasmic reticulum membrane. This is the experimentally established site of
+      GPI-T action and is corroborated by an EXP annotation to the same term.
+    action: ACCEPT
+    reason: Correct core CC term; PIGK is an ER membrane protein whose catalytic domain
+      faces the ER lumen where GPI anchoring occurs.
+    supported_by:
+      - reference_id: PMID:35551457
+        supporting_text: are catalyzed by an endoplasmic reticulum membrane GPI transamidase
+          complex
+- term:
+    id: GO:0006508
+    label: proteolysis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: InterPro2GO mapping from the Peptidase_C13 domain (IPR001096) to proteolysis.
+      PIGK is genuinely a legumain-like cysteine protease that cleaves the C-terminal
+      GPI-attachment signal peptide, so this is biologically accurate, but proteolysis
+      is only one half of the transamidation reaction and is far less informative than
+      GPI-anchor transamidase activity.
+    action: KEEP_AS_NON_CORE
+    reason: Not incorrect - the C13 peptidase activity underlies signal-peptide cleavage
+      - but it captures only the cleavage step and does not describe the integrated
+      transamidation function; retained as non-core context.
+    supported_by:
+      - reference_id: PMID:10793132
+        supporting_text: Gpi8p is a catalytic component that cleaves the GPI attachment
+          signal peptide
+- term:
+    id: GO:0008233
+    label: peptidase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO mapping from the Peptidase_C13 domain (IPR001096) to the general
+      MF peptidase activity. PIGK is a cysteine protease of the C13/legumain family
+      (MEROPS C13.005), so the domain-based inference is sound, but peptidase activity
+      is a general parent that undersells the specific transamidase activity.
+    action: KEEP_AS_NON_CORE
+    reason: Accurate at the domain level (C13 cysteine protease) but too general to
+      be a core term; the informative MF is GPI-anchor transamidase activity (GO:0003923).
+    supported_by:
+      - reference_id: file:human/PIGK/PIGK-uniprot.txt
+        supporting_text: Belongs to the peptidase C13 family
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Combined-automated-annotation (ARBA/InterPro) electronic annotation to
+      the core BP attachment of GPI anchor to protein. Redundant with the IBA and
+      IDA annotations to the same term and biologically correct.
+    action: ACCEPT
+    reason: Correct core BP annotation, consistent with experimental evidence.
+    supported_by:
+      - reference_id: PMID:34576938
+        supporting_text: recognizes and cleaves the C-terminal GPI attachment signal
+          of
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: part_of
+  review:
+    summary: Combined-automated-annotation (ARBA/InterPro) electronic annotation placing
+      PIGK in the GPI-anchor transamidase complex. Redundant with, and consistent
+      with, the curated IDA/IBA complex annotations.
+    action: ACCEPT
+    reason: Correct core CC annotation; PIGK is a bona fide subunit of the GPI-T complex.
+    supported_by:
+      - reference_id: PMID:34576938
+        supporting_text: &#39;GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS,
+          and&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:10793132
+  qualifier: enables
+  review:
+    summary: IntAct protein-protein interaction (PIGK with GPAA1, UniProtKB:O43292).
+      This documents PIGK-GPAA1 association within the GPI-T complex, which is real,
+      but the bare term protein binding is uninformative as a molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;The interaction (PIGK-GPAA1) is genuine and biologically meaningful, but
+      GO:0005515 protein binding is not an informative MF; the interaction is already
+      captured by GPI-anchor transamidase complex membership (GO:0042765). Retained
+      per curation policy rather than removed.&#39;
+    supported_by:
+      - reference_id: PMID:10793132
+        supporting_text: Gaa1p and Gpi8p are associated with each other
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:11483512
+  qualifier: enables
+  review:
+    summary: IntAct protein-protein interaction annotations (PIGK with GPAA1/PIGT/PIGS).
+      These document GPI-T subunit associations but the bare protein binding term
+      is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Genuine intra-complex interactions, but GO:0005515 is uninformative and
+      redundant with the GPI-anchor transamidase complex CC annotation. Retained per
+      policy.
+    supported_by:
+      - reference_id: PMID:11483512
+        supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12802054
+  qualifier: enables
+  review:
+    summary: IntAct protein-protein interaction annotations (PIGK with GPAA1/PIGT).
+      Documents intra-complex associations of the GPI-T subunits.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Real interaction but uninformative bare protein binding term; complex membership
+      is already annotated (GO:0042765). Retained per policy.
+    supported_by:
+      - reference_id: PMID:12802054
+        supporting_text: The GPI transamidase complex affinity-purified from cells
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: High-throughput interactome (BioPlex-type affinity-purification MS) protein
+      binding annotation (PIGK with GPAA1/PIGT). Large-scale interaction screen capturing
+      GPI-T subunit associations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare protein binding term from a high-throughput interactome;
+      the biologically meaningful content (GPI-T subunit association) is already captured
+      by complex membership. Retained per policy.
+    additional_reference_ids:
+      - PMID:11483512
+    supported_by:
+      - reference_id: PMID:11483512
+        supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: High-throughput dual-proteome interactome protein binding annotation (PIGK
+      with GPAA1/PIGT). Large-scale interaction screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare protein binding term from a high-throughput interactome;
+      redundant with complex membership. Retained per policy.
+    additional_reference_ids:
+      - PMID:11483512
+    supported_by:
+      - reference_id: PMID:11483512
+        supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: High-throughput multimodal cell-map interactome protein binding annotation
+      (PIGK with GPAA1/PIGT). Large-scale interaction/proximity screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare protein binding term from a high-throughput interactome;
+      redundant with complex membership. Retained per policy.
+    additional_reference_ids:
+      - PMID:11483512
+    supported_by:
+      - reference_id: PMID:11483512
+        supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162791
+  qualifier: involved_in
+  review:
+    summary: Reactome traceable annotation for the GPI-T reaction attaching a GPI anchor
+      to uPAR (a representative GPI-anchored substrate), mapped to attachment of GPI
+      anchor to protein. Correctly represents the core BP.
+    action: ACCEPT
+    reason: Correct core BP annotation via a specific curated Reactome pathway event.
+    supported_by:
+      - reference_id: PMID:34576938
+        supporting_text: recognizes and cleaves the C-terminal GPI attachment signal
+          of
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000041
+  qualifier: involved_in
+  review:
+    summary: UniPathway-based electronic annotation (UPA00196) to GPI anchor biosynthetic
+      process. GPI-T catalyzes the terminal transamidation step of GPI-anchor biosynthesis,
+      so this parent BP is accurate.
+    action: ACCEPT
+    reason: Correct core BP; the transamidation/attachment step is part of GPI-anchor
+      biosynthesis. Consistent with the UniProt PATHWAY (glycosylphosphatidylinositol-anchor
+      biosynthesis).
+    supported_by:
+      - reference_id: PMID:35551457
+        supporting_text: are catalyzed by an endoplasmic reticulum membrane GPI transamidase
+          complex
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:12802054
+  qualifier: located_in
+  review:
+    summary: ComplexPortal (CPX-6503) non-traceable statement locating the GPI-T complex,
+      including PIGK, at the ER membrane. Corroborated by an independent EXP annotation
+      to the same term.
+    action: ACCEPT
+    reason: Correct core CC; PIGK/GPI-T resides in the ER membrane.
+    supported_by:
+      - reference_id: PMID:35551457
+        supporting_text: are catalyzed by an endoplasmic reticulum membrane GPI transamidase
+          complex
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: NAS
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal non-traceable statement annotating the GPI-T complex to
+      attachment of GPI anchor to protein. Consistent with abundant direct evidence
+      for PIGK.
+    action: ACCEPT
+    reason: Correct core BP annotation.
+    supported_by:
+      - reference_id: PMID:34576938
+        supporting_text: recognizes and cleaves the C-terminal GPI attachment signal
+          of
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IPI
+  original_reference_id: PMID:12802054
+  qualifier: part_of
+  review:
+    summary: ComplexPortal-curated complex membership of PIGK in the GPI-anchor transamidase
+      complex (CPX-6503). PMID:12802054 established PIG-U as the fifth subunit and
+      confirmed the affinity-purified GPI8-containing complex.
+    action: ACCEPT
+    reason: Correct core CC annotation of PIGK as a subunit of the GPI-T complex.
+    supported_by:
+      - reference_id: PMID:12802054
+        supporting_text: The GPI transamidase complex affinity-purified from cells
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: EXP
+  original_reference_id: PMID:11483512
+  qualifier: located_in
+  review:
+    summary: Experimental evidence localizing PIGK/GPI8 (and the GPI-T complex) to
+      the endoplasmic reticulum membrane. This is the definitive experimental support
+      for the ER-membrane location.
+    action: ACCEPT
+    reason: Correct core CC term, directly supported by experiment.
+    supported_by:
+      - reference_id: PMID:11483512
+        supporting_text: The GPI transamidase mediates GPI anchoring
+- term:
+    id: GO:0003923
+    label: GPI-anchor transamidase activity
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: enables
+  review:
+    summary: Direct experimental evidence (cryo-EM structure plus structure-based mutagenesis
+      of the reconstituted human GPI-T) for GPI-anchor transamidase activity, with
+      PIGK as the catalytic subunit. This is the primary core MF annotation.
+    action: ACCEPT
+    reason: Correct core MF term with strong direct experimental support; matches the
+      exact GOA term.
+    supported_by:
+      - reference_id: PMID:35551457
+        supporting_text: suggests a legumain-like
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence (structure and functional analysis of human
+      GPI-T) that PIGK participates in GPI anchored protein biosynthesis. GO:0180046
+      is the current specific BP for the GPI-AP maturation process.
+    action: ACCEPT
+    reason: Correct core BP; PIGK is essential for GPI-anchored protein biosynthesis
+      (maturation), as shown by the catalytic dyad requirement.
+    supported_by:
+      - reference_id: PMID:35165458
+        supporting_text: which is essential for
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence that PIGK/GPI-T is required for GPI anchored
+      protein biosynthesis, from the cryo-EM structure and functional mutagenesis of
+      the human complex.
+    action: ACCEPT
+    reason: Correct core BP annotation, redundant with and consistent with the other
+      IDA to GO:0180046.
+    supported_by:
+      - reference_id: PMID:35551457
+        supporting_text: important step towards the mechanistic understanding of
+- term:
+    id: GO:0003923
+    label: GPI-anchor transamidase activity
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: enables
+  review:
+    summary: Direct experimental evidence for GPI-anchor transamidase activity from
+      substrate- and product-bound cryo-EM structures of human GPI-T, defining a caspase-like
+      catalytic mechanism with PIGK as the catalytic subunit (Cys206 nucleophile /
+      His164 proton donor).
+    action: ACCEPT
+    reason: Correct core MF term with strong structural/mechanistic support.
+    supported_by:
+      - reference_id: PMID:37684232
+        supporting_text: inform a caspase-like catalytic mechanism
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence that PIGK/GPI-T is required for attachment
+      of GPI anchor to protein. Class-U (PIG-U-deficient) cells lacking a functional
+      GPI-T could not cleave the GPI attachment signal peptide.
+    action: ACCEPT
+    reason: Correct core BP annotation supported by loss-of-function cell evidence.
+    supported_by:
+      - reference_id: PMID:12802054
+        supporting_text: had no ability to cleave the GPI attachment signal peptide
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence (subunit mutagenesis affecting GPI-anchor
+      attachment to protein) that PIGK is required for attachment of GPI anchor to
+      protein.
+    action: ACCEPT
+    reason: Correct core BP annotation; mutagenesis of PIGK catalytic residues (e.g.
+      His164, Cys206) abolishes GPI-anchor attachment.
+    supported_by:
+      - reference_id: PMID:34576938
+        supporting_text: recognizes and cleaves the C-terminal GPI attachment signal
+          of
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence from substrate/product-bound GPI-T structures
+      that PIGK mediates attachment of GPI anchor to protein via the transamidation
+      reaction.
+    action: ACCEPT
+    reason: Correct core BP annotation with mechanistic structural support.
+    supported_by:
+      - reference_id: PMID:37684232
+        supporting_text: replaces it with GPI via a transamida
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: part_of
+  review:
+    summary: Direct experimental (cryo-EM) evidence identifying PIGK as a subunit of
+      the GPI-anchor transamidase complex, resolved together with GPAA1, PIGS, PIGT
+      and PIGU.
+    action: ACCEPT
+    reason: Correct core CC annotation with direct structural support.
+    supported_by:
+      - reference_id: PMID:37684232
+        supporting_text: &#39;The transmembrane complex GPI-T&#39;
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence (human GPI-T structure and mutagenesis of
+      the C206-H164-N58 catalytic triad) that PIGK mediates attachment of GPI anchor
+      to protein.
+    action: ACCEPT
+    reason: Correct core BP annotation with strong structural/functional support.
+    supported_by:
+      - reference_id: PMID:35165458
+        supporting_text: Attaching GPI to the protein in the endoplasmic reticulum
+          (ER) is catalyzed by
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence (2.53-A cryo-EM structure and structure-based
+      mutagenesis) that PIGK/GPI-T mediates attachment of GPI anchor to protein.
+    action: ACCEPT
+    reason: Correct core BP annotation, redundant with and consistent with other IDAs.
+    supported_by:
+      - reference_id: PMID:35551457
+        supporting_text: covalent attachment of GPI at the new carboxyl terminus
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: part_of
+  review:
+    summary: Direct experimental (cryo-EM) identification of PIGK as the catalytic
+      subunit of the GPI-anchor transamidase complex, resolved with the four other
+      subunits.
+    action: ACCEPT
+    reason: Correct core CC annotation with direct structural support.
+    supported_by:
+      - reference_id: PMID:35165458
+        supporting_text: The PIGK subunit
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: part_of
+  review:
+    summary: Direct experimental (cryo-EM) evidence resolving PIGK within the equimolar
+      heteropentameric GPI-anchor transamidase complex.
+    action: ACCEPT
+    reason: Correct core CC annotation with direct structural support.
+    supported_by:
+      - reference_id: PMID:35551457
+        supporting_text: revealing an equimolar
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:10793132
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence that GPI8/PIGK is required for GPI attachment;
+      conserved cysteine and histidine residues essential for the carbonyl intermediate
+      identify PIGK as the catalytic component that cleaves the GPI signal peptide.
+    action: ACCEPT
+    reason: Correct core BP annotation, supported by mutagenesis of catalytic residues.
+    supported_by:
+      - reference_id: PMID:10793132
+        supporting_text: Gpi8p is a catalytic component that cleaves the GPI attachment
+          signal peptide
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:9356492
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence identifying hGPI8/PIGK as the gene defective
+      in the class-K GPI-deficient mutant; reconstitution with hGPI8 restored C-terminal
+      processing of GPI-anchored proteins.
+    action: ACCEPT
+    reason: Foundational functional evidence for the core BP; PIGK loss abolishes,
+      and its restoration rescues, GPI anchor attachment.
+    supported_by:
+      - reference_id: PMID:9356492
+        supporting_text: restores the ability
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12582175
+  qualifier: part_of
+  review:
+    summary: Direct experimental evidence that GPI8/PIGK is a subunit of the multimeric
+      mammalian GPI transamidase and forms a functionally important disulfide bond
+      with PIG-T within the complex.
+    action: ACCEPT
+    reason: Correct core CC annotation; PIGK-PIGT disulfide within the GPI-T complex.
+    supported_by:
+      - reference_id: PMID:12582175
+        supporting_text: is a multimeric complex consisting of at least five subunits
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: part_of
+  review:
+    summary: Direct experimental evidence (purification and functional analysis of
+      the five-subunit human GPI-TA) confirming PIGK as a subunit of the GPI-anchor
+      transamidase complex.
+    action: ACCEPT
+    reason: Correct core CC annotation.
+    supported_by:
+      - reference_id: PMID:34576938
+        supporting_text: &#39;GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS,
+          and&#39;
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12802054
+  qualifier: part_of
+  review:
+    summary: Direct experimental evidence that the GPI8/PIGK-containing GPI transamidase
+      complex affinity-purified from cells contains PIG-U and four other components,
+      confirming PIGK complex membership.
+    action: ACCEPT
+    reason: Correct core CC annotation.
+    supported_by:
+      - reference_id: PMID:12802054
+        supporting_text: The GPI transamidase complex affinity-purified from cells
+- term:
+    id: GO:0003923
+    label: GPI-anchor transamidase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162836
+  qualifier: enables
+  review:
+    summary: Reactome traceable annotation for the GPI-T-catalyzed reaction (uPAR precursor
+      + acyl-GPI -&gt; uPAR-acyl-GPI + propeptide), mapped to GPI-anchor transamidase
+      activity - the exact GOA core MF term.
+    action: ACCEPT
+    reason: Correct core MF annotation via a curated Reactome reaction.
+    supported_by:
+      - reference_id: PMID:35165458
+        supporting_text: functions as the catalytic component
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:11483512
+  qualifier: part_of
+  review:
+    summary: Direct experimental evidence that PIG-S and PIG-T form a complex with
+      GAA1 and GPI8/PIGK, establishing PIGK membership in the GPI-anchor transamidase
+      complex.
+    action: ACCEPT
+    reason: Correct core CC annotation.
+    supported_by:
+      - reference_id: PMID:11483512
+        supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: High-throughput mass-spectrometry detection of PIGK in an NK-cell membrane
+      proteome. Consistent with PIGK being membrane-associated but the generic term
+      membrane is far less informative than the established ER membrane location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Not incorrect (PIGK is a membrane protein) but GO:0016020 membrane is uninformatively
+      general and is superseded by the specific ER membrane (GO:0005789) annotations.
+    supported_by:
+      - reference_id: PMID:19946888
+        supporting_text: define the composition of the membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162836
+  qualifier: located_in
+  review:
+    summary: Reactome traceable annotation placing the GPI transamidase (including
+      PIGK) at the ER membrane, consistent with the experimental EXP annotation.
+    action: ACCEPT
+    reason: Correct core CC annotation.
+    supported_by:
+      - reference_id: PMID:35551457
+        supporting_text: are catalyzed by an endoplasmic reticulum membrane GPI transamidase
+          complex
+- term:
+    id: GO:0034235
+    label: GPI anchor binding
+  evidence_type: TAS
+  original_reference_id: PMID:10793132
+  qualifier: contributes_to
+  review:
+    summary: Traceable annotation that PIGK contributes_to GPI anchor binding. The
+      GPI-T complex binds the preassembled GPI lipid substrate (a composite GPI-binding
+      cavity is resolved in structures), and PIGK contributes to this binding as the
+      catalytic subunit acting on the GPI ethanolamine.
+    action: KEEP_AS_NON_CORE
+    reason: &#39;Biologically reasonable with the contributes_to qualifier: GPI binding
+      is a complex-level property to which PIGK contributes, not an independent PIGK
+      activity. Retained as non-core supporting MF.&#39;
+    supported_by:
+      - reference_id: PMID:35551457
+        supporting_text: an endogenous GPI in the structure defines a composite cavity
+          for the lipid
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: TAS
+  original_reference_id: PMID:11483512
+  qualifier: involved_in
+  review:
+    summary: Traceable annotation that PIGK/GPI-T mediates GPI anchor attachment to
+      proteins in the ER by replacing the C-terminal GPI-attachment signal peptide.
+    action: ACCEPT
+    reason: Correct core BP annotation.
+    supported_by:
+      - reference_id: PMID:11483512
+        supporting_text: The GPI transamidase mediates GPI anchoring
+- term:
+    id: GO:0003923
+    label: GPI-anchor transamidase activity
+  evidence_type: IMP
+  original_reference_id: PMID:10793132
+  qualifier: enables
+  review:
+    summary: Mutational evidence that conserved catalytic cysteine/histidine residues
+      of GPI8/PIGK are essential for the carbonyl intermediate, i.e. for GPI-anchor
+      transamidase activity. Catalytic-residue mutants abolish activity.
+    action: ACCEPT
+    reason: Correct core MF term with genetic/mutational support (loss of transamidase
+      activity on mutating catalytic residues).
+    supported_by:
+      - reference_id: PMID:10793132
+        supporting_text: essential for generation of a carbonyl intermediate
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IMP
+  original_reference_id: PMID:10793132
+  qualifier: part_of
+  review:
+    summary: Evidence that Gaa1p and Gpi8p/PIGK associate as components of the GPI
+      transamidase, placing PIGK in the GPI-anchor transamidase complex.
+    action: ACCEPT
+    reason: Correct core CC annotation.
+    supported_by:
+      - reference_id: PMID:10793132
+        supporting_text: Gaa1p and Gpi8p are associated with each other
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000041
+  title: Gene Ontology annotation based on UniPathway vocabulary mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10793132
+  title: Gaa1p and gpi8p are components of a glycosylphosphatidylinositol (GPI) transamidase
+    that mediates attachment of GPI to proteins.
+  findings: []
+- id: PMID:11483512
+  title: PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a
+    complex with GAA1 and GPI8.
+  findings: []
+- id: PMID:12582175
+  title: Two subunits of glycosylphosphatidylinositol transamidase, GPI8 and PIG-T,
+    form a functionally important intermolecular disulfide bridge.
+  findings: []
+- id: PMID:12802054
+  title: Human PIG-U and yeast Cdc91p are the fifth subunit of GPI transamidase that
+    attaches GPI-anchors to proteins.
+  findings: []
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+- id: PMID:34576938
+  title: Functional Analysis of the GPI Transamidase Complex by Screening for Amino
+    Acid Mutations in Each Subunit.
+  findings: []
+- id: PMID:35165458
+  title: Structure of human glycosylphosphatidylinositol transamidase.
+  findings: []
+- id: PMID:35551457
+  title: Molecular insights into biogenesis of glycosylphosphatidylinositol anchor
+    proteins.
+  findings: []
+- id: PMID:37684232
+  title: Structures of liganded glycosylphosphatidylinositol transamidase illuminate
+    GPI-AP biogenesis.
+  findings: []
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+- id: PMID:9356492
+  title: The affected gene underlying the class K glycosylphosphatidylinositol (GPI)
+    surface protein defect codes for the GPI transamidase.
+  findings: []
+- id: Reactome:R-HSA-162791
+  title: Attachment of GPI anchor to uPAR
+  findings: []
+- id: Reactome:R-HSA-162836
+  title: uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + uPAR propeptide
+  findings: []
+- id: file:human/PIGK/PIGK-uniprot.txt
+  title: UniProtKB entry Q92643 (GPI8_HUMAN)
+  findings: []
+core_functions:
+- description: Catalytic (cysteine-protease-like) subunit of the ER-membrane GPI-anchor
+    transamidase (GPI-T) complex that attaches preassembled GPI anchors to proteins.
+    PIGK cleaves the C-terminal GPI-attachment signal peptide of nascent proproteins
+    (nucleophile Cys206, proton donor His164) forming an acyl(carbonyl)-enzyme thioester
+    intermediate, then transfers the GPI anchor onto the newly exposed omega-site via
+    a transamidation reaction.
+  molecular_function:
+    id: GO:0003923
+    label: GPI-anchor transamidase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  - id: GO:0016255
+    label: attachment of GPI anchor to protein
+  - id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  supported_by:
+  - reference_id: PMID:35165458
+    supporting_text: The PIGK subunit
+  - reference_id: PMID:10793132
+    supporting_text: Gpi8p is a catalytic component that cleaves the GPI attachment
+      signal peptide
+  - reference_id: file:human/PIGK/PIGK-uniprot.txt
+    supporting_text: Catalytic subunit of the glycosylphosphatidylinositol-anchor
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGS/PIGS-ai-review.html
+++ b/genes/human/PIGS/PIGS-ai-review.html
@@ -1,0 +1,5411 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGS - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGS</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q96S52" target="_blank" class="term-link">
+                        Q96S52
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGS";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q96S52" data-a="DESCRIPTION: PIGS (phosphatidylinositol-glycan biosynthesis cla..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGS (phosphatidylinositol-glycan biosynthesis class S protein) is a non-catalytic accessory subunit of the glycosylphosphatidylinositol-anchor transamidase (GPI-T) complex, an endoplasmic reticulum membrane enzyme complex. GPI-T is an equimolar heteropentamer of PIGK, GPAA1, PIGT, PIGS and PIGU that post-translationally attaches a pre-assembled GPI anchor to the C-terminus of GPI-anchored proteins, replacing their C-terminal GPI-attachment signal peptide. Within the complex, PIGK is the catalytic (cysteine-protease/transaminase-like) subunit and GPAA1 forms the amide bond, whereas PIGS is an indispensable but non-catalytic subunit whose precise molecular role is not fully defined; loss of PIGS abolishes complex activity. PIGS is a multi-pass ER membrane glycoprotein with a large lumenal domain flanked by two transmembrane helices. Biallelic loss-of-function variants cause the autosomal recessive inherited GPI-deficiency disorder GPIBD18, presenting with severe developmental delay, seizures, hypotonia and dysmorphic features.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0016255" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred involvement in attachment of GPI anchor to protein. This is the accepted core biological process for PIGS as a required subunit of the GPI transamidase complex, and is well supported by direct experimental evidence in human and orthologs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA annotation consistent with experimental data. PIGS is an essential component of the GPI transamidase complex that attaches pre-assembled GPI anchors to the C-terminus of GPI-anchored proteins in the ER.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase mediates GPI anchoring in the endoplasmic reticulum, by replacing a protein&#39;s C-terminal GPI attachment signal peptide with a pre-assembled GPI.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred membership of the GPI-anchor transamidase complex. This is the core cellular component annotation for PIGS and is directly established by biochemistry and cryo-EM structures.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGS is one of the five subunits (PIGK, GPAA1, PIGT, PIGS, PIGU) of the GPI-T complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here, we report two new components of this enzyme: PIG-S and PIG-T.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to ER membrane from the UniProt Subcellular Location mapping. This is the correct and informative location for PIGS and is supported by experimental cryo-EM structural work.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGS is a multi-pass ER membrane protein, consistent with the ER-resident GPI-T complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGS/PIGS-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0016255" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (combined IEA methods, via InterPro/ortholog) to attachment of GPI anchor to protein. Consistent with the experimentally established function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matches the well-supported core biological process; the InterPro PIG-S domain (IPR019540) is diagnostic of this family/function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a complex with GAA1 and GPI8.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to GPI-anchor transamidase complex via combined IEA methods. Redundant with, and confirmed by, the experimental IDA/IBA complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct complex membership, supported by biochemistry and structure.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0005515" data-r="PMID:11483512" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Physical interaction (IPI) with PIGT (Q969N2). PIGT is a genuine partner within the GPI-T complex, so the interaction is biologically real, but the bare &#39;protein binding&#39; term is uninformative and does not capture PIGS&#39;s role as a complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, &#39;protein binding&#39; (GO:0005515) is uninformative. The meaningful assertion (physical partnership with PIGT within GPI-T) is already captured by the GPI-anchor transamidase complex (GO:0042765) annotations. Retained but marked as over-annotated rather than removed, following policy on experimental IPIs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0005515" data-r="PMID:12802054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Physical interaction (IPI) with PIGT (Q969N2) reported in the study that identified PIG-U as the fifth GPI-T subunit. Real interaction within GPI-T, but the generic term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative; the underlying biology (subunit of GPI-T) is captured by GO:0042765. Marked as over-annotated per policy rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mammalian GPI transamidase is a complex of at least four subunits, GPI8, GAA1, PIG-S, and PIG-T.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interactions reported from a proteome-scale (Y2H) binary interactome map. Partners here include keratin-associated proteins (P60410/KRTAP10-8, Q6A162/KRT40, Q7Z3S9/NOTCH2NLA), which are unlikely to be biologically meaningful GPI-T partners and are characteristic sticky/false-positive hits of large-scale binary screens.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative protein binding from a high-throughput interactome; partners are not established GPI-T components. Retained but marked over-annotated per policy on high-throughput IPIs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                                        PMID:25416956
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binary protein-protein interactions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interactions from a reference binary human interactome map (HuRI). Includes PIGT (Q969N2), TRIP6 (Q15654) and multiple keratin-associated/NOTCH2NL proteins; only PIGT is a bona fide GPI-T partner.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding from a large-scale binary interactome; mostly non-physiological partners. Marked over-annotated per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reference map of the human binary protein interactome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction with PIGT (Q969N2) from an AP-MS proteome-scale interactome (BioPlex). The PIGT interaction is consistent with GPI-T membership, but the generic term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative protein binding; the meaningful PIGT partnership is captured by the GPI-T complex annotation. Marked over-annotated per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cell-specific remodeling of the human interactome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction with PIGT (Q969N2) from a multimodal (AP-MS/imaging) cell-map interactome study. Consistent with GPI-T assembly but reported as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative protein binding; underlying biology captured by GPI-T complex membership. Marked over-annotated per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                                        PMID:40205054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000041
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0006506" data-r="GO_REF:0000041" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to GPI anchor biosynthetic process via UniPathway mapping (UPA00196). PIGS participates in the terminal (transamidation) step of GPI-anchor biosynthesis and this broader parent process is appropriate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct pathway-level BP; PIGS&#39;s UniProt PATHWAY is glycolipid biosynthesis; glycosylphosphatidylinositol-anchor biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">covalent attachment of GPI at the new carboxyl terminus are catalyzed by an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among all eukaryotes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0005789" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable-author-statement ER membrane localization (ComplexPortal, based on the GPI-T complex). Correct and now confirmed by structural studies.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ER membrane is the established, informative location for the GPI-T complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                                        PMID:12582175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI transamidase is localized in the endoplasmic reticulum and mediates post-translational transfer of preformed GPI to proteins bearing a carboxyl-terminal GPI attachment signal.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NAS annotation (ComplexPortal) to attachment of GPI anchor to protein. Correct core biological process for the GPI-T complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GPI-T complex, of which PIGS is a subunit, attaches GPI anchors to proteins.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">attaches GPI-anchors to proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Physical-interaction-based (ComplexPortal) membership of the GPI-anchor transamidase complex. Directly supported by affinity purification identifying PIG-S among the complex components.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIG-S co-purifies as a component of the affinity-purified GPI transamidase complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase complex affinity-purified from cells expressing epitope-tagged-GPI8 contained PIG-U and four other known components.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0180046" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (cryo-EM structure of the human GPI-T complex) supporting PIGS&#39;s involvement in GPI-anchored protein biosynthesis. The structure defines the assembly and the substrate-binding cleft of the ER GPI-T complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structural evidence directly supports PIGS as part of the machinery for GPI-AP biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed by the transmembrane GPI transamidase (GPIT) complex, which is essential for maturation of the GPI-anchored proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0180046" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (cryo-EM structure of human GPI-T) supporting involvement in GPI-anchored protein biosynthesis. Reveals the equimolar heteropentameric assembly including PIGS.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structural evidence directly supports PIGS&#39;s role in GPI-AP biogenesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">revealing an equimolar heteropentameric assembly</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0180046" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence from gene-disruption experiments (PIG-S knockout cells defective in GPI transfer) supporting involvement in GPI-anchored protein biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Knockout of PIG-S impairs transfer of GPI to proteins, demonstrating its role in GPI-AP biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T knockout cells were defective in transfer of GPI to proteins, particularly in formation of the carbonyl intermediates.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30269814" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30269814
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in PIGS, Encoding a GPI Transamidase, Cause a Neur...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0180046" data-r="PMID:30269814" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence from patient/cell studies (GPIBD18) showing PIGS loss of function produces a GPI-AP deficiency profile, supporting its role in GPI-anchored protein biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Human loss-of-function causes GPI-AP deficiency, directly implicating PIGS in GPI-AP biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30269814" target="_blank" class="term-link">
+                                        PMID:30269814
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Flow-cytometry analyses demonstrated that the individuals with PIGS mutations show a GPI-AP deficiency profile.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0180046" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct functional assay (rescue of GPI-AP surface expression in PIGS-KO cells) supporting PIGS&#39;s role in GPI-anchored protein biosynthesis; PIGS is indispensable for GPI-T activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Functional complementation in PIGS-KO cells directly supports involvement in GPI-AP biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGS is an indispensable subunit of GPI-TA activity, although its role is unclear.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence (affinity purification / in vitro transamidase assays with the five-subunit complex) supporting PIGS&#39;s involvement in attachment of GPI anchor to protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The affinity-purified complex containing PIG-S mediates GPI attachment; loss of subunits abolishes transamidase activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">attaches GPI-anchors to proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0016255" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct functional assay supporting involvement in attachment of GPI anchor to protein; PIGS is required for GPI-T activity (loss of any subunit abolishes activity).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mutagenesis/complementation confirms PIGS is required for GPI attachment activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA) complex, which recognizes and cleaves the C-terminal GPI attachment signal of precursor proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0016255" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence from liganded (substrate/product-bound) cryo-EM structures of human GPI-T illuminating the transamidation/GPI-attachment mechanism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Substrate- and product-bound structures directly define the GPI-attachment reaction of the complex containing PIGS.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The transmembrane complex GPI-T recognizes diverse proproteins at a signal peptide region that lacks consensus sequence and replaces it with GPI via a transamidation reaction.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct structural evidence (liganded cryo-EM structures, PDB 8IMX/8IMY) for PIGS as a subunit of the GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGS is resolved as a subunit in the cryo-EM structures of the human GPI-T complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">substrates- and products-bound human GPI-T structures</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0016255" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence (cryo-EM structure) supporting involvement in attachment of GPI anchor to protein; the structure identifies the catalytic triad and GPI substrate-binding cleft of the complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structural work directly supports the GPI-attachment function of the complex containing PIGS.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed by the transmembrane GPI transamidase (GPIT) complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0016255" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence (cryo-EM structure) supporting involvement in attachment of GPI anchor to protein; structure-based mutagenesis supports the transamidation mechanism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structural evidence directly supports the GPI-attachment function of the GPI-T complex that includes PIGS.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The removal of a hydrophobic signal peptide and covalent attachment of GPI at the new carboxyl terminus are catalyzed by an endoplasmic reticulum membrane GPI transamidase complex (GPI-T)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct structural evidence (cryo-EM, PDB 7W72) for PIGS as one of the five subunits of the GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGS is resolved as a subunit of the human GPI-T complex in the cryo-EM structure.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPIT complex is known to be composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct structural evidence (cryo-EM) for PIGS as a subunit of the equimolar heteropentameric GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGS is a subunit of the human GPI-T heteropentamer.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">revealing an equimolar heteropentameric assembly</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12582175
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Two subunits of glycosylphosphatidylinositol transamidase, G...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="PMID:12582175" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence for PIGS as part of the multimeric GPI transamidase complex; this study on the GPI8-PIG-T disulfide bridge confirms an inactive five-component complex holds the substrate protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biochemistry places PIG-S among the five components of the mammalian GPI transamidase complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                                        PMID:12582175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an inactive human GPI transamidase complex that consists of non-functional GPI8 and four other components</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence (co-purification of all five subunits confirmed by mass spectrometry) for PIGS as a subunit of the GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> All five GPI-TA subunits, including PIGS, co-purify as the assembled complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU, and the absence of any subunit leads to the loss of activity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence (affinity purification of the complex) for PIGS as a component of the GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIG-S is a component of the affinity-purified GPI transamidase complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase complex affinity-purified from cells expressing epitope-tagged-GPI8 contained PIG-U and four other known components.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence for PIG-S as a component of the GPI transamidase complex, forming a complex with GAA1, GPI8 (PIGK) and PIG-T.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Foundational biochemical identification of PIG-S as a GPI-T subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomics detected PIGS in the membrane proteome of an NK-like cell line. This localizes PIGS to a membrane but is far less informative than the established ER membrane annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0016020 (membrane) is a correct but unspecific parent; the informative location is endoplasmic reticulum membrane (GO:0005789). Retained but marked as over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">define the composition of the membrane proteome of the Natural Killer (NK) like cell line YTS</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162836
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0005789" data-r="Reactome:R-HSA-162836" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement (Reactome) localization to the ER membrane, in the context of GPI-anchor attachment reactions. Correct and consistent with all other evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ER membrane is the established location of the GPI-T complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGS/PIGS-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0016255" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement to attachment of GPI anchor to protein, from the paper identifying PIG-S as essential for GPI anchor attachment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, well-supported biological process for PIGS.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a complex with GAA1 and GPI8.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15713669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Endoplasmic reticulum localization of Gaa1 and PIG-T, subuni...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96S52" data-a="GO:0042765" data-r="PMID:15713669" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement for PIGS as one of the five subunits of the ER-localized GPI transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the established five-subunit GPI-T complex membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link">
+                                        PMID:15713669
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">two of the five subunits of the ER-localized glycosylphosphatidylinositol transamidase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PIGS is a required, non-catalytic subunit of the ER membrane GPI-anchor transamidase (GPI-T) complex, which post-translationally attaches a pre-assembled GPI anchor to the C-terminus of GPI-anchored proteins, replacing their C-terminal GPI-attachment signal peptide. PIGS is indispensable for complex activity but does not itself catalyze the reaction (PIGK is catalytic; GPAA1 forms the amide bond).</h3>
+                <span class="vote-buttons" data-g="Q96S52" data-a="FUNCTION: PIGS is a required, non-catalytic subunit of the E..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                attachment of GPI anchor to protein
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                            GPI-anchor transamidase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                PMID:11483512
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a complex with GAA1 and GPI8.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                PMID:34576938
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PIGS is an indispensable subunit of GPI-TA activity, although its role is unclear.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                PMID:35551457
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The removal of a hydrophobic signal peptide and covalent attachment of GPI at the new carboxyl terminus are catalyzed by an endoplasmic reticulum membrane GPI transamidase complex (GPI-T)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000041.md" target="_blank" class="term-link">
+                            GO_REF:0000041
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniPathway vocabulary mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGS/PIGS-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q96S52 (PIGS_HUMAN), GPI-anchor transamidase component PIGS</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                            PMID:11483512
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a complex with GAA1 and GPI8.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                            PMID:12582175
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Two subunits of glycosylphosphatidylinositol transamidase, GPI8 and PIG-T, form a functionally important intermolecular disulfide bridge.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                            PMID:12802054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human PIG-U and yeast Cdc91p are the fifth subunit of GPI transamidase that attaches GPI-anchors to proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link">
+                            PMID:15713669
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Endoplasmic reticulum localization of Gaa1 and PIG-T, subunits of the glycosylphosphatidylinositol transamidase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30269814" target="_blank" class="term-link">
+                            PMID:30269814
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in PIGS, Encoding a GPI Transamidase, Cause a Neurological Syndrome Ranging from Fetal Akinesia to Epileptic Encephalopathy.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                            PMID:34576938
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional Analysis of the GPI Transamidase Complex by Screening for Amino Acid Mutations in Each Subunit.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                            PMID:35165458
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of human glycosylphosphatidylinositol transamidase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                            PMID:35551457
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular insights into biogenesis of glycosylphosphatidylinositol anchor proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                            PMID:37684232
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structures of liganded glycosylphosphatidylinositol transamidase illuminate GPI-AP biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162836
+
+                    </span>
+                </div>
+
+                <div class="reference-title">uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + uPAR propeptide</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the specific molecular role of PIGS within the GPI-T complex (e.g. substrate proprotein recognition, lumenal-domain scaffolding, or stabilization of catalytic subunits), given that it is indispensable for activity yet non-catalytic?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Taroh Kinoshita</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q96S52" data-a="Q: What is the specific molecular role of PIGS within..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided mutagenesis of the PIGS lumenal domain interface with PIGK/GPAA1 combined with in vitro transamidase and cell-surface GPI-AP rescue assays to define which PIGS surfaces are required for substrate handling versus complex assembly.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PIGS contributes to substrate proprotein recognition and/or stabilization of the catalytic subunits rather than to catalysis itself.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q96S52" data-a="EXPERIMENT: Structure-guided mutagenesis of the PIGS lumenal d..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGS-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q96S52" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigs-q96s52-review-notes">PIGS (Q96S52) review notes</h1>
+<h2 id="summary-of-verified-biology">Summary of verified biology</h2>
+<p>PIGS is the <strong>PIG-S subunit of the GPI transamidase (GPI-T) complex</strong> (a.k.a.<br />
+phosphatidylinositol-glycan biosynthesis class S protein). GPI-T is an ER membrane,<br />
+equimolar heteropentameric complex of <strong>PIGK, GPAA1, PIGT, PIGS and PIGU</strong> that<br />
+post-translationally attaches a pre-assembled GPI anchor to the C-terminus of GPI-anchored<br />
+proteins, replacing the C-terminal GPI-attachment signal peptide.</p>
+<ul>
+<li><strong>PIGK</strong> is the catalytic (cysteine-protease/transaminase-like) subunit; the catalytic<br />
+  triad is C206-H164-N58 <a href="https://pubmed.ncbi.nlm.nih.gov/35165458">PMID:35165458</a>. <strong>GPAA1</strong> (M28-peptidase-like) is proposed to<br />
+  form the amide bond with the bridging EtNP.</li>
+<li><strong>PIGS is a required, non-catalytic accessory subunit</strong> — "PIGS is an indispensable<br />
+  subunit of GPI-TA activity, although its role is unclear" <a href="https://pubmed.ncbi.nlm.nih.gov/34576938">PMID:34576938</a>. Loss of any<br />
+  one subunit abolishes activity.</li>
+<li>Topology: multi-pass ER membrane protein; N-terminal TM (19-39) and C-terminal TM<br />
+  (518-532), large lumenal domain (40-517) [UniProt; PMID:35165458, PMID:35551457].</li>
+<li>Structures: human GPI-T cryo-EM (PDB 7W72 <a href="https://pubmed.ncbi.nlm.nih.gov/35165458">PMID:35165458</a>, 7WLD <a href="https://pubmed.ncbi.nlm.nih.gov/35551457">PMID:35551457</a>,<br />
+  8IMX/8IMY liganded <a href="https://pubmed.ncbi.nlm.nih.gov/37684232">PMID:37684232</a>).</li>
+</ul>
+<h2 id="provenance-for-key-claims">Provenance for key claims</h2>
+<ul>
+<li>Complex membership + 4 named partners: [PMID:11483512 "we report two new components of<br />
+  this enzyme: PIG-S and PIG-T"; "PIG-S and PIG-T form a protein complex with GAA1 and<br />
+  GPI8"]. Fifth subunit PIG-U added in <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" title="PIG-U and the yeast orthologue   Cdc91p are the fifth component of GPI transamidase">PMID:12802054</a>.</li>
+<li>ER localization of GPI-T: <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" title="the five subunits of the ER-localized   glycosylphosphatidylinositol transamidase complex">PMID:15713669</a>; <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" title="GPI transamidase is   localized in the endoplasmic reticulum and mediates post-translational transfer of   preformed GPI to proteins">PMID:12582175</a>; cryo-EM structures place complex in ER membrane<br />
+  [PMID:35165458, PMID:35551457].</li>
+<li>Function of the complex: <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" title="The GPI transamidase mediates GPI anchoring in   the endoplasmic reticulum, by replacing a protein's C-terminal GPI attachment signal   peptide with a pre-assembled GPI">PMID:11483512</a>.</li>
+<li>PIGS required for activity: <a href="https://pubmed.ncbi.nlm.nih.gov/34576938">PMID:34576938</a>; PIGS/PIGT knockout cells defective in GPI<br />
+  transfer <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" title="PIG-S and PIG-T knockout cells were defective in transfer of GPI   to proteins">PMID:11483512</a>.</li>
+<li>Disease: GPIBD18 (autosomal recessive; developmental delay, seizures, hypotonia)<br />
+  [PMID:30269814; UniProt DISEASE].</li>
+</ul>
+<h2 id="annotation-notes">Annotation notes</h2>
+<ul>
+<li>GOA carries NO catalytic MF term for PIGS. The only MF is <code>protein binding</code> (GO:0005515),<br />
+  from IntAct/large-scale interactome IPIs (PIGT partner Q969N2, plus keratin-associated<br />
+  proteins and other proteins from binary screens). These are uninformative and<br />
+  over-annotate a subunit whose real role is complex membership -&gt; MARK_AS_OVER_ANNOTATED<br />
+  (per policy: do not REMOVE bare protein-binding IPIs).</li>
+<li>Core BP: GPI anchor biosynthetic process (GO:0006506) and attachment of GPI anchor to<br />
+  protein (GO:0016255) / GPI anchored protein biosynthesis (GO:0180046) — all accept.</li>
+<li>Core CC: GPI-anchor transamidase complex (GO:0042765); ER membrane (GO:0005789).</li>
+<li><code>membrane</code> (GO:0016020, HDA, NK-cell membrane proteome PMID:19946888) is a correct but<br />
+  unspecific location -&gt; MARK_AS_OVER_ANNOTATED (ER membrane is the informative term).</li>
+<li>Because PIGS is non-catalytic and GOA has no MF, core_functions omits <code>molecular_function</code><br />
+  and instead uses directly_involved_in (BP) + locations (ER membrane) + in_complex (GPI-T).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q96S52
+gene_symbol: PIGS
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGS (phosphatidylinositol-glycan biosynthesis class S protein) is a non-catalytic
+  accessory subunit of the glycosylphosphatidylinositol-anchor transamidase (GPI-T) complex,
+  an endoplasmic reticulum membrane enzyme complex. GPI-T is an equimolar heteropentamer of
+  PIGK, GPAA1, PIGT, PIGS and PIGU that post-translationally attaches a pre-assembled GPI
+  anchor to the C-terminus of GPI-anchored proteins, replacing their C-terminal GPI-attachment
+  signal peptide. Within the complex, PIGK is the catalytic (cysteine-protease/transaminase-like)
+  subunit and GPAA1 forms the amide bond, whereas PIGS is an indispensable but non-catalytic
+  subunit whose precise molecular role is not fully defined; loss of PIGS abolishes complex
+  activity. PIGS is a multi-pass ER membrane glycoprotein with a large lumenal domain flanked
+  by two transmembrane helices. Biallelic loss-of-function variants cause the autosomal
+  recessive inherited GPI-deficiency disorder GPIBD18, presenting with severe developmental
+  delay, seizures, hypotonia and dysmorphic features.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q96S52-1
+- name: &#39;2&#39;
+  id: Q96S52-2
+  sequence_note: VSP_013158
+existing_annotations:
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetically-inferred involvement in attachment of GPI anchor to protein.
+      This is the accepted core biological process for PIGS as a required subunit of the GPI
+      transamidase complex, and is well supported by direct experimental evidence in human
+      and orthologs.
+    action: ACCEPT
+    reason: IBA annotation consistent with experimental data. PIGS is an essential component
+      of the GPI transamidase complex that attaches pre-assembled GPI anchors to the C-terminus
+      of GPI-anchored proteins in the ER.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: The GPI transamidase mediates GPI anchoring in the endoplasmic reticulum,
+        by replacing a protein&#39;s C-terminal GPI attachment signal peptide with a pre-assembled GPI.
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: Phylogenetically-inferred membership of the GPI-anchor transamidase complex. This
+      is the core cellular component annotation for PIGS and is directly established by
+      biochemistry and cryo-EM structures.
+    action: ACCEPT
+    reason: PIGS is one of the five subunits (PIGK, GPAA1, PIGT, PIGS, PIGU) of the GPI-T complex.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: &#39;Here, we report two new components of this enzyme: PIG-S and PIG-T.&#39;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic annotation to ER membrane from the UniProt Subcellular Location mapping.
+      This is the correct and informative location for PIGS and is supported by experimental
+      cryo-EM structural work.
+    action: ACCEPT
+    reason: PIGS is a multi-pass ER membrane protein, consistent with the ER-resident GPI-T complex.
+    supported_by:
+    - reference_id: file:human/PIGS/PIGS-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic annotation (combined IEA methods, via InterPro/ortholog) to attachment
+      of GPI anchor to protein. Consistent with the experimentally established function.
+    action: ACCEPT
+    reason: Matches the well-supported core biological process; the InterPro PIG-S domain
+      (IPR019540) is diagnostic of this family/function.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a
+        complex with GAA1 and GPI8.
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: part_of
+  review:
+    summary: Electronic annotation to GPI-anchor transamidase complex via combined IEA methods.
+      Redundant with, and confirmed by, the experimental IDA/IBA complex annotations.
+    action: ACCEPT
+    reason: Correct complex membership, supported by biochemistry and structure.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:11483512
+  qualifier: enables
+  review:
+    summary: Physical interaction (IPI) with PIGT (Q969N2). PIGT is a genuine partner within the
+      GPI-T complex, so the interaction is biologically real, but the bare &#39;protein binding&#39;
+      term is uninformative and does not capture PIGS&#39;s role as a complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per curation guidelines, &#39;protein binding&#39; (GO:0005515) is uninformative. The
+      meaningful assertion (physical partnership with PIGT within GPI-T) is already captured by
+      the GPI-anchor transamidase complex (GO:0042765) annotations. Retained but marked as
+      over-annotated rather than removed, following policy on experimental IPIs.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12802054
+  qualifier: enables
+  review:
+    summary: Physical interaction (IPI) with PIGT (Q969N2) reported in the study that identified
+      PIG-U as the fifth GPI-T subunit. Real interaction within GPI-T, but the generic term is
+      uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;Bare protein binding is uninformative; the underlying biology (subunit of GPI-T) is
+      captured by GO:0042765. Marked as over-annotated per policy rather than removed.&#39;
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: The mammalian GPI transamidase is a complex of at least four subunits,
+        GPI8, GAA1, PIG-S, and PIG-T.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  qualifier: enables
+  review:
+    summary: Interactions reported from a proteome-scale (Y2H) binary interactome map. Partners
+      here include keratin-associated proteins (P60410/KRTAP10-8, Q6A162/KRT40, Q7Z3S9/NOTCH2NLA),
+      which are unlikely to be biologically meaningful GPI-T partners and are characteristic
+      sticky/false-positive hits of large-scale binary screens.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;Uninformative protein binding from a high-throughput interactome; partners are not
+      established GPI-T components. Retained but marked over-annotated per policy on high-throughput
+      IPIs.&#39;
+    supported_by:
+    - reference_id: PMID:25416956
+      supporting_text: binary protein-protein interactions
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: Interactions from a reference binary human interactome map (HuRI). Includes PIGT
+      (Q969N2), TRIP6 (Q15654) and multiple keratin-associated/NOTCH2NL proteins; only PIGT is a
+      bona fide GPI-T partner.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;Generic protein binding from a large-scale binary interactome; mostly non-physiological
+      partners. Marked over-annotated per policy.&#39;
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: reference map of the human binary protein interactome
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: Interaction with PIGT (Q969N2) from an AP-MS proteome-scale interactome (BioPlex).
+      The PIGT interaction is consistent with GPI-T membership, but the generic term is
+      uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;Uninformative protein binding; the meaningful PIGT partnership is captured by the
+      GPI-T complex annotation. Marked over-annotated per policy.&#39;
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: cell-specific remodeling of the human interactome
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: Interaction with PIGT (Q969N2) from a multimodal (AP-MS/imaging) cell-map interactome
+      study. Consistent with GPI-T assembly but reported as generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;Uninformative protein binding; underlying biology captured by GPI-T complex membership.
+      Marked over-annotated per policy.&#39;
+    supported_by:
+    - reference_id: PMID:40205054
+      supporting_text: Multimodal cell maps as a foundation for structural and functional genomics.
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000041
+  qualifier: involved_in
+  review:
+    summary: Electronic annotation to GPI anchor biosynthetic process via UniPathway mapping
+      (UPA00196). PIGS participates in the terminal (transamidation) step of GPI-anchor
+      biosynthesis and this broader parent process is appropriate.
+    action: ACCEPT
+    reason: Correct pathway-level BP; PIGS&#39;s UniProt PATHWAY is glycolipid biosynthesis;
+      glycosylphosphatidylinositol-anchor biosynthesis.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: covalent attachment of GPI at the new carboxyl terminus are catalyzed by
+        an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among all
+        eukaryotes
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:12802054
+  qualifier: located_in
+  review:
+    summary: Non-traceable-author-statement ER membrane localization (ComplexPortal, based on the
+      GPI-T complex). Correct and now confirmed by structural studies.
+    action: ACCEPT
+    reason: ER membrane is the established, informative location for the GPI-T complex.
+    supported_by:
+    - reference_id: PMID:12582175
+      supporting_text: GPI transamidase is localized in the endoplasmic reticulum and mediates
+        post-translational transfer of preformed GPI to proteins bearing a carboxyl-terminal GPI
+        attachment signal.
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: NAS
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: NAS annotation (ComplexPortal) to attachment of GPI anchor to protein. Correct core
+      biological process for the GPI-T complex.
+    action: ACCEPT
+    reason: The GPI-T complex, of which PIGS is a subunit, attaches GPI anchors to proteins.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: attaches GPI-anchors to proteins
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IPI
+  original_reference_id: PMID:12802054
+  qualifier: part_of
+  review:
+    summary: Physical-interaction-based (ComplexPortal) membership of the GPI-anchor transamidase
+      complex. Directly supported by affinity purification identifying PIG-S among the complex
+      components.
+    action: ACCEPT
+    reason: PIG-S co-purifies as a component of the affinity-purified GPI transamidase complex.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: The GPI transamidase complex affinity-purified from cells expressing
+        epitope-tagged-GPI8 contained PIG-U and four other known components.
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: involved_in
+  review:
+    summary: Direct assay (cryo-EM structure of the human GPI-T complex) supporting PIGS&#39;s
+      involvement in GPI-anchored protein biosynthesis. The structure defines the assembly and
+      the substrate-binding cleft of the ER GPI-T complex.
+    action: ACCEPT
+    reason: Structural evidence directly supports PIGS as part of the machinery for GPI-AP
+      biosynthesis.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed
+        by the transmembrane GPI transamidase (GPIT) complex, which is essential for maturation of
+        the GPI-anchored proteins.
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: involved_in
+  review:
+    summary: Direct assay (cryo-EM structure of human GPI-T) supporting involvement in
+      GPI-anchored protein biosynthesis. Reveals the equimolar heteropentameric assembly including
+      PIGS.
+    action: ACCEPT
+    reason: Structural evidence directly supports PIGS&#39;s role in GPI-AP biogenesis.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: revealing an equimolar heteropentameric assembly
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:11483512
+  qualifier: involved_in
+  review:
+    summary: Direct evidence from gene-disruption experiments (PIG-S knockout cells defective in
+      GPI transfer) supporting involvement in GPI-anchored protein biosynthesis.
+    action: ACCEPT
+    reason: Knockout of PIG-S impairs transfer of GPI to proteins, demonstrating its role in
+      GPI-AP biosynthesis.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T knockout cells were defective in transfer of GPI to
+        proteins, particularly in formation of the carbonyl intermediates.
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:30269814
+  qualifier: involved_in
+  review:
+    summary: Direct evidence from patient/cell studies (GPIBD18) showing PIGS loss of function
+      produces a GPI-AP deficiency profile, supporting its role in GPI-anchored protein
+      biosynthesis.
+    action: ACCEPT
+    reason: Human loss-of-function causes GPI-AP deficiency, directly implicating PIGS in GPI-AP
+      biosynthesis.
+    supported_by:
+    - reference_id: PMID:30269814
+      supporting_text: Flow-cytometry analyses demonstrated that the individuals with PIGS
+        mutations show a GPI-AP deficiency profile.
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: involved_in
+  review:
+    summary: Direct functional assay (rescue of GPI-AP surface expression in PIGS-KO cells)
+      supporting PIGS&#39;s role in GPI-anchored protein biosynthesis; PIGS is indispensable for
+      GPI-T activity.
+    action: ACCEPT
+    reason: Functional complementation in PIGS-KO cells directly supports involvement in GPI-AP
+      biosynthesis.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: PIGS is an indispensable subunit of GPI-TA activity, although its role is
+        unclear.
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: Direct evidence (affinity purification / in vitro transamidase assays with the
+      five-subunit complex) supporting PIGS&#39;s involvement in attachment of GPI anchor to protein.
+    action: ACCEPT
+    reason: The affinity-purified complex containing PIG-S mediates GPI attachment; loss of
+      subunits abolishes transamidase activity.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: attaches GPI-anchors to proteins
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: involved_in
+  review:
+    summary: Direct functional assay supporting involvement in attachment of GPI anchor to protein;
+      PIGS is required for GPI-T activity (loss of any subunit abolishes activity).
+    action: ACCEPT
+    reason: Mutagenesis/complementation confirms PIGS is required for GPI attachment activity.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA)
+        complex, which recognizes and cleaves the C-terminal GPI attachment signal of precursor
+        proteins.
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: involved_in
+  review:
+    summary: Direct evidence from liganded (substrate/product-bound) cryo-EM structures of human
+      GPI-T illuminating the transamidation/GPI-attachment mechanism.
+    action: ACCEPT
+    reason: Substrate- and product-bound structures directly define the GPI-attachment reaction of
+      the complex containing PIGS.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: The transmembrane complex GPI-T recognizes diverse proproteins at a signal
+        peptide region that lacks consensus sequence and replaces it with GPI via a transamidation
+        reaction.
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: part_of
+  review:
+    summary: Direct structural evidence (liganded cryo-EM structures, PDB 8IMX/8IMY) for PIGS as a
+      subunit of the GPI-anchor transamidase complex.
+    action: ACCEPT
+    reason: PIGS is resolved as a subunit in the cryo-EM structures of the human GPI-T complex.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: substrates- and products-bound human GPI-T structures
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: involved_in
+  review:
+    summary: Direct evidence (cryo-EM structure) supporting involvement in attachment of GPI
+      anchor to protein; the structure identifies the catalytic triad and GPI substrate-binding
+      cleft of the complex.
+    action: ACCEPT
+    reason: Structural work directly supports the GPI-attachment function of the complex containing
+      PIGS.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed
+        by the transmembrane GPI transamidase (GPIT) complex
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: involved_in
+  review:
+    summary: Direct evidence (cryo-EM structure) supporting involvement in attachment of GPI
+      anchor to protein; structure-based mutagenesis supports the transamidation mechanism.
+    action: ACCEPT
+    reason: Structural evidence directly supports the GPI-attachment function of the GPI-T complex
+      that includes PIGS.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: The removal of a hydrophobic signal peptide and covalent attachment of GPI
+        at the new carboxyl terminus are catalyzed by an endoplasmic reticulum membrane GPI
+        transamidase complex (GPI-T)
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: part_of
+  review:
+    summary: Direct structural evidence (cryo-EM, PDB 7W72) for PIGS as one of the five subunits
+      of the GPI-anchor transamidase complex.
+    action: ACCEPT
+    reason: PIGS is resolved as a subunit of the human GPI-T complex in the cryo-EM structure.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: &#39;The GPIT complex is known to be composed of five subunits: PIGK, PIGU,
+        PIGT, PIGS and GPAA1.&#39;
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: part_of
+  review:
+    summary: Direct structural evidence (cryo-EM) for PIGS as a subunit of the equimolar
+      heteropentameric GPI-anchor transamidase complex.
+    action: ACCEPT
+    reason: PIGS is a subunit of the human GPI-T heteropentamer.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: revealing an equimolar heteropentameric assembly
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12582175
+  qualifier: part_of
+  review:
+    summary: Direct evidence for PIGS as part of the multimeric GPI transamidase complex; this
+      study on the GPI8-PIG-T disulfide bridge confirms an inactive five-component complex holds
+      the substrate protein.
+    action: ACCEPT
+    reason: Biochemistry places PIG-S among the five components of the mammalian GPI transamidase
+      complex.
+    supported_by:
+    - reference_id: PMID:12582175
+      supporting_text: an inactive human GPI transamidase complex that consists of non-functional
+        GPI8 and four other components
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: part_of
+  review:
+    summary: Direct evidence (co-purification of all five subunits confirmed by mass spectrometry)
+      for PIGS as a subunit of the GPI-anchor transamidase complex.
+    action: ACCEPT
+    reason: All five GPI-TA subunits, including PIGS, co-purify as the assembled complex.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &#39;GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU, and
+        the absence of any subunit leads to the loss of activity.&#39;
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12802054
+  qualifier: part_of
+  review:
+    summary: Direct evidence (affinity purification of the complex) for PIGS as a component of the
+      GPI-anchor transamidase complex.
+    action: ACCEPT
+    reason: PIG-S is a component of the affinity-purified GPI transamidase complex.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: The GPI transamidase complex affinity-purified from cells expressing
+        epitope-tagged-GPI8 contained PIG-U and four other known components.
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:11483512
+  qualifier: part_of
+  review:
+    summary: Direct evidence for PIG-S as a component of the GPI transamidase complex, forming a
+      complex with GAA1, GPI8 (PIGK) and PIG-T.
+    action: ACCEPT
+    reason: Foundational biochemical identification of PIG-S as a GPI-T subunit.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomics detected PIGS in the membrane proteome of an NK-like cell
+      line. This localizes PIGS to a membrane but is far less informative than the established ER
+      membrane annotation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;GO:0016020 (membrane) is a correct but unspecific parent; the informative location is
+      endoplasmic reticulum membrane (GO:0005789). Retained but marked as over-annotated.&#39;
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: define the composition of the membrane proteome of the Natural Killer (NK)
+        like cell line YTS
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162836
+  qualifier: located_in
+  review:
+    summary: Traceable-author-statement (Reactome) localization to the ER membrane, in the context
+      of GPI-anchor attachment reactions. Correct and consistent with all other evidence.
+    action: ACCEPT
+    reason: ER membrane is the established location of the GPI-T complex.
+    supported_by:
+    - reference_id: file:human/PIGS/PIGS-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: TAS
+  original_reference_id: PMID:11483512
+  qualifier: involved_in
+  review:
+    summary: Traceable-author-statement to attachment of GPI anchor to protein, from the paper
+      identifying PIG-S as essential for GPI anchor attachment.
+    action: ACCEPT
+    reason: Core, well-supported biological process for PIGS.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a
+        complex with GAA1 and GPI8.
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: TAS
+  original_reference_id: PMID:15713669
+  qualifier: part_of
+  review:
+    summary: Traceable-author-statement for PIGS as one of the five subunits of the ER-localized
+      GPI transamidase complex.
+    action: ACCEPT
+    reason: Consistent with the established five-subunit GPI-T complex membership.
+    supported_by:
+    - reference_id: PMID:15713669
+      supporting_text: two of the five subunits of the ER-localized glycosylphosphatidylinositol
+        transamidase complex
+core_functions:
+- description: PIGS is a required, non-catalytic subunit of the ER membrane GPI-anchor
+    transamidase (GPI-T) complex, which post-translationally attaches a pre-assembled GPI anchor
+    to the C-terminus of GPI-anchored proteins, replacing their C-terminal GPI-attachment signal
+    peptide. PIGS is indispensable for complex activity but does not itself catalyze the reaction
+    (PIGK is catalytic; GPAA1 forms the amide bond).
+  directly_involved_in:
+  - id: GO:0016255
+    label: attachment of GPI anchor to protein
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  supported_by:
+  - reference_id: PMID:11483512
+    supporting_text: PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a
+      complex with GAA1 and GPI8.
+  - reference_id: PMID:34576938
+    supporting_text: PIGS is an indispensable subunit of GPI-TA activity, although its role is
+      unclear.
+  - reference_id: PMID:35551457
+    supporting_text: The removal of a hydrophobic signal peptide and covalent attachment of GPI at
+      the new carboxyl terminus are catalyzed by an endoplasmic reticulum membrane GPI transamidase
+      complex (GPI-T)
+proposed_new_terms: []
+suggested_questions:
+- question: What is the specific molecular role of PIGS within the GPI-T complex (e.g. substrate
+    proprotein recognition, lumenal-domain scaffolding, or stabilization of catalytic subunits),
+    given that it is indispensable for activity yet non-catalytic?
+  experts:
+  - Taroh Kinoshita
+suggested_experiments:
+- description: Structure-guided mutagenesis of the PIGS lumenal domain interface with PIGK/GPAA1
+    combined with in vitro transamidase and cell-surface GPI-AP rescue assays to define which
+    PIGS surfaces are required for substrate handling versus complex assembly.
+  hypothesis: PIGS contributes to substrate proprotein recognition and/or stabilization of the
+    catalytic subunits rather than to catalysis itself.
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000041
+  title: Gene Ontology annotation based on UniPathway vocabulary mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: file:human/PIGS/PIGS-uniprot.txt
+  title: UniProtKB entry Q96S52 (PIGS_HUMAN), GPI-anchor transamidase component PIGS
+  findings: []
+- id: PMID:11483512
+  title: PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a
+    complex with GAA1 and GPI8.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Foundational paper identifying PIG-S as an essential GPI transamidase
+      subunit forming a complex with GAA1, GPI8 (PIGK) and PIG-T; abstract directly supports
+      complex membership and function.
+- id: PMID:12582175
+  title: Two subunits of glycosylphosphatidylinositol transamidase, GPI8 and PIG-T,
+    form a functionally important intermolecular disulfide bridge.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Focus is the GPI8-PIG-T disulfide bond, but the abstract confirms the
+      five-component mammalian GPI transamidase complex that includes PIG-S; supports complex
+      membership.
+- id: PMID:12802054
+  title: Human PIG-U and yeast Cdc91p are the fifth subunit of GPI transamidase that
+    attaches GPI-anchors to proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Identifies PIG-U as the fifth subunit; affinity-purified complex includes
+      PIG-S; supports complex membership and GPI-attachment function.
+- id: PMID:15713669
+  title: Endoplasmic reticulum localization of Gaa1 and PIG-T, subunits of the glycosylphosphatidylinositol
+    transamidase complex.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Establishes ER localization of GPI-T subunits and references the five-subunit
+      ER-localized complex that includes PIG-S.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput membrane proteomics of an NK-like cell line; supports only a
+      generic membrane localization for PIGS.
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Large-scale binary interactome; PIGS interactions here are mostly
+      non-physiological (keratin-associated proteins) and support only generic protein binding.
+- id: PMID:30269814
+  title: Mutations in PIGS, Encoding a GPI Transamidase, Cause a Neurological Syndrome
+    Ranging from Fetal Akinesia to Epileptic Encephalopathy.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Defines GPIBD18; biallelic PIGS loss-of-function causes GPI-AP deficiency,
+      directly linking PIGS to GPI-AP biosynthesis.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: HuRI binary interactome; only the PIGT interaction is a bona fide GPI-T partner,
+      the rest support only generic protein binding.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: BioPlex AP-MS; PIGT interaction consistent with GPI-T membership but recorded as
+      generic protein binding.
+- id: PMID:34576938
+  title: Functional Analysis of the GPI Transamidase Complex by Screening for Amino
+    Acid Mutations in Each Subunit.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Full text available; states GPI-TA has five subunits, that PIGS is indispensable
+      for activity, and characterizes functionally important residues; supports complex membership
+      and requirement.
+- id: PMID:35165458
+  title: Structure of human glycosylphosphatidylinositol transamidase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cryo-EM structure of human GPI-T (PDB 7W72); PIGS resolved as one of five
+      subunits; identifies PIGK catalytic triad and substrate-binding cleft.
+- id: PMID:35551457
+  title: Molecular insights into biogenesis of glycosylphosphatidylinositol anchor
+    proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cryo-EM structure showing equimolar heteropentameric GPI-T assembly
+      including PIGS; ER membrane localization confirmed.
+- id: PMID:37684232
+  title: Structures of liganded glycosylphosphatidylinositol transamidase illuminate
+    GPI-AP biogenesis.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Substrate/product-bound cryo-EM structures (PDB 8IMX/8IMY) of human GPI-T
+      including PIGS; illuminates the transamidation mechanism.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Multimodal cell-map interactome; PIGT interaction consistent with GPI-T, but
+      recorded as generic protein binding.
+- id: Reactome:R-HSA-162836
+  title: uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + uPAR propeptide
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGT/PIGT-ai-review.html
+++ b/genes/human/PIGT/PIGT-ai-review.html
@@ -1,0 +1,6433 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGT - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGT</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q969N2" target="_blank" class="term-link">
+                        Q969N2
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGT";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q969N2" data-a="DESCRIPTION: PIGT (GPI-anchor transamidase component PIG-T) is ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGT (GPI-anchor transamidase component PIG-T) is one of the five subunits of the glycosylphosphatidylinositol-anchor transamidase (GPI-T) complex, an endoplasmic reticulum membrane enzyme complex that attaches the pre-assembled GPI anchor to the C-terminus of GPI-anchored proteins after cleaving their C-terminal GPI-attachment signal peptide. The complex comprises the catalytic subunit PIGK (GPI8) together with GPAA1, PIGS, PIGU and PIGT as an equimolar heteropentamer. PIGT is a single-pass type I ER membrane glycoprotein that acts as a required structural subunit; it forms an interchain disulfide bond with the catalytic PIGK/GPI8 (PIGT Cys182 to PIGK Cys92) and stabilises and holds the complex together, and it also contributes to binding of the GPI lipid substrate. PIGT itself is not an independent enzyme, the transamidation catalysis residing in PIGK. Biallelic loss-of-function variants in PIGT cause the inherited GPI deficiency multiple congenital anomalies-hypotonia-seizures syndrome 3 (MCAHS3), and germline plus somatic PIGT variants can produce a paroxysmal nocturnal hemoglobinuria-like phenotype (PNH2).</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to the core biological process of PIGT and its orthologues, the attachment of GPI anchors to proteins. This is the well-established, correct core function of the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This IBA annotation correctly captures PIGT&#39;s core biological role as a subunit of the GPI transamidase, which attaches pre-assembled GPI to proteins in the ER. It is supported by experimental knockout data and by the entire structural/biochemical literature.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T knockout cells were defective in transfer of GPI</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation placing PIGT as a part of the GPI-anchor transamidase complex, the correct and core cellular component for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGT is a bona fide subunit of the heteropentameric GPI-T complex (PIGK, GPAA1, PIGS, PIGU, PIGT). This is directly established experimentally and structurally.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">revealing an equimolar</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (from UniProt Subcellular Location mapping) to the ER membrane, the correct localisation of PIGT and the GPI-T complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGT is a single-pass type I ER membrane protein; the GPI-T complex is an ER membrane complex. This IEA mapping is fully consistent with experimental localisation data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link">
+                                        PMID:15713669
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-T is a type I</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed by</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (combined IEA methods, via mouse ortholog and InterPro PIG-T domain) annotation to GPI anchor attachment, the core BP of PIGT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This electronic annotation agrees with the IBA and multiple experimental annotations for the same process. It is correct at an appropriate level of specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (combined IEA methods) annotation to the GPI-anchor transamidase complex, agreeing with the experimental IDA/IBA complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct complex membership, redundant with but consistent with the experimental and phylogenetic annotations of the same complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0005515" data-r="PMID:11483512" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI capturing PIGT physical interactions with other GPI-T subunits (GPAA1/PIGK/PIGS). Bare &#39;protein binding&#39; is uninformative about the actual molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The interaction is real and biologically meaningful, but the generic &#39;protein binding&#39; term conveys no functional information beyond what is already captured more informatively by the GPI-anchor transamidase complex (GO:0042765) membership. Per curation guidance, bare protein binding is discouraged in favour of a more specific term. Retained rather than removed because it reflects a genuine curated interaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0005515" data-r="PMID:12802054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI recording PIGT interaction with GPI-T subunits identified during characterisation of PIG-U as the fifth subunit. Bare &#39;protein binding&#39; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine interaction within the GPI-T complex, but &#39;protein binding&#39; is too generic; the informative content is already captured by GO:0042765. Retained as a valid curated interaction rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mammalian GPI transamidase is a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI derived from the BioPlex 2.0 large-scale affinity-purification interactome. Bare &#39;protein binding&#39; with no specific functional information.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput interactome data supporting membership in a protein community, but the generic &#39;protein binding&#39; term is uninformative and redundant with the more specific complex annotation (GO:0042765).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                                        PMID:28514442
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">networks of protein-protein interactions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI derived from the BioPlex 3.0 proteome-scale interactome. Bare &#39;protein binding&#39; term, uninformative about molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Large-scale interactome evidence; generic and redundant with the GPI-anchor transamidase complex annotation. Retained as valid interaction data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Thousands of interactions assemble proteins into modules</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI from a multimodal cell-map/interactome study. Bare &#39;protein binding&#39; term without specific molecular-function content.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Systematic interactome mapping; genuine but generic. The informative function is captured by complex membership (GO:0042765).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                                        PMID:40205054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Multimodal cell maps as a foundation for structural and functional genomics</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000041
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0006506" data-r="GO_REF:0000041" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (UniPathway mapping, UPA00196 glycosylphosphatidylinositol-anchor biosynthesis) to the GPI anchor biosynthetic process. PIGT participates in the final transamidation/attachment step of this pathway as part of GPI-T.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGT participates in the terminal step of GPI anchor biosynthesis (attachment of the anchor to protein). This pathway-level BP is correct and consistent with the UniProt PATHWAY annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">covalent attachment of GPI at the new carboxyl terminus are catalyzed by an</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0005789" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-statement (NAS, ComplexPortal) annotation to the ER membrane, matching the established localisation of PIGT within the ER-membrane GPI-T complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localisation. The GPI transamidase is an ER-membrane complex and PIGT is an integral ER membrane protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">posttranslationally attached to the</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link">
+                                        PMID:15713669
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-T is a type I</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-statement (NAS, ComplexPortal) annotation to GPI anchor attachment, the core BP of the GPI-T complex to which PIGT belongs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core process; redundant with but consistent with the IBA and IDA annotations for the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">carboxyl-terminus by GPI transamidase. The mammalian GPI transamidase is a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI (ComplexPortal, CPX-6503) annotation placing PIGT in the GPI-anchor transamidase complex, based on affinity-purification of the complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported complex membership; PIGT co-purifies with the other four GPI-T subunits. This is the core cellular component for PIGT.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mammalian GPI transamidase is a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0180046" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA (cryo-EM structure of the human GPI-T complex) annotation to GPI anchored protein biosynthesis, the overall process to which the PIGT-containing complex contributes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The structure confirms PIGT as a subunit of the complex that catalyses GPI-AP biogenesis. This BP is correct; it is the pathway output of GPI anchor attachment, so somewhat broader/less specific than GO:0016255 but valid.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which is essential for</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0180046" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA (2.53-Angstrom cryo-EM structure of the human GPI-T heteropentamer) annotation to GPI anchored protein biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structure of the GPI-T complex directly implicates PIGT in GPI-AP biogenesis. Correct process-level annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">covalent attachment of GPI at the new carboxyl terminus are catalyzed by an</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28327575" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28327575
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of exome data for 4293 trios suggests GPI-anchor bi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="PMID:28327575" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchor attachment based on functional characterisation of MCAHS3 patient variants that impair GPI-anchored protein surface expression.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Patient-variant and rescue assays demonstrate that PIGT function is required for attachment of GPI anchors to proteins. Core BP, correctly annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28327575" target="_blank" class="term-link">
+                                        PMID:28327575
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutations in 18 genes that encode</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36970549" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36970549
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Case report: Functional analysis of the p.Arg507Trp variant ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="PMID:36970549" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchor attachment from FACS analysis of PIGT-knockout cells rescued with wild-type versus p.Arg507Trp mutant cDNA, showing the variant reduces activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Functional assay directly links PIGT to GPI anchor attachment activity; pathogenic variants reduce it. Core BP, correctly annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36970549" target="_blank" class="term-link">
+                                        PMID:36970549
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">leads to mildly reduced</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS annotation to GPI anchor attachment from the liganded GPI-T structural study describing the transamidation reaction catalysed by the complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GPI-T complex, of which PIGT is a subunit, replaces the signal peptide with GPI via transamidation. Correct core BP.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">replaces it with GPI via a transamidation reaction</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034235" target="_blank" class="term-link">
+                                    GO:0034235
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0034235" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation that PIGT binds the GPI anchor. This is an informative molecular function for PIGT, which contributes lipid-substrate binding residues within the GPI-T complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the most informative MF annotation present for PIGT and is retained. Subsequent cryo-EM structures corroborate that the GPI lipid substrate is bound in a composite cavity of the complex, with PIGT contributing binding residues (UniProt BINDING sites 461/521/523/527). Per policy, an experimental IDA whose full text is unavailable to me is not removed; the function is biologically sound.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">endogenous GPI in the structure defines a composite cavity for the lipid</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0180046" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchored protein biosynthesis based on PIG-T knockout cells being defective in transfer of GPI to proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Knockout data directly implicate PIGT in GPI-AP biogenesis. Correct process annotation (pathway output of GPI anchor attachment).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T knockout cells were defective in transfer of GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12582175
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Two subunits of glycosylphosphatidylinositol transamidase, G...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0180046" data-r="PMID:12582175" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchored protein biosynthesis from the study of the functionally important PIG-T/GPI8 intermolecular disulfide bond.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGT is required for full transamidase activity of the complex that produces GPI-anchored proteins. Correct process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                                        PMID:12582175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">required for full transamidase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28327575" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28327575
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of exome data for 4293 trios suggests GPI-anchor bi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0180046" data-r="PMID:28327575" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchored protein biosynthesis from functional analysis of MCAHS3 patient variants reducing GPI-AP surface display.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Variant/rescue data show PIGT is needed for GPI-AP biogenesis. Correct process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28327575" target="_blank" class="term-link">
+                                        PMID:28327575
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutations in 18 genes that encode</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0180046" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchored protein biosynthesis from functional analysis of amino-acid mutations across the five GPI-TA subunits including PIGT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mutational screening confirms PIGT function within the GPI-TA complex that biosynthesises GPI-anchored proteins. Correct process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the absence of any subunit leads to the loss of activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36970549" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36970549
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Case report: Functional analysis of the p.Arg507Trp variant ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0180046" data-r="PMID:36970549" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchored protein biosynthesis from knockout-rescue functional analysis of the p.Arg507Trp PIGT variant.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Functional assay implicates PIGT in GPI-AP biogenesis. Correct process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36970549" target="_blank" class="term-link">
+                                        PMID:36970549
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">leads to mildly reduced</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0180046" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchored protein biosynthesis from the liganded GPI-T structural study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GPI-T structure, including PIGT, directly informs the biogenesis of GPI-anchored proteins. Correct process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">replaces it with GPI via a transamidation reaction</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchor attachment from the characterisation of the five-subunit GPI transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The reconstituted five-subunit complex (including PIGT) performs GPI anchor attachment. Core BP, correctly annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">carboxyl-terminus by GPI transamidase. The mammalian GPI transamidase is a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchor attachment from mutational analysis of the GPI-TA complex subunits.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Confirms PIGT contribution to GPI anchor attachment activity of the complex. Core BP, correctly annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchor attachment from the liganded GPI-T structures illuminating substrate recognition and transamidation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The complex containing PIGT attaches GPI to proprotein C-termini by transamidation. Core BP, correctly annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">replaces it with GPI via a transamidation reaction</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA (cryo-EM) annotation placing PIGT in the GPI-anchor transamidase complex, resolved as a heteropentamer with bound GPI/substrate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structurally confirmed complex membership. Core cellular component for PIGT.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">replaces it with GPI via a transamidation reaction</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchor attachment from the first human GPI-T cryo-EM structure, which identified the PIGK catalytic triad and the GPI substrate cleft.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The structure directly demonstrates how the PIGT-containing complex attaches GPI to proteins. Core BP, correctly annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed by</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchor attachment from the 2.53-Angstrom human GPI-T structure with endogenous GPI bound.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structure of the heteropentameric complex including PIGT elucidates GPI anchor attachment. Core BP, correctly annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">covalent attachment of GPI at the new carboxyl terminus are catalyzed by an</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA (cryo-EM) annotation placing PIGT in the GPI-anchor transamidase complex, composed of PIGK, PIGU, PIGT, PIGS and GPAA1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structurally confirmed complex membership. Core cellular component.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPIT complex is known to be</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA (cryo-EM) annotation placing PIGT in the GPI-anchor transamidase complex, resolved as an equimolar heteropentamer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structurally confirmed complex membership. Core cellular component.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">revealing an equimolar</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12582175
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Two subunits of glycosylphosphatidylinositol transamidase, G...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="PMID:12582175" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation placing PIGT in the GPI transamidase complex, based on the demonstration that GPI8/PIGK and PIG-T form a functionally important disulfide bond within the multimeric complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGT is a subunit that disulfide-links to catalytic PIGK; the intact complex is composed of five subunits. Core cellular component.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                                        PMID:12582175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">two subunits of mammalian GPI transamidase, GPI8 and PIG-T, form</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                                        PMID:12582175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">these five components are sufficient to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation placing PIGT in the GPI-anchor transamidase complex, from the purification and mutational analysis of the five-subunit GPI-TA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGT is one of the five subunits of the purified GPI-TA. Core cellular component.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation placing PIGT in the GPI-anchor transamidase complex, from affinity purification of the epitope-tagged complex containing PIG-U and PIGT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGT co-purifies as a subunit of the GPI transamidase complex. Core cellular component.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mammalian GPI transamidase is a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation placing PIGT in the GPI-anchor transamidase complex, from the original identification of PIG-S and PIG-T as subunits complexing with GAA1 and GPI8.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Foundational experimental demonstration that PIGT is a subunit of the GPI transamidase complex and stabilises it. Core cellular component.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T form a protein complex with GAA1 and GPI8</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-T maintains the complex by stabilizing the expression of GAA1 and GPI8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016020" data-r="PMID:19946888" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput (HDA) proteomics annotation to the generic &#39;membrane&#39; term, from a membrane-proteome analysis of an NK-like cell line.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGT is indeed a membrane protein, so the annotation is not wrong, but &#39;membrane&#39; is far less specific than the well-supported ER membrane (GO:0005789) localisation. Kept as non-core given the more informative CC terms already present.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Defining the membrane proteome of NK cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162836
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0005789" data-r="Reactome:R-HSA-162836" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS (Reactome) annotation to the ER membrane, from the uPAR GPI-attachment reaction catalysed by the ER-membrane GPI transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localisation consistent with all other CC evidence for PIGT and the GPI-T complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162836
+
+                                </span>
+
+                                <div class="support-text">a complex of at least five proteins associated with the lumenal surface of the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12052837" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12052837
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural requirements for the recruitment of Gaa1 into a f...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0005789" data-r="PMID:12052837" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-statement (NAS) annotation to the ER membrane, from the study of Gaa1 recruitment into the ER-localised GPI transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localisation; the GPI transamidase (including PIGT) is an ER-membrane complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12052837" target="_blank" class="term-link">
+                                        PMID:12052837
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Gaa1 is an endoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0016255" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS annotation to GPI anchor attachment from the original PIG-S/PIG-T identification paper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIG-T is essential for attachment of GPI anchors to proteins. Core BP, correctly annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-S and PIG-T knockout cells were defective in transfer of GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15713669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Endoplasmic reticulum localization of Gaa1 and PIG-T, subuni...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0005515" data-r="PMID:15713669" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI annotation of a PIGT interaction (with GPAA1/O43292) from the study of ER localisation of Gaa1 and PIG-T. Bare &#39;protein binding&#39; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine interaction with a partner GPI-T subunit, but &#39;protein binding&#39; is uninformative and redundant with the complex membership annotation (GO:0042765). Retained as a valid curated interaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link">
+                                        PMID:15713669
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">subunits of the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15713669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Endoplasmic reticulum localization of Gaa1 and PIG-T, subuni...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q969N2" data-a="GO:0042765" data-r="PMID:15713669" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS annotation placing PIGT in the GPI transamidase complex, from the study of ER localisation of two of its subunits (Gaa1 and PIG-T).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGT is described as one of the five subunits of the GPI transamidase complex. Core cellular component.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link">
+                                        PMID:15713669
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">subunits of the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As a required structural subunit of the endoplasmic reticulum membrane GPI-anchor transamidase (GPI-T) complex, PIGT binds the GPI lipid substrate and, by forming an interchain disulfide bond with the catalytic subunit PIGK/GPI8 and stabilising the complex, contributes to attachment of pre-assembled GPI anchors to the C-terminus of GPI-anchored proteins during GPI anchor biosynthesis.</h3>
+                <span class="vote-buttons" data-g="Q969N2" data-a="FUNCTION: As a required structural subunit of the endoplasmi..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034235" target="_blank" class="term-link">
+                            GPI anchor binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                attachment of GPI anchor to protein
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                            GPI-anchor transamidase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                PMID:11483512
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PIG-T maintains the complex by stabilizing the expression of GAA1 and GPI8</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                                PMID:12582175
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">required for full transamidase activity</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                PMID:35551457
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">endogenous GPI in the structure defines a composite cavity for the lipid</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000041.md" target="_blank" class="term-link">
+                            GO_REF:0000041
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniPathway vocabulary mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                            PMID:11483512
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a complex with GAA1 and GPI8.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12052837" target="_blank" class="term-link">
+                            PMID:12052837
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural requirements for the recruitment of Gaa1 into a functional glycosylphosphatidylinositol transamidase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12582175" target="_blank" class="term-link">
+                            PMID:12582175
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Two subunits of glycosylphosphatidylinositol transamidase, GPI8 and PIG-T, form a functionally important intermolecular disulfide bridge.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                            PMID:12802054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human PIG-U and yeast Cdc91p are the fifth subunit of GPI transamidase that attaches GPI-anchors to proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15713669" target="_blank" class="term-link">
+                            PMID:15713669
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Endoplasmic reticulum localization of Gaa1 and PIG-T, subunits of the glycosylphosphatidylinositol transamidase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28327575" target="_blank" class="term-link">
+                            PMID:28327575
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of exome data for 4293 trios suggests GPI-anchor biogenesis defects are a rare cause of developmental disorders.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                            PMID:34576938
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional Analysis of the GPI Transamidase Complex by Screening for Amino Acid Mutations in Each Subunit.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                            PMID:35165458
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of human glycosylphosphatidylinositol transamidase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                            PMID:35551457
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular insights into biogenesis of glycosylphosphatidylinositol anchor proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36970549" target="_blank" class="term-link">
+                            PMID:36970549
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Case report: Functional analysis of the p.Arg507Trp variant of the PIGT gene supporting the moderate epilepsy phenotype of mutations in the C-terminal region.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                            PMID:37684232
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structures of liganded glycosylphosphatidylinositol transamidase illuminate GPI-AP biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162836
+
+                    </span>
+                </div>
+
+                <div class="reference-title">uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + uPAR propeptide</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does PIGT contribute directly to GPI lipid-substrate recognition/binding beyond a purely structural role, and can its binding residues (e.g. positions 461/521/523/527) be functionally separated from its complex-stabilising function?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q969N2" data-a="Q: Does PIGT contribute directly to GPI lipid-substra..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How do specific MCAHS3 missense variants map onto the complex-stabilising versus substrate-binding roles of PIGT, and does this explain the mild-versus-severe epilepsy phenotype spectrum?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q969N2" data-a="Q: How do specific MCAHS3 missense variants map onto ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided mutagenesis of PIGT GPI-lipid-binding residues in a PIGT-knockout rescue system, measuring cell-surface GPI-anchored protein display (CD59/CD16b) versus complex assembly, to dissect PIGT&#39;s substrate-binding contribution from its structural/stabilising role.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q969N2" data-a="EXPERIMENT: Structure-guided mutagenesis of PIGT GPI-lipid-bin..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGT-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q969N2" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigt-q969n2-review-notes">PIGT (Q969N2) review notes</h1>
+<h2 id="summary-of-function">Summary of function</h2>
+<p>PIGT (GPI-anchor transamidase component PIG-T) is one of five subunits of the<br />
+glycosylphosphatidylinositol-anchor transamidase (GPI-T) complex, an ER-membrane<br />
+enzyme complex that attaches the pre-assembled GPI anchor to the C-terminus of<br />
+GPI-anchored proteins (GPI-APs). The complex is PIGK (catalytic, GPI8), GPAA1,<br />
+PIGS, PIGT, PIGU. It is NOT an independent enzyme; the catalytic activity resides<br />
+in PIGK.</p>
+<ul>
+<li>PIGT is a <strong>required structural subunit</strong>: it disulfide-links to the catalytic<br />
+  PIGK/GPI8 (Cys182 of PIGT ↔ Cys92 of PIGK) and stabilises/holds the complex<br />
+  together. <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" title="we demonstrate that PIG-S and PIG-T form a protein   complex with GAA1 and GPI8, and that PIG-T maintains the complex by stabilizing   the expression of GAA1 and GPI8">PMID:11483512</a>; disulfide bridge [PMID:12582175 "two subunits<br />
+  of mammalian GPI transamidase, GPI8 and PIG-T, form" ... "required for full<br />
+  transamidase activity"].</li>
+<li>Cryo-EM structures confirm an equimolar heteropentamer; PIGK holds the catalytic<br />
+  triad; a GPI substrate-binding cleft is formed by transmembrane helices under<br />
+  PIGK, and PIGT contributes lipid-substrate binding residues (UniProt BINDING<br />
+  461/521/523/527). [PMID:35551457 "revealing an equimolar" heteropentameric<br />
+  assembly; "endogenous GPI in the structure defines a composite cavity for the<br />
+  lipid"]; [PMID:35165458 "The PIGK subunit" is the catalytic component;<br />
+  "C206-H164-N58" triad]; <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" title="replaces it with GPI via a transamidation   reaction">PMID:37684232</a>.</li>
+<li>Localisation: ER membrane, single-pass type I membrane protein; ER retention is<br />
+  encoded in its transmembrane span. [PMID:15713669 "PIG-T is a type I" membrane<br />
+  glycoprotein; "PIG-T revealed that it is ER-localized because of information in<br />
+  its" transmembrane span].</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<p>Biallelic loss-of-function variants cause <strong>multiple congenital anomalies-hypotonia-<br />
+seizures syndrome 3 (MCAHS3; MIM:615398)</strong>, an inherited GPI deficiency<br />
+(intellectual disability, hypotonia, epilepsy, dysmorphism, skeletal/endocrine/<br />
+ophthalmologic anomalies). A germline + somatic PIGT combination also causes a<br />
+<strong>paroxysmal nocturnal hemoglobinuria-like phenotype (PNH2; MIM:615399)</strong>. Patient<br />
+and knockout-rescue assays show variants reduce cell-surface GPI-AP display<br />
+(CD16b/CD59). [PMID:28327575; PMID:36970549 "leads to mildly reduced" activity]</p>
+<h2 id="goa-term-inventory-what-is-actually-present">GOA term inventory (what is actually present)</h2>
+<ul>
+<li>MF present: GO:0005515 protein binding (IPI, multiple); GO:0034235 GPI anchor<br />
+  binding (IDA, PMID:11483512). <strong>No independent catalytic MF is annotated</strong> — do<br />
+  not invent one; the transamidase catalysis is PIGK's.</li>
+<li>BP: GO:0016255 attachment of GPI anchor to protein; GO:0006506 GPI anchor<br />
+  biosynthetic process; GO:0180046 GPI anchored protein biosynthesis.</li>
+<li>CC: GO:0042765 GPI-anchor transamidase complex; GO:0005789 ER membrane;<br />
+  GO:0016020 membrane (HDA proteomics).</li>
+</ul>
+<h2 id="curation-decisions">Curation decisions</h2>
+<ul>
+<li>Core BP = GO:0016255 / GO:0006506 (GPI anchor attachment / biosynthesis).</li>
+<li>Core CC = GO:0042765 (GPI-anchor transamidase complex) + GO:0005789 (ER membrane).</li>
+<li>GO:0034235 GPI anchor binding = informative MF, ACCEPT (structural support:<br />
+  PIGT lipid-binding residues; do not REMOVE an IDA whose full text I cannot see).</li>
+<li>GO:0005515 protein binding IPIs → MARK_AS_OVER_ANNOTATED (uninformative bare<br />
+  binding; the informative content is captured by GO:0042765 / GO:0034235). Per<br />
+  policy not REMOVE.</li>
+<li>GO:0016020 membrane (HDA, NK-cell membrane proteome) → too general vs ER<br />
+  membrane; KEEP_AS_NON_CORE.</li>
+<li>GO:0180046 GPI anchored protein biosynthesis — sibling/parent-level BP for the<br />
+  pathway output; ACCEPT (many IDA) but non-core relative to the direct<br />
+  attachment step; treat as accepted supporting BP.</li>
+</ul>
+<h2 id="no-deep-research-file">No deep-research file</h2>
+<p>falcon is out of credits (HTTP 402); no -deep-research-<em>.md generated. Grounded in<br />
+PIGT-uniprot.txt, PIGT-goa.tsv, and cached publications/PMID_</em>.md.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q969N2
+gene_symbol: PIGT
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PIGT (GPI-anchor transamidase component PIG-T) is one of the five subunits of the
+  glycosylphosphatidylinositol-anchor transamidase (GPI-T) complex, an endoplasmic
+  reticulum membrane enzyme complex that attaches the pre-assembled GPI anchor to the
+  C-terminus of GPI-anchored proteins after cleaving their C-terminal GPI-attachment
+  signal peptide. The complex comprises the catalytic subunit PIGK (GPI8) together with
+  GPAA1, PIGS, PIGU and PIGT as an equimolar heteropentamer. PIGT is a single-pass type
+  I ER membrane glycoprotein that acts as a required structural subunit; it forms an
+  interchain disulfide bond with the catalytic PIGK/GPI8 (PIGT Cys182 to PIGK Cys92) and
+  stabilises and holds the complex together, and it also contributes to binding of the
+  GPI lipid substrate. PIGT itself is not an independent enzyme, the transamidation
+  catalysis residing in PIGK. Biallelic loss-of-function variants in PIGT cause the
+  inherited GPI deficiency multiple congenital anomalies-hypotonia-seizures syndrome 3
+  (MCAHS3), and germline plus somatic PIGT variants can produce a paroxysmal nocturnal
+  hemoglobinuria-like phenotype (PNH2).
+alternative_products:
+- name: &#39;1&#39;
+  id: Q969N2-1
+- name: &#39;2&#39;
+  id: Q969N2-2
+  sequence_note: VSP_009537
+- name: &#39;3&#39;
+  id: Q969N2-3
+  sequence_note: VSP_009536, VSP_009539, VSP_009540
+- name: &#39;4&#39;
+  id: Q969N2-4
+  sequence_note: VSP_009538
+- name: &#39;5&#39;
+  id: Q969N2-5
+  sequence_note: VSP_043167
+- name: &#39;6&#39;
+  id: Q969N2-6
+  sequence_note: VSP_009540
+existing_annotations:
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation to the core biological process of PIGT and its
+      orthologues, the attachment of GPI anchors to proteins. This is the well-established,
+      correct core function of the gene.
+    action: ACCEPT
+    reason: &gt;-
+      This IBA annotation correctly captures PIGT&#39;s core biological role as a subunit of
+      the GPI transamidase, which attaches pre-assembled GPI to proteins in the ER. It is
+      supported by experimental knockout data and by the entire structural/biochemical
+      literature.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T knockout cells were defective in transfer of GPI
+    - reference_id: PMID:34576938
+      supporting_text: Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA)
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation placing PIGT as a part of the GPI-anchor transamidase
+      complex, the correct and core cellular component for this gene.
+    action: ACCEPT
+    reason: &gt;-
+      PIGT is a bona fide subunit of the heteropentameric GPI-T complex (PIGK, GPAA1,
+      PIGS, PIGU, PIGT). This is directly established experimentally and structurally.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8
+    - reference_id: PMID:35551457
+      supporting_text: revealing an equimolar
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation (from UniProt Subcellular Location mapping) to the ER
+      membrane, the correct localisation of PIGT and the GPI-T complex.
+    action: ACCEPT
+    reason: &gt;-
+      PIGT is a single-pass type I ER membrane protein; the GPI-T complex is an ER
+      membrane complex. This IEA mapping is fully consistent with experimental
+      localisation data.
+    supported_by:
+    - reference_id: PMID:15713669
+      supporting_text: PIG-T is a type I
+    - reference_id: PMID:35165458
+      supporting_text: Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed by
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (combined IEA methods, via mouse ortholog and InterPro PIG-T domain)
+      annotation to GPI anchor attachment, the core BP of PIGT.
+    action: ACCEPT
+    reason: &gt;-
+      This electronic annotation agrees with the IBA and multiple experimental
+      annotations for the same process. It is correct at an appropriate level of
+      specificity.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA)
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Electronic (combined IEA methods) annotation to the GPI-anchor transamidase
+      complex, agreeing with the experimental IDA/IBA complex annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Correct complex membership, redundant with but consistent with the experimental and
+      phylogenetic annotations of the same complex.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &#39;GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:11483512
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI capturing PIGT physical interactions with other GPI-T subunits
+      (GPAA1/PIGK/PIGS). Bare &#39;protein binding&#39; is uninformative about the actual
+      molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The interaction is real and biologically meaningful, but the generic &#39;protein
+      binding&#39; term conveys no functional information beyond what is already captured more
+      informatively by the GPI-anchor transamidase complex (GO:0042765) membership. Per
+      curation guidance, bare protein binding is discouraged in favour of a more specific
+      term. Retained rather than removed because it reflects a genuine curated interaction.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12802054
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI recording PIGT interaction with GPI-T subunits identified during
+      characterisation of PIG-U as the fifth subunit. Bare &#39;protein binding&#39; is
+      uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Genuine interaction within the GPI-T complex, but &#39;protein binding&#39; is too generic;
+      the informative content is already captured by GO:0042765. Retained as a valid
+      curated interaction rather than removed.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: The mammalian GPI transamidase is a
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI derived from the BioPlex 2.0 large-scale affinity-purification
+      interactome. Bare &#39;protein binding&#39; with no specific functional information.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput interactome data supporting membership in a protein community, but
+      the generic &#39;protein binding&#39; term is uninformative and redundant with the more
+      specific complex annotation (GO:0042765).
+    supported_by:
+    - reference_id: PMID:28514442
+      supporting_text: networks of protein-protein interactions
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI derived from the BioPlex 3.0 proteome-scale interactome. Bare &#39;protein
+      binding&#39; term, uninformative about molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Large-scale interactome evidence; generic and redundant with the GPI-anchor
+      transamidase complex annotation. Retained as valid interaction data.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: Thousands of interactions assemble proteins into modules
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI from a multimodal cell-map/interactome study. Bare &#39;protein binding&#39; term
+      without specific molecular-function content.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Systematic interactome mapping; genuine but generic. The informative function is
+      captured by complex membership (GO:0042765).
+    supported_by:
+    - reference_id: PMID:40205054
+      supporting_text: Multimodal cell maps as a foundation for structural and functional genomics
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000041
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic annotation (UniPathway mapping, UPA00196 glycosylphosphatidylinositol-anchor
+      biosynthesis) to the GPI anchor biosynthetic process. PIGT participates in the final
+      transamidation/attachment step of this pathway as part of GPI-T.
+    action: ACCEPT
+    reason: &gt;-
+      PIGT participates in the terminal step of GPI anchor biosynthesis (attachment of the
+      anchor to protein). This pathway-level BP is correct and consistent with the UniProt
+      PATHWAY annotation.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: covalent attachment of GPI at the new carboxyl terminus are catalyzed by an
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:12802054
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Author-statement (NAS, ComplexPortal) annotation to the ER membrane, matching the
+      established localisation of PIGT within the ER-membrane GPI-T complex.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localisation. The GPI transamidase is an ER-membrane complex and PIGT is an
+      integral ER membrane protein.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: posttranslationally attached to the
+    - reference_id: PMID:15713669
+      supporting_text: PIG-T is a type I
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: NAS
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Author-statement (NAS, ComplexPortal) annotation to GPI anchor attachment, the core
+      BP of the GPI-T complex to which PIGT belongs.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core process; redundant with but consistent with the IBA and IDA
+      annotations for the same term.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &#39;carboxyl-terminus by GPI transamidase. The mammalian GPI transamidase is a&#39;
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IPI
+  original_reference_id: PMID:12802054
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IPI (ComplexPortal, CPX-6503) annotation placing PIGT in the GPI-anchor transamidase
+      complex, based on affinity-purification of the complex.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported complex membership; PIGT co-purifies with the other four GPI-T
+      subunits. This is the core cellular component for PIGT.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: The mammalian GPI transamidase is a
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA (cryo-EM structure of the human GPI-T complex) annotation to GPI anchored
+      protein biosynthesis, the overall process to which the PIGT-containing complex
+      contributes.
+    action: ACCEPT
+    reason: &gt;-
+      The structure confirms PIGT as a subunit of the complex that catalyses GPI-AP
+      biogenesis. This BP is correct; it is the pathway output of GPI anchor attachment,
+      so somewhat broader/less specific than GO:0016255 but valid.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: which is essential for
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA (2.53-Angstrom cryo-EM structure of the human GPI-T heteropentamer) annotation
+      to GPI anchored protein biosynthesis.
+    action: ACCEPT
+    reason: &gt;-
+      Structure of the GPI-T complex directly implicates PIGT in GPI-AP biogenesis.
+      Correct process-level annotation.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: covalent attachment of GPI at the new carboxyl terminus are catalyzed by an
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:28327575
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchor attachment based on functional characterisation of
+      MCAHS3 patient variants that impair GPI-anchored protein surface expression.
+    action: ACCEPT
+    reason: &gt;-
+      Patient-variant and rescue assays demonstrate that PIGT function is required for
+      attachment of GPI anchors to proteins. Core BP, correctly annotated.
+    supported_by:
+    - reference_id: PMID:28327575
+      supporting_text: &#39;Mutations in 18 genes that encode&#39;
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:36970549
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchor attachment from FACS analysis of PIGT-knockout cells
+      rescued with wild-type versus p.Arg507Trp mutant cDNA, showing the variant reduces
+      activity.
+    action: ACCEPT
+    reason: &gt;-
+      Functional assay directly links PIGT to GPI anchor attachment activity; pathogenic
+      variants reduce it. Core BP, correctly annotated.
+    supported_by:
+    - reference_id: PMID:36970549
+      supporting_text: leads to mildly reduced
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: TAS
+  original_reference_id: PMID:37684232
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAS annotation to GPI anchor attachment from the liganded GPI-T structural study
+      describing the transamidation reaction catalysed by the complex.
+    action: ACCEPT
+    reason: &gt;-
+      The GPI-T complex, of which PIGT is a subunit, replaces the signal peptide with GPI
+      via transamidation. Correct core BP.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: replaces it with GPI via a transamidation reaction
+- term:
+    id: GO:0034235
+    label: GPI anchor binding
+  evidence_type: IDA
+  original_reference_id: PMID:11483512
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IDA annotation that PIGT binds the GPI anchor. This is an informative molecular
+      function for PIGT, which contributes lipid-substrate binding residues within the
+      GPI-T complex.
+    action: ACCEPT
+    reason: &gt;-
+      This is the most informative MF annotation present for PIGT and is retained.
+      Subsequent cryo-EM structures corroborate that the GPI lipid substrate is bound in a
+      composite cavity of the complex, with PIGT contributing binding residues (UniProt
+      BINDING sites 461/521/523/527). Per policy, an experimental IDA whose full text is
+      unavailable to me is not removed; the function is biologically sound.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: endogenous GPI in the structure defines a composite cavity for the lipid
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:11483512
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchored protein biosynthesis based on PIG-T knockout cells
+      being defective in transfer of GPI to proteins.
+    action: ACCEPT
+    reason: &gt;-
+      Knockout data directly implicate PIGT in GPI-AP biogenesis. Correct process
+      annotation (pathway output of GPI anchor attachment).
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T knockout cells were defective in transfer of GPI
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:12582175
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchored protein biosynthesis from the study of the
+      functionally important PIG-T/GPI8 intermolecular disulfide bond.
+    action: ACCEPT
+    reason: &gt;-
+      PIGT is required for full transamidase activity of the complex that produces
+      GPI-anchored proteins. Correct process annotation.
+    supported_by:
+    - reference_id: PMID:12582175
+      supporting_text: required for full transamidase activity
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:28327575
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchored protein biosynthesis from functional analysis of
+      MCAHS3 patient variants reducing GPI-AP surface display.
+    action: ACCEPT
+    reason: &gt;-
+      Variant/rescue data show PIGT is needed for GPI-AP biogenesis. Correct process
+      annotation.
+    supported_by:
+    - reference_id: PMID:28327575
+      supporting_text: &#39;Mutations in 18 genes that encode&#39;
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchored protein biosynthesis from functional analysis of
+      amino-acid mutations across the five GPI-TA subunits including PIGT.
+    action: ACCEPT
+    reason: &gt;-
+      Mutational screening confirms PIGT function within the GPI-TA complex that
+      biosynthesises GPI-anchored proteins. Correct process annotation.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: the absence of any subunit leads to the loss of activity
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:36970549
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchored protein biosynthesis from knockout-rescue functional
+      analysis of the p.Arg507Trp PIGT variant.
+    action: ACCEPT
+    reason: &gt;-
+      Functional assay implicates PIGT in GPI-AP biogenesis. Correct process annotation.
+    supported_by:
+    - reference_id: PMID:36970549
+      supporting_text: leads to mildly reduced
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchored protein biosynthesis from the liganded GPI-T
+      structural study.
+    action: ACCEPT
+    reason: &gt;-
+      The GPI-T structure, including PIGT, directly informs the biogenesis of
+      GPI-anchored proteins. Correct process annotation.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: replaces it with GPI via a transamidation reaction
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchor attachment from the characterisation of the
+      five-subunit GPI transamidase complex.
+    action: ACCEPT
+    reason: &gt;-
+      The reconstituted five-subunit complex (including PIGT) performs GPI anchor
+      attachment. Core BP, correctly annotated.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &#39;carboxyl-terminus by GPI transamidase. The mammalian GPI transamidase is a&#39;
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchor attachment from mutational analysis of the GPI-TA
+      complex subunits.
+    action: ACCEPT
+    reason: &gt;-
+      Confirms PIGT contribution to GPI anchor attachment activity of the complex. Core
+      BP, correctly annotated.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA)
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchor attachment from the liganded GPI-T structures
+      illuminating substrate recognition and transamidation.
+    action: ACCEPT
+    reason: &gt;-
+      The complex containing PIGT attaches GPI to proprotein C-termini by transamidation.
+      Core BP, correctly annotated.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: replaces it with GPI via a transamidation reaction
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IDA (cryo-EM) annotation placing PIGT in the GPI-anchor transamidase complex,
+      resolved as a heteropentamer with bound GPI/substrate.
+    action: ACCEPT
+    reason: &gt;-
+      Structurally confirmed complex membership. Core cellular component for PIGT.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: replaces it with GPI via a transamidation reaction
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchor attachment from the first human GPI-T cryo-EM structure,
+      which identified the PIGK catalytic triad and the GPI substrate cleft.
+    action: ACCEPT
+    reason: &gt;-
+      The structure directly demonstrates how the PIGT-containing complex attaches GPI to
+      proteins. Core BP, correctly annotated.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed by
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchor attachment from the 2.53-Angstrom human GPI-T structure
+      with endogenous GPI bound.
+    action: ACCEPT
+    reason: &gt;-
+      Structure of the heteropentameric complex including PIGT elucidates GPI anchor
+      attachment. Core BP, correctly annotated.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: covalent attachment of GPI at the new carboxyl terminus are catalyzed by an
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IDA (cryo-EM) annotation placing PIGT in the GPI-anchor transamidase complex,
+      composed of PIGK, PIGU, PIGT, PIGS and GPAA1.
+    action: ACCEPT
+    reason: &gt;-
+      Structurally confirmed complex membership. Core cellular component.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: The GPIT complex is known to be
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IDA (cryo-EM) annotation placing PIGT in the GPI-anchor transamidase complex,
+      resolved as an equimolar heteropentamer.
+    action: ACCEPT
+    reason: &gt;-
+      Structurally confirmed complex membership. Core cellular component.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: revealing an equimolar
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12582175
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IDA annotation placing PIGT in the GPI transamidase complex, based on the
+      demonstration that GPI8/PIGK and PIG-T form a functionally important disulfide bond
+      within the multimeric complex.
+    action: ACCEPT
+    reason: &gt;-
+      PIGT is a subunit that disulfide-links to catalytic PIGK; the intact complex is
+      composed of five subunits. Core cellular component.
+    supported_by:
+    - reference_id: PMID:12582175
+      supporting_text: &#39;two subunits of mammalian GPI transamidase, GPI8 and PIG-T, form&#39;
+    - reference_id: PMID:12582175
+      supporting_text: these five components are sufficient to
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IDA annotation placing PIGT in the GPI-anchor transamidase complex, from the
+      purification and mutational analysis of the five-subunit GPI-TA.
+    action: ACCEPT
+    reason: &gt;-
+      PIGT is one of the five subunits of the purified GPI-TA. Core cellular component.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &#39;GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and&#39;
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12802054
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IDA annotation placing PIGT in the GPI-anchor transamidase complex, from affinity
+      purification of the epitope-tagged complex containing PIG-U and PIGT.
+    action: ACCEPT
+    reason: &gt;-
+      PIGT co-purifies as a subunit of the GPI transamidase complex. Core cellular
+      component.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: The mammalian GPI transamidase is a
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:11483512
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IDA annotation placing PIGT in the GPI-anchor transamidase complex, from the
+      original identification of PIG-S and PIG-T as subunits complexing with GAA1 and
+      GPI8.
+    action: ACCEPT
+    reason: &gt;-
+      Foundational experimental demonstration that PIGT is a subunit of the GPI
+      transamidase complex and stabilises it. Core cellular component.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T form a protein complex with GAA1 and GPI8
+    - reference_id: PMID:11483512
+      supporting_text: PIG-T maintains the complex by stabilizing the expression of GAA1 and GPI8
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput (HDA) proteomics annotation to the generic &#39;membrane&#39; term, from a
+      membrane-proteome analysis of an NK-like cell line.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      PIGT is indeed a membrane protein, so the annotation is not wrong, but &#39;membrane&#39; is
+      far less specific than the well-supported ER membrane (GO:0005789) localisation.
+      Kept as non-core given the more informative CC terms already present.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: Defining the membrane proteome of NK cells
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162836
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAS (Reactome) annotation to the ER membrane, from the uPAR GPI-attachment reaction
+      catalysed by the ER-membrane GPI transamidase complex.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localisation consistent with all other CC evidence for PIGT and the GPI-T
+      complex.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162836
+      supporting_text: a complex of at least five proteins associated with the lumenal surface of the endoplasmic reticulum membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:12052837
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Author-statement (NAS) annotation to the ER membrane, from the study of Gaa1
+      recruitment into the ER-localised GPI transamidase complex.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localisation; the GPI transamidase (including PIGT) is an ER-membrane
+      complex.
+    supported_by:
+    - reference_id: PMID:12052837
+      supporting_text: Gaa1 is an endoplasmic
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: TAS
+  original_reference_id: PMID:11483512
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAS annotation to GPI anchor attachment from the original PIG-S/PIG-T identification
+      paper.
+    action: ACCEPT
+    reason: &gt;-
+      PIG-T is essential for attachment of GPI anchors to proteins. Core BP, correctly
+      annotated.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: PIG-S and PIG-T knockout cells were defective in transfer of GPI
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:15713669
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI annotation of a PIGT interaction (with GPAA1/O43292) from the study of ER
+      localisation of Gaa1 and PIG-T. Bare &#39;protein binding&#39; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Genuine interaction with a partner GPI-T subunit, but &#39;protein binding&#39; is
+      uninformative and redundant with the complex membership annotation (GO:0042765).
+      Retained as a valid curated interaction.
+    supported_by:
+    - reference_id: PMID:15713669
+      supporting_text: subunits of the
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: TAS
+  original_reference_id: PMID:15713669
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      TAS annotation placing PIGT in the GPI transamidase complex, from the study of ER
+      localisation of two of its subunits (Gaa1 and PIG-T).
+    action: ACCEPT
+    reason: &gt;-
+      PIGT is described as one of the five subunits of the GPI transamidase complex. Core
+      cellular component.
+    supported_by:
+    - reference_id: PMID:15713669
+      supporting_text: subunits of the
+core_functions:
+- description: &gt;-
+    As a required structural subunit of the endoplasmic reticulum membrane GPI-anchor
+    transamidase (GPI-T) complex, PIGT binds the GPI lipid substrate and, by forming an
+    interchain disulfide bond with the catalytic subunit PIGK/GPI8 and stabilising the
+    complex, contributes to attachment of pre-assembled GPI anchors to the C-terminus of
+    GPI-anchored proteins during GPI anchor biosynthesis.
+  molecular_function:
+    id: GO:0034235
+    label: GPI anchor binding
+  directly_involved_in:
+  - id: GO:0016255
+    label: attachment of GPI anchor to protein
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  supported_by:
+  - reference_id: PMID:11483512
+    supporting_text: PIG-T maintains the complex by stabilizing the expression of GAA1 and GPI8
+  - reference_id: PMID:12582175
+    supporting_text: required for full transamidase activity
+  - reference_id: PMID:35551457
+    supporting_text: endogenous GPI in the structure defines a composite cavity for the lipid
+suggested_questions:
+- question: &gt;-
+    Does PIGT contribute directly to GPI lipid-substrate recognition/binding beyond a
+    purely structural role, and can its binding residues (e.g. positions 461/521/523/527)
+    be functionally separated from its complex-stabilising function?
+- question: &gt;-
+    How do specific MCAHS3 missense variants map onto the complex-stabilising versus
+    substrate-binding roles of PIGT, and does this explain the mild-versus-severe epilepsy
+    phenotype spectrum?
+suggested_experiments:
+- description: &gt;-
+    Structure-guided mutagenesis of PIGT GPI-lipid-binding residues in a PIGT-knockout
+    rescue system, measuring cell-surface GPI-anchored protein display (CD59/CD16b) versus
+    complex assembly, to dissect PIGT&#39;s substrate-binding contribution from its
+    structural/stabilising role.
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000041
+  title: Gene Ontology annotation based on UniPathway vocabulary mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:11483512
+  title: PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a
+    complex with GAA1 and GPI8.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Foundational paper identifying PIG-S and PIG-T as GPI-T subunits and showing PIG-T
+      stabilises the complex; verified against cached abstract.
+- id: PMID:12052837
+  title: Structural requirements for the recruitment of Gaa1 into a functional glycosylphosphatidylinositol
+    transamidase complex.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes the ER-localised GPI transamidase as a Gaa1/Gpi8/PIG-S/PIG-T complex;
+      supports ER membrane localisation.
+- id: PMID:12582175
+  title: Two subunits of glycosylphosphatidylinositol transamidase, GPI8 and PIG-T,
+    form a functionally important intermolecular disulfide bridge.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Demonstrates the PIGT-PIGK/GPI8 interchain disulfide bond required for full
+      transamidase activity; verified against cached abstract.
+- id: PMID:12802054
+  title: Human PIG-U and yeast Cdc91p are the fifth subunit of GPI transamidase that
+    attaches GPI-anchors to proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Defines the five-subunit GPI transamidase and its role in attaching GPI to proteins;
+      PIGT is one of the subunits.
+- id: PMID:15713669
+  title: Endoplasmic reticulum localization of Gaa1 and PIG-T, subunits of the glycosylphosphatidylinositol
+    transamidase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Shows PIG-T is a type I ER membrane protein retained in the ER via its transmembrane
+      span; supports ER membrane localisation.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput membrane proteome; only supports the generic &#39;membrane&#39; localisation,
+      not specific function.
+- id: PMID:28327575
+  title: Analysis of exome data for 4293 trios suggests GPI-anchor biogenesis defects
+    are a rare cause of developmental disorders.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Identifies biallelic PIGT variants in developmental-disorder trios and demonstrates
+      impaired GPI-AP biogenesis; supports MCAHS3 and the GPI-attachment BP.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex 2.0 large-scale interactome; supports generic protein-binding interactions
+      only.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex 3.0 proteome-scale interactome; supports generic protein-binding interactions
+      only.
+- id: PMID:34576938
+  title: Functional Analysis of the GPI Transamidase Complex by Screening for Amino
+    Acid Mutations in Each Subunit.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Mutational analysis of all five GPI-TA subunits including PIGT; shows loss of any
+      subunit abolishes activity.
+- id: PMID:35165458
+  title: Structure of human glycosylphosphatidylinositol transamidase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      First cryo-EM structure of human GPI-T; PIGK is catalytic, complex is ER-membrane;
+      PIGT is a subunit.
+- id: PMID:35551457
+  title: Molecular insights into biogenesis of glycosylphosphatidylinositol anchor
+    proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      2.53-Angstrom cryo-EM structure of the equimolar heteropentameric GPI-T with bound
+      GPI; defines the lipid-substrate cavity.
+- id: PMID:36970549
+  title: &#39;Case report: Functional analysis of the p.Arg507Trp variant of the PIGT
+    gene supporting the moderate epilepsy phenotype of mutations in the C-terminal
+    region.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Knockout-rescue FACS assay of a PIGT MCAHS3 variant; directly ties PIGT to
+      GPI-anchor attachment activity.
+- id: PMID:37684232
+  title: Structures of liganded glycosylphosphatidylinositol transamidase illuminate
+    GPI-AP biogenesis.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Substrate/product-bound GPI-T structures describing the transamidation reaction;
+      PIGT is a subunit and binds GPI.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Multimodal interactome/cell-map study; supports generic protein-binding interactions
+      only.
+- id: Reactome:R-HSA-162836
+  title: uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + uPAR propeptide
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reactome reaction catalysed by the ER-membrane GPI transamidase complex; supports ER
+      membrane localisation of the complex containing PIGT.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGU/PIGU-ai-review.html
+++ b/genes/human/PIGU/PIGU-ai-review.html
@@ -1,0 +1,5427 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGU - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGU</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9H490" target="_blank" class="term-link">
+                        Q9H490
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGU";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9H490" data-a="DESCRIPTION: PIGU (GPI-anchor transamidase component PIG-U; als..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGU (GPI-anchor transamidase component PIG-U; also called CDC91L1) is a multi-pass endoplasmic reticulum membrane protein that is one of the five subunits of the glycosylphosphatidylinositol (GPI) transamidase (GPI-T) complex, together with the catalytic subunit PIGK and the accessory subunits GPAA1, PIGT and PIGS. GPI-T acts in the ER lumen to remove the C-terminal GPI-attachment signal peptide from proprotein substrates and covalently attach a pre-assembled GPI anchor at the newly exposed C-terminus (the omega-site), thereby generating mature GPI-anchored proteins. PIGU is a non-catalytic, accessory subunit: it binds the lipid portion of the GPI substrate and is thought to help recognise and present the lipid GPI, and to organise the transmembrane layer of the complex by recruiting the other subunits; cells lacking PIGU still assemble the remaining four subunits but have no transamidase activity. Biallelic loss-of-function variants in PIGU cause an inherited GPI-anchor deficiency (a GPI biosynthesis deficiency, GPIBD), a neurodevelopmental disorder with developmental delay, intellectual disability, epilepsy and brain anomalies.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred annotation that PIGU participates in attachment of the GPI anchor to protein. This is the core biological process of PIGU as a subunit of the GPI transamidase complex, well supported by experimental and structural work.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGU is an essential subunit of the ER GPI transamidase complex, whose function is to attach pre-assembled GPI anchors to the C-terminus of proprotein substrates. The IBA is at the correct level of specificity for this shared ancestral function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA) complex, which recognizes and cleaves the C-terminal GPI attachment signal of precursor proteins</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">posttranslationally attached to the carboxyl-terminus by GPI transamidase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0042765" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred annotation that PIGU is part of the GPI-anchor transamidase complex. This is the core cellular-component annotation for PIGU.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGU is one of the five conserved subunits of the GPI transamidase complex (PIGK, GPAA1, PIGT, PIGS, PIGU), confirmed biochemically and by cryo-EM structures.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU, and the absence of any subunit leads to the loss of activity</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPIT complex is known to be composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (UniProt Subcellular Location mapping) placing PIGU in the ER membrane. This matches the experimentally established localization of GPI-T.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGU is a multi-pass ER membrane protein; GPI anchoring occurs in the ER. The IEA subcellular-location mapping is correct and specific.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among all eukaryotes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation to the generic parent term membrane. Correct but uninformative given the specific ER membrane annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGU is an integral membrane protein, so membrane is not wrong, but it is a broad parent of the more specific and better-supported endoplasmic reticulum membrane (GO:0005789) annotation. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among all eukaryotes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation (IPR009600, PIG-U) that PIGU is involved in attachment of the GPI anchor to protein. Consistent with the core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro PIG-U signature maps to the correct core biological process; this is the same well-supported function inferred by IBA and demonstrated experimentally.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA) complex, which recognizes and cleaves the C-terminal GPI attachment signal of precursor proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0042765" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation that PIGU is part of the GPI-anchor transamidase complex, consistent with experimental evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro PIG-U signature correctly maps PIGU to its complex; supported by biochemistry and cryo-EM structures.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPIT complex is known to be composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct annotation of a binary interaction (PIGU with KASH5/Q8N6L0) captured in the HuRI high-throughput yeast two-hybrid interactome map. protein binding is an uninformative molecular-function term and this specific interaction is not part of PIGU&#39;s established function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic protein binding term conveys no specific molecular function, and the single high-throughput Y2H interaction with KASH5 has no established role in GPI transamidase biology. Per curation policy this bare protein-binding IPI is marked as over-annotated rather than removed. PIGU&#39;s informative binding activity (GPI anchor binding) is captured by a separate annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">With approximately 53,000 protein-protein interactions, HuRI has approximately four times as many such interactions as there are high-quality curated interactions from small-scale studies</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0180046" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-based electronic annotation (Ensembl Compara, from rat Pigu) that PIGU is involved in GPI anchored protein biosynthesis. Consistent with the core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GPI anchored protein biosynthesis is the pathway that GPI-T (and therefore PIGU) participates in; the orthology transfer is appropriate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA) complex, which recognizes and cleaves the C-terminal GPI attachment signal of precursor proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000041
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0006506" data-r="GO_REF:0000041" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniPathway-based electronic annotation (UPA00196) to GPI anchor biosynthetic process. This is the pathway to which PIGU/GPI-T contributes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GPI transamidase step is part of GPI-anchor biosynthesis; the UniPathway mapping is correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a transmembrane complex composed of five subunits: GAAP1 (Gaa1p), PIGK (Gpi8p), PIGS (Gpi17p), PIGT (Gpi16p), and PIGU (Gab1p)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0005789" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation placing PIGU in the ER membrane, consistent with the established ER localization of GPI-T.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GPI anchoring occurs on the ER membrane and PIGU is a multi-pass ER membrane subunit; the ER membrane location is well established.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase mediates GPI anchoring in the endoplasmic reticulum</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among all eukaryotes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation that PIGU is involved in attachment of the GPI anchor to protein, the core process for the GPI transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Hong et al. established PIGU (PIG-U) as the fifth subunit of GPI transamidase, which attaches GPI anchors to proteins; this is the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-U and the yeast orthologue Cdc91p are the fifth component of GPI transamidase that may be involved in the recognition of either the GPI attachment signal or the lipid portion of GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0042765" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IPI annotation that PIGU is part of the GPI-anchor transamidase complex, based on affinity purification of the complex containing PIG-U.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GPI transamidase complex affinity-purified from cells contained PIG-U together with the four other known components, directly demonstrating complex membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase complex affinity-purified from cells expressing epitope-tagged-GPI8 contained PIG-U and four other known components</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0180046" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation (cryo-EM structure of the human GPI transamidase) that PIGU is involved in GPI anchored protein biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The structural study resolved PIGU as one of the five subunits of the ER GPI transamidase that is essential for maturation of GPI-anchored proteins.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed by the transmembrane GPI transamidase (GPIT) complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0180046" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation (cryo-EM of the equimolar heteropentameric human GPI-T) that PIGU is involved in GPI anchored protein biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The structure of the five-subunit ER GPI-T, including PIGU, supports its role in the biosynthesis of GPI-anchored proteins.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among all eukaryotes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034235" target="_blank" class="term-link">
+                                    GO:0034235
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0034235" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation that PIGU binds the GPI anchor. The liganded GPI-T structures show that PIGU contacts the GPI substrate, and UniProt records that PIGU binds the lipid portion of the GPI-anchor. This is the informative subunit-level molecular function of PIGU (distinct from the complex-level transamidase catalysis, which is performed by PIGK).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGU is the subunit thought to recognise and present the lipid GPI substrate; it binds the lipid portion of the GPI-anchor. GPI anchor binding is an informative molecular-function term consistent with the structural data and PIGU&#39;s homology to lipid-handling GPI biosynthetic enzymes.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGU/PIGU-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Binds the lipid portion of GPI-anchor (PubMed:37684232). May act as an</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGU is homologous with other GPI biosynthetic enzymes (such as PIGW and PIGM), suggesting that it recognizes the lipid portion of GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation that PIGU is involved in attachment of the GPI anchor to protein. Class U (PIGU-deficient) cells lack GPI transamidase activity and cannot cleave the GPI attachment signal peptide.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Loss of PIGU abolishes GPI transamidase activity in cells, directly demonstrating that PIGU is required for attachment of the GPI anchor to protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The class U cells accumulated mature and immature GPI and did not have in vitro GPI transamidase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31353022" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31353022
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in PIGU Impair the Function of the GPI Transamidas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="PMID:31353022" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation from the disease study that PIGU is involved in attachment of the GPI anchor to protein; PIGU is described as an essential component of the GPI transamidase complex, and pathogenic variants impair GPI-anchored protein surface expression.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Functional characterization of NEDBSS variants showed reduced GPI-anchored protein expression, confirming PIGU&#39;s essential role in GPI anchor attachment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31353022" target="_blank" class="term-link">
+                                        PMID:31353022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">An essential component of the GPI transamidase complex is PIGU, along with PIGK, PIGS, PIGT, and GPAA1, all of which link GPI-anchored proteins (GPI-APs) onto the GPI anchor in the endoplasmic reticulum (ER)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation that PIGU is involved in attachment of the GPI anchor to protein; mutagenesis of PIGU residues (Leu375/Trp376) reduced GPI-TA rescue activity, and loss of PIGU abolishes activity of the complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Functional analysis of GPI-TA subunits demonstrated that PIGU is required for transamidase activity and identified functionally important PIGU residues.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Lacking PIGU, other subunits (PIGK, GPAA1, PIGT and PIGS) still form a complex, but have no activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180046" target="_blank" class="term-link">
+                                    GO:0180046
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchored protein biosynthesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31353022" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31353022
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in PIGU Impair the Function of the GPI Transamidas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0180046" data-r="PMID:31353022" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation from the disease study that PIGU is involved in GPI anchored protein biosynthesis; variant cells show reduced surface GPI-anchored proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGU is required for biosynthesis/surface expression of GPI-anchored proteins, and biallelic PIGU variants cause an inherited GPI-anchor deficiency.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31353022" target="_blank" class="term-link">
+                                        PMID:31353022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">An essential component of the GPI transamidase complex is PIGU, along with PIGK, PIGS, PIGT, and GPAA1, all of which link GPI-anchored proteins (GPI-APs) onto the GPI anchor in the endoplasmic reticulum (ER)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation (liganded GPI-T structures) that PIGU is involved in attachment of the GPI anchor to protein, as a subunit of the transmembrane complex that adds GPI to proproteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The substrate- and product-bound GPI-T structures include PIGU as one of the five subunits that together carry out the transamidation reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a transmembrane complex composed of five subunits: GAAP1 (Gaa1p), PIGK (Gpi8p), PIGS (Gpi17p), PIGT (Gpi16p), and PIGU (Gab1p)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37684232
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of liganded glycosylphosphatidylinositol transami...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0042765" data-r="PMID:37684232" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation (cryo-EM) that PIGU is part of the GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The liganded GPI-T structures resolve PIGU as an integral subunit of the five-subunit complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                                        PMID:37684232
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a transmembrane complex composed of five subunits: GAAP1 (Gaa1p), PIGK (Gpi8p), PIGS (Gpi17p), PIGT (Gpi16p), and PIGU (Gab1p)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation (cryo-EM structure) that PIGU is involved in attachment of the GPI anchor to protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The human GPI-T structure, including PIGU, defines the transmembrane GPI substrate-binding cleft and supports the complex&#39;s role in attaching GPI to proteins.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Transmembrane helices constitute a widely opened cleft, which is located underneath PIGK, serving as a GPI substrate-binding site</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation (cryo-EM structure) that PIGU is involved in attachment of the GPI anchor to protein, as a subunit of the ER GPI transamidase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The equimolar heteropentameric GPI-T structure, including PIGU, supports its role in attaching GPI anchors to proproteins in the ER.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among all eukaryotes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35165458
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of human glycosylphosphatidylinositol transamidase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0042765" data-r="PMID:35165458" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation (cryo-EM) that PIGU is part of the GPI-anchor transamidase complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The human GPI-T structure directly resolves PIGU as one of the five subunits of the complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                                        PMID:35165458
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPIT complex is known to be composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35551457
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular insights into biogenesis of glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0042765" data-r="PMID:35551457" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation (cryo-EM) that PIGU is part of the GPI-anchor transamidase complex, an equimolar heteropentamer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The structure reveals an equimolar heteropentameric assembly that includes PIGU.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">revealing an equimolar heteropentameric assembly</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34576938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional Analysis of the GPI Transamidase Complex by Scree...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0042765" data-r="PMID:34576938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation that PIGU is part of the GPI-anchor transamidase complex, which was purified with all five subunits including PIGU.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GPI-TA consists of five subunits including PIGU, and the purified complex contained all five; PIGU is a bona fide member.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                        PMID:34576938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU, and the absence of any subunit leads to the loss of activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016020" data-r="PMID:19946888" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomics (membrane proteome of an NK-like cell line) detected PIGU in the membrane fraction. Correct but non-specific relative to the ER membrane annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with PIGU being an integral membrane protein, but membrane is a broad parent term; the specific ER membrane location is better supported. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mass spectrometric analysis identified 1843 proteins with high confidence scores</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162836
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0005789" data-r="Reactome:R-HSA-162836" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement annotation placing PIGU in the ER membrane in the context of the GPI-anchor attachment reaction. Consistent with the established localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GPI anchoring occurs on the ER membrane; the Reactome pathway correctly localizes PIGU there.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among all eukaryotes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype annotation: PIGU-deficient (class U) cells cannot attach GPI anchors to proteins and lack transamidase activity, demonstrating PIGU&#39;s requirement in this process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Class U cells accumulate GPI and lack GPI transamidase activity, and cannot cleave the GPI attachment signal peptide, directly implicating PIGU in GPI anchor attachment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The class U cells accumulated mature and immature GPI and did not have in vitro GPI transamidase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034235" target="_blank" class="term-link">
+                                    GO:0034235
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0034235" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype annotation (contributes_to) that PIGU contributes to GPI anchor binding within the transamidase complex. Hong et al. proposed that PIG-U/Cdc91p is involved in recognition of the lipid portion of GPI.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The contributes_to qualifier is appropriate for an accessory subunit: PIGU is proposed to recognise the lipid portion of the GPI substrate as part of the complex, consistent with later structural evidence that PIGU binds the lipid portion of the GPI-anchor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-U and the yeast orthologue Cdc91p are the fifth component of GPI transamidase that may be involved in the recognition of either the GPI attachment signal or the lipid portion of GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                                    GO:0042765
+                                </a>
+                            </span>
+                            <span class="term-label">GPI-anchor transamidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12802054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human PIG-U and yeast Cdc91p are the fifth subunit of GPI tr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0042765" data-r="PMID:12802054" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation that PIGU is part of the GPI-anchor transamidase complex, based on affinity purification of the complex containing PIG-U and four other components.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The affinity-purified GPI transamidase complex contained PIG-U together with the four other known subunits, directly demonstrating complex membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                                        PMID:12802054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase complex affinity-purified from cells expressing epitope-tagged-GPI8 contained PIG-U and four other known components</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15034568" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15034568
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CDC91L1 (PIG-U) is a newly discovered oncogene in human blad...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0005886" data-r="PMID:15034568" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation to plasma membrane from the bladder-cancer oncogene study of overexpressed CDC91L1 (PIG-U). PIGU is an ER-resident, multi-pass ER membrane protein; its established site of action is the ER membrane, not the plasma membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Later biochemical and structural work firmly localizes PIGU/GPI-T to the ER membrane, where GPI anchoring occurs; the plasma membrane localization does not represent PIGU&#39;s core function and likely reflects the overexpression/oncogene context. Per curation policy this experimental annotation is marked as over-annotated rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                                        PMID:35551457
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among all eukaryotes</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15034568" target="_blank" class="term-link">
+                                        PMID:15034568
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a transamidase complex unit in the glycosylphosphatidylinositol (GPI) anchoring pathway</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15034568" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15034568
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CDC91L1 (PIG-U) is a newly discovered oncogene in human blad...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0006506" data-r="PMID:15034568" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation that PIGU is involved in GPI anchor biosynthetic process, from the bladder-cancer study describing PIG-U as a transamidase-complex unit in the GPI anchoring pathway. Consistent with PIGU&#39;s core role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIG-U is described as a transamidase-complex unit in the GPI anchoring pathway; this is the correct, core biosynthetic process, corroborated by all subsequent work.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15034568" target="_blank" class="term-link">
+                                        PMID:15034568
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a transamidase complex unit in the glycosylphosphatidylinositol (GPI) anchoring pathway</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046425" target="_blank" class="term-link">
+                                    GO:0046425
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of receptor signaling pathway via JAK-STAT</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15034568" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15034568
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CDC91L1 (PIG-U) is a newly discovered oncogene in human blad...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0046425" data-r="PMID:15034568" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation derived from the bladder-cancer study, where PIG-U overexpression upregulated the GPI-anchored urokinase receptor (uPAR) and increased STAT-3 phosphorylation. This is a downstream, indirect consequence of aberrant PIGU overexpression, not a core direct molecular activity of PIGU.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGU has no direct role in JAK-STAT signaling; the observed STAT-3 phosphorylation is an indirect effect of increased surface uPAR (a GPI-anchored protein) upon PIG-U overexpression in cancer cells. This reflects a pathological overexpression phenotype rather than PIGU&#39;s normal function, so it is marked as over-annotated (kept, not removed, per policy for experimental annotations).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15034568" target="_blank" class="term-link">
+                                        PMID:15034568
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Overexpression of CDC91L1 also resulted in upregulation of the urokinase receptor (uPAR), a GPI-anchored protein, and in turn increased STAT-3 phosphorylation in bladder cancer cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                    GO:0016255
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of GPI anchor to protein</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11483512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-S and PIG-T, essential for GPI anchor attachment to prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H490" data-a="GO:0016255" data-r="PMID:11483512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement annotation that PIGU is involved in attachment of the GPI anchor to protein. This paper describes the GPI transamidase complex (GAA1, GPI8, PIG-S, PIG-T) that mediates GPI anchoring in the ER; PIGU was later identified as the fifth subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GPI transamidase attaches GPI anchors to proteins in the ER by replacing the C-terminal GPI attachment signal peptide with a pre-assembled GPI; PIGU is an essential subunit of this complex. The core process is correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                                        PMID:11483512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI transamidase mediates GPI anchoring in the endoplasmic reticulum, by replacing a protein&#39;s C-terminal GPI attachment signal peptide with a pre-assembled GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As a non-catalytic accessory subunit of the ER GPI transamidase (GPI-T) complex, PIGU binds the lipid portion of the GPI substrate and contributes to attachment of the pre-assembled GPI anchor to the C-terminus of proprotein substrates, generating mature GPI-anchored proteins.</h3>
+                <span class="vote-buttons" data-g="Q9H490" data-a="FUNCTION: As a non-catalytic accessory subunit of the ER GPI..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034235" target="_blank" class="term-link">
+                            GPI anchor binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016255" target="_blank" class="term-link">
+                                attachment of GPI anchor to protein
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042765" target="_blank" class="term-link">
+                            GPI-anchor transamidase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                PMID:34576938
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU, and the absence of any subunit leads to the loss of activity</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                                PMID:34576938
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PIGU is homologous with other GPI biosynthetic enzymes (such as PIGW and PIGM), suggesting that it recognizes the lipid portion of GPI</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGU/PIGU-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Binds the lipid portion of GPI-anchor (PubMed:37684232). May act as an</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000041.md" target="_blank" class="term-link">
+                            GO_REF:0000041
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniPathway vocabulary mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11483512" target="_blank" class="term-link">
+                            PMID:11483512
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a complex with GAA1 and GPI8.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12802054" target="_blank" class="term-link">
+                            PMID:12802054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human PIG-U and yeast Cdc91p are the fifth subunit of GPI transamidase that attaches GPI-anchors to proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15034568" target="_blank" class="term-link">
+                            PMID:15034568
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CDC91L1 (PIG-U) is a newly discovered oncogene in human bladder cancer.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31353022" target="_blank" class="term-link">
+                            PMID:31353022
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in PIGU Impair the Function of the GPI Transamidase Complex, Causing Severe Intellectual Disability, Epilepsy, and Brain Anomalies.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34576938" target="_blank" class="term-link">
+                            PMID:34576938
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional Analysis of the GPI Transamidase Complex by Screening for Amino Acid Mutations in Each Subunit.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35165458" target="_blank" class="term-link">
+                            PMID:35165458
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of human glycosylphosphatidylinositol transamidase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35551457" target="_blank" class="term-link">
+                            PMID:35551457
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular insights into biogenesis of glycosylphosphatidylinositol anchor proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37684232" target="_blank" class="term-link">
+                            PMID:37684232
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structures of liganded glycosylphosphatidylinositol transamidase illuminate GPI-AP biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162836
+
+                    </span>
+                </div>
+
+                <div class="reference-title">uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + uPAR propeptide</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGU/PIGU-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry PIGU_HUMAN (Q9H490)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGU-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9H490" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigu-q9h490-review-notes">PIGU (Q9H490) review notes</h1>
+<h2 id="summary-of-verified-biology">Summary of verified biology</h2>
+<p>PIGU (GPI-anchor transamidase component PIG-U; CDC91L1) is one of five subunits of the<br />
+glycosylphosphatidylinositol (GPI) transamidase (GPI-T) complex — PIGK, GPAA1, PIGT, PIGS, PIGU.<br />
+GPI-T is an ER-membrane complex that removes the C-terminal GPI-attachment signal peptide of<br />
+proprotein substrates and covalently attaches a pre-assembled GPI anchor to the newly exposed<br />
+C-terminus (the ω-site) in the ER lumen. PIGK is the catalytic (cysteine-protease/legumain-like)<br />
+subunit; GPAA1 is proposed to form the amide bond. PIGU is a <strong>non-catalytic accessory subunit</strong>:<br />
+it is a multi-pass ER membrane protein that binds the lipid portion of the GPI substrate and is<br />
+thought to help recognise/present the lipid GPI and to organise the transmembrane layer of the<br />
+complex (recruiting other subunits). Cells lacking PIGU still assemble the other four subunits but<br />
+have no transamidase activity.</p>
+<h2 id="key-provenance">Key provenance</h2>
+<ul>
+<li>Five-subunit complex, ER, PIGU = fifth subunit; class-U mutant cells accumulate GPI, lack in-vitro<br />
+  transamidase activity, and lose ability to cleave the GPI attachment signal peptide<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12802054" title="PIG-U and the yeast orthologue Cdc91p are the fifth component of GPI transamidase that may be involved in the recognition of either the GPI attachment signal or the lipid portion of GPI">PMID:12802054</a>;<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12802054" title="The class U cells accumulated mature and immature GPI and did not have in vitro GPI transamidase activity">PMID:12802054</a>.</li>
+<li>GPI-T is ER-membrane, replaces C-terminal GPI attachment signal with pre-assembled GPI<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11483512" title="The GPI transamidase mediates GPI anchoring in the endoplasmic reticulum, by replacing a protein's C-terminal GPI attachment signal peptide with a pre-assembled GPI">PMID:11483512</a>.</li>
+<li>Five subunits, PIGK catalytic, PIGU recognises lipid portion of GPI, loss of PIGU abolishes activity<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/34576938" title="PIGU is homologous with other GPI biosynthetic enzymes (such as PIGW and PIGM), suggesting that it recognizes the lipid portion of GPI">PMID:34576938</a>;<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/34576938" title="Lacking PIGU, other subunits (PIGK, GPAA1, PIGT and PIGS) still form a complex, but have no activity">PMID:34576938</a>.</li>
+<li>Cryo-EM structure of five-subunit human GPI-T; PIGK catalytic; TM cleft = GPI substrate-binding site<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/35165458" title="The GPIT complex is known to be composed of five subunits: PIGK, PIGU, PIGT, PIGS and GPAA1">PMID:35165458</a>.</li>
+<li>Equimolar heteropentamer, ER-membrane GPI-T conserved among eukaryotes<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/35551457" title="an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among all eukaryotes">PMID:35551457</a>;<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/35551457" title="revealing an equimolar heteropentameric assembly">PMID:35551457</a>.</li>
+<li>Liganded GPI-T structures; GPI binds GPI-T; PIGU is one of the five subunits contacting GPI<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/37684232" title="The glycolipid is then added to the proproteins by the GPI transamidase (GPI-T), a transmembrane complex composed of five subunits">PMID:37684232</a>.</li>
+<li>Disease: biallelic PIGU variants cause NEDBSS / inherited GPI-anchor deficiency (GPIBD) with<br />
+  developmental delay, intellectual disability, epilepsy, brain anomalies<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31353022" title="An essential component of the GPI transamidase complex is PIGU, along with PIGK, PIGS, PIGT, and GPAA1, all of which link GPI-anchored proteins (GPI-APs) onto the GPI anchor in the endoplasmic reticulum (ER)">PMID:31353022</a>.</li>
+</ul>
+<h2 id="annotation-decisions-high-level">Annotation decisions (high-level)</h2>
+<ul>
+<li>Core: BP = GPI anchor biosynthetic process (GO:0006506) / attachment of GPI anchor to protein<br />
+  (GO:0016255); CC = ER membrane (GO:0005789) + GPI-anchor transamidase complex (GO:0042765).</li>
+<li>MF: GOA carries NO catalytic MF for PIGU. The only MF terms are <code>protein binding</code> (GO:0005515, IPI,<br />
+  HuRI high-throughput — mark over-annotated) and <code>GPI anchor binding</code> (GO:0034235, IDA/IMP —<br />
+  accept as a subunit-level binding activity, PIGU binds the lipid portion of GPI). Note: UniProt DR<br />
+  block lists an IBA <code>GPI-anchor transamidase activity</code> (GO:0003923) but it is NOT in the GOA TSV, so<br />
+  it is not reviewed here and NOT invented as a core function (PIGU is non-catalytic).</li>
+<li><code>plasma membrane</code> (GO:0005886, IDA, PMID:15034568) and <code>regulation of receptor signaling pathway
+  via JAK-STAT</code> (GO:0046425, IDA, PMID:15034568): from the bladder-cancer oncogene paper. These are<br />
+  downstream/indirect consequences of PIGU overexpression (uPAR up, STAT3 phosphorylation), not the<br />
+  core ER-lumenal biosynthetic function. PIGU itself is an ER-membrane protein, not a PM protein;<br />
+  the paper reports overexpression effects. Mark over-annotated / non-core rather than core.</li>
+<li><code>membrane</code> (GO:0016020) IEA/HDA: correct but non-informative parent of ER membrane; keep as<br />
+  non-core.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9H490
+gene_symbol: PIGU
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PIGU (GPI-anchor transamidase component PIG-U; also called CDC91L1) is a multi-pass
+  endoplasmic reticulum membrane protein that is one of the five subunits of the
+  glycosylphosphatidylinositol (GPI) transamidase (GPI-T) complex, together with the
+  catalytic subunit PIGK and the accessory subunits GPAA1, PIGT and PIGS. GPI-T acts in
+  the ER lumen to remove the C-terminal GPI-attachment signal peptide from proprotein
+  substrates and covalently attach a pre-assembled GPI anchor at the newly exposed
+  C-terminus (the omega-site), thereby generating mature GPI-anchored proteins. PIGU is a
+  non-catalytic, accessory subunit: it binds the lipid portion of the GPI substrate and is
+  thought to help recognise and present the lipid GPI, and to organise the transmembrane
+  layer of the complex by recruiting the other subunits; cells lacking PIGU still assemble
+  the remaining four subunits but have no transamidase activity. Biallelic loss-of-function
+  variants in PIGU cause an inherited GPI-anchor deficiency (a GPI biosynthesis deficiency,
+  GPIBD), a neurodevelopmental disorder with developmental delay, intellectual disability,
+  epilepsy and brain anomalies.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q9H490-1
+- name: &#39;2&#39;
+  id: Q9H490-2
+  sequence_note: VSP_009543
+existing_annotations:
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically-inferred annotation that PIGU participates in attachment of the GPI
+      anchor to protein. This is the core biological process of PIGU as a subunit of the
+      GPI transamidase complex, well supported by experimental and structural work.
+    action: ACCEPT
+    reason: &gt;-
+      PIGU is an essential subunit of the ER GPI transamidase complex, whose function is to
+      attach pre-assembled GPI anchors to the C-terminus of proprotein substrates. The IBA
+      is at the correct level of specificity for this shared ancestral function.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA) complex,
+        which recognizes and cleaves the C-terminal GPI attachment signal of precursor
+        proteins
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        posttranslationally attached to the carboxyl-terminus by GPI transamidase
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Phylogenetically-inferred annotation that PIGU is part of the GPI-anchor transamidase
+      complex. This is the core cellular-component annotation for PIGU.
+    action: ACCEPT
+    reason: &gt;-
+      PIGU is one of the five conserved subunits of the GPI transamidase complex (PIGK,
+      GPAA1, PIGT, PIGS, PIGU), confirmed biochemically and by cryo-EM structures.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU, and the absence
+        of any subunit leads to the loss of activity
+    - reference_id: PMID:35165458
+      supporting_text: &gt;-
+        The GPIT complex is known to be composed of five subunits: PIGK, PIGU, PIGT, PIGS
+        and GPAA1
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation (UniProt Subcellular Location mapping) placing PIGU in the ER
+      membrane. This matches the experimentally established localization of GPI-T.
+    action: ACCEPT
+    reason: &gt;-
+      PIGU is a multi-pass ER membrane protein; GPI anchoring occurs in the ER. The IEA
+      subcellular-location mapping is correct and specific.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among
+        all eukaryotes
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation to the generic parent term membrane. Correct but
+      uninformative given the specific ER membrane annotation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      PIGU is an integral membrane protein, so membrane is not wrong, but it is a broad
+      parent of the more specific and better-supported endoplasmic reticulum membrane
+      (GO:0005789) annotation. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among
+        all eukaryotes
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation (IPR009600, PIG-U) that PIGU is involved in
+      attachment of the GPI anchor to protein. Consistent with the core function.
+    action: ACCEPT
+    reason: &gt;-
+      The InterPro PIG-U signature maps to the correct core biological process; this is the
+      same well-supported function inferred by IBA and demonstrated experimentally.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA) complex,
+        which recognizes and cleaves the C-terminal GPI attachment signal of precursor
+        proteins
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation that PIGU is part of the GPI-anchor transamidase
+      complex, consistent with experimental evidence.
+    action: ACCEPT
+    reason: &gt;-
+      The InterPro PIG-U signature correctly maps PIGU to its complex; supported by
+      biochemistry and cryo-EM structures.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: &gt;-
+        The GPIT complex is known to be composed of five subunits: PIGK, PIGU, PIGT, PIGS
+        and GPAA1
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct annotation of a binary interaction (PIGU with KASH5/Q8N6L0) captured in the
+      HuRI high-throughput yeast two-hybrid interactome map. protein binding is an
+      uninformative molecular-function term and this specific interaction is not part of
+      PIGU&#39;s established function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The generic protein binding term conveys no specific molecular function, and the
+      single high-throughput Y2H interaction with KASH5 has no established role in GPI
+      transamidase biology. Per curation policy this bare protein-binding IPI is marked as
+      over-annotated rather than removed. PIGU&#39;s informative binding activity (GPI anchor
+      binding) is captured by a separate annotation.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &gt;-
+        With approximately 53,000 protein-protein interactions, HuRI has approximately four
+        times as many such interactions as there are high-quality curated interactions from
+        small-scale studies
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-based electronic annotation (Ensembl Compara, from rat Pigu) that PIGU is
+      involved in GPI anchored protein biosynthesis. Consistent with the core function.
+    action: ACCEPT
+    reason: &gt;-
+      GPI anchored protein biosynthesis is the pathway that GPI-T (and therefore PIGU)
+      participates in; the orthology transfer is appropriate.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        Attachment of GPI to proteins is mediated by the GPI-transamidase (GPI-TA) complex,
+        which recognizes and cleaves the C-terminal GPI attachment signal of precursor
+        proteins
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000041
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      UniPathway-based electronic annotation (UPA00196) to GPI anchor biosynthetic process.
+      This is the pathway to which PIGU/GPI-T contributes.
+    action: ACCEPT
+    reason: &gt;-
+      The GPI transamidase step is part of GPI-anchor biosynthesis; the UniPathway mapping
+      is correct.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: &gt;-
+        a transmembrane complex composed of five subunits: GAAP1 (Gaa1p), PIGK (Gpi8p),
+        PIGS (Gpi17p), PIGT (Gpi16p), and PIGU (Gab1p)
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:12802054
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ComplexPortal NAS annotation placing PIGU in the ER membrane, consistent with the
+      established ER localization of GPI-T.
+    action: ACCEPT
+    reason: &gt;-
+      GPI anchoring occurs on the ER membrane and PIGU is a multi-pass ER membrane subunit;
+      the ER membrane location is well established.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: &gt;-
+        The GPI transamidase mediates GPI anchoring in the endoplasmic reticulum
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among
+        all eukaryotes
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: NAS
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal NAS annotation that PIGU is involved in attachment of the GPI anchor to
+      protein, the core process for the GPI transamidase complex.
+    action: ACCEPT
+    reason: &gt;-
+      Hong et al. established PIGU (PIG-U) as the fifth subunit of GPI transamidase, which
+      attaches GPI anchors to proteins; this is the core function.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        PIG-U and the yeast orthologue Cdc91p are the fifth component of GPI transamidase
+        that may be involved in the recognition of either the GPI attachment signal or the
+        lipid portion of GPI
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IPI
+  original_reference_id: PMID:12802054
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ComplexPortal IPI annotation that PIGU is part of the GPI-anchor transamidase complex,
+      based on affinity purification of the complex containing PIG-U.
+    action: ACCEPT
+    reason: &gt;-
+      The GPI transamidase complex affinity-purified from cells contained PIG-U together
+      with the four other known components, directly demonstrating complex membership.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        The GPI transamidase complex affinity-purified from cells expressing
+        epitope-tagged-GPI8 contained PIG-U and four other known components
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct-assay annotation (cryo-EM structure of the human GPI transamidase) that PIGU is
+      involved in GPI anchored protein biosynthesis.
+    action: ACCEPT
+    reason: &gt;-
+      The structural study resolved PIGU as one of the five subunits of the ER GPI
+      transamidase that is essential for maturation of GPI-anchored proteins.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: &gt;-
+        Attaching GPI to the protein in the endoplasmic reticulum (ER) is catalyzed by the
+        transmembrane GPI transamidase (GPIT) complex
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct-assay annotation (cryo-EM of the equimolar heteropentameric human GPI-T) that
+      PIGU is involved in GPI anchored protein biosynthesis.
+    action: ACCEPT
+    reason: &gt;-
+      The structure of the five-subunit ER GPI-T, including PIGU, supports its role in the
+      biosynthesis of GPI-anchored proteins.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among
+        all eukaryotes
+- term:
+    id: GO:0034235
+    label: GPI anchor binding
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct-assay annotation that PIGU binds the GPI anchor. The liganded GPI-T structures
+      show that PIGU contacts the GPI substrate, and UniProt records that PIGU binds the
+      lipid portion of the GPI-anchor. This is the informative subunit-level molecular
+      function of PIGU (distinct from the complex-level transamidase catalysis, which is
+      performed by PIGK).
+    action: ACCEPT
+    reason: &gt;-
+      PIGU is the subunit thought to recognise and present the lipid GPI substrate; it binds
+      the lipid portion of the GPI-anchor. GPI anchor binding is an informative
+      molecular-function term consistent with the structural data and PIGU&#39;s homology to
+      lipid-handling GPI biosynthetic enzymes.
+    supported_by:
+    - reference_id: file:human/PIGU/PIGU-uniprot.txt
+      supporting_text: &gt;-
+        Binds the lipid portion of GPI-anchor (PubMed:37684232). May act as an
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        PIGU is homologous with other GPI biosynthetic enzymes (such as PIGW and PIGM),
+        suggesting that it recognizes the lipid portion of GPI
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct-assay annotation that PIGU is involved in attachment of the GPI anchor to
+      protein. Class U (PIGU-deficient) cells lack GPI transamidase activity and cannot
+      cleave the GPI attachment signal peptide.
+    action: ACCEPT
+    reason: &gt;-
+      Loss of PIGU abolishes GPI transamidase activity in cells, directly demonstrating that
+      PIGU is required for attachment of the GPI anchor to protein.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        The class U cells accumulated mature and immature GPI and did not have in vitro GPI
+        transamidase activity
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:31353022
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct-assay annotation from the disease study that PIGU is involved in attachment of
+      the GPI anchor to protein; PIGU is described as an essential component of the GPI
+      transamidase complex, and pathogenic variants impair GPI-anchored protein surface
+      expression.
+    action: ACCEPT
+    reason: &gt;-
+      Functional characterization of NEDBSS variants showed reduced GPI-anchored protein
+      expression, confirming PIGU&#39;s essential role in GPI anchor attachment.
+    supported_by:
+    - reference_id: PMID:31353022
+      supporting_text: &gt;-
+        An essential component of the GPI transamidase complex is PIGU, along with PIGK,
+        PIGS, PIGT, and GPAA1, all of which link GPI-anchored proteins (GPI-APs) onto the GPI
+        anchor in the endoplasmic reticulum (ER)
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct-assay annotation that PIGU is involved in attachment of the GPI anchor to
+      protein; mutagenesis of PIGU residues (Leu375/Trp376) reduced GPI-TA rescue activity,
+      and loss of PIGU abolishes activity of the complex.
+    action: ACCEPT
+    reason: &gt;-
+      Functional analysis of GPI-TA subunits demonstrated that PIGU is required for
+      transamidase activity and identified functionally important PIGU residues.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        Lacking PIGU, other subunits (PIGK, GPAA1, PIGT and PIGS) still form a complex, but
+        have no activity
+- term:
+    id: GO:0180046
+    label: GPI anchored protein biosynthesis
+  evidence_type: IDA
+  original_reference_id: PMID:31353022
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct-assay annotation from the disease study that PIGU is involved in GPI anchored
+      protein biosynthesis; variant cells show reduced surface GPI-anchored proteins.
+    action: ACCEPT
+    reason: &gt;-
+      PIGU is required for biosynthesis/surface expression of GPI-anchored proteins, and
+      biallelic PIGU variants cause an inherited GPI-anchor deficiency.
+    supported_by:
+    - reference_id: PMID:31353022
+      supporting_text: &gt;-
+        An essential component of the GPI transamidase complex is PIGU, along with PIGK,
+        PIGS, PIGT, and GPAA1, all of which link GPI-anchored proteins (GPI-APs) onto the GPI
+        anchor in the endoplasmic reticulum (ER)
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct-assay annotation (liganded GPI-T structures) that PIGU is involved in
+      attachment of the GPI anchor to protein, as a subunit of the transmembrane complex
+      that adds GPI to proproteins.
+    action: ACCEPT
+    reason: &gt;-
+      The substrate- and product-bound GPI-T structures include PIGU as one of the five
+      subunits that together carry out the transamidation reaction.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: &gt;-
+        a transmembrane complex composed of five subunits: GAAP1 (Gaa1p), PIGK (Gpi8p),
+        PIGS (Gpi17p), PIGT (Gpi16p), and PIGU (Gab1p)
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:37684232
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct-assay annotation (cryo-EM) that PIGU is part of the GPI-anchor transamidase
+      complex.
+    action: ACCEPT
+    reason: &gt;-
+      The liganded GPI-T structures resolve PIGU as an integral subunit of the five-subunit
+      complex.
+    supported_by:
+    - reference_id: PMID:37684232
+      supporting_text: &gt;-
+        a transmembrane complex composed of five subunits: GAAP1 (Gaa1p), PIGK (Gpi8p),
+        PIGS (Gpi17p), PIGT (Gpi16p), and PIGU (Gab1p)
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct-assay annotation (cryo-EM structure) that PIGU is involved in attachment of the
+      GPI anchor to protein.
+    action: ACCEPT
+    reason: &gt;-
+      The human GPI-T structure, including PIGU, defines the transmembrane GPI
+      substrate-binding cleft and supports the complex&#39;s role in attaching GPI to proteins.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: &gt;-
+        Transmembrane helices constitute a widely opened cleft, which is located underneath
+        PIGK, serving as a GPI substrate-binding site
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct-assay annotation (cryo-EM structure) that PIGU is involved in attachment of the
+      GPI anchor to protein, as a subunit of the ER GPI transamidase.
+    action: ACCEPT
+    reason: &gt;-
+      The equimolar heteropentameric GPI-T structure, including PIGU, supports its role in
+      attaching GPI anchors to proproteins in the ER.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among
+        all eukaryotes
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:35165458
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct-assay annotation (cryo-EM) that PIGU is part of the GPI-anchor transamidase
+      complex.
+    action: ACCEPT
+    reason: &gt;-
+      The human GPI-T structure directly resolves PIGU as one of the five subunits of the
+      complex.
+    supported_by:
+    - reference_id: PMID:35165458
+      supporting_text: &gt;-
+        The GPIT complex is known to be composed of five subunits: PIGK, PIGU, PIGT, PIGS
+        and GPAA1
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:35551457
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct-assay annotation (cryo-EM) that PIGU is part of the GPI-anchor transamidase
+      complex, an equimolar heteropentamer.
+    action: ACCEPT
+    reason: &gt;-
+      The structure reveals an equimolar heteropentameric assembly that includes PIGU.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        revealing an equimolar heteropentameric assembly
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:34576938
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct-assay annotation that PIGU is part of the GPI-anchor transamidase complex,
+      which was purified with all five subunits including PIGU.
+    action: ACCEPT
+    reason: &gt;-
+      GPI-TA consists of five subunits including PIGU, and the purified complex contained
+      all five; PIGU is a bona fide member.
+    supported_by:
+    - reference_id: PMID:34576938
+      supporting_text: &gt;-
+        GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU, and the absence
+        of any subunit leads to the loss of activity
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomics (membrane proteome of an NK-like cell line) detected PIGU in
+      the membrane fraction. Correct but non-specific relative to the ER membrane annotation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent with PIGU being an integral membrane protein, but membrane is a broad parent
+      term; the specific ER membrane location is better supported. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: &gt;-
+        Mass spectrometric analysis identified 1843 proteins with high confidence scores
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162836
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement annotation placing PIGU in the ER membrane in the
+      context of the GPI-anchor attachment reaction. Consistent with the established
+      localization.
+    action: ACCEPT
+    reason: &gt;-
+      GPI anchoring occurs on the ER membrane; the Reactome pathway correctly localizes PIGU
+      there.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among
+        all eukaryotes
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: IMP
+  original_reference_id: PMID:12802054
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mutant-phenotype annotation: PIGU-deficient (class U) cells cannot attach GPI anchors to
+      proteins and lack transamidase activity, demonstrating PIGU&#39;s requirement in this
+      process.
+    action: ACCEPT
+    reason: &gt;-
+      Class U cells accumulate GPI and lack GPI transamidase activity, and cannot cleave the
+      GPI attachment signal peptide, directly implicating PIGU in GPI anchor attachment.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        The class U cells accumulated mature and immature GPI and did not have in vitro GPI
+        transamidase activity
+- term:
+    id: GO:0034235
+    label: GPI anchor binding
+  evidence_type: IMP
+  original_reference_id: PMID:12802054
+  qualifier: contributes_to
+  review:
+    summary: &gt;-
+      Mutant-phenotype annotation (contributes_to) that PIGU contributes to GPI anchor
+      binding within the transamidase complex. Hong et al. proposed that PIG-U/Cdc91p is
+      involved in recognition of the lipid portion of GPI.
+    action: ACCEPT
+    reason: &gt;-
+      The contributes_to qualifier is appropriate for an accessory subunit: PIGU is proposed
+      to recognise the lipid portion of the GPI substrate as part of the complex, consistent
+      with later structural evidence that PIGU binds the lipid portion of the GPI-anchor.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        PIG-U and the yeast orthologue Cdc91p are the fifth component of GPI transamidase
+        that may be involved in the recognition of either the GPI attachment signal or the
+        lipid portion of GPI
+- term:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12802054
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct-assay annotation that PIGU is part of the GPI-anchor transamidase complex,
+      based on affinity purification of the complex containing PIG-U and four other
+      components.
+    action: ACCEPT
+    reason: &gt;-
+      The affinity-purified GPI transamidase complex contained PIG-U together with the four
+      other known subunits, directly demonstrating complex membership.
+    supported_by:
+    - reference_id: PMID:12802054
+      supporting_text: &gt;-
+        The GPI transamidase complex affinity-purified from cells expressing
+        epitope-tagged-GPI8 contained PIG-U and four other known components
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IDA
+  original_reference_id: PMID:15034568
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Annotation to plasma membrane from the bladder-cancer oncogene study of overexpressed
+      CDC91L1 (PIG-U). PIGU is an ER-resident, multi-pass ER membrane protein; its
+      established site of action is the ER membrane, not the plasma membrane.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Later biochemical and structural work firmly localizes PIGU/GPI-T to the ER membrane,
+      where GPI anchoring occurs; the plasma membrane localization does not represent PIGU&#39;s
+      core function and likely reflects the overexpression/oncogene context. Per curation
+      policy this experimental annotation is marked as over-annotated rather than removed.
+    supported_by:
+    - reference_id: PMID:35551457
+      supporting_text: &gt;-
+        an endoplasmic reticulum membrane GPI transamidase complex (GPI-T) conserved among
+        all eukaryotes
+    - reference_id: PMID:15034568
+      supporting_text: &gt;-
+        a transamidase complex unit in the glycosylphosphatidylinositol (GPI) anchoring
+        pathway
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:15034568
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Annotation that PIGU is involved in GPI anchor biosynthetic process, from the
+      bladder-cancer study describing PIG-U as a transamidase-complex unit in the GPI
+      anchoring pathway. Consistent with PIGU&#39;s core role.
+    action: ACCEPT
+    reason: &gt;-
+      PIG-U is described as a transamidase-complex unit in the GPI anchoring pathway; this is
+      the correct, core biosynthetic process, corroborated by all subsequent work.
+    supported_by:
+    - reference_id: PMID:15034568
+      supporting_text: &gt;-
+        a transamidase complex unit in the glycosylphosphatidylinositol (GPI) anchoring
+        pathway
+- term:
+    id: GO:0046425
+    label: regulation of receptor signaling pathway via JAK-STAT
+  evidence_type: IDA
+  original_reference_id: PMID:15034568
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Annotation derived from the bladder-cancer study, where PIG-U overexpression upregulated
+      the GPI-anchored urokinase receptor (uPAR) and increased STAT-3 phosphorylation. This is
+      a downstream, indirect consequence of aberrant PIGU overexpression, not a core direct
+      molecular activity of PIGU.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      PIGU has no direct role in JAK-STAT signaling; the observed STAT-3 phosphorylation is an
+      indirect effect of increased surface uPAR (a GPI-anchored protein) upon PIG-U
+      overexpression in cancer cells. This reflects a pathological overexpression phenotype
+      rather than PIGU&#39;s normal function, so it is marked as over-annotated (kept, not
+      removed, per policy for experimental annotations).
+    supported_by:
+    - reference_id: PMID:15034568
+      supporting_text: &gt;-
+        Overexpression of CDC91L1 also resulted in upregulation of the urokinase receptor
+        (uPAR), a GPI-anchored protein, and in turn increased STAT-3 phosphorylation in
+        bladder cancer cells
+- term:
+    id: GO:0016255
+    label: attachment of GPI anchor to protein
+  evidence_type: TAS
+  original_reference_id: PMID:11483512
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Traceable-author-statement annotation that PIGU is involved in attachment of the GPI
+      anchor to protein. This paper describes the GPI transamidase complex (GAA1, GPI8,
+      PIG-S, PIG-T) that mediates GPI anchoring in the ER; PIGU was later identified as the
+      fifth subunit.
+    action: ACCEPT
+    reason: &gt;-
+      The GPI transamidase attaches GPI anchors to proteins in the ER by replacing the
+      C-terminal GPI attachment signal peptide with a pre-assembled GPI; PIGU is an essential
+      subunit of this complex. The core process is correct.
+    supported_by:
+    - reference_id: PMID:11483512
+      supporting_text: &gt;-
+        The GPI transamidase mediates GPI anchoring in the endoplasmic reticulum, by
+        replacing a protein&#39;s C-terminal GPI attachment signal peptide with a pre-assembled
+        GPI
+core_functions:
+- description: &gt;-
+    As a non-catalytic accessory subunit of the ER GPI transamidase (GPI-T) complex, PIGU
+    binds the lipid portion of the GPI substrate and contributes to attachment of the
+    pre-assembled GPI anchor to the C-terminus of proprotein substrates, generating mature
+    GPI-anchored proteins.
+  molecular_function:
+    id: GO:0034235
+    label: GPI anchor binding
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  - id: GO:0016255
+    label: attachment of GPI anchor to protein
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:0042765
+    label: GPI-anchor transamidase complex
+  supported_by:
+  - reference_id: PMID:34576938
+    supporting_text: &gt;-
+      GPI-TA consists of five subunits: PIGK, GPAA1, PIGT, PIGS, and PIGU, and the absence of
+      any subunit leads to the loss of activity
+  - reference_id: PMID:34576938
+    supporting_text: &gt;-
+      PIGU is homologous with other GPI biosynthetic enzymes (such as PIGW and PIGM),
+      suggesting that it recognizes the lipid portion of GPI
+  - reference_id: file:human/PIGU/PIGU-uniprot.txt
+    supporting_text: &gt;-
+      Binds the lipid portion of GPI-anchor (PubMed:37684232). May act as an
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000041
+  title: Gene Ontology annotation based on UniPathway vocabulary mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: PMID:11483512
+  title: PIG-S and PIG-T, essential for GPI anchor attachment to proteins, form a
+    complex with GAA1 and GPI8.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Establishes the GPI transamidase complex (GAA1, GPI8/PIGK, PIG-S,
+      PIG-T) and that it mediates GPI anchoring in the ER by replacing the C-terminal GPI
+      attachment signal peptide; PIGU was identified later as the fifth subunit. Supports the
+      pathway/localization framing but does not itself assay PIGU.
+- id: PMID:12802054
+  title: Human PIG-U and yeast Cdc91p are the fifth subunit of GPI transamidase that
+    attaches GPI-anchors to proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Primary paper identifying PIGU (PIG-U) as the fifth subunit of GPI
+      transamidase; class-U cells lack transamidase activity and cannot cleave the GPI
+      attachment signal; proposes PIGU recognises the GPI attachment signal or the lipid
+      portion of GPI.
+- id: PMID:15034568
+  title: CDC91L1 (PIG-U) is a newly discovered oncogene in human bladder cancer.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Correctly identifies PIG-U as a GPI transamidase-complex unit and
+      supports its role in the GPI anchoring pathway. The plasma-membrane and JAK-STAT
+      annotations derived from this overexpression/oncogene study are downstream/indirect
+      effects (uPAR upregulation, STAT-3 phosphorylation), not PIGU&#39;s core ER function.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. High-throughput membrane proteomics of an NK-like cell line; supports
+      only the generic membrane localization of PIGU.
+- id: PMID:31353022
+  title: Mutations in PIGU Impair the Function of the GPI Transamidase Complex, Causing
+    Severe Intellectual Disability, Epilepsy, and Brain Anomalies.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Establishes PIGU as an essential GPI transamidase subunit and links
+      biallelic PIGU variants to an inherited GPI-anchor deficiency (NEDBSS/GPIBD) with
+      intellectual disability, epilepsy and brain anomalies; variant cells show reduced
+      surface GPI-anchored proteins.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. HuRI high-throughput Y2H interactome map; source of the single
+      PIGU-KASH5 binary interaction underlying the generic protein binding IPI. Not
+      informative for PIGU&#39;s specific molecular function.
+- id: PMID:34576938
+  title: Functional Analysis of the GPI Transamidase Complex by Screening for Amino
+    Acid Mutations in Each Subunit.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; full text available. Confirms PIGU is one of five GPI-TA subunits,
+      that loss of PIGU abolishes complex activity, that PIGU is homologous to lipid-handling
+      GPI biosynthetic enzymes (recognises the lipid portion of GPI), and identifies
+      functionally important PIGU residues (Leu375/Trp376).
+- id: PMID:35165458
+  title: Structure of human glycosylphosphatidylinositol transamidase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Cryo-EM structure of the five-subunit human GPI-T (including PIGU);
+      identifies the PIGK catalytic triad and the transmembrane GPI substrate-binding cleft.
+- id: PMID:35551457
+  title: Molecular insights into biogenesis of glycosylphosphatidylinositol anchor
+    proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Cryo-EM structure of the equimolar heteropentameric human GPI-T (ER
+      membrane), including PIGU; defines a composite cavity for the lipid substrate.
+- id: PMID:37684232
+  title: Structures of liganded glycosylphosphatidylinositol transamidase illuminate
+    GPI-AP biogenesis.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; full text available. Substrate/product-bound GPI-T structures showing
+      PIGU as one of five subunits contacting GPI; basis for the UniProt statement that PIGU
+      binds the lipid portion of the GPI-anchor.
+- id: Reactome:R-HSA-162836
+  title: uPAR precursor + acyl-GPI -&gt; uPAR-acyl-GPI + uPAR propeptide
+  findings: []
+- id: file:human/PIGU/PIGU-uniprot.txt
+  title: UniProtKB entry PIGU_HUMAN (Q9H490)
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/worm/csr-1/csr-1-ai-review.html
+++ b/genes/worm/csr-1/csr-1-ai-review.html
@@ -3255,6 +3255,314 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
 
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(csr-1-hypotheses/prediction-tf-metabolic-regulation/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q21992" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">AIGR Deep Research — csr-1 (Q21992): predicted DNA-binding TF activity &amp; metabolic-process regulation</span>
+
+
+                    <span class="report-badge">OpenScientist</span>
+
+
+                    <span class="report-badge">openscientist-autonomous</span>
+
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-09T14:08:35.325564</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="csr-1-hypotheses/prediction-tf-metabolic-regulation/openscientist_artifacts/final_report.html" class="term-link">OpenScientist final report</a>
+                        <span>(text/html)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="csr-1-hypotheses/prediction-tf-metabolic-regulation/openscientist_artifacts/final_report.pdf" class="term-link">OpenScientist final report</a>
+                        <span>(application/pdf)</span>
+                    </div>
+
+
+                </div>
+
+                <h1 id="aigr-deep-research-csr-1-q21992-predicted-dna-binding-tf-activity-metabolic-process-regulation">AIGR Deep Research — csr-1 (Q21992): predicted DNA-binding TF activity &amp; metabolic-process regulation</h1>
+<p><strong>Gene:</strong> csr-1 (C. elegans, NCBITaxon:6239) | <strong>Seed accession:</strong> Q21992<br />
+<strong>Hypothesis (BioReason-Pro SFT):</strong> DNA-binding transcription factor activity (GO:0003700) and regulation of metabolic process (GO:0019222; positive regulation GO:0009893).</p>
+<h2 id="executive-judgment">Executive Judgment</h2>
+<p><strong>Verdict: REFUTED (with a critical accession-mismatch caveat).</strong></p>
+<p>The prediction of <strong>DNA-binding transcription factor activity (GO:0003700)</strong> is refuted under <em>both</em> plausible identities of the supplied identifier:</p>
+<ol>
+<li><strong>The gene named <code>csr-1</code></strong> (WormBase locus <strong>F20D12.1</strong>) encodes the <strong>CSR-1 Argonaute</strong> — a small-RNA (22G-RNA)-guided effector with <strong>PAZ (IPR003100) + PIWI (IPR003165 / Pfam PF02171) + RNaseH-like</strong> domains. It is a post-transcriptional/chromatin-associated RNA slicer, <strong>not</strong> a sequence-specific DNA-binding transcription factor. Current UniProt accessions: <strong>H2KZD5</strong> (CSR-1a, 1030 aa) and <strong>Q27GU1</strong> (CSR-1b, 867 aa).</li>
+<li><strong>The supplied accession Q21992 is DELETED</strong> in UniProt (Inactive/DELETED; UniParc UPI000007665A). Its sequence maps unambiguously to a <strong>different gene — R144.7 = <code>larp-1</code> (La-related protein 1)</strong>, an RNA-binding translational regulator (current reviewed entry <strong>D5MCN2</strong>, 1150 aa; RefSeq NP_001040868.3 "La-related protein 1"). LARP-1 binds RNA (poly-U/poly-G, RNA cap) and positively regulates translation — it is <strong>also not</strong> a DNA-binding transcription factor.</li>
+</ol>
+<p>Neither identity supports GO:0003700. The <strong>metabolic-process regulation</strong> terms (GO:0019222 / GO:0009893) are so broad that they are <em>technically not false</em> for either gene (both regulate a macromolecule-metabolic process — gene silencing or translation), but they are <strong>uninformatively broad and non-core</strong>, and they do not rescue the mechanistic TF claim, which is the substantive part of the prediction.</p>
+<p><strong>Most important caveat:</strong> There is a genuine identifier problem. The seed pairs symbol <code>csr-1</code> with accession <code>Q21992</code>, but Q21992 ≠ CSR-1. A curator must first resolve which protein is intended. Under either resolution the TF prediction fails.</p>
+<h2 id="sequence-level-provenance-computed-this-run">Sequence-Level Provenance (computed this run)</h2>
+<p>Direct pairwise 6-mer containment on retrieved sequences resolves the identity quantitatively:</p>
+<table>
+<thead>
+<tr>
+<th>Comparison</th>
+<th>Lengths</th>
+<th>6-mer containment</th>
+<th>Interpretation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Q21992 (deleted seq) vs <strong>LARP-1 (D5MCN2)</strong></td>
+<td>1065 vs 1150</td>
+<td><strong>0.971</strong></td>
+<td>Same protein (identical N-terminus <code>MAEKQPMLSFAKVVSGQAED...</code>); Q21992 is an older LARP-1 isoform</td>
+</tr>
+<tr>
+<td>Q21992 vs <strong>CSR-1a Argonaute (H2KZD5)</strong></td>
+<td>1065 vs 1030</td>
+<td><strong>0.000</strong></td>
+<td>Unrelated — no shared 6-mers</td>
+</tr>
+<tr>
+<td>LARP-1 (D5MCN2) vs CSR-1a (H2KZD5)</td>
+<td>1150 vs 1030</td>
+<td><strong>0.000</strong></td>
+<td>Unrelated proteins</td>
+</tr>
+</tbody>
+</table>
+<p>This confirms the seed's <code>csr-1 → Q21992</code> pairing is an accession error: Q21992 is larp-1, sharing zero detectable sequence with the CSR-1 Argonaute.</p>
+<h2 id="evidence-matrix">Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence type</th>
+<th>Supports/Refutes</th>
+<th>Claim tested</th>
+<th>Key finding</th>
+<th>Context</th>
+<th>Confidence / limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>UniProt H2KZD5, Q27GU1 (database)</td>
+<td>Structural/domain</td>
+<td><strong>Refutes</strong> GO:0003700</td>
+<td>csr-1 is a DNA-binding TF</td>
+<td>CSR-1a/b carry PAZ + PIWI + RNaseH-like; no DNA-binding/TF domain</td>
+<td>C. elegans, protein family</td>
+<td>High; database-level but based on curated domain models</td>
+</tr>
+<tr>
+<td>PMID 19804758 (Claycomb 2009)</td>
+<td>Mutant phenotype / localization</td>
+<td>Refutes</td>
+<td>csr-1 identity/function</td>
+<td>CSR-1 Argonaute + EGO-1/DRH-3/EKL-1 localize to chromosomes and are required for chromosome segregation via 22G-RNAs; CSR-1 does not down-regulate target mRNA/protein</td>
+<td>C. elegans germline/embryo</td>
+<td>High; primary paper</td>
+</tr>
+<tr>
+<td>PMID 24178449 (Wedeles 2013, review)</td>
+<td>Review synthesis</td>
+<td>Refutes</td>
+<td>csr-1 identity</td>
+<td>CSR-1 binds 22G-RNAs complementary to ~25% of genes; only essential Argonaute of 24</td>
+<td>C. elegans</td>
+<td>High for identity; review-level</td>
+</tr>
+<tr>
+<td>PMID 22863779 (Avgousti 2012)</td>
+<td>Direct assay</td>
+<td>Qualifies (BP)</td>
+<td>csr-1 regulates gene expression</td>
+<td>CSR-1 directly binds histone mRNA; RNAi pathway positively regulates histone expression</td>
+<td>C. elegans germline</td>
+<td>High; shows post-transcriptional (not TF) regulation</td>
+</tr>
+<tr>
+<td>PMID 25510497 (Tu 2015)</td>
+<td>Comparative genomics</td>
+<td>Refutes</td>
+<td>csr-1 identity</td>
+<td>Conserved nuclear Argonaute role in chromatin/segregation/germline expression across Caenorhabditis</td>
+<td>C. elegans / C. briggsae</td>
+<td>High</td>
+</tr>
+<tr>
+<td>UniProt Q21992 record (database)</td>
+<td>Database</td>
+<td><strong>Competing/refutes</strong></td>
+<td>Q21992 = csr-1</td>
+<td>Q21992 is DELETED; UniParc maps to R144.7 (larp-1), RefSeq NP_001040868 = "La-related protein 1"</td>
+<td>Identifier check</td>
+<td>High; direct record retrieval</td>
+</tr>
+<tr>
+<td>UniProt D5MCN2 (database)</td>
+<td>Structural/domain</td>
+<td>Refutes</td>
+<td>Q21992-seq is a DNA-binding TF</td>
+<td>LARP-1: La domain (IPR045180), DM15, La-HTH; only a winged-helix-<strong>like</strong> structural fold (IPR036388); function = RNA binding + positive regulation of translation</td>
+<td>C. elegans</td>
+<td>High; La proteins bind RNA, not DNA</td>
+</tr>
+<tr>
+<td>PMID 18515547 (Nykamp 2008)</td>
+<td>Mutant phenotype / localization</td>
+<td>Refutes (for larp-1 identity)</td>
+<td>Q21992/larp-1 is a DNA-binding TF</td>
+<td>LARP-1 has La motif + LARP1 domain, binds RNA in vitro, localizes to germline P bodies, and attenuates Ras-MAPK signaling by controlling pathway mRNA/protein abundance</td>
+<td>C. elegans germline/oogenesis</td>
+<td>High; primary paper — RNA-binding, not DNA-binding TF</td>
+</tr>
+<tr>
+<td>Computed provenance (this run)</td>
+<td>Computational</td>
+<td>Refutes/Competing</td>
+<td>Q21992 = csr-1</td>
+<td>6-mer containment: Q21992↔LARP-1 = 0.971; Q21992↔CSR-1a = 0.000</td>
+<td>Sequence analysis</td>
+<td>High; direct calculation</td>
+</tr>
+<tr>
+<td>UniProt Q17370 (database)</td>
+<td>Database</td>
+<td>Competing</td>
+<td>Source of TF signal</td>
+<td>nhr-47 (Nuclear hormone receptor) surfaces on <code>gene:csr-1</code> text search — a genuine DNA-binding TF but a <em>distinct</em> gene</td>
+<td>C. elegans</td>
+<td>Medium; illustrates possible name/paralog confusion</td>
+</tr>
+</tbody>
+</table>
+<h2 id="go-decision-table-leads-require-curator-verification">GO Decision Table (leads — require curator verification)</h2>
+<table>
+<thead>
+<tr>
+<th>Predicted term</th>
+<th>Aspect</th>
+<th>Applies to CSR-1 Argonaute?</th>
+<th>Applies to Q21992/LARP-1?</th>
+<th>Recommended action</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0003700 DNA-binding transcription factor activity</td>
+<td>MF</td>
+<td>No (PAZ/PIWI RNA slicer)</td>
+<td>No (La/LARP1 RNA-binding)</td>
+<td><strong>Reject / do not add</strong></td>
+</tr>
+<tr>
+<td>GO:0019222 regulation of metabolic process</td>
+<td>BP</td>
+<td>Only as over-broad parent of ncRNA gene silencing</td>
+<td>Only as over-broad parent of translation regulation</td>
+<td><strong>Do not add — too broad, non-core</strong></td>
+</tr>
+<tr>
+<td>GO:0009893 positive regulation of metabolic process</td>
+<td>BP</td>
+<td>No specific support</td>
+<td>Weak/broad (positive regulation of translation)</td>
+<td><strong>Do not add — too broad, non-core</strong></td>
+</tr>
+<tr>
+<td>GO:0070551 endoribonuclease cleaving siRNA-paired mRNA</td>
+<td>MF</td>
+<td><strong>Yes (IDA, WormBase)</strong></td>
+<td>n/a</td>
+<td>Correct MF for CSR-1 (already annotated)</td>
+</tr>
+<tr>
+<td>GO:0008266 poly(U) RNA binding</td>
+<td>MF</td>
+<td>n/a</td>
+<td><strong>Yes (IDA, WormBase)</strong></td>
+<td>Correct MF for LARP-1 (already annotated)</td>
+</tr>
+</tbody>
+</table>
+<h2 id="go-curation-implications-leads-require-curator-verification">GO Curation Implications (leads — require curator verification)</h2>
+<ul>
+<li><strong>GO:0003700 (DNA-binding transcription factor activity, MF): DO NOT ADD / REJECT.</strong> Refuted for both csr-1 (Argonaute) and Q21992/larp-1 (RNA-binding). No experimental or domain evidence for sequence-specific DNA binding.</li>
+<li><strong>GO:0019222 / GO:0009893 (regulation / positive regulation of metabolic process, BP): treat as NON-CORE and too broad.</strong> Do not add on the strength of this prediction. If any regulatory BP is warranted it should be specific and mechanism-appropriate:</li>
+<li>For <strong>CSR-1</strong>: e.g., <em>regulatory ncRNA-mediated post-transcriptional gene silencing</em> (GO:0035194), <em>siRNA-mediated gene silencing by mRNA destabilization</em> (GO:0090625) — already present with experimental evidence.</li>
+<li>For <strong>LARP-1</strong> (if that is the intended protein): <em>positive regulation of translation</em> (GO:0045727) — already present.</li>
+<li><strong>Recommended MF for the actual proteins</strong> (informative, not "protein binding"):</li>
+<li>CSR-1: <em>endoribonuclease activity, cleaving siRNA-paired mRNA</em> (GO:0070551); <em>siRNA binding / RNA binding</em>.</li>
+<li>LARP-1: <em>poly(U) RNA binding</em> (GO:0008266); RNA cap binding.</li>
+</ul>
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<p>The predicted MF (DNA-binding TF) posits <strong>direct, sequence-specific DNA binding driving transcription</strong>. The actual immediate molecular activities are RNA-centric: CSR-1 is a <strong>small-RNA-guided endoribonuclease/effector</strong> that recognizes target mRNAs by 22G-RNA base-pairing (chromosome segregation, histone-mRNA and germline-mRNA regulation, mRNA surveillance/licensing). LARP-1 is an <strong>RNA-binding translational regulator</strong>. Any "regulation of metabolic process" is a <em>downstream, category-level</em> description of gene-expression regulation, not a direct DNA-binding transcriptional activity.</p>
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<ul>
+<li><strong>Identifier/accession mismatch (primary conflict):</strong> Q21992 (deleted) ≠ csr-1; it is larp-1/R144.7. This is the single most important issue for the curator.</li>
+<li><strong>Winged-helix-like fold artifact:</strong> LARP-1 carries a <em>winged-helix-LIKE DNA-binding structural superfamily</em> fold (IPR036388/IPR036390). A predictor keying on that structural signature could spuriously infer "DNA-binding" — but La/winged-helix proteins bind <strong>RNA</strong>, so this is a false positive.</li>
+<li><strong>Paralog/name confusion:</strong> A text search on <code>gene:csr-1</code> also surfaces <strong>nhr-47</strong> (a nuclear hormone receptor and bona fide DNA-binding TF). Frequency bias toward abundant TF/NHR classes plus fuzzy name/xref linking is a plausible origin of the GO:0003700 prediction, but nhr-47 is a separate gene.</li>
+<li>No primary literature attributes DNA-binding transcription-factor activity to CSR-1 or LARP-1.</li>
+</ul>
+<h2 id="knowledge-gaps">Knowledge Gaps</h2>
+<ol>
+<li><strong>Which protein does the prediction actually target?</strong> Checked: Q21992 is deleted and maps to larp-1; the symbol says csr-1 (Argonaute). Resolution needed from the curator/model provenance. Matters because the correct-function assignment differs (Argonaute vs La-protein), though the TF verdict is the same. Resolve by confirming the sequence the model was given (compare to H2KZD5/Q27GU1 vs D5MCN2).</li>
+<li><strong>Did BioReason ingest the stale/deleted record?</strong> If the model used Q21992's larp-1 sequence but the symbol csr-1, that is a data-hygiene error worth flagging upstream.</li>
+<li><strong>Basis of the TF signal.</strong> Not directly observable here; a domain/embedding attribution (winged-helix-like fold vs nhr text co-occurrence) would confirm the false-positive mechanism.</li>
+</ol>
+<h2 id="discriminating-tests">Discriminating Tests</h2>
+<ul>
+<li><strong>Sequence-identity check:</strong> Align the exact sequence behind the prediction against H2KZD5/Q27GU1 (CSR-1) and D5MCN2 (LARP-1); % identity resolves identity instantly.</li>
+<li><strong>Domain scan (InterProScan/HMMER):</strong> Presence of PIWI+PAZ ⇒ Argonaute; La+DM15 ⇒ LARP; absence of homeodomain/zinc-finger/bHLH/NHR DNA-binding domains ⇒ not a TF.</li>
+<li><strong>DNA vs RNA binding assay class:</strong> Curated evidence for CSR-1 is IP-small-RNA-seq / mRNA binding; for a TF one would expect ChIP-seq/EMSA on DNA motifs — none exists.</li>
+<li><strong>Compare against <code>nhr-47</code> (Q17370):</strong> confirms the true DNA-binding TF neighbor is a different gene.</li>
+</ul>
+<h2 id="curation-leads">Curation Leads</h2>
+<ul>
+<li><strong>Action:</strong> Reject the BioReason-Pro prediction of GO:0003700 for csr-1/Q21992 as an over-annotation/mis-identification. Do not add GO:0019222 or GO:0009893 (too broad / non-core).</li>
+<li><strong>Flag the accession:</strong> Note in the review that Q21992 is a DELETED UniProt entry corresponding to larp-1 (R144.7), not the csr-1 Argonaute locus (F20D12.1; current H2KZD5 / Q27GU1). Recommend the review use a current csr-1 accession.</li>
+<li><strong>Candidate references to verify (exact snippets):</strong></li>
+<li>PMID 19804758 — "the Argonaute CSR-1 … are required for proper chromosome segregation."</li>
+<li>PMID 24178449 — "CSR-1 interacts with small RNAs known as 22G-RNAs … the only essential C. elegans Argonaute out of 24 family members."</li>
+<li>PMID 22863779 — "CSR-1 directly binds to histone mRNA in an ego-1-dependent manner."</li>
+<li><strong>Suggested curator questions:</strong> (a) Which sequence did the model score? (b) Is the TF call driven by the LARP winged-helix-like fold or by nhr-name co-occurrence? (c) Should the review record be re-keyed to a live csr-1 accession?</li>
+<li><strong>Suggested experiment (if identity ever in doubt):</strong> InterProScan + reciprocal-best-hit orthology to human AGO/PIWI vs LARP1; ChIP-seq would be expected to be negative for DNA-motif occupancy.</li>
+</ul>
+<hr />
+<p><em>Provenance:</em> UniProt REST (Q21992 status, H2KZD5, Q27GU1, D5MCN2), UniParc UPI000007665A cross-references, NCBI eutils esummary (NP_001040868 = "La-related protein 1"), and PubMed primary/review literature. All retrievals executed programmatically in this run.</p>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="csr-1-hypotheses/prediction-tf-metabolic-regulation/openscientist_artifacts/final_report.html">OpenScientist final report</a></li>
+<li><a href="csr-1-hypotheses/prediction-tf-metabolic-regulation/openscientist_artifacts/final_report.pdf">OpenScientist final report</a></li>
+</ul>
+            </div>
+        </details>
+
     </div>
 
 

--- a/pages/modules/gpi_anchor_remodeling.html
+++ b/pages/modules/gpi_anchor_remodeling.html
@@ -1,0 +1,855 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GPI anchor biosynthesis V — post-attachment lipid remodeling; PGAP1/PGAP3/PGAP2 - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / GPI anchor biosynthesis V — post-attachment lipid remodeling; PGAP1/PGAP3/PGAP2
+    </nav>
+
+    <header class="header">
+        <h1>GPI anchor biosynthesis V — post-attachment lipid remodeling; PGAP1/PGAP3/PGAP2</h1>            <p class="description">After a protein has been GPI-anchored by the transamidase, the anchor&#39;s lipid moiety is remodeled so the mature GPI-anchored protein can exit the ER, traffic through the Golgi and partition into membrane microdomains (lipid rafts). Three post-GPI-attachment factors carry out the remodeling. In the endoplasmic reticulum, PGAP1 is a GPI inositol-deacylase that removes the acyl chain from the inositol ring of the anchor (the acyl group added earlier by PIGW); this inositol-deacylation is required for efficient ER-to-Golgi transport of GPI-anchored proteins. In the Golgi, fatty-acid remodeling then exchanges the unsaturated sn-2 chain of the phosphatidylinositol for a saturated one: the GPI-specific phospholipase A2 PGAP3 first removes the sn-2 unsaturated fatty acid, and PGAP2 is required to reacylate the resulting lyso-GPI intermediate with a saturated (stearoyl) chain, generating the mature, raft-associating anchor needed for stable cell-surface expression. Inherited defects cause GPI-deficiency disease: PGAP1 (intellectual disability / encephalopathy), PGAP3 (hyperphosphatasia with mental retardation syndrome 4, HPMRS4) and PGAP2 (HPMRS3).</p>        <div class="meta-row"><span class="pill">MODULE:gpi_anchor_remodeling</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/gpi_anchor_remodeling.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor remodelling</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0120574" target="_blank" rel="noopener">GO:0120574</a></span>                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0120574" target="_blank" rel="noopener">GO:0120574</a><div><strong>GPI anchor remodelling</strong></div><div>The module is grounded in GPI anchor remodelling (GO:0120574): post-attachment inositol-deacylation and fatty-acid remodeling of the GPI-anchored protein&#39;s lipid moiety.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-162710</span><div><strong>Synthesis of glycosylphosphatidylinositol (GPI)</strong></div><div>The inositol-deacylation step (PGAP1) follows the human Reactome reaction R-HSA-162729 (uPAR-acyl-GPI + H2O -&gt; uPAR + long-chain fatty acid), part of &#34;Synthesis of GPI&#34;.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PGAP1/PGAP1-ai-review.yaml</span><div><strong>PGAP1 gene review (human)</strong></div><div>The ER inositol-deacylation step (UniProtKB:Q75T13, GO:0160215) matches the completed human PGAP1 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PGAP3/PGAP3-ai-review.yaml</span><div><strong>PGAP3 gene review (human)</strong></div><div>The Golgi GPI-specific phospholipase-A2 (sn-2 deacylation) step (UniProtKB:Q96FM1, GO:0016788) matches the completed human PGAP3 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PGAP2/PGAP2-ai-review.yaml</span><div><strong>PGAP2 gene review (human)</strong></div><div>The Golgi reacylation (fatty-acid remodeling) step (UniProtKB:Q9UHJ9, GPI anchor remodelling GO:0120574) matches the completed human PGAP2 review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">4</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:gpi_anchor_remodeling</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(3/3 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        3 complete review(s) &middot;
+                        0 with deep research &middot;
+                        0 missing review &middot;
+                        3 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>PGAP1
+                                        <span class="muted term-id">Q75T13</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PGAP2
+                                        <span class="muted term-id">Q9UHJ9</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PGAP3
+                                        <span class="muted term-id">Q96FM1</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-gpi_anchor_remodeling">GPI anchor post-attachment lipid remodeling</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">gpi_anchor_remodeling</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. ER inositol-deacylation</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pgap1_step">removal of the inositol-linked acyl chain from the GPI anchor</a><span class="pill type">Reaction</span><span class="tree-id">pgap1_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pgap1_activity">PGAP1: GPI inositol-deacylase</a>
+                                <span class="tree-id">Family: PGAP1 GPI inositol-deacylase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. Golgi sn-2 deacylation (fatty-acid remodeling step 1)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pgap3_step">removal of the sn-2 unsaturated fatty acid from the GPI anchor</a><span class="pill type">Reaction</span><span class="tree-id">pgap3_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pgap3_activity">PGAP3: GPI-specific phospholipase A2</a>
+                                <span class="tree-id">Family: PGAP3/CREST GPI phospholipase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. Golgi reacylation (fatty-acid remodeling step 2)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pgap2_step">reacylation of the lyso-GPI anchor with a saturated fatty acid</a><span class="pill type">Reaction</span><span class="tree-id">pgap2_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pgap2_activity">PGAP2: GPI fatty-acid reacylation factor</a>
+                                <span class="tree-id">Family: PGAP2 family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>                <span class="descriptor">
+            <span>Golgi membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0000139" target="_blank" rel="noopener">GO:0000139</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-gpi_anchor_remodeling">
+        <div class="node-heading">
+            <span class="node-title">GPI anchor post-attachment lipid remodeling</span><span class="pill type">Metabolic Pathway</span><span class="pill">gpi_anchor_remodeling</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor remodelling</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0120574" target="_blank" rel="noopener">GO:0120574</a></span>                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>                <span class="descriptor">
+            <span>Golgi membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0000139" target="_blank" rel="noopener">GO:0000139</a></span>        </div>
+
+            </div>
+        <p class="muted small">GPI-anchor post-attachment lipid-remodeling segment, grounded to the human enzymes PGAP1 (UniProtKB:Q75T13, GO:0160215 deacylase activity; ER) and the Golgi fatty-acid-remodeling pair PGAP3 (Q96FM1, GO:0016788 ester-bond hydrolase / GPI-specific phospholipase A2) and PGAP2 (Q9UHJ9; no catalytic MF in GOA — modelled by its GPI anchor remodelling BP role). GO molecular-function/BP/location terms were taken from the completed human gene reviews and verified against the local go.db; the PGAP1 reaction (R-HSA-162729) and parent pathway (R-HSA-162710) were verified against the local reactome cache. Each step uses a PANTHER family selector with the human enzyme as representative. Note the two-compartment organisation: PGAP1 inositol-deacylation is an ER-membrane step required for ER exit, whereas the PGAP3/PGAP2 fatty-acid remodeling (sn-2 unsaturated -&gt; saturated) occurs in the Golgi and confers lipid-raft association / stable surface expression. Upstream is the GPI-transamidase module (PIGK/PIGS/PIGT/PIGU/GPAA1) that attaches the anchor; this remodeling module completes GPI-anchor maturation. This is the FIFTH and final module of the GPI-anchor biosynthesis series (GnT -&gt; core glycan -&gt; EtNP additions -&gt; transamidase -&gt; remodeling). Disorders: PGAP1 GPI-deficiency (intellectual disability/encephalopathy), PGAP3 HPMRS4, PGAP2 HPMRS3.</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pgap1_step">pgap1_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pgap3_step">pgap3_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">The inositol-deacylated GPI-anchored protein (ER exit competent) undergoes Golgi fatty-acid remodeling, beginning with PGAP3 sn-2 deacylation.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pgap3_step">pgap3_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pgap2_step">pgap2_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">The lyso-GPI intermediate from PGAP3 is reacylated by PGAP2 with a saturated chain.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: ER inositol-deacylation</div>
+                <section class="node-detail depth-1" id="node-pgap1_step">
+        <div class="node-heading">
+            <span class="node-title">removal of the inositol-linked acyl chain from the GPI anchor</span><span class="pill type">Reaction</span><span class="pill">pgap1_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pgap1_activity">
+        <div class="annoton-title">PGAP1: GPI inositol-deacylase</div>
+        <div class="small muted">pgap1_activity</div>            <div class="small"><strong>Participant:</strong> Family: PGAP1 GPI inositol-deacylase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PGAP1 GPI inositol-deacylase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR15495" target="_blank" rel="noopener">PANTHER:PTHR15495</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PGAP1 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q75T13/entry" target="_blank" rel="noopener">UniProtKB:Q75T13</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>deacylase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0160215" target="_blank" rel="noopener">GO:0160215</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>inositol-acylated GPI-anchored protein</span></span>                            <span class="descriptor">
+            <span>H2O</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>inositol-deacylated GPI-anchored protein</span></span>                            <span class="descriptor">
+            <span>long-chain fatty acid</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Removes the inositol acyl chain in the ER; required for ER exit of GPI-anchored proteins. Deficiency = GPIBD (intellectual disability/encephalopathy).</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: Golgi sn-2 deacylation (fatty-acid remodeling step 1)</div>
+                <section class="node-detail depth-1" id="node-pgap3_step">
+        <div class="node-heading">
+            <span class="node-title">removal of the sn-2 unsaturated fatty acid from the GPI anchor</span><span class="pill type">Reaction</span><span class="pill">pgap3_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pgap3_activity">
+        <div class="annoton-title">PGAP3: GPI-specific phospholipase A2</div>
+        <div class="small muted">pgap3_activity</div>            <div class="small"><strong>Participant:</strong> Family: PGAP3/CREST GPI phospholipase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PGAP3/CREST GPI phospholipase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR13148" target="_blank" rel="noopener">PANTHER:PTHR13148</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PGAP3 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q96FM1/entry" target="_blank" rel="noopener">UniProtKB:Q96FM1</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>hydrolase activity, acting on ester bonds</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016788" target="_blank" rel="noopener">GO:0016788</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>GPI-anchored protein (sn-2 unsaturated acyl-PI)</span></span>                            <span class="descriptor">
+            <span>H2O</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>lyso-GPI-anchored protein</span></span>                            <span class="descriptor">
+            <span>unsaturated fatty acid</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>Golgi membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0000139" target="_blank" rel="noopener">GO:0000139</a></span>        </div>            <p class="role-description">Removes the sn-2 unsaturated fatty acid in the Golgi (fatty-acid remodeling step 1). Deficiency = HPMRS4.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: Golgi reacylation (fatty-acid remodeling step 2)</div>
+                <section class="node-detail depth-1" id="node-pgap2_step">
+        <div class="node-heading">
+            <span class="node-title">reacylation of the lyso-GPI anchor with a saturated fatty acid</span><span class="pill type">Reaction</span><span class="pill">pgap2_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pgap2_activity">
+        <div class="annoton-title">PGAP2: GPI fatty-acid reacylation factor</div>
+        <div class="small muted">pgap2_activity</div>            <div class="small"><strong>Participant:</strong> Family: PGAP2 family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PGAP2 family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12892" target="_blank" rel="noopener">PANTHER:PTHR12892</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PGAP2 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9UHJ9/entry" target="_blank" rel="noopener">UniProtKB:Q9UHJ9</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor remodelling</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0120574" target="_blank" rel="noopener">GO:0120574</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>Golgi membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0000139" target="_blank" rel="noopener">GO:0000139</a></span>        </div>            <p class="role-description">Reacylates the lyso-GPI anchor with a saturated fatty acid (remodeling step 2), producing the mature raft-associating anchor. Deficiency = HPMRS3. (GOA carries no catalytic MF for PGAP2 — its precise catalytic vs accessory role is debated — so it is represented by its GPI-remodelling BP role.)</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:human/PGAP2/PGAP2-ai-review.yaml</span><div>required for reacylation of the lyso-GPI intermediate with a saturated (stearoyl) chain after PGAP3; generates the mature raft-associating anchor; deficiency = HPMRS3</div></div>        </div></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/gpi_anchor_transamidase.html
+++ b/pages/modules/gpi_anchor_transamidase.html
@@ -1,0 +1,856 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GPI anchor biosynthesis IV — transamidase complex (attachment to protein); PIGK/PIGS/PIGT/PIGU/GPAA1 - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / GPI anchor biosynthesis IV — transamidase complex (attachment to protein); PIGK/PIGS/PIGT/PIGU/GPAA1
+    </nav>
+
+    <header class="header">
+        <h1>GPI anchor biosynthesis IV — transamidase complex (attachment to protein); PIGK/PIGS/PIGT/PIGU/GPAA1</h1>            <p class="description">The final step that commits a protein to a GPI anchor is transamidation: in the ER lumen the five-subunit GPI transamidase (GPI-T) complex recognises the C-terminal GPI-attachment signal peptide of a nascent protein, cleaves it, and forms an amide bond between the new C-terminus and the amino group of the bridging ethanolamine-phosphate on the third mannose of the completed GPI precursor. PIGK (GPI8) is the catalytic subunit, a cysteine-protease-like enzyme that forms the carbonyl(acyl-enzyme) intermediate; PIGT disulfide-links to and stabilises PIGK and holds the complex together; GPAA1 helps present the GPI substrate and stabilise the intermediate for amide-bond formation; PIGU assists GPI-substrate recognition; and PIGS is an indispensable but non-catalytic subunit. The product is a mature GPI-anchored protein that is then exported and remodelled. Defects across the complex cause GPI-deficiency disease with overlapping developmental/epileptic-encephalopathy, cerebellar-atrophy and hyperphosphatasia phenotypes: PIGK, PIGS, PIGT (MCAHS3 / a PNH-like phenotype), PIGU and GPAA1.</p>        <div class="meta-row"><span class="pill">MODULE:gpi_anchor_transamidase</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/gpi_anchor_transamidase.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>attachment of GPI anchor to protein</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016255" target="_blank" rel="noopener">GO:0016255</a></span>                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0016255" target="_blank" rel="noopener">GO:0016255</a><div><strong>attachment of GPI anchor to protein</strong></div><div>The module is grounded in attachment of GPI anchor to protein (GO:0016255): the GPI-T complex transfers the completed GPI anchor onto the protein C-terminus.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a><div><strong>GPI anchor biosynthetic process</strong></div><div>The transamidation step is the terminal reaction of GPI anchor biosynthesis (GO:0006506).</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-162791</span><div><strong>Attachment of GPI anchor to uPAR</strong></div><div>The transamidation reaction follows the human Reactome &#34;Attachment of GPI anchor to uPAR&#34; reaction (a representative GPI-T substrate), part of &#34;Synthesis of GPI&#34; (R-HSA-162710).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGK/PIGK-ai-review.yaml</span><div><strong>PIGK gene review (human)</strong></div><div>The catalytic transamidase subunit (UniProtKB:Q92643, GO:0003923) matches the completed human PIGK review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGS/PIGS-ai-review.yaml</span><div><strong>PIGS gene review (human)</strong></div><div>The indispensable non-catalytic subunit (UniProtKB:Q96S52, GPI-T complex GO:0042765) matches the completed human PIGS review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGT/PIGT-ai-review.yaml</span><div><strong>PIGT gene review (human)</strong></div><div>The PIGK-stabilising/GPI-anchor-binding subunit (UniProtKB:Q969N2, GO:0034235) matches the completed human PIGT review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGU/PIGU-ai-review.yaml</span><div><strong>PIGU gene review (human)</strong></div><div>The GPI-substrate-recognition subunit (UniProtKB:Q9H490, GO:0034235) matches the completed human PIGU review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/GPAA1/GPAA1-ai-review.yaml</span><div><strong>GPAA1 gene review (human)</strong></div><div>The intermediate-stabilising/GPI-anchor-binding subunit (UniProtKB:O43292, GO:0034235) matches the completed human GPAA1 review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">1</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">5</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:gpi_anchor_transamidase</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(5/5 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        5 complete review(s) &middot;
+                        0 with deep research &middot;
+                        0 missing review &middot;
+                        5 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>GPAA1
+                                        <span class="muted term-id">O43292</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGK
+                                        <span class="muted term-id">Q92643</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGS
+                                        <span class="muted term-id">Q96S52</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGT
+                                        <span class="muted term-id">Q969N2</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGU
+                                        <span class="muted term-id">Q9H490</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-gpi_anchor_transamidase">GPI anchor transamidase complex (attachment to protein)</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">gpi_anchor_transamidase</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. transamidation (GPI anchor attachment to protein)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-gpi_transamidase_step">transfer of the completed GPI anchor onto the protein C-terminus</a><span class="pill type">Protein Complex</span><span class="tree-id">gpi_transamidase_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigk_activity">PIGK (GPI8): catalytic transamidase subunit</a>
+                                <span class="tree-id">Family: GPI transamidase GPI8/PIGK family</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigt_activity">PIGT: PIGK-stabilising / GPI-anchor-binding subunit</a>
+                                <span class="tree-id">Family: GPI transamidase PIG-T family</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-gpaa1_activity">GPAA1 (GAA1): intermediate-stabilising / GPI-anchor-binding subunit</a>
+                                <span class="tree-id">Family: GPI transamidase GAA1/GPAA1 family</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigu_activity">PIGU: GPI-substrate-recognition subunit</a>
+                                <span class="tree-id">Family: GPI transamidase PIG-U family</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigs_activity">PIGS: indispensable non-catalytic subunit</a>
+                                <span class="tree-id">Family: GPI transamidase PIG-S family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-gpi_anchor_transamidase">
+        <div class="node-heading">
+            <span class="node-title">GPI anchor transamidase complex (attachment to protein)</span><span class="pill type">Metabolic Pathway</span><span class="pill">gpi_anchor_transamidase</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>attachment of GPI anchor to protein</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016255" target="_blank" rel="noopener">GO:0016255</a></span>                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>
+
+            </div>
+        <p class="muted small">GPI-transamidase (attachment-to-protein) segment, grounded to the human GPI-T complex (GO:0042765): catalytic PIGK (UniProtKB:Q92643, GO:0003923) plus PIGT (Q969N2), GPAA1 (O43292) and PIGU (Q9H490) — all carrying GPI anchor binding (GO:0034235) as their informative subunit-level MF — and the indispensable non-catalytic PIGS (Q96S52). GO molecular-function/BP/location terms were taken from the completed human gene reviews and verified against the local go.db; the reaction (R-HSA-162791) and parent pathway (R-HSA-162710) were verified against the local reactome cache. Modelled as a single PROTEIN_COMPLEX node: only PIGK carries a catalytic MF (GPI-anchor transamidase activity); PIGT/GPAA1/PIGU carry GPI-anchor-binding, and PIGS (no MF) is represented by its BP role. The complex cleaves the C-terminal GPI-attachment signal of nascent proteins and transfers the completed GPI precursor (from the mannosylation + EtNP modules) onto the new C-terminus. Downstream, the GPI-anchored protein is remodelled (PGAP1 inositol deacylation; PGAP2/PGAP3 fatty-acid remodelling — a separate module) and exported. Disorders across the complex: GPIBD/developmental-epileptic encephalopathy (PIGK, PIGS, PIGU), MCAHS3 / PNH-like (PIGT) and GPIBD with cerebellar atrophy (GPAA1).</p>                <div class="part-marker">
+                    Part 1: transamidation (GPI anchor attachment to protein)</div>
+                <section class="node-detail depth-1" id="node-gpi_transamidase_step">
+        <div class="node-heading">
+            <span class="node-title">transfer of the completed GPI anchor onto the protein C-terminus</span><span class="pill type">Protein Complex</span><span class="pill">gpi_transamidase_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pigk_activity">
+        <div class="annoton-title">PIGK (GPI8): catalytic transamidase subunit</div>
+        <div class="small muted">pigk_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI transamidase GPI8/PIGK family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI transamidase GPI8/PIGK family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR48067" target="_blank" rel="noopener">PANTHER:PTHR48067</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGK (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q92643/entry" target="_blank" rel="noopener">UniProtKB:Q92643</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>GPI-anchor transamidase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003923" target="_blank" rel="noopener">GO:0003923</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>completed GPI precursor (EtNP-Man3 GPI)</span></span>                            <span class="descriptor">
+            <span>pro-protein bearing C-terminal GPI-attachment signal</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>GPI-anchored protein</span></span>                            <span class="descriptor">
+            <span>cleaved C-terminal signal peptide</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Catalytic subunit of the GPI transamidase complex.</p></article>                    <article class="annoton-card" id="annoton-pigt_activity">
+        <div class="annoton-title">PIGT: PIGK-stabilising / GPI-anchor-binding subunit</div>
+        <div class="small muted">pigt_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI transamidase PIG-T family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI transamidase PIG-T family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12959" target="_blank" rel="noopener">PANTHER:PTHR12959</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGT (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q969N2/entry" target="_blank" rel="noopener">UniProtKB:Q969N2</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>GPI anchor binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034235" target="_blank" rel="noopener">GO:0034235</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>GPI precursor (lipid moiety)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>complex-bound GPI substrate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Stabilises the catalytic PIGK and binds the GPI substrate.</p></article>                    <article class="annoton-card" id="annoton-gpaa1_activity">
+        <div class="annoton-title">GPAA1 (GAA1): intermediate-stabilising / GPI-anchor-binding subunit</div>
+        <div class="small muted">gpaa1_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI transamidase GAA1/GPAA1 family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI transamidase GAA1/GPAA1 family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR13304" target="_blank" rel="noopener">PANTHER:PTHR13304</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>GPAA1 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/O43292/entry" target="_blank" rel="noopener">UniProtKB:O43292</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>GPI anchor binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034235" target="_blank" rel="noopener">GO:0034235</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>GPI precursor</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>presented GPI substrate for amide-bond formation</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Presents the GPI substrate and stabilises the reaction intermediate.</p></article>                    <article class="annoton-card" id="annoton-pigu_activity">
+        <div class="annoton-title">PIGU: GPI-substrate-recognition subunit</div>
+        <div class="small muted">pigu_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI transamidase PIG-U family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI transamidase PIG-U family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR13121" target="_blank" rel="noopener">PANTHER:PTHR13121</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGU (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9H490/entry" target="_blank" rel="noopener">UniProtKB:Q9H490</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>GPI anchor binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034235" target="_blank" rel="noopener">GO:0034235</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>GPI precursor (lipid moiety)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>recognised GPI substrate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Assists recognition/binding of the lipid GPI substrate.</p></article>                    <article class="annoton-card" id="annoton-pigs_activity">
+        <div class="annoton-title">PIGS: indispensable non-catalytic subunit</div>
+        <div class="small muted">pigs_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI transamidase PIG-S family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI transamidase PIG-S family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR21072" target="_blank" rel="noopener">PANTHER:PTHR21072</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGS (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q96S52/entry" target="_blank" rel="noopener">UniProtKB:Q96S52</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>attachment of GPI anchor to protein</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016255" target="_blank" rel="noopener">GO:0016255</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Indispensable non-catalytic subunit of the complex.</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:human/PIGS/PIGS-ai-review.yaml</span><div>indispensable but non-catalytic subunit of the GPI-T complex (role unclear); deficiency = GPIBD18</div></div>        </div></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -285,7 +285,7 @@
 
     <section class="toolbar">
         <input class="search" type="search" placeholder="Filter modules" data-module-search>
-        <div class="count"><span data-visible-count>143</span> / 143 modules</div>
+        <div class="count"><span data-visible-count>145</span> / 145 modules</div>
     </section>
 
     <div class="table-wrap">
@@ -1531,6 +1531,52 @@ Design intent: the module is organized as a driver layer (PUFA-phospholipid supp
                         0
                     </td>
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/gpi_anchor_ethanolamine_phosphate.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="GPI anchor biosynthesis IV — transamidase complex (attachment to protein); PIGK/PIGS/PIGT/PIGU/GPAA1">
+                        <a class="module-name" href="gpi_anchor_transamidase.html">GPI anchor biosynthesis IV — transamidase complex (attachment to protein); PIGK/PIGS/PIGT/PIGU/GPAA1</a><span class="module-id">MODULE:gpi_anchor_transamidase</span>                        <span class="module-desc">The final step that commits a protein to a GPI anchor is transamidation: in the ER lumen the five-subunit GPI transamidase (GPI-T) complex...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">The final step that commits a protein to a GPI anchor is transamidation: in the ER lumen the five-subunit GPI transamidase (GPI-T) complex recognises the C-terminal GPI-attachment signal peptide of a nascent protein, cleaves it, and forms an amide bond between the new C-terminus and the amino group of the bridging ethanolamine-phosphate on the third mannose of the completed GPI precursor. PIGK (GPI8) is the catalytic subunit, a cysteine-protease-like enzyme that forms the carbonyl(acyl-enzyme) intermediate; PIGT disulfide-links to and stabilises PIGK and holds the complex together; GPAA1 helps present the GPI substrate and stabilise the intermediate for amide-bond formation; PIGU assists GPI-substrate recognition; and PIGS is an indispensable but non-catalytic subunit. The product is a mature GPI-anchored protein that is then exported and remodelled. Defects across the complex cause GPI-deficiency disease with overlapping developmental/epileptic-encephalopathy, cerebellar-atrophy and hyperphosphatasia phenotypes: PIGK, PIGS, PIGT (MCAHS3 / a PNH-like phenotype), PIGU and GPAA1.</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="2">                        <div class="concepts">                            <span class="pill">attachment of GPI anchor to protein</span>                            <span class="pill">GPI anchor biosynthetic process</span>                        </div>                    </td>
+                    <td class="num">2</td>
+                    <td class="num">5</td>
+                    <td class="num">1</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>                    <td class="num" data-sort-value="5">
+                        5/5
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/gpi_anchor_transamidase.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="GPI anchor biosynthesis V — post-attachment lipid remodeling; PGAP1/PGAP3/PGAP2">
+                        <a class="module-name" href="gpi_anchor_remodeling.html">GPI anchor biosynthesis V — post-attachment lipid remodeling; PGAP1/PGAP3/PGAP2</a><span class="module-id">MODULE:gpi_anchor_remodeling</span>                        <span class="module-desc">After a protein has been GPI-anchored by the transamidase, the anchor&#39;s lipid moiety is remodeled so the mature GPI-anchored protein can exit the...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">After a protein has been GPI-anchored by the transamidase, the anchor&#39;s lipid moiety is remodeled so the mature GPI-anchored protein can exit the ER, traffic through the Golgi and partition into membrane microdomains (lipid rafts). Three post-GPI-attachment factors carry out the remodeling. In the endoplasmic reticulum, PGAP1 is a GPI inositol-deacylase that removes the acyl chain from the inositol ring of the anchor (the acyl group added earlier by PIGW); this inositol-deacylation is required for efficient ER-to-Golgi transport of GPI-anchored proteins. In the Golgi, fatty-acid remodeling then exchanges the unsaturated sn-2 chain of the phosphatidylinositol for a saturated one: the GPI-specific phospholipase A2 PGAP3 first removes the sn-2 unsaturated fatty acid, and PGAP2 is required to reacylate the resulting lyso-GPI intermediate with a saturated (stearoyl) chain, generating the mature, raft-associating anchor needed for stable cell-surface expression. Inherited defects cause GPI-deficiency disease: PGAP1 (intellectual disability / encephalopathy), PGAP3 (hyperphosphatasia with mental retardation syndrome 4, HPMRS4) and PGAP2 (HPMRS3).</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="2">                        <div class="concepts">                            <span class="pill">GPI anchor remodelling</span>                            <span class="pill">GPI anchor biosynthetic process</span>                        </div>                    </td>
+                    <td class="num">4</td>
+                    <td class="num">3</td>
+                    <td class="num">3</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">2</td>                    <td class="num" data-sort-value="3">
+                        3/3
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/gpi_anchor_remodeling.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="Galactose catabolism (Leloir pathway)">
                         <a class="module-name" href="galactose_leloir_pathway.html">Galactose catabolism (Leloir pathway)</a><span class="module-id">MODULE:galactose_leloir_pathway</span>                        <span class="module-desc">The Leloir pathway, the main route by which dietary D-galactose (chiefly from the milk sugar lactose) is converted to glucose-1-phosphate and...</span>                        <details class="module-desc-more">


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3251 |
| Gene review HTML pages | 3251 |
| Project pages | 1111 |
| Module pages | 146 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
