### PR TITLE
[codex] Clean up EF-P module structure

### DIFF
--- a/modules/efp_translation_stall_rescue.yaml
+++ b/modules/efp_translation_stall_rescue.yaml
@@ -15,11 +15,6 @@ evidence:
     statement: >-
       The local UPA00345 membership set contains efp as the elongation factor P
       member of protein biosynthesis/polypeptide-chain elongation.
-  - source_id: GO:0003746
-    title: translation elongation factor activity
-    statement: >-
-      GO:0003746 captures EF-P's molecular function as a translation elongation
-      factor.
   - source_id: GO:0072344
     title: rescue of stalled cytosolic ribosome
     statement: >-
@@ -32,39 +27,11 @@ evidence:
       bacterial representatives such as PSEPK Q88LS0, E. coli K-12 P0A6N4,
       P. aeruginosa PAO1 Q9HZZ2, Shewanella oneidensis Q8EEP9, Neisseria
       meningitidis Q9JZQ8, and Thermus thermophilus HB8 Q76G20.
-  - source_id: PANTHER:PTN000769376
-    title: PAINT EF-P/YeiP translation elongation factor node
-    statement: >-
-      QuickGO IBA rows for E. coli EF-P and several other reviewed bacterial
-      EF-P entries use PTN000769376 with GO_REF:0000033 for translation
-      elongation factor activity.
-  - source_id: PANTHER:PTN002409107
-    title: PSEPK Q88LS0 PANTHER with/from node
-    statement: >-
-      The PSEPK Q88LS0 GOA rows cite PTN002409107 in the with/from column for
-      translation elongation factor activity and cytoplasm, providing a
-      concrete PSEPK-specific PANTHER anchor.
   - source_id: UniProtKB:Q88LS0
     title: PSEPK efp UniProt exemplar
     statement: >-
       Q88LS0 is the curated P. putida KT2440 EF-P member of UPA00345 and is
       used here as an exemplar for the local PSEPK pathway bucket.
-  - source_id: UniProtKB:P0A6N4
-    title: E. coli K-12 EF-P exemplar
-    statement: >-
-      P0A6N4 is a reviewed EF-P exemplar with direct experimental GO support
-      for translation elongation factor activity, translational elongation, and
-      stalled-cytosolic-ribosome rescue.
-  - source_id: UniProtKB:Q9HZZ2
-    title: Pseudomonas aeruginosa PAO1 EF-P exemplar
-    statement: >-
-      Q9HZZ2 is a reviewed pseudomonad EF-P exemplar with direct Arg32
-      rhamnosylation evidence and PTHR30053:SF12 family membership.
-  - source_id: UniProtKB:Q76G20
-    title: Thermus thermophilus HB8 EF-P structural exemplar
-    statement: >-
-      Q76G20 is the Thermus thermophilus HB8 EF-P whose structures include the
-      free protein and an EF-P-bound 70S ribosome complex.
   - source_id: PMID:25686373
     title: Arginine-rhamnosylation as new strategy to activate translation elongation factor P.
     statement: >-
@@ -75,14 +42,14 @@ evidence:
     title: Curated efp review
     statement: >-
       The efp review accepts translation elongation factor activity,
-      translational elongation, cytoplasm/cytosol, and stalled-ribosome rescue,
-      while keeping broad peptide biosynthesis and regulation of translation as
-      non-core context.
+      translational elongation, EF-P localization annotations, and
+      stalled-ribosome rescue, while keeping broad peptide biosynthesis and
+      regulation of translation as non-core context.
   - source_id: file:PSEPK/efp/efp-uniprot.txt
     title: UniProtKB reviewed entry for efp
     statement: >-
-      UniProt describes EF-P as cytoplasmic, involved in peptide-bond synthesis,
-      and assigned to protein biosynthesis/polypeptide-chain elongation.
+      UniProt describes EF-P as involved in peptide-bond synthesis and assigned
+      to protein biosynthesis/polypeptide-chain elongation.
   - source_id: file:modules/efp_translation_stall_rescue-deep-research-openscientist.md
     title: OpenScientist module research for EF-P translation stall rescue
     statement: >-
@@ -99,26 +66,21 @@ evidence:
       dTDP-L-rhamnose supply correctly treated as adjacent activation context.
 notes: >-
   First-pass interpretation: the reusable module is a species-neutral bacterial
-  EF-P-family stall-rescue module. The PSEPK UPA00345 instantiation is
-  satisfiable as a compact single-gene pathway bucket, represented by
-  efp/PP_1858/Q88LS0. The functional boundary should include EF-P's direct
-  elongation and stall-rescue roles, while treating EarP, Rml dTDP-rhamnose
-  biosynthesis, EpmA/EpmB/EpmC, and other activation dependencies as linked
-  context handled by their own modules. OpenScientist's PSEPK-specific review
-  supports this single-gene boundary, notes that KT2440 lacks an EfpL/YeiP
-  paralog and the E. coli-style EpmA/EpmB/EpmC beta-lysylation route, and flags
-  the adjacent EarP/Q88LS1 UniProt "Lys-32" target text as a likely residue-label
-  typo because pseudomonad EF-P is Arg32-rhamnosylated.
+  EF-P-family stall-rescue module with two mechanistic roles: engagement of the
+  stalled cytosolic ribosome and EF-P-dependent stimulation of elongation/stall
+  rescue. The PSEPK UPA00345 instantiation is satisfiable as a compact
+  single-gene pathway bucket, represented by efp/PP_1858/Q88LS0. Treat EarP, Rml
+  dTDP-rhamnose biosynthesis, EpmA/EpmB/EpmC, and other activation dependencies
+  as linked context handled by their own modules. OpenScientist's PSEPK-specific
+  review supports this single-gene boundary, notes that KT2440 lacks an
+  EfpL/YeiP paralog and the E. coli-style EpmA/EpmB/EpmC beta-lysylation route,
+  and flags the adjacent EarP/Q88LS1 UniProt "Lys-32" target text as a likely
+  residue-label typo because pseudomonad EF-P is Arg32-rhamnosylated.
 module:
   id: efp_translation_stall_rescue
   label: EF-P translation stall rescue
   module_type: BIOLOGICAL_PROCESS
   concepts:
-    - preferred_term: translation elongation factor activity
-      term:
-        id: GO:0003746
-        label: translation elongation factor activity
-      description: Molecular function of EF-P as a bacterial translation elongation factor.
     - preferred_term: translational elongation
       term:
         id: GO:0006414
@@ -129,11 +91,6 @@ module:
         id: GO:0072344
         label: rescue of stalled cytosolic ribosome
       description: Specific process of relieving stalled ribosomes, especially at polyproline-containing motifs.
-    - preferred_term: peptide biosynthetic process
-      term:
-        id: GO:0043043
-        label: peptide biosynthetic process
-      description: Broad parent process retained as context rather than the module core.
   context:
     taxa:
       - preferred_term: bacteria
@@ -144,28 +101,75 @@ module:
           EF-P is the bacterial family member; eukaryotic/archaeal eIF5A/aIF5A
           homologs are related biology but outside this bacterial EF-P module.
     cellular_components:
-      - preferred_term: cytoplasm
-        term:
-          id: GO:0005737
-          label: cytoplasm
-        description: Cytoplasmic location assigned by UniProt and GOA.
       - preferred_term: cytosol
         term:
           id: GO:0005829
           label: cytosol
-        description: ARBA-supported soluble cytosolic context for EF-P action on ribosomes.
+        description: Soluble cytosolic context for EF-P action on cytosolic ribosomes.
   parts:
     - order: 1
-      role: EF-P-dependent rescue of stalled translation elongation
+      role: EF-P engagement of a stalled cytosolic ribosome
       node:
-        id: efp_translation_stall_rescue_step
-        label: EF-P stalled-ribosome rescue
+        id: efp_stalled_ribosome_engagement
+        label: EF-P stalled-ribosome engagement
         module_type: BIOLOGICAL_PROCESS
         description: >-
-          EF-P-family translation factors bind stalled bacterial ribosomes and
-          stimulate peptide-bond formation during elongation, especially at
-          polyproline-containing motifs. The activating post-translational
-          modification is lineage-specific and modeled as adjacent context.
+          EF-P binds a stalled cytosolic ribosome and positions the P-site
+          peptidyl-tRNA/rRNA interface so the nascent chain can continue
+          through difficult motifs such as polyproline stretches.
+        annotons:
+          - id: efp_ribosome_binding
+            label: "EF-P family: stalled-ribosome binding"
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: elongation factor P family
+                term:
+                  id: PANTHER:PTHR30053
+                  label: ELONGATION FACTOR P
+                description: >-
+                  Bacterial EF-P-family proteins that bind stalled ribosomes
+                  during cytosolic translational elongation.
+            function:
+              preferred_term: ribosome binding
+              term:
+                id: GO:0043022
+                label: ribosome binding
+              evidence:
+                - source_id: UniProtKB:P0A6N4
+                  statement: >-
+                    E. coli EF-P has direct EcoCyc GO support for ribosome
+                    binding and curated tRNA/rRNA-binding annotations.
+                - source_id: UniProtKB:Q76G20
+                  statement: >-
+                    Thermus thermophilus EF-P structural records include an
+                    EF-P-bound 70S ribosome complex with initiator tRNA and
+                    rRNA contacts.
+            processes:
+              - preferred_term: rescue of stalled cytosolic ribosome
+                term:
+                  id: GO:0072344
+                  label: rescue of stalled cytosolic ribosome
+            locations:
+              - preferred_term: cytosol
+                term:
+                  id: GO:0005829
+                  label: cytosol
+            role_description: >-
+              Binding/positioning role that engages stalled cytosolic ribosomes;
+              tRNA and rRNA binding are supporting mechanistic observations in
+              characterized EF-P exemplars.
+    - order: 2
+      role: EF-P-dependent stimulation of stalled translation elongation
+      node:
+        id: efp_translation_stall_rescue_step
+        label: EF-P elongation/stall-rescue activity
+        module_type: BIOLOGICAL_PROCESS
+        description: >-
+          EF-P-family translation factors stimulate peptide-bond formation and
+          restore productive elongation at stalled cytosolic ribosomes. The
+          activating post-translational modification is lineage-specific and
+          modeled as adjacent context.
         annotons:
           - id: efp_translation_elongation_factor
             label: "EF-P family: translation elongation factor"
@@ -196,34 +200,6 @@ module:
                       Experimentally characterized beta-lysylated EF-P
                       exemplar with direct GO support for elongation and
                       stalled-ribosome rescue.
-                  - preferred_term: Pseudomonas aeruginosa PAO1 efp exemplar
-                    term:
-                      id: UniProtKB:Q9HZZ2
-                      label: Elongation factor P
-                    description: >-
-                      Pseudomonad EF-P exemplar with direct Arg32
-                      rhamnosylation evidence.
-                  - preferred_term: Shewanella oneidensis MR-1 efp exemplar
-                    term:
-                      id: UniProtKB:Q8EEP9
-                      label: Elongation factor P
-                    description: >-
-                      Reviewed EF-P exemplar in an EarP/rhamnose-lineage
-                      organism.
-                  - preferred_term: Neisseria meningitidis MC58 efp exemplar
-                    term:
-                      id: UniProtKB:Q9JZQ8
-                      label: Elongation factor P
-                    description: >-
-                      Reviewed EF-P exemplar in a lineage where EF-P/Arg32
-                      biology is reported as essential.
-                  - preferred_term: Thermus thermophilus HB8 efp structural exemplar
-                    term:
-                      id: UniProtKB:Q76G20
-                      label: Elongation factor P
-                    description: >-
-                      Structural EF-P exemplar with free EF-P and EF-P-bound
-                      70S ribosome structures.
                 ancestral_nodes:
                   - preferred_term: PAINT EF-P/YeiP translation factor node PTN000769376
                     term:
@@ -232,8 +208,8 @@ module:
                     description: >-
                       PANTHER PAINT node in PTHR30053 used by GO_Central IBA
                       rows for translation elongation factor activity and
-                      cytoplasmic activity in multiple reviewed bacterial EF-P
-                      entries.
+                      cellular-component placement in multiple reviewed
+                      bacterial EF-P entries.
                     evidence:
                       - source_id: GO_REF:0000033
                         statement: >-
@@ -253,12 +229,23 @@ module:
                 - source_id: file:PSEPK/efp/efp-goa.tsv
                   statement: >-
                     Q88LS0 GOA cites PANTHER:PTN002409107 for translation
-                    elongation factor activity and cytoplasm.
+                    elongation factor activity and cellular-component
+                    placement.
             function:
               preferred_term: translation elongation factor activity
               term:
                 id: GO:0003746
                 label: translation elongation factor activity
+              evidence:
+                - source_id: GO:0003746
+                  statement: >-
+                    GO:0003746 captures the EF-P-family elongation-factor
+                    activity that stimulates peptide-bond formation at stalled
+                    ribosomes.
+                - source_id: PANTHER:PTN000769376
+                  statement: >-
+                    The local PTHR30053 PAINT slice includes a positive IBD row
+                    from PTN000769376 to GO:0003746.
             processes:
               - preferred_term: translational elongation
                 term:
@@ -269,16 +256,12 @@ module:
                   id: GO:0072344
                   label: rescue of stalled cytosolic ribosome
             locations:
-              - preferred_term: cytoplasm
-                term:
-                  id: GO:0005737
-                  label: cytoplasm
               - preferred_term: cytosol
                 term:
                   id: GO:0005829
                   label: cytosol
             role_description: >-
-              Cytoplasmic elongation factor that promotes peptide-bond
+              Cytosolic elongation factor that promotes peptide-bond
               formation and relieves stalled translation elongation.
   knowledge_gaps:
     - gap_statement: >-

--- a/pages/modules/efp_translation_stall_rescue.html
+++ b/pages/modules/efp_translation_stall_rescue.html
@@ -555,17 +555,15 @@
         <h1>EF-P translation stall rescue</h1>            <p class="description">A species-neutral bacterial EF-P-family module for elongation factor P-dependent stimulation of peptide-bond formation and rescue of stalled cytosolic ribosomes. Pseudomonas putida KT2440 efp/PP_1858 (UniProtKB:Q88LS0) is the local UPA00345 exemplar, not the defining scope of the module. Lineage-specific EF-P activation chemistry, including pseudomonad EarP-dependent Arg32 rhamnosylation and enterobacterial beta-lysylation, is adjacent context rather than a member of the EF-P step itself.</p>        <div class="meta-row"><span class="pill">MODULE:efp_translation_stall_rescue</span><span class="pill status">DRAFT</span><span class="pill type">Biological Process</span><span class="pill">modules/efp_translation_stall_rescue.yaml</span>
         </div>
         <div class="descriptor-list">                <span class="descriptor">
-            <span>translation elongation factor activity</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003746" target="_blank" rel="noopener">GO:0003746</a></span>                <span class="descriptor">
             <span>translational elongation</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006414" target="_blank" rel="noopener">GO:0006414</a></span>                <span class="descriptor">
-            <span>rescue of stalled cytosolic ribosome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a></span>                <span class="descriptor">
-            <span>peptide biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0043043" target="_blank" rel="noopener">GO:0043043</a></span>        </div>
-        <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">UniPathway:UPA00345</span><div><strong>UniPathway UPA00345</strong></div><div>The local UPA00345 membership set contains efp as the elongation factor P member of protein biosynthesis/polypeptide-chain elongation.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0003746" target="_blank" rel="noopener">GO:0003746</a><div><strong>translation elongation factor activity</strong></div><div>GO:0003746 captures EF-P&#39;s molecular function as a translation elongation factor.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a><div><strong>rescue of stalled cytosolic ribosome</strong></div><div>GO:0072344 captures EF-P&#39;s more specific role in relieving stalled ribosomes during translation.</div></div>                <div class="evidence-card small"><span class="source-id">PANTHER:PTHR30053</span><div><strong>PANTHER elongation factor P family</strong></div><div>PTHR30053 grounds the annoton as an EF-P-family role and includes broad bacterial representatives such as PSEPK Q88LS0, E. coli K-12 P0A6N4, P. aeruginosa PAO1 Q9HZZ2, Shewanella oneidensis Q8EEP9, Neisseria meningitidis Q9JZQ8, and Thermus thermophilus HB8 Q76G20.</div></div>                <div class="evidence-card small"><span class="source-id">PANTHER:PTN000769376</span><div><strong>PAINT EF-P/YeiP translation elongation factor node</strong></div><div>QuickGO IBA rows for E. coli EF-P and several other reviewed bacterial EF-P entries use PTN000769376 with GO_REF:0000033 for translation elongation factor activity.</div></div>                <div class="evidence-card small"><span class="source-id">PANTHER:PTN002409107</span><div><strong>PSEPK Q88LS0 PANTHER with/from node</strong></div><div>The PSEPK Q88LS0 GOA rows cite PTN002409107 in the with/from column for translation elongation factor activity and cytoplasm, providing a concrete PSEPK-specific PANTHER anchor.</div></div>                <div class="evidence-card small"><span class="source-id">UniProtKB:Q88LS0</span><div><strong>PSEPK efp UniProt exemplar</strong></div><div>Q88LS0 is the curated P. putida KT2440 EF-P member of UPA00345 and is used here as an exemplar for the local PSEPK pathway bucket.</div></div>                <div class="evidence-card small"><span class="source-id">UniProtKB:P0A6N4</span><div><strong>E. coli K-12 EF-P exemplar</strong></div><div>P0A6N4 is a reviewed EF-P exemplar with direct experimental GO support for translation elongation factor activity, translational elongation, and stalled-cytosolic-ribosome rescue.</div></div>                <div class="evidence-card small"><span class="source-id">UniProtKB:Q9HZZ2</span><div><strong>Pseudomonas aeruginosa PAO1 EF-P exemplar</strong></div><div>Q9HZZ2 is a reviewed pseudomonad EF-P exemplar with direct Arg32 rhamnosylation evidence and PTHR30053:SF12 family membership.</div></div>                <div class="evidence-card small"><span class="source-id">UniProtKB:Q76G20</span><div><strong>Thermus thermophilus HB8 EF-P structural exemplar</strong></div><div>Q76G20 is the Thermus thermophilus HB8 EF-P whose structures include the free protein and an EF-P-bound 70S ribosome complex.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/25686373/" target="_blank" rel="noopener">PMID:25686373</a><div><strong>Arginine-rhamnosylation as new strategy to activate translation elongation factor P.</strong></div><div>This study supports EF-P as the bacterial factor that rescues stalled ribosomes, with activation by EarP-mediated rhamnosylation in the Arg-type EF-P subfamily.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-ai-review.yaml</span><div><strong>Curated efp review</strong></div><div>The efp review accepts translation elongation factor activity, translational elongation, cytoplasm/cytosol, and stalled-ribosome rescue, while keeping broad peptide biosynthesis and regulation of translation as non-core context.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-uniprot.txt</span><div><strong>UniProtKB reviewed entry for efp</strong></div><div>UniProt describes EF-P as cytoplasmic, involved in peptide-bond synthesis, and assigned to protein biosynthesis/polypeptide-chain elongation.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/efp_translation_stall_rescue-deep-research-openscientist.md</span><div><strong>OpenScientist module research for EF-P translation stall rescue</strong></div><div>OpenScientist module-level research supports EF-P as a conserved translation factor that rescues polyproline and related elongation stalls, with pseudomonad EarP/rhamnose-dependent activation treated as context rather than as part of the single-gene UPA00345 module.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__efp_translation_stall_rescue__upa00345-deep-research-openscientist.md</span><div><strong>OpenScientist PSEPK UPA00345 pathway satisfiability review</strong></div><div>The PSEPK-specific OpenScientist report finds the UPA00345 core step satisfied by efp/PP_1858/Q88LS0, with no EfpL/YeiP paralog ambiguity, EpmA/EpmB/EpmC beta-lysylation genes not expected in KT2440, and EarP plus dTDP-L-rhamnose supply correctly treated as adjacent activation context.</div></div>        </div><p class="muted small">First-pass interpretation: the reusable module is a species-neutral bacterial EF-P-family stall-rescue module. The PSEPK UPA00345 instantiation is satisfiable as a compact single-gene pathway bucket, represented by efp/PP_1858/Q88LS0. The functional boundary should include EF-P&#39;s direct elongation and stall-rescue roles, while treating EarP, Rml dTDP-rhamnose biosynthesis, EpmA/EpmB/EpmC, and other activation dependencies as linked context handled by their own modules. OpenScientist&#39;s PSEPK-specific review supports this single-gene boundary, notes that KT2440 lacks an EfpL/YeiP paralog and the E. coli-style EpmA/EpmB/EpmC beta-lysylation route, and flags the adjacent EarP/Q88LS1 UniProt &#34;Lys-32&#34; target text as a likely residue-label typo because pseudomonad EF-P is Arg32-rhamnosylated.</p></header>
+            <span>rescue of stalled cytosolic ribosome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">UniPathway:UPA00345</span><div><strong>UniPathway UPA00345</strong></div><div>The local UPA00345 membership set contains efp as the elongation factor P member of protein biosynthesis/polypeptide-chain elongation.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a><div><strong>rescue of stalled cytosolic ribosome</strong></div><div>GO:0072344 captures EF-P&#39;s more specific role in relieving stalled ribosomes during translation.</div></div>                <div class="evidence-card small"><span class="source-id">PANTHER:PTHR30053</span><div><strong>PANTHER elongation factor P family</strong></div><div>PTHR30053 grounds the annoton as an EF-P-family role and includes broad bacterial representatives such as PSEPK Q88LS0, E. coli K-12 P0A6N4, P. aeruginosa PAO1 Q9HZZ2, Shewanella oneidensis Q8EEP9, Neisseria meningitidis Q9JZQ8, and Thermus thermophilus HB8 Q76G20.</div></div>                <div class="evidence-card small"><span class="source-id">UniProtKB:Q88LS0</span><div><strong>PSEPK efp UniProt exemplar</strong></div><div>Q88LS0 is the curated P. putida KT2440 EF-P member of UPA00345 and is used here as an exemplar for the local PSEPK pathway bucket.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/25686373/" target="_blank" rel="noopener">PMID:25686373</a><div><strong>Arginine-rhamnosylation as new strategy to activate translation elongation factor P.</strong></div><div>This study supports EF-P as the bacterial factor that rescues stalled ribosomes, with activation by EarP-mediated rhamnosylation in the Arg-type EF-P subfamily.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-ai-review.yaml</span><div><strong>Curated efp review</strong></div><div>The efp review accepts translation elongation factor activity, translational elongation, EF-P localization annotations, and stalled-ribosome rescue, while keeping broad peptide biosynthesis and regulation of translation as non-core context.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-uniprot.txt</span><div><strong>UniProtKB reviewed entry for efp</strong></div><div>UniProt describes EF-P as involved in peptide-bond synthesis and assigned to protein biosynthesis/polypeptide-chain elongation.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/efp_translation_stall_rescue-deep-research-openscientist.md</span><div><strong>OpenScientist module research for EF-P translation stall rescue</strong></div><div>OpenScientist module-level research supports EF-P as a conserved translation factor that rescues polyproline and related elongation stalls, with pseudomonad EarP/rhamnose-dependent activation treated as context rather than as part of the single-gene UPA00345 module.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__efp_translation_stall_rescue__upa00345-deep-research-openscientist.md</span><div><strong>OpenScientist PSEPK UPA00345 pathway satisfiability review</strong></div><div>The PSEPK-specific OpenScientist report finds the UPA00345 core step satisfied by efp/PP_1858/Q88LS0, with no EfpL/YeiP paralog ambiguity, EpmA/EpmB/EpmC beta-lysylation genes not expected in KT2440, and EarP plus dTDP-L-rhamnose supply correctly treated as adjacent activation context.</div></div>        </div><p class="muted small">First-pass interpretation: the reusable module is a species-neutral bacterial EF-P-family stall-rescue module with two mechanistic roles: engagement of the stalled cytosolic ribosome and EF-P-dependent stimulation of elongation/stall rescue. The PSEPK UPA00345 instantiation is satisfiable as a compact single-gene pathway bucket, represented by efp/PP_1858/Q88LS0. Treat EarP, Rml dTDP-rhamnose biosynthesis, EpmA/EpmB/EpmC, and other activation dependencies as linked context handled by their own modules. OpenScientist&#39;s PSEPK-specific review supports this single-gene boundary, notes that KT2440 lacks an EfpL/YeiP paralog and the E. coli-style EpmA/EpmB/EpmC beta-lysylation route, and flags the adjacent EarP/Q88LS1 UniProt &#34;Lys-32&#34; target text as a likely residue-label typo because pseudomonad EF-P is Arg32-rhamnosylated.</p></header>
     <section class="stats" aria-label="Module counts">
-        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Nodes</span></div>
-        <div class="stat"><span class="stat-value">1</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Parts</span></div>
         <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
         <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
-        <div class="stat"><span class="stat-value">1</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Annotons</span></div>
         <div class="stat"><span class="stat-value">0</span><span class="stat-label">Connections</span></div>
     </section>    <section class="qc-panel panel" aria-label="Derived QC">
         <div class="panel-header">
@@ -585,17 +583,18 @@
                     <ul class="qc-list small">                            <li>efp_translation_stall_rescue-deep-research-openscientist.md <span class="muted">(openscientist)</span></li>                    </ul>            </div>
 
             <div class="qc-card">
-                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+                <h3>Leaf nodes lacking representative members</h3>                    <p class="small">1 leaf node(s) with no concrete protein grounding:</p>
+                    <ul class="qc-list small">                            <li><a href="#node-efp_stalled_ribosome_engagement">EF-P stalled-ribosome engagement</a> <span class="muted">FAMILY</span></li>                    </ul>            </div>
 
             <div class="qc-card">
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(1/6 grounded genes reviewed)</span>
+                    <span class="muted small">(1/2 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
                         1 complete review(s) &middot;
                         1 with deep research &middot;
-                        5 missing review &middot;
+                        1 missing review &middot;
                         0 reviewed but lacking deep research
                     </p>
                     <table class="qc-table small">
@@ -616,30 +615,6 @@
                                 </tr>                                <tr>
                                     <td>E. coli K-12 efp exemplar
                                         <span class="muted term-id">P0A6N4</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>Thermus thermophilus HB8 efp structural exemplar
-                                        <span class="muted term-id">Q76G20</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>Shewanella oneidensis MR-1 efp exemplar
-                                        <span class="muted term-id">Q8EEP9</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>Pseudomonas aeruginosa PAO1 efp exemplar
-                                        <span class="muted term-id">Q9HZZ2</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>Neisseria meningitidis MC58 efp exemplar
-                                        <span class="muted term-id">Q9JZQ8</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>
@@ -667,12 +642,28 @@
                 </span>
             </summary>                <div class="tree-group-title">Parts</div>
                 <ol>                            <li>
-                                <div class="edge-note">1. EF-P-dependent rescue of stalled translation elongation</div>
+                                <div class="edge-note">1. EF-P engagement of a stalled cytosolic ribosome</div>
                                 <li class="tree-entry">
         <details class="tree-node" open>
             <summary>
                 <span class="tree-row">
-                    <a class="tree-link" href="#node-efp_translation_stall_rescue_step">EF-P stalled-ribosome rescue</a><span class="pill type">Biological Process</span><span class="tree-id">efp_translation_stall_rescue_step</span>
+                    <a class="tree-link" href="#node-efp_stalled_ribosome_engagement">EF-P stalled-ribosome engagement</a><span class="pill type">Biological Process</span><span class="tree-id">efp_stalled_ribosome_engagement</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-efp_ribosome_binding">EF-P family: stalled-ribosome binding</a>
+                                <span class="tree-id">Family: elongation factor P family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. EF-P-dependent stimulation of stalled translation elongation</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-efp_translation_stall_rescue_step">EF-P elongation/stall-rescue activity</a><span class="pill type">Biological Process</span><span class="tree-id">efp_translation_stall_rescue_step</span>
                 </span>
             </summary>                <div class="tree-group-title">Annotons</div>
                 <ul>                        <li class="annoton-item tree-entry">
@@ -701,7 +692,6 @@
 
 
             <div class="descriptor-list">                <span class="descriptor">
-            <span>cytoplasm</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005737" target="_blank" rel="noopener">GO:0005737</a></span>                <span class="descriptor">
             <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
 
             </div>
@@ -709,10 +699,8 @@
         <div class="node-heading">
             <span class="node-title">EF-P translation stall rescue</span><span class="pill type">Biological Process</span><span class="pill">efp_translation_stall_rescue</span>
         </div><div class="descriptor-list">                <span class="descriptor">
-            <span>translation elongation factor activity</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003746" target="_blank" rel="noopener">GO:0003746</a></span>                <span class="descriptor">
             <span>translational elongation</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006414" target="_blank" rel="noopener">GO:0006414</a></span>                <span class="descriptor">
-            <span>rescue of stalled cytosolic ribosome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a></span>                <span class="descriptor">
-            <span>peptide biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0043043" target="_blank" rel="noopener">GO:0043043</a></span>        </div>
+            <span>rescue of stalled cytosolic ribosome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a></span>        </div>
         <div class="context-card small">
             <strong>Context</strong>
             <div class="descriptor-list">                <span class="descriptor">
@@ -721,16 +709,36 @@
 
 
             <div class="descriptor-list">                <span class="descriptor">
-            <span>cytoplasm</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005737" target="_blank" rel="noopener">GO:0005737</a></span>                <span class="descriptor">
             <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
 
             </div>
                         <div class="part-marker">
-                    Part 1: EF-P-dependent rescue of stalled translation elongation</div>
+                    Part 1: EF-P engagement of a stalled cytosolic ribosome</div>
+                <section class="node-detail depth-1" id="node-efp_stalled_ribosome_engagement">
+        <div class="node-heading">
+            <span class="node-title">EF-P stalled-ribosome engagement</span><span class="pill type">Biological Process</span><span class="pill">efp_stalled_ribosome_engagement</span>
+        </div>            <p class="node-description">EF-P binds a stalled cytosolic ribosome and positions the P-site peptidyl-tRNA/rRNA interface so the nascent chain can continue through difficult motifs such as polyproline stretches.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-efp_ribosome_binding">
+        <div class="annoton-title">EF-P family: stalled-ribosome binding</div>
+        <div class="small muted">efp_ribosome_binding</div>            <div class="small"><strong>Participant:</strong> Family: elongation factor P family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>elongation factor P family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR30053" target="_blank" rel="noopener">PANTHER:PTHR30053</a>                <span class="descriptor-description">Bacterial EF-P-family proteins that bind stalled ribosomes during cytosolic translational elongation.</span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>ribosome binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0043022" target="_blank" rel="noopener">GO:0043022</a></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>rescue of stalled cytosolic ribosome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Binding/positioning role that engages stalled cytosolic ribosomes; tRNA and rRNA binding are supporting mechanistic observations in characterized EF-P exemplars.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: EF-P-dependent stimulation of stalled translation elongation</div>
                 <section class="node-detail depth-1" id="node-efp_translation_stall_rescue_step">
         <div class="node-heading">
-            <span class="node-title">EF-P stalled-ribosome rescue</span><span class="pill type">Biological Process</span><span class="pill">efp_translation_stall_rescue_step</span>
-        </div>            <p class="node-description">EF-P-family translation factors bind stalled bacterial ribosomes and stimulate peptide-bond formation during elongation, especially at polyproline-containing motifs. The activating post-translational modification is lineage-specific and modeled as adjacent context.</p>
+            <span class="node-title">EF-P elongation/stall-rescue activity</span><span class="pill type">Biological Process</span><span class="pill">efp_translation_stall_rescue_step</span>
+        </div>            <p class="node-description">EF-P-family translation factors stimulate peptide-bond formation and restore productive elongation at stalled cytosolic ribosomes. The activating post-translational modification is lineage-specific and modeled as adjacent context.</p>
 
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-efp_translation_elongation_factor">
@@ -742,20 +750,15 @@
             <span><strong>elongation factor P family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR30053" target="_blank" rel="noopener">PANTHER:PTHR30053</a>                <span class="descriptor-description">Bacterial EF-P/YeiP-family proteins that stimulate peptide-bond formation and rescue slow elongation. The module core is represented by canonical EF-P; EfpL/YeiP paralogs are related family members and should be handled explicitly when present in a target organism.</span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88LS0/entry" target="_blank" rel="noopener">UniProtKB:Q88LS0</a></span>                            <span class="descriptor">
-            <span>E. coli K-12 efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0A6N4/entry" target="_blank" rel="noopener">UniProtKB:P0A6N4</a></span>                            <span class="descriptor">
-            <span>Pseudomonas aeruginosa PAO1 efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9HZZ2/entry" target="_blank" rel="noopener">UniProtKB:Q9HZZ2</a></span>                            <span class="descriptor">
-            <span>Shewanella oneidensis MR-1 efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8EEP9/entry" target="_blank" rel="noopener">UniProtKB:Q8EEP9</a></span>                            <span class="descriptor">
-            <span>Neisseria meningitidis MC58 efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9JZQ8/entry" target="_blank" rel="noopener">UniProtKB:Q9JZQ8</a></span>                            <span class="descriptor">
-            <span>Thermus thermophilus HB8 efp structural exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q76G20/entry" target="_blank" rel="noopener">UniProtKB:Q76G20</a></span>                    </div></div>
-                    </div>                <div class="small muted">Select canonical bacterial EF-P-family members with translation elongation factor activity. PSEPK Q88LS0 is an exemplar for the P. putida KT2440 UPA00345 bucket, while the family selector keeps the reusable module from being PSEPK-specific.</div><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:interpro/panther/PTHR30053/PTHR30053-entries.csv</span><div>Local PTHR30053 entries include Q88LS0, P0A6N4, Q9HZZ2, Q8EEP9, Q9JZQ8, and Q76G20 as EF-P-family members.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-goa.tsv</span><div>Q88LS0 GOA cites PANTHER:PTN002409107 for translation elongation factor activity and cytoplasm.</div></div>        </div></div>            <h4>Function</h4>
+            <span>E. coli K-12 efp exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0A6N4/entry" target="_blank" rel="noopener">UniProtKB:P0A6N4</a></span>                    </div></div>
+                    </div>                <div class="small muted">Select canonical bacterial EF-P-family members with translation elongation factor activity. PSEPK Q88LS0 is an exemplar for the P. putida KT2440 UPA00345 bucket, while the family selector keeps the reusable module from being PSEPK-specific.</div><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:interpro/panther/PTHR30053/PTHR30053-entries.csv</span><div>Local PTHR30053 entries include Q88LS0, P0A6N4, Q9HZZ2, Q8EEP9, Q9JZQ8, and Q76G20 as EF-P-family members.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/efp/efp-goa.tsv</span><div>Q88LS0 GOA cites PANTHER:PTN002409107 for translation elongation factor activity and cellular-component placement.</div></div>        </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>translation elongation factor activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003746" target="_blank" rel="noopener">GO:0003746</a></div>            <h4>Processes</h4>
             <div class="descriptor-list">                <span class="descriptor">
             <span>translational elongation</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006414" target="_blank" rel="noopener">GO:0006414</a></span>                <span class="descriptor">
             <span>rescue of stalled cytosolic ribosome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0072344" target="_blank" rel="noopener">GO:0072344</a></span>        </div>            <h4>Locations</h4>
             <div class="descriptor-list">                <span class="descriptor">
-            <span>cytoplasm</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005737" target="_blank" rel="noopener">GO:0005737</a></span>                <span class="descriptor">
-            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Cytoplasmic elongation factor that promotes peptide-bond formation and relieves stalled translation elongation.</p></article>            </div>    </section>    </section>
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Cytosolic elongation factor that promotes peptide-bond formation and relieves stalled translation elongation.</p></article>            </div>    </section>    </section>
             </div>
         </section>
     </section>

--- a/pages/projects/P_PUTIDA/batches/UPA00345_efp_translation_stall_rescue.html
+++ b/pages/projects/P_PUTIDA/batches/UPA00345_efp_translation_stall_rescue.html
@@ -422,18 +422,22 @@
 <li>Fetched by accession alias, Asta-backed, curated, and validated the single<br />
   UniPathway member: <code>efp</code> / PP_1858 / Q88LS0.</li>
 <li>Created and validated <code>modules/efp_translation_stall_rescue.yaml</code> as a compact<br />
-  single-gene UPA00345 module for cytoplasmic EF-P translation elongation and<br />
-  stalled-ribosome rescue.</li>
+  single-gene UPA00345 module with two EF-P roles: stalled-ribosome engagement<br />
+  and EF-P-dependent elongation/stall rescue.</li>
 <li>Follow-up after PR #2051 review: generalized the reusable module from a<br />
   PSEPK-centered wording to a species-neutral bacterial EF-P-family module.<br />
 <code>efp</code> / PP_1858 / Q88LS0 is now recorded as the PSEPK UniProt exemplar rather<br />
   than as the module's full scope, with additional representative EF-P members<br />
   and PAINT/PTN anchors recorded in the module.</li>
+<li>Follow-up after PR #2071 review: removed module-level molecular-function<br />
+  concepts, collapsed redundant cytoplasm/cytosol locations to cytosol, and<br />
+  split the module into explicit ribosome-engagement and elongation/stall-rescue<br />
+  roles.</li>
 <li>Corrected the accession-based seed so <code>gene_symbol</code> is <code>efp</code> rather than<br />
 <a href="https://www.uniprot.org/uniprotkb/Q88LS0/entry">Q88LS0</a>.</li>
 <li><code>efp</code> accepts translation elongation factor activity, translational<br />
-  elongation, cytoplasm/cytosol, and rescue of stalled cytosolic ribosome as<br />
-  core annotations.</li>
+  elongation, cytosolic localization, and rescue of stalled cytosolic ribosome<br />
+  as core annotations.</li>
 <li>Broad <code>regulation of translation</code> and <code>peptide biosynthetic process</code><br />
   annotations were retained as non-core context because the more informative<br />
   module core is EF-P-dependent elongation and stall rescue.</li>

--- a/projects/P_PUTIDA/batches/UPA00345_efp_translation_stall_rescue.md
+++ b/projects/P_PUTIDA/batches/UPA00345_efp_translation_stall_rescue.md
@@ -40,18 +40,22 @@ Generated UTC: 2026-07-10T01:23:19.469718+00:00
 - Fetched by accession alias, Asta-backed, curated, and validated the single
   UniPathway member: `efp` / PP_1858 / Q88LS0.
 - Created and validated `modules/efp_translation_stall_rescue.yaml` as a compact
-  single-gene UPA00345 module for cytoplasmic EF-P translation elongation and
-  stalled-ribosome rescue.
+  single-gene UPA00345 module with two EF-P roles: stalled-ribosome engagement
+  and EF-P-dependent elongation/stall rescue.
 - Follow-up after PR #2051 review: generalized the reusable module from a
   PSEPK-centered wording to a species-neutral bacterial EF-P-family module.
   `efp` / PP_1858 / Q88LS0 is now recorded as the PSEPK UniProt exemplar rather
   than as the module's full scope, with additional representative EF-P members
   and PAINT/PTN anchors recorded in the module.
+- Follow-up after PR #2071 review: removed module-level molecular-function
+  concepts, collapsed redundant cytoplasm/cytosol locations to cytosol, and
+  split the module into explicit ribosome-engagement and elongation/stall-rescue
+  roles.
 - Corrected the accession-based seed so `gene_symbol` is `efp` rather than
   `Q88LS0`.
 - `efp` accepts translation elongation factor activity, translational
-  elongation, cytoplasm/cytosol, and rescue of stalled cytosolic ribosome as
-  core annotations.
+  elongation, cytosolic localization, and rescue of stalled cytosolic ribosome
+  as core annotations.
 - Broad `regulation of translation` and `peptide biosynthetic process`
   annotations were retained as non-core context because the more informative
   module core is EF-P-dependent elongation and stall rescue.


### PR DESCRIPTION
## Summary
- remove molecular-function and broad peptide-process concepts from the EF-P module-level concept list
- collapse structured EF-P location modeling to cytosol only, avoiding duplicate cytoplasm/cytosol placement
- split the previous one-part EF-P module into two ordered roles: stalled-ribosome engagement and elongation/stall-rescue activity
- keep extra EF-P exemplars/PTN evidence as supporting evidence rather than inflating representative members
- update the rendered module and Putida batch pages

## Rationale
The prior module mixed module-level process scope with step-level molecular function, duplicated cytoplasm and cytosol locations, and rendered as an odd one-part module. This follow-up keeps the reusable module species-neutral while putting MF assertions on the relevant annoton steps.

## Validation
- uv run linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/efp_translation_stall_rescue.yaml
- uv run python -m ai_gene_review.validation.module_validator modules/efp_translation_stall_rescue.yaml
- just render-module modules/efp_translation_stall_rescue.yaml
- uv run ai-gene-review render-projects projects/P_PUTIDA/batches/UPA00345_efp_translation_stall_rescue.md -o pages/projects
- just validate PSEPK efp (passes with existing warning: annotations do not reference efp-deep-research-asta.md)