### PR TITLE
Fix main CI: skip mypy analysis of pyhmmer's unparseable type stub

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,12 @@ python_version = 3.10
 [mypy-pandas.*]
 ignore_missing_imports = True
 
+[mypy-pyhmmer.*]
+# pyhmmer ships a type stub (plan7.pyi) that this mypy version cannot parse;
+# skip following it (pyhmmer is only used at runtime via lazy imports).
+follow_imports = skip
+ignore_missing_imports = True
+
 [mypy-ai_gene_review.draw.*]
 ignore_errors = True
 


### PR DESCRIPTION
## Summary

- Fixes the failing `test` job on `main`. PR #2053 added the `pyhmmer` dependency (for the `scan-module` genome-scan tool), which broke the `mypy` step: mypy tries to parse pyhmmer's shipped stub `pyhmmer/plan7.pyi`, which contains a syntax error this mypy version rejects (`Expected an indented block after function definition on line 405`), aborting the whole `just mypy` recipe with exit code 2.
- pyhmmer is only used at runtime via lazy (in-function) imports, so this skips following it in mypy:

  ```ini
  [mypy-pyhmmer.*]
  follow_imports = skip
  ignore_missing_imports = True
  ```

- One-line-family config change; no source or behavior change.

Closes #

## Validation

n/a (no gene-review content changes). Type-checking now passes:

```
$ uv run mypy src tests --exclude "src/ai_gene_review/(datamodel|tools|export)/"
Success: no issues found in 113 source files
```

## Test plan

- [x] `uv run mypy ...` succeeds locally (was failing on `pyhmmer/plan7.pyi:406` before the override)
- [x] `uv run pytest tests/test_module_scan.py` passes (8 passed)
- [ ] CI `test (3.12)` job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEmXWaHVSMfS9Gwbuc5z8s)_