### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -1118,14 +1118,14 @@ Design intent: the module is organized as an upstream copper-homeostasis layer t
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/dolichol_phosphate_sugar_donor_supply.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="EF-P translation stall rescue">
-                        <a class="module-name" href="efp_translation_stall_rescue.html">EF-P translation stall rescue</a><span class="module-id">MODULE:efp_translation_stall_rescue</span>                        <span class="module-desc">A Pseudomonas putida KT2440 UniPathway UPA00345 module for elongation factor P-dependent stimulation of peptide-bond formation and rescue of...</span>                        <details class="module-desc-more">
+                        <a class="module-name" href="efp_translation_stall_rescue.html">EF-P translation stall rescue</a><span class="module-id">MODULE:efp_translation_stall_rescue</span>                        <span class="module-desc">A species-neutral bacterial EF-P-family module for elongation factor P-dependent stimulation of peptide-bond formation and rescue of stalled...</span>                        <details class="module-desc-more">
                             <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
-                            <span class="module-desc-full">A Pseudomonas putida KT2440 UniPathway UPA00345 module for elongation factor P-dependent stimulation of peptide-bond formation and rescue of stalled cytosolic ribosomes. The module is centered on efp (PP_1858, UniProtKB:Q88LS0). EarP-dependent Arg32 rhamnosylation and dTDP-L-rhamnose supply are activation context for pseudomonad EF-P, but they are not members of the single-gene UPA00345 pathway bucket.</span>
+                            <span class="module-desc-full">A species-neutral bacterial EF-P-family module for elongation factor P-dependent stimulation of peptide-bond formation and rescue of stalled cytosolic ribosomes. Pseudomonas putida KT2440 efp/PP_1858 (UniProtKB:Q88LS0) is the local UPA00345 exemplar, not the defining scope of the module. Lineage-specific EF-P activation chemistry, including pseudomonad EarP-dependent Arg32 rhamnosylation and enterobacterial beta-lysylation, is adjacent context rather than a member of the EF-P step itself.</span>
                         </details>                    </td>
                     <td data-sort-value="Biological Process"><span class="pill type">Biological Process</span>                    </td>
                     <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
-                    <td data-sort-value="">                    </td>
-                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="bacteria">                        <div class="taxa">                            <span class="pill">bacteria</span>                        </div>                    </td>
+                    <td class="num" data-sort-value="1">1</td>
                     <td data-sort-value="4">                        <div class="concepts">                            <span class="pill">translation elongation factor activity</span>                            <span class="pill">translational elongation</span>                            <span class="pill">rescue of stalled cytosolic ribosome</span>                            <span class="pill">peptide biosynthetic process</span>                        </div>                    </td>
                     <td class="num">2</td>
                     <td class="num">1</td>
@@ -1133,7 +1133,7 @@ Design intent: the module is organized as an upstream copper-homeostasis layer t
                     <td class="num">0</td>
                     <td class="num">0</td>
                     <td class="num">0</td>                    <td class="num" data-sort-value="1">
-                        1/1
+                        1/6
                     </td>
                     <td class="num" data-sort-value="0">
                         0


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3358 |
| Gene review HTML pages | 3358 |
| Project pages | 1145 |
| Module pages | 168 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
