### PR TITLE
[codex] Add module curation skill

### DIFF
--- a/.claude/skills/module-curation/SKILL.md
+++ b/.claude/skills/module-curation/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: module-curation
+description: Curate, review, or repair ai-gene-review ModuleReview YAML documents under modules/, including pathway/module boundary setting, parts and variant modeling, annoton-level molecular functions, representative UniProt/PTN grounding, module deep-research provenance, validation, rendering, and project batch updates.
+---
+
+# Module Curation
+
+Use this skill for `modules/*.yaml` work and for project pages that describe
+module/pathway curation. The goal is a reusable, defensible biological module,
+not a flat list of annotations or a species-specific note disguised as a module.
+
+## Workflow
+
+1. Read the local context before editing:
+   - `modules/README.md`
+   - the target `modules/<module>.yaml`
+   - any adjacent `<module>-deep-research-*.md`
+   - related `projects/**` batch page(s), if the task is pathway-batch work
+   - relevant gene reviews and UniProt/GOA files for concrete members
+2. Decide the module boundary before filling YAML:
+   - What biological process, complex, reaction chain, or reusable motif is the
+     module?
+   - Which genes/proteins are core members, and which are activation context,
+     substrate supply, regulation, upstream/downstream biology, or separate modules?
+   - Is this a concrete species/pathway instance or an abstract reusable motif?
+3. Model the structure:
+   - Put module-level process/complex/context terms on `module.concepts` and
+     `module.context`.
+   - Put molecular functions on leaf `annotons[].function`, not on a
+     biological-process module just because the member protein has that MF.
+   - Use `parts` for required steps or roles, `variant_sets` for alternatives,
+     and `connections` for ordered/causal links.
+4. Ground claims with checkable provenance:
+   - Use exact UniProt, GO, Rhea, ChEBI, PANTHER `PTHR`, and PAINT `PTN` ids.
+   - Never guess PTNs or identifiers. Resolve PTNs from local PANTHER/PAINT data
+     or GOA WITH/FROM evidence.
+   - Use representative members to orient family-level claims without turning a
+     reusable module into a species-specific member list.
+5. Validate and render before committing:
+   - `uv run linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/<module>.yaml`
+   - `uv run python -m ai_gene_review.validation.module_validator modules/<module>.yaml`
+   - `just render-module modules/<module>.yaml`
+   - render any touched project page with `uv run ai-gene-review render-projects ...`
+   - run `git diff --check`
+
+## Reference Files
+
+Load only the reference needed for the decision at hand:
+
+- `references/modeling.md` — module-vs-annoton placement, parts, variants,
+  locations, exemplars, PTNs, and common anti-patterns.
+- `references/research-and-grounding.md` — module deep research, species/pathway
+  satisfiability checks, gene review integration, and provenance rules.
+- `references/validation-and-pr.md` — validation, rendering, derived QC, cache
+  noise, and PR checklist.
+
+## Curation Rules
+
+- Prefer a small, explicit decomposition over a one-part wrapper that adds no
+  modeling value. If a module has one gene but two separable roles, model two
+  parts or annotons.
+- Avoid redundant parent/child context such as both cytoplasm and cytosol unless
+  the distinction is intentional and explained.
+- Do not use broad parent processes as the module core when a specific process
+  or reaction step is available. Keep broad terms as prose/context if needed.
+- Keep species-specific notes in evidence, notes, project pages, or concrete
+  instantiations; reusable modules should stay species-neutral unless the scope
+  is deliberately concrete.
+- Treat deep research as retrieval support, not authority. Every structural
+  claim must still be grounded in identifiers, gene reviews, GOA/UniProt, GO-CAM,
+  literature, or explicit curator judgment.

--- a/.claude/skills/module-curation/SKILL.md
+++ b/.claude/skills/module-curation/SKILL.md
@@ -23,6 +23,10 @@ not a flat list of annotations or a species-specific note disguised as a module.
    - Which genes/proteins are core members, and which are activation context,
      substrate supply, regulation, upstream/downstream biology, or separate modules?
    - Is this a concrete species/pathway instance or an abstract reusable motif?
+   - Does the boundary have at least two substantive parts/roles/steps? If it
+     collapses to one gene, one enzyme, or one reaction, do not create or retain
+     a standalone `ModuleReview`; record it as pathway/gene curation and fold it
+     into a broader module later.
 3. Model the structure:
    - Put module-level process/complex/context terms on `module.concepts` and
      `module.context`.
@@ -56,9 +60,9 @@ Load only the reference needed for the decision at hand:
 
 ## Curation Rules
 
-- Prefer a small, explicit decomposition over a one-part wrapper that adds no
-  modeling value. If a module has one gene but two separable roles, model two
-  parts or annotons.
+- Do not create or retain one-part modules. A standalone module needs at least
+  two substantive parts/roles/steps at the modeled boundary; otherwise keep the
+  work as pathway/gene curation or fold it into a broader multi-part module.
 - Avoid redundant parent/child context such as both cytoplasm and cytosol unless
   the distinction is intentional and explained.
 - Do not use broad parent processes as the module core when a specific process

--- a/.claude/skills/module-curation/agents/openai.yaml
+++ b/.claude/skills/module-curation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Module Curation"
+  short_description: "Curate and validate module YAML"
+  default_prompt: "Use $module-curation to curate a module YAML and run the relevant validation checks."

--- a/.claude/skills/module-curation/references/modeling.md
+++ b/.claude/skills/module-curation/references/modeling.md
@@ -1,0 +1,76 @@
+# Module Modeling
+
+## Choose The Right Level
+
+- `ModuleReview` describes a recursively decomposable biological module:
+  pathway, complex, organelle lifecycle, developmental program, molecular
+  function program, reaction chain, or abstract motif.
+- `ModuleNode` owns the module or submodule identity: `concepts`, `context`,
+  `parts`, `variant_sets`, `connections`, and `gocam_associations`.
+- `ModuleAnnoton` owns leaf role assertions: participant, molecular function,
+  processes, locations, and role description.
+
+For a `BIOLOGICAL_PROCESS` module, place molecular function terms under the leaf
+annoton that performs the activity. Do not put an enzyme/adapter/binding MF in
+`module.concepts` just because the module has one protein member. Use
+module-level MF concepts only when the node itself is intentionally a
+`MOLECULAR_FUNCTION` module or motif.
+
+## Concepts And Context
+
+- Use `module.concepts` for ontology/database terms that describe the module
+  node as a whole.
+- Use `module.context` for shared taxon, cell type, compartment, condition, or
+  developmental scope.
+- Use leaf `annotons[].locations` when the location applies to a specific
+  activity rather than the whole module.
+- Avoid redundant parent/child context (`cytoplasm` plus `cytosol`,
+  `membrane` plus `plasma membrane`) unless both are needed for a reason recorded
+  in `description` or `notes`.
+
+## Parts, Variants, And Connections
+
+- Use `parts` for required steps, roles, subcomplexes, or submodules.
+- Use `variant_sets` for alternative implementations along an explicit axis such
+  as taxon, compartment, enzyme family, substrate route, developmental context,
+  or cell type.
+- Use `connections` for relationships between document-scoped ids. For reaction
+  chains, add `chaining_status` and `chaining_note` when the advisory CoA
+  continuity check needs curator adjudication.
+- Avoid a one-part wrapper unless the parent carries meaningful context or is an
+  intentional concrete instantiation of a reusable template. If one protein has
+  multiple mechanistic roles, model multiple parts or multiple leaf annotons.
+
+## Participants
+
+- Use `selector_type: GENE` or `GENE_PRODUCT` for a concrete species member.
+- Use `FAMILY`, `DOMAIN`, `HOMOLOG_OF`, `ORTHOLOG_OF`, `ANY_WITH_FUNCTION`, or
+  `ANY_WITH_DOMAIN` for reusable roles.
+- Use `active_units` inside complex descriptors when a complex has role-bearing
+  subunits that must remain visible to reasoning.
+- Keep activation enzymes, cofactor biosynthesis, transport, regulation, and
+  upstream/downstream biology outside the module core unless they are required
+  parts of the pathway definition.
+
+## Representative Members And PTNs
+
+- Use `representative_members` on family descriptors for concrete UniProt
+  exemplars that orient the reader and satisfy leaf grounding QC.
+- Representative members are examples, not an exhaustive species list and not a
+  claim that the module is limited to those proteins.
+- Use `ancestral_nodes` for the stronger PAINT claim that a function arose at or
+  was present in a PANTHER ancestral node and is inherited by descendants unless
+  diverged.
+- Ground ancestral nodes with exact `PANTHER:PTN...` ids from local canonical
+  IBD data under `interpro/panther/<PTHR>/<PTHR>-paint.tsv` or from GOA
+  WITH/FROM evidence with `GO_REF:0000033`. Never guess PTN ids.
+
+## Common Anti-Patterns
+
+- Module-level MF term on a process module when the MF belongs to a step.
+- Broad process term as module core when a specific process/reaction term exists.
+- Parent and child locations both asserted without explanation.
+- Species-specific wording in a reusable module label or description.
+- Inflating representative members to every species mentioned in evidence.
+- Treating generated deep-research prose as a source of identifiers without
+  checking UniProt, GOA, PANTHER, Rhea, ChEBI, GO-CAM, or publications.

--- a/.claude/skills/module-curation/references/modeling.md
+++ b/.claude/skills/module-curation/references/modeling.md
@@ -37,9 +37,12 @@ module-level MF concepts only when the node itself is intentionally a
 - Use `connections` for relationships between document-scoped ids. For reaction
   chains, add `chaining_status` and `chaining_note` when the advisory CoA
   continuity check needs curator adjudication.
-- Avoid a one-part wrapper unless the parent carries meaningful context or is an
-  intentional concrete instantiation of a reusable template. If one protein has
-  multiple mechanistic roles, model multiple parts or multiple leaf annotons.
+- Do not use a one-part wrapper as a standalone module. The root module boundary
+  should expose at least two substantive parts/roles/steps; if the proposed
+  scope is one gene, one enzyme, or one reaction, record it as pathway/gene
+  curation until it can be folded into a broader module. If one protein has
+  multiple mechanistic roles, model those roles explicitly, but do not mistake a
+  single leaf annoton for a module.
 
 ## Participants
 
@@ -68,6 +71,7 @@ module-level MF concepts only when the node itself is intentionally a
 ## Common Anti-Patterns
 
 - Module-level MF term on a process module when the MF belongs to a step.
+- Single species-specific enzyme or reaction represented as a standalone module.
 - Broad process term as module core when a specific process/reaction term exists.
 - Parent and child locations both asserted without explanation.
 - Species-specific wording in a reusable module label or description.

--- a/.claude/skills/module-curation/references/research-and-grounding.md
+++ b/.claude/skills/module-curation/references/research-and-grounding.md
@@ -1,0 +1,61 @@
+# Research And Grounding
+
+## Module Research
+
+Use module-level deep research to establish pathway boundaries, missing steps,
+candidate members, and known variants. When the task is species/pathway
+satisfiability, research the combination of module + pathway/accession + taxon
+or species, not only the generic pathway.
+
+Generated provider files must be produced by the configured commands. Do not
+write original prose and name it `*-deep-research-<provider>.md`. If provider
+research is unavailable or manual triage is needed, write notes in a normal
+project/gene/module notes file or use a clearly manual filename.
+
+Known commands from `modules/README.md`:
+
+```bash
+just module-deep-research-perplexity peroxisome-lifecycle
+just module-deep-research-openai modules/gluconeogenesis.yaml
+```
+
+If a different provider is wired in locally, follow the repo's just recipes and
+record the provider-specific output path in evidence.
+
+## Gene Review Integration
+
+For concrete UniProt members:
+
+- ensure the corresponding gene review exists when the module relies on that
+  member;
+- read the gene review's accepted core functions, non-core context, proposed
+  terms, and notes;
+- do not use module curation to silently override a gene review; record
+  disagreements as knowledge gaps or follow-up questions;
+- run `just fetch-gene <species> <gene>` only when creating a missing review
+  scaffold is part of the task.
+
+For Pseudomonas putida KT2440, the species directory is `PSEPK`.
+
+## Identifier Discipline
+
+- Never guess GO, UniProt, PANTHER, PTN, Rhea, ChEBI, PMID, taxon, or gene
+  identifiers.
+- Prefer local derived files first: gene `*-uniprot.txt`, `*-goa.tsv`,
+  `interpro/panther/**`, `gocams/index.tsv`, cached GO-CAMs, and cached
+  publications.
+- If local files are insufficient and the identifier may have changed, look it
+  up from an authoritative source.
+- For GO term placement, check the aspect: MF terms belong in annoton
+  `function`, BP terms in module/process concepts or annoton `processes`, and CC
+  terms in context or locations.
+
+## Evidence Placement
+
+- Put top-level `evidence` on the `ModuleReview` for sources supporting the
+  overall module boundary.
+- Put node/part/annoton evidence as close as possible to the claim it supports.
+- Use `notes` for curator rationale and caveats; use `knowledge_gaps` for open
+  biological or curation questions.
+- Keep project-history commentary in `projects/**`, not in reusable module
+  descriptions.

--- a/.claude/skills/module-curation/references/validation-and-pr.md
+++ b/.claude/skills/module-curation/references/validation-and-pr.md
@@ -1,0 +1,63 @@
+# Validation And PR Checklist
+
+## Required Checks
+
+Run these for any edited module YAML:
+
+```bash
+uv run linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/<module>.yaml
+uv run python -m ai_gene_review.validation.module_validator modules/<module>.yaml
+just render-module modules/<module>.yaml
+git diff --check
+```
+
+If project markdown changed, render the touched project page:
+
+```bash
+uv run ai-gene-review render-projects projects/<path>.md -o pages/projects
+```
+
+If concrete gene reviews were edited or are central to the module claim, run:
+
+```bash
+just validate <species> <gene>
+```
+
+## Derived QC
+
+Rendered module pages include derived QC from `ai_gene_review.module_qc`:
+
+- recommended-field compliance;
+- module deep-research provider detection;
+- leaf nodes lacking representative members;
+- gene-review completeness for UniProt groundings;
+- advisory reaction chaining for `PRECEDES` connections.
+
+Treat leaf-grounding warnings as modeling signals. Add a concrete UniProt
+representative only when it truly helps orient an abstract family role; do not
+add every organism mentioned in evidence just to improve a count.
+
+## Cache Noise
+
+Validation may update ontology cache files such as `cache/go/terms.csv`. Do not
+include these incidental timestamp/cache changes in a module-curation PR unless
+the task explicitly requires cache refresh. Remove them from the diff before
+staging.
+
+## PR Scope
+
+A clean module-curation PR usually includes:
+
+- the edited `modules/<module>.yaml`;
+- rendered `pages/modules/<module>.html`;
+- any touched project markdown and rendered page;
+- generated deep-research files only if they were produced by an approved
+  provider command and are part of the requested work.
+
+The PR body should state:
+
+- what boundary/modeling decision changed;
+- where terms were placed and why;
+- which exemplars/PTNs/GO-CAMs/gene reviews ground the module;
+- validation and render commands run;
+- known warnings or follow-up issues.

--- a/.claude/skills/module-curation/references/validation-and-pr.md
+++ b/.claude/skills/module-curation/references/validation-and-pr.md
@@ -11,6 +11,24 @@ just render-module modules/<module>.yaml
 git diff --check
 ```
 
+Check that each edited standalone module has a real decomposition. Prefer at
+least two root `module.parts`; a root `variant_sets` decomposition is acceptable
+only when it has multiple substantive alternatives. A single gene, enzyme, or
+reaction should be recorded as pathway/gene curation instead of a module:
+
+```bash
+python3 - <<'PY' modules/<module>.yaml
+import sys, yaml
+for path in sys.argv[1:]:
+    data = yaml.safe_load(open(path)) or {}
+    module = data.get("module") or {}
+    parts = module.get("parts") or []
+    variants = sum(len(vs.get("variants") or []) for vs in module.get("variant_sets") or [])
+    if len(parts) < 2 and variants < 2:
+        raise SystemExit(f"{path}: standalone modules need at least two substantive parts or variants")
+PY
+```
+
 If project markdown changed, render the touched project page:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a dedicated `module-curation` skill for creating, reviewing, and repairing `ModuleReview` YAML under `modules/`
- capture module-specific modeling rules for boundaries, module-vs-annoton term placement, parts/variants, locations, representative UniProt members, and PAINT/PTN grounding
- make the granularity rule explicit: do not create or retain standalone one-part modules; single-gene/single-reaction pathway seeds should remain pathway/gene curation until folded into a broader multi-part module
- add focused references for research/provenance handling and validation/render/PR checks, including a local decomposition QC snippet
- include `agents/openai.yaml` metadata generated from the skill-creator workflow

## Rationale
We did not have an explicit module curation skill. The closest existing skill was `gocam-curation`, which is for read-only GO-CAM activity review and does not encode the module YAML workflow or recent modeling lessons, including the distinction between reusable modules and one-step species-specific pathway notes.

## Validation
- `python3 /Users/cjm/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/module-curation`
- `git diff --check`
- earlier setup pass: `rg -n "TODO|placeholder|\[TODO" .claude/skills/module-curation`