### PR TITLE
[codex] Generalize EF-P module exemplars

### DIFF
--- a/interpro/panther/PTHR30053/PTHR30053-paint.tsv
+++ b/interpro/panther/PTHR30053/PTHR30053-paint.tsv
@@ -1,0 +1,3 @@
+family	node	go_id	aspect	evidence	negated	seeds	taxon	date
+PTHR30053	PTN000769376	GO:0005737	C	IBD	false	UniProtKB:P0A6N4|UniProtKB:P0A6N8	taxon:	20260529
+PTHR30053	PTN000769376	GO:0003746	F	IBD	false	UniProtKB:P0A6N8|UniProtKB:P0A6N4	taxon:	20250904

--- a/modules/efp_translation_stall_rescue.yaml
+++ b/modules/efp_translation_stall_rescue.yaml
@@ -1,12 +1,13 @@
 id: MODULE:efp_translation_stall_rescue
 title: EF-P translation stall rescue
 description: >-
-  A Pseudomonas putida KT2440 UniPathway UPA00345 module for elongation factor
+  A species-neutral bacterial EF-P-family module for elongation factor
   P-dependent stimulation of peptide-bond formation and rescue of stalled
-  cytosolic ribosomes. The module is centered on efp (PP_1858, UniProtKB:Q88LS0).
-  EarP-dependent Arg32 rhamnosylation and dTDP-L-rhamnose supply are activation
-  context for pseudomonad EF-P, but they are not members of the single-gene
-  UPA00345 pathway bucket.
+  cytosolic ribosomes. Pseudomonas putida KT2440 efp/PP_1858
+  (UniProtKB:Q88LS0) is the local UPA00345 exemplar, not the defining scope of
+  the module. Lineage-specific EF-P activation chemistry, including pseudomonad
+  EarP-dependent Arg32 rhamnosylation and enterobacterial beta-lysylation, is
+  adjacent context rather than a member of the EF-P step itself.
 status: DRAFT
 evidence:
   - source_id: UniPathway:UPA00345
@@ -24,6 +25,46 @@ evidence:
     statement: >-
       GO:0072344 captures EF-P's more specific role in relieving stalled
       ribosomes during translation.
+  - source_id: PANTHER:PTHR30053
+    title: PANTHER elongation factor P family
+    statement: >-
+      PTHR30053 grounds the annoton as an EF-P-family role and includes broad
+      bacterial representatives such as PSEPK Q88LS0, E. coli K-12 P0A6N4,
+      P. aeruginosa PAO1 Q9HZZ2, Shewanella oneidensis Q8EEP9, Neisseria
+      meningitidis Q9JZQ8, and Thermus thermophilus HB8 Q76G20.
+  - source_id: PANTHER:PTN000769376
+    title: PAINT EF-P/YeiP translation elongation factor node
+    statement: >-
+      QuickGO IBA rows for E. coli EF-P and several other reviewed bacterial
+      EF-P entries use PTN000769376 with GO_REF:0000033 for translation
+      elongation factor activity.
+  - source_id: PANTHER:PTN002409107
+    title: PSEPK Q88LS0 PANTHER with/from node
+    statement: >-
+      The PSEPK Q88LS0 GOA rows cite PTN002409107 in the with/from column for
+      translation elongation factor activity and cytoplasm, providing a
+      concrete PSEPK-specific PANTHER anchor.
+  - source_id: UniProtKB:Q88LS0
+    title: PSEPK efp UniProt exemplar
+    statement: >-
+      Q88LS0 is the curated P. putida KT2440 EF-P member of UPA00345 and is
+      used here as an exemplar for the local PSEPK pathway bucket.
+  - source_id: UniProtKB:P0A6N4
+    title: E. coli K-12 EF-P exemplar
+    statement: >-
+      P0A6N4 is a reviewed EF-P exemplar with direct experimental GO support
+      for translation elongation factor activity, translational elongation, and
+      stalled-cytosolic-ribosome rescue.
+  - source_id: UniProtKB:Q9HZZ2
+    title: Pseudomonas aeruginosa PAO1 EF-P exemplar
+    statement: >-
+      Q9HZZ2 is a reviewed pseudomonad EF-P exemplar with direct Arg32
+      rhamnosylation evidence and PTHR30053:SF12 family membership.
+  - source_id: UniProtKB:Q76G20
+    title: Thermus thermophilus HB8 EF-P structural exemplar
+    statement: >-
+      Q76G20 is the Thermus thermophilus HB8 EF-P whose structures include the
+      free protein and an EF-P-bound 70S ribosome complex.
   - source_id: PMID:25686373
     title: Arginine-rhamnosylation as new strategy to activate translation elongation factor P.
     statement: >-
@@ -57,10 +98,12 @@ evidence:
       EpmA/EpmB/EpmC beta-lysylation genes not expected in KT2440, and EarP plus
       dTDP-L-rhamnose supply correctly treated as adjacent activation context.
 notes: >-
-  First-pass interpretation: UPA00345 is satisfiable as a compact single-gene
-  translation-factor module in KT2440. The functional boundary should include
-  EF-P's direct elongation and stall-rescue roles, while treating EarP, Rml
-  dTDP-rhamnose biosynthesis, and other activation dependencies as linked
+  First-pass interpretation: the reusable module is a species-neutral bacterial
+  EF-P-family stall-rescue module. The PSEPK UPA00345 instantiation is
+  satisfiable as a compact single-gene pathway bucket, represented by
+  efp/PP_1858/Q88LS0. The functional boundary should include EF-P's direct
+  elongation and stall-rescue roles, while treating EarP, Rml dTDP-rhamnose
+  biosynthesis, EpmA/EpmB/EpmC, and other activation dependencies as linked
   context handled by their own modules. OpenScientist's PSEPK-specific review
   supports this single-gene boundary, notes that KT2440 lacks an EfpL/YeiP
   paralog and the E. coli-style EpmA/EpmB/EpmC beta-lysylation route, and flags
@@ -92,6 +135,14 @@ module:
         label: peptide biosynthetic process
       description: Broad parent process retained as context rather than the module core.
   context:
+    taxa:
+      - preferred_term: bacteria
+        term:
+          id: NCBITaxon:2
+          label: Bacteria
+        description: >-
+          EF-P is the bacterial family member; eukaryotic/archaeal eIF5A/aIF5A
+          homologs are related biology but outside this bacterial EF-P module.
     cellular_components:
       - preferred_term: cytoplasm
         term:
@@ -111,19 +162,98 @@ module:
         label: EF-P stalled-ribosome rescue
         module_type: BIOLOGICAL_PROCESS
         description: >-
-          EF-P binds stalled bacterial ribosomes and stimulates peptide-bond
-          formation during elongation, with the pseudomonad protein requiring
-          EarP-dependent Arg32 rhamnosylation for full activity.
+          EF-P-family translation factors bind stalled bacterial ribosomes and
+          stimulate peptide-bond formation during elongation, especially at
+          polyproline-containing motifs. The activating post-translational
+          modification is lineage-specific and modeled as adjacent context.
         annotons:
           - id: efp_translation_elongation_factor
-            label: "efp: elongation factor P"
+            label: "EF-P family: translation elongation factor"
             participant:
-              selector_type: GENE_PRODUCT
-              gene_product:
-                preferred_term: PSEPK efp
+              selector_type: FAMILY
+              family:
+                preferred_term: elongation factor P family
                 term:
-                  id: UniProtKB:Q88LS0
-                  label: Elongation factor P
+                  id: PANTHER:PTHR30053
+                  label: ELONGATION FACTOR P
+                description: >-
+                  Bacterial EF-P/YeiP-family proteins that stimulate
+                  peptide-bond formation and rescue slow elongation. The module
+                  core is represented by canonical EF-P; EfpL/YeiP paralogs are
+                  related family members and should be handled explicitly when
+                  present in a target organism.
+                representative_members:
+                  - preferred_term: PSEPK efp exemplar
+                    term:
+                      id: UniProtKB:Q88LS0
+                      label: Elongation factor P
+                    description: Pseudomonas putida KT2440 UPA00345 exemplar.
+                  - preferred_term: E. coli K-12 efp exemplar
+                    term:
+                      id: UniProtKB:P0A6N4
+                      label: Elongation factor P
+                    description: >-
+                      Experimentally characterized beta-lysylated EF-P
+                      exemplar with direct GO support for elongation and
+                      stalled-ribosome rescue.
+                  - preferred_term: Pseudomonas aeruginosa PAO1 efp exemplar
+                    term:
+                      id: UniProtKB:Q9HZZ2
+                      label: Elongation factor P
+                    description: >-
+                      Pseudomonad EF-P exemplar with direct Arg32
+                      rhamnosylation evidence.
+                  - preferred_term: Shewanella oneidensis MR-1 efp exemplar
+                    term:
+                      id: UniProtKB:Q8EEP9
+                      label: Elongation factor P
+                    description: >-
+                      Reviewed EF-P exemplar in an EarP/rhamnose-lineage
+                      organism.
+                  - preferred_term: Neisseria meningitidis MC58 efp exemplar
+                    term:
+                      id: UniProtKB:Q9JZQ8
+                      label: Elongation factor P
+                    description: >-
+                      Reviewed EF-P exemplar in a lineage where EF-P/Arg32
+                      biology is reported as essential.
+                  - preferred_term: Thermus thermophilus HB8 efp structural exemplar
+                    term:
+                      id: UniProtKB:Q76G20
+                      label: Elongation factor P
+                    description: >-
+                      Structural EF-P exemplar with free EF-P and EF-P-bound
+                      70S ribosome structures.
+                ancestral_nodes:
+                  - preferred_term: PAINT EF-P/YeiP translation factor node PTN000769376
+                    term:
+                      id: PANTHER:PTN000769376
+                      label: PTN000769376
+                    description: >-
+                      PANTHER PAINT node in PTHR30053 used by GO_Central IBA
+                      rows for translation elongation factor activity and
+                      cytoplasmic activity in multiple reviewed bacterial EF-P
+                      entries.
+                    evidence:
+                      - source_id: GO_REF:0000033
+                        statement: >-
+                          QuickGO IBA rows for P0A6N4, Q9HZZ2, Q8EEP9, and
+                          Q9JZQ8 cite PTN000769376 in PTHR30053.
+              description: >-
+                Select canonical bacterial EF-P-family members with
+                translation elongation factor activity. PSEPK Q88LS0 is an
+                exemplar for the P. putida KT2440 UPA00345 bucket, while the
+                family selector keeps the reusable module from being
+                PSEPK-specific.
+              evidence:
+                - source_id: file:interpro/panther/PTHR30053/PTHR30053-entries.csv
+                  statement: >-
+                    Local PTHR30053 entries include Q88LS0, P0A6N4, Q9HZZ2,
+                    Q8EEP9, Q9JZQ8, and Q76G20 as EF-P-family members.
+                - source_id: file:PSEPK/efp/efp-goa.tsv
+                  statement: >-
+                    Q88LS0 GOA cites PANTHER:PTN002409107 for translation
+                    elongation factor activity and cytoplasm.
             function:
               preferred_term: translation elongation factor activity
               term:

--- a/pages/modules/efp_translation_stall_rescue.html
+++ b/pages/modules/efp_translation_stall_rescue.html
@@ -552,14 +552,14 @@
     </nav>
 
     <header class="header">
-        <h1>EF-P translation stall rescue</h1>            <p class="description">A Pseudomonas putida KT2440 UniPathway UPA00345 module for elongation factor P-dependent stimulation of peptide-bond formation and rescue of stalled cytosolic ribosomes. The module is centered on efp (PP_1858, UniProtKB:Q88LS0). EarP-dependent Arg32 rhamnosylation and dTDP-L-rhamnose supply are activation context for pseudomonad EF-P, but they are not members of the single-gene UPA00345 pathway bucket.</p>        <div class="meta-row"><span class="pill">MODULE:efp_translation_stall_rescue</span><span class="pill status">DRAFT</span><span class="pill type">Biological Process</span><span class="pill">modules/efp_translation_stall_rescue.yaml</span>
+        <h1>EF-P translation stall rescue</h1>            <p class="description">A species-neutral bacterial EF-P-family module for elongation factor P-dependent stimulation of peptide-bond formation and rescue of stalled cytosolic ribosomes. Pseudomonas putida KT2440 efp/PP_1858 (UniProtKB:Q88LS0) is the local UPA00345 exemplar, not the defining scope of the module. Lineage-specific EF-P activation chemistry, including pseudomonad EarP-dependent Arg32 rhamnosylation and enterobacterial beta-lysylation, is adjacent context rather than a member of the EF-P step itself.</p>        <div class="meta-row"><span class="pill">MODULE:efp_translation_stall_rescue</span><span class="pill status">DRAFT</span><span class="pill type">Biological Process</span><span class="pill">modules/efp_translation_stall_rescue.yaml</span>
         </div>
         <div class="descriptor-list">                <span class="descriptor">
             <span>translation elongation factor activity</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003746" target="_blank" rel="noopener">GO:0003746</a></span>                <span class="descriptor">
             <span>translational elongation</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006414" target="_blank" rel="noopener">GO:0006414</a></span>                <span class="descriptor">
             <span>rescue of stalled cytosolic ribosome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a></span>                <span class="descriptor">
             <span>peptide biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0043043" target="_blank" rel="noopener">GO:0043043</a></span>        </div>
-        <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">UniPathway:UPA00345</span><div><strong>UniPathway UPA00345</strong></div><div>The local UPA00345 membership set contains efp as the elongation factor P member of protein biosynthesis/polypeptide-chain elongation.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0003746" target="_blank" rel="noopener">GO:0003746</a><div><strong>translation elongation factor activity</strong></div><div>GO:0003746 captures EF-P&#39;s molecular function as a translation elongation factor.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a><div><strong>rescue of stalled cytosolic ribosome</strong></div><div>GO:0072344 captures EF-P&#39;s more specific role in relieving stalled ribosomes during translation.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/25686373/" target="_blank" rel="noopener">PMID:25686373</a><div><strong>Arginine-rhamnosylation as new strategy to activate translation elongation factor P.</strong></div><div>This study supports EF-P as the bacterial factor that rescues stalled ribosomes, with activation by EarP-mediated rhamnosylation in the Arg-type EF-P subfamily.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-ai-review.yaml</span><div><strong>Curated efp review</strong></div><div>The efp review accepts translation elongation factor activity, translational elongation, cytoplasm/cytosol, and stalled-ribosome rescue, while keeping broad peptide biosynthesis and regulation of translation as non-core context.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-uniprot.txt</span><div><strong>UniProtKB reviewed entry for efp</strong></div><div>UniProt describes EF-P as cytoplasmic, involved in peptide-bond synthesis, and assigned to protein biosynthesis/polypeptide-chain elongation.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/efp_translation_stall_rescue-deep-research-openscientist.md</span><div><strong>OpenScientist module research for EF-P translation stall rescue</strong></div><div>OpenScientist module-level research supports EF-P as a conserved translation factor that rescues polyproline and related elongation stalls, with pseudomonad EarP/rhamnose-dependent activation treated as context rather than as part of the single-gene UPA00345 module.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__efp_translation_stall_rescue__upa00345-deep-research-openscientist.md</span><div><strong>OpenScientist PSEPK UPA00345 pathway satisfiability review</strong></div><div>The PSEPK-specific OpenScientist report finds the UPA00345 core step satisfied by efp/PP_1858/Q88LS0, with no EfpL/YeiP paralog ambiguity, EpmA/EpmB/EpmC beta-lysylation genes not expected in KT2440, and EarP plus dTDP-L-rhamnose supply correctly treated as adjacent activation context.</div></div>        </div><p class="muted small">First-pass interpretation: UPA00345 is satisfiable as a compact single-gene translation-factor module in KT2440. The functional boundary should include EF-P&#39;s direct elongation and stall-rescue roles, while treating EarP, Rml dTDP-rhamnose biosynthesis, and other activation dependencies as linked context handled by their own modules. OpenScientist&#39;s PSEPK-specific review supports this single-gene boundary, notes that KT2440 lacks an EfpL/YeiP paralog and the E. coli-style EpmA/EpmB/EpmC beta-lysylation route, and flags the adjacent EarP/Q88LS1 UniProt &#34;Lys-32&#34; target text as a likely residue-label typo because pseudomonad EF-P is Arg32-rhamnosylated.</p></header>
+        <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">UniPathway:UPA00345</span><div><strong>UniPathway UPA00345</strong></div><div>The local UPA00345 membership set contains efp as the elongation factor P member of protein biosynthesis/polypeptide-chain elongation.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0003746" target="_blank" rel="noopener">GO:0003746</a><div><strong>translation elongation factor activity</strong></div><div>GO:0003746 captures EF-P&#39;s molecular function as a translation elongation factor.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a><div><strong>rescue of stalled cytosolic ribosome</strong></div><div>GO:0072344 captures EF-P&#39;s more specific role in relieving stalled ribosomes during translation.</div></div>                <div class="evidence-card small"><span class="source-id">PANTHER:PTHR30053</span><div><strong>PANTHER elongation factor P family</strong></div><div>PTHR30053 grounds the annoton as an EF-P-family role and includes broad bacterial representatives such as PSEPK Q88LS0, E. coli K-12 P0A6N4, P. aeruginosa PAO1 Q9HZZ2, Shewanella oneidensis Q8EEP9, Neisseria meningitidis Q9JZQ8, and Thermus thermophilus HB8 Q76G20.</div></div>                <div class="evidence-card small"><span class="source-id">PANTHER:PTN000769376</span><div><strong>PAINT EF-P/YeiP translation elongation factor node</strong></div><div>QuickGO IBA rows for E. coli EF-P and several other reviewed bacterial EF-P entries use PTN000769376 with GO_REF:0000033 for translation elongation factor activity.</div></div>                <div class="evidence-card small"><span class="source-id">PANTHER:PTN002409107</span><div><strong>PSEPK Q88LS0 PANTHER with/from node</strong></div><div>The PSEPK Q88LS0 GOA rows cite PTN002409107 in the with/from column for translation elongation factor activity and cytoplasm, providing a concrete PSEPK-specific PANTHER anchor.</div></div>                <div class="evidence-card small"><span class="source-id">UniProtKB:Q88LS0</span><div><strong>PSEPK efp UniProt exemplar</strong></div><div>Q88LS0 is the curated P. putida KT2440 EF-P member of UPA00345 and is used here as an exemplar for the local PSEPK pathway bucket.</div></div>                <div class="evidence-card small"><span class="source-id">UniProtKB:P0A6N4</span><div><strong>E. coli K-12 EF-P exemplar</strong></div><div>P0A6N4 is a reviewed EF-P exemplar with direct experimental GO support for translation elongation factor activity, translational elongation, and stalled-cytosolic-ribosome rescue.</div></div>                <div class="evidence-card small"><span class="source-id">UniProtKB:Q9HZZ2</span><div><strong>Pseudomonas aeruginosa PAO1 EF-P exemplar</strong></div><div>Q9HZZ2 is a reviewed pseudomonad EF-P exemplar with direct Arg32 rhamnosylation evidence and PTHR30053:SF12 family membership.</div></div>                <div class="evidence-card small"><span class="source-id">UniProtKB:Q76G20</span><div><strong>Thermus thermophilus HB8 EF-P structural exemplar</strong></div><div>Q76G20 is the Thermus thermophilus HB8 EF-P whose structures include the free protein and an EF-P-bound 70S ribosome complex.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/25686373/" target="_blank" rel="noopener">PMID:25686373</a><div><strong>Arginine-rhamnosylation as new strategy to activate translation elongation factor P.</strong></div><div>This study supports EF-P as the bacterial factor that rescues stalled ribosomes, with activation by EarP-mediated rhamnosylation in the Arg-type EF-P subfamily.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-ai-review.yaml</span><div><strong>Curated efp review</strong></div><div>The efp review accepts translation elongation factor activity, translational elongation, cytoplasm/cytosol, and stalled-ribosome rescue, while keeping broad peptide biosynthesis and regulation of translation as non-core context.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-uniprot.txt</span><div><strong>UniProtKB reviewed entry for efp</strong></div><div>UniProt describes EF-P as cytoplasmic, involved in peptide-bond synthesis, and assigned to protein biosynthesis/polypeptide-chain elongation.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/efp_translation_stall_rescue-deep-research-openscientist.md</span><div><strong>OpenScientist module research for EF-P translation stall rescue</strong></div><div>OpenScientist module-level research supports EF-P as a conserved translation factor that rescues polyproline and related elongation stalls, with pseudomonad EarP/rhamnose-dependent activation treated as context rather than as part of the single-gene UPA00345 module.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__efp_translation_stall_rescue__upa00345-deep-research-openscientist.md</span><div><strong>OpenScientist PSEPK UPA00345 pathway satisfiability review</strong></div><div>The PSEPK-specific OpenScientist report finds the UPA00345 core step satisfied by efp/PP_1858/Q88LS0, with no EfpL/YeiP paralog ambiguity, EpmA/EpmB/EpmC beta-lysylation genes not expected in KT2440, and EarP plus dTDP-L-rhamnose supply correctly treated as adjacent activation context.</div></div>        </div><p class="muted small">First-pass interpretation: the reusable module is a species-neutral bacterial EF-P-family stall-rescue module. The PSEPK UPA00345 instantiation is satisfiable as a compact single-gene pathway bucket, represented by efp/PP_1858/Q88LS0. The functional boundary should include EF-P&#39;s direct elongation and stall-rescue roles, while treating EarP, Rml dTDP-rhamnose biosynthesis, EpmA/EpmB/EpmC, and other activation dependencies as linked context handled by their own modules. OpenScientist&#39;s PSEPK-specific review supports this single-gene boundary, notes that KT2440 lacks an EfpL/YeiP paralog and the E. coli-style EpmA/EpmB/EpmC beta-lysylation route, and flags the adjacent EarP/Q88LS1 UniProt &#34;Lys-32&#34; target text as a likely residue-label typo because pseudomonad EF-P is Arg32-rhamnosylated.</p></header>
     <section class="stats" aria-label="Module counts">
         <div class="stat"><span class="stat-value">2</span><span class="stat-label">Nodes</span></div>
         <div class="stat"><span class="stat-value">1</span><span class="stat-label">Parts</span></div>
@@ -591,11 +591,11 @@
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(1/1 grounded genes reviewed)</span>
+                    <span class="muted small">(1/6 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
                         1 complete review(s) &middot;
                         1 with deep research &middot;
-                        0 missing review &middot;
+                        5 missing review &middot;
                         0 reviewed but lacking deep research
                     </p>
                     <table class="qc-table small">
@@ -613,6 +613,36 @@
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>E. coli K-12 efp exemplar
+                                        <span class="muted term-id">P0A6N4</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
+                                </tr>                                <tr>
+                                    <td>Thermus thermophilus HB8 efp structural exemplar
+                                        <span class="muted term-id">Q76G20</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
+                                </tr>                                <tr>
+                                    <td>Shewanella oneidensis MR-1 efp exemplar
+                                        <span class="muted term-id">Q8EEP9</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
+                                </tr>                                <tr>
+                                    <td>Pseudomonas aeruginosa PAO1 efp exemplar
+                                        <span class="muted term-id">Q9HZZ2</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
+                                </tr>                                <tr>
+                                    <td>Neisseria meningitidis MC58 efp exemplar
+                                        <span class="muted term-id">Q9JZQ8</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                        </tbody>
                     </table>            </div>
         </div>
@@ -647,8 +677,8 @@
             </summary>                <div class="tree-group-title">Annotons</div>
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
-                                <a href="#annoton-efp_translation_elongation_factor">efp: elongation factor P</a>
-                                <span class="tree-id">Gene Product: PSEPK efp</span>
+                                <a href="#annoton-efp_translation_elongation_factor">EF-P family: translation elongation factor</a>
+                                <span class="tree-id">Family: elongation factor P family</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -665,7 +695,8 @@
             <div class="panel-body">
                 <div class="context-card small">
             <strong>Context</strong>
-
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>bacteria</span><a class="term-id" href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2" target="_blank" rel="noopener">NCBITaxon:2</a></span>        </div>
 
 
 
@@ -684,7 +715,8 @@
             <span>peptide biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0043043" target="_blank" rel="noopener">GO:0043043</a></span>        </div>
         <div class="context-card small">
             <strong>Context</strong>
-
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>bacteria</span><a class="term-id" href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2" target="_blank" rel="noopener">NCBITaxon:2</a></span>        </div>
 
 
 
@@ -698,17 +730,24 @@
                 <section class="node-detail depth-1" id="node-efp_translation_stall_rescue_step">
         <div class="node-heading">
             <span class="node-title">EF-P stalled-ribosome rescue</span><span class="pill type">Biological Process</span><span class="pill">efp_translation_stall_rescue_step</span>
-        </div>            <p class="node-description">EF-P binds stalled bacterial ribosomes and stimulates peptide-bond formation during elongation, with the pseudomonad protein requiring EarP-dependent Arg32 rhamnosylation for full activity.</p>
+        </div>            <p class="node-description">EF-P-family translation factors bind stalled bacterial ribosomes and stimulate peptide-bond formation during elongation, especially at polyproline-containing motifs. The activating post-translational modification is lineage-specific and modeled as adjacent context.</p>
 
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-efp_translation_elongation_factor">
-        <div class="annoton-title">efp: elongation factor P</div>
-        <div class="small muted">efp_translation_elongation_factor</div>            <div class="small"><strong>Participant:</strong> Gene Product: PSEPK efp</div>
+        <div class="annoton-title">EF-P family: translation elongation factor</div>
+        <div class="small muted">efp_translation_elongation_factor</div>            <div class="small"><strong>Participant:</strong> Family: elongation factor P family</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Gene Product:</span>
+                        <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>PSEPK efp</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88LS0/entry" target="_blank" rel="noopener">UniProtKB:Q88LS0</a></div>
-                    </div></div>            <h4>Function</h4>
+            <span><strong>elongation factor P family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR30053" target="_blank" rel="noopener">PANTHER:PTHR30053</a>                <span class="descriptor-description">Bacterial EF-P/YeiP-family proteins that stimulate peptide-bond formation and rescue slow elongation. The module core is represented by canonical EF-P; EfpL/YeiP paralogs are related family members and should be handled explicitly when present in a target organism.</span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88LS0/entry" target="_blank" rel="noopener">UniProtKB:Q88LS0</a></span>                            <span class="descriptor">
+            <span>E. coli K-12 efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0A6N4/entry" target="_blank" rel="noopener">UniProtKB:P0A6N4</a></span>                            <span class="descriptor">
+            <span>Pseudomonas aeruginosa PAO1 efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9HZZ2/entry" target="_blank" rel="noopener">UniProtKB:Q9HZZ2</a></span>                            <span class="descriptor">
+            <span>Shewanella oneidensis MR-1 efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8EEP9/entry" target="_blank" rel="noopener">UniProtKB:Q8EEP9</a></span>                            <span class="descriptor">
+            <span>Neisseria meningitidis MC58 efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9JZQ8/entry" target="_blank" rel="noopener">UniProtKB:Q9JZQ8</a></span>                            <span class="descriptor">
+            <span>Thermus thermophilus HB8 efp structural exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q76G20/entry" target="_blank" rel="noopener">UniProtKB:Q76G20</a></span>                    </div></div>
+                    </div>                <div class="small muted">Select canonical bacterial EF-P-family members with translation elongation factor activity. PSEPK Q88LS0 is an exemplar for the P. putida KT2440 UPA00345 bucket, while the family selector keeps the reusable module from being PSEPK-specific.</div><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:interpro/panther/PTHR30053/PTHR30053-entries.csv</span><div>Local PTHR30053 entries include Q88LS0, P0A6N4, Q9HZZ2, Q8EEP9, Q9JZQ8, and Q76G20 as EF-P-family members.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-goa.tsv</span><div>Q88LS0 GOA cites PANTHER:PTN002409107 for translation elongation factor activity and cytoplasm.</div></div>        </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>translation elongation factor activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003746" target="_blank" rel="noopener">GO:0003746</a></div>            <h4>Processes</h4>
             <div class="descriptor-list">                <span class="descriptor">

--- a/pages/projects/P_PUTIDA/batches/UPA00345_efp_translation_stall_rescue.html
+++ b/pages/projects/P_PUTIDA/batches/UPA00345_efp_translation_stall_rescue.html
@@ -385,7 +385,7 @@
 <li>[x] Curate each selected gene review.</li>
 <li>[x] Validate module and gene reviews.</li>
 <li>[x] Open one PR for this module/pathway: <a href="https://github.com/ai4curation/ai-gene-review/pull/2051">PR #2051</a>.</li>
-<li>[ ] Shepherd PR through review, CI, and merge readiness.</li>
+<li>[x] Shepherd PR through review, CI, and merge readiness.</li>
 </ul>
 <h2 id="candidate-genes">Candidate Genes</h2>
 <table>
@@ -424,6 +424,11 @@
 <li>Created and validated <code>modules/efp_translation_stall_rescue.yaml</code> as a compact<br />
   single-gene UPA00345 module for cytoplasmic EF-P translation elongation and<br />
   stalled-ribosome rescue.</li>
+<li>Follow-up after PR #2051 review: generalized the reusable module from a<br />
+  PSEPK-centered wording to a species-neutral bacterial EF-P-family module.<br />
+<code>efp</code> / PP_1858 / Q88LS0 is now recorded as the PSEPK UniProt exemplar rather<br />
+  than as the module's full scope, with additional representative EF-P members<br />
+  and PAINT/PTN anchors recorded in the module.</li>
 <li>Corrected the accession-based seed so <code>gene_symbol</code> is <code>efp</code> rather than<br />
 <a href="https://www.uniprot.org/uniprotkb/Q88LS0/entry">Q88LS0</a>.</li>
 <li><code>efp</code> accepts translation elongation factor activity, translational<br />

--- a/projects/P_PUTIDA/batches/UPA00345_efp_translation_stall_rescue.md
+++ b/projects/P_PUTIDA/batches/UPA00345_efp_translation_stall_rescue.md
@@ -25,7 +25,7 @@ autolink_gene_symbols: false
 - [x] Curate each selected gene review.
 - [x] Validate module and gene reviews.
 - [x] Open one PR for this module/pathway: [PR #2051](https://github.com/ai4curation/ai-gene-review/pull/2051).
-- [ ] Shepherd PR through review, CI, and merge readiness.
+- [x] Shepherd PR through review, CI, and merge readiness.
 
 ## Candidate Genes
 
@@ -42,6 +42,11 @@ Generated UTC: 2026-07-10T01:23:19.469718+00:00
 - Created and validated `modules/efp_translation_stall_rescue.yaml` as a compact
   single-gene UPA00345 module for cytoplasmic EF-P translation elongation and
   stalled-ribosome rescue.
+- Follow-up after PR #2051 review: generalized the reusable module from a
+  PSEPK-centered wording to a species-neutral bacterial EF-P-family module.
+  `efp` / PP_1858 / Q88LS0 is now recorded as the PSEPK UniProt exemplar rather
+  than as the module's full scope, with additional representative EF-P members
+  and PAINT/PTN anchors recorded in the module.
 - Corrected the accession-based seed so `gene_symbol` is `efp` rather than
   `Q88LS0`.
 - `efp` accepts translation elongation factor activity, translational


### PR DESCRIPTION
## Summary
- Reframes `efp_translation_stall_rescue` as a species-neutral bacterial EF-P-family module rather than a PSEPK-scoped module.
- Records PSEPK `UniProtKB:Q88LS0` as the local UPA00345 exemplar and adds additional reviewed EF-P representative members.
- Materializes `PTHR30053-paint.tsv` and adds the verified PAINT `PTN000769376` anchor, while keeping the PSEPK `PTN002409107` with/from node as local GOA evidence.
- Updates and renders the PSEPK UPA00345 batch page.

## Root Cause
PR #2051 correctly curated the PSEPK UPA00345 batch, but the reusable module text and participant selector made the module look centered on PSEPK `efp` rather than on the broader bacterial EF-P family.

## Validation
- `uv run linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/efp_translation_stall_rescue.yaml`
- `uv run python -m ai_gene_review.validation.module_validator modules/efp_translation_stall_rescue.yaml` (passes with only the NCBITaxon lookup warning)
- `just render-module modules/efp_translation_stall_rescue.yaml`
- `uv run ai-gene-review render-projects projects/P_PUTIDA/batches/UPA00345_efp_translation_stall_rescue.md -o pages/projects`
- `just validate PSEPK efp` (passes; existing warning about no annotation citing the Asta deep research file)