### PR TITLE
[codex] Address Putida methionine review follow-up

### DIFF
--- a/genes/PSEPK/PP_2528/PP_2528-ai-review.html
+++ b/genes/PSEPK/PP_2528/PP_2528-ai-review.html
@@ -830,7 +830,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>PP_2528 encodes a cytosolic PLP-dependent O-acetylhomoserine sulfhydrylase family enzyme that is predicted to produce L-homocysteine from O-acetyl-L-homoserine and sulfide. In KT2440 it is a substrate-mismatched candidate for the main methionine module, because the supported upstream activation route produces O-succinyl-L-homoserine; several cysteine/transsulfuration GO annotations appear to come from broad family propagation rather than this specific methionine route.</p>
+        <p>PP_2528 encodes a cytosolic PLP-dependent O-acetylhomoserine sulfhydrylase family enzyme predicted to produce L-homocysteine from O-acetyl-L-homoserine and sulfide. Its substrate preference places it among MetY/OAHS enzymes at the boundary of methionine biosynthesis and related cysteine/transsulfuration PLP-dependent lyase chemistry.</p>
     </div>
 
 
@@ -2436,11 +2436,10 @@ taxon:
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950
     / KT2440)
 description: PP_2528 encodes a cytosolic PLP-dependent O-acetylhomoserine sulfhydrylase
-  family enzyme that is predicted to produce L-homocysteine from O-acetyl-L-homoserine
-  and sulfide. In KT2440 it is a substrate-mismatched candidate for the main methionine
-  module, because the supported upstream activation route produces O-succinyl-L-homoserine;
-  several cysteine/transsulfuration GO annotations appear to come from broad family
-  propagation rather than this specific methionine route.
+  family enzyme predicted to produce L-homocysteine from O-acetyl-L-homoserine
+  and sulfide. Its substrate preference places it among MetY/OAHS enzymes at
+  the boundary of methionine biosynthesis and related cysteine/transsulfuration
+  PLP-dependent lyase chemistry.
 existing_annotations:
 - term:
     id: GO:0003961

--- a/genes/PSEPK/PP_2528/PP_2528-ai-review.yaml
+++ b/genes/PSEPK/PP_2528/PP_2528-ai-review.yaml
@@ -7,11 +7,10 @@ taxon:
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950
     / KT2440)
 description: PP_2528 encodes a cytosolic PLP-dependent O-acetylhomoserine sulfhydrylase
-  family enzyme that is predicted to produce L-homocysteine from O-acetyl-L-homoserine
-  and sulfide. In KT2440 it is a substrate-mismatched candidate for the main methionine
-  module, because the supported upstream activation route produces O-succinyl-L-homoserine;
-  several cysteine/transsulfuration GO annotations appear to come from broad family
-  propagation rather than this specific methionine route.
+  family enzyme predicted to produce L-homocysteine from O-acetyl-L-homoserine
+  and sulfide. Its substrate preference places it among MetY/OAHS enzymes at
+  the boundary of methionine biosynthesis and related cysteine/transsulfuration
+  PLP-dependent lyase chemistry.
 existing_annotations:
 - term:
     id: GO:0003961

--- a/genes/PSEPK/PP_4348/PP_4348-ai-review.html
+++ b/genes/PSEPK/PP_4348/PP_4348-ai-review.html
@@ -1157,7 +1157,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> UniProt records cystathionine beta-lyase catalytic activity producing L-homocysteine, pyruvate, and ammonium from cystathionine, matching the module need for a cystathionine-cleavage step.
+                            <strong>Reason:</strong> UniProt records cystathionine beta-lyase catalytic activity producing L-homocysteine, pyruvate, and ammonium from cystathionine, matching the trans-sulfuration cystathionine-cleavage reaction. The older GO:0004121 cystathionine beta-lyase term is obsolete and equivalent to the current GO:0047804 term, so the valid GOA molecular-function term is retained while the physiological cystathionine substrate is stated explicitly.
                         </div>
 
 
@@ -2145,8 +2145,11 @@ existing_annotations:
     summary: The beta-lyase activity captures the PP_4348 trans-sulfuration reaction.
     action: ACCEPT
     reason: UniProt records cystathionine beta-lyase catalytic activity producing
-      L-homocysteine, pyruvate, and ammonium from cystathionine, matching the module
-      need for a cystathionine-cleavage step.
+      L-homocysteine, pyruvate, and ammonium from cystathionine, matching the trans-sulfuration
+      cystathionine-cleavage reaction. The older GO:0004121 cystathionine beta-lyase
+      term is obsolete and equivalent to the current GO:0047804 term, so the valid
+      GOA molecular-function term is retained while the physiological cystathionine
+      substrate is stated explicitly.
     supported_by:
     - reference_id: file:PSEPK/PP_4348/PP_4348-uniprot.txt
       supporting_text: &#34;Reaction=L,L-cystathionine + H2O = L-homocysteine + pyruvate + NH4(+)&#34;

--- a/genes/PSEPK/PP_4348/PP_4348-ai-review.html
+++ b/genes/PSEPK/PP_4348/PP_4348-ai-review.html
@@ -1188,6 +1188,17 @@
 
                             </div>
 
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:PSEPK/PP_4348/PP_4348-notes.md
+
+                                </span>
+
+                                <div class="support-text">The reason for obsoletion is that this term is equivalent to GO:0047804 cysteine-S-conjugate beta-lyase activity.</div>
+
+                            </div>
+
                         </div>
 
 
@@ -1450,6 +1461,31 @@
                         <div class="finding-statement">OpenScientist confirmed PP_4348 as a MetC/cystathionine beta-lyase for the trans-sulfuration branch.</div>
 
                         <div class="finding-text">"PP_4348 (Q88EV4) of *Pseudomonas putida* KT2440 is a cytoplasmic, PLP-dependent **cystathionine β-lyase (MetC, EC 4.4.1.8)**"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:PSEPK/PP_4348/PP_4348-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PP_4348 manual curation notes</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">QuickGO confirms that GO:0004121 is obsolete because it is equivalent to the live GO:0047804 term.</div>
+
+                        <div class="finding-text">"The reason for obsoletion is that this term is equivalent to GO:0047804 cysteine-S-conjugate beta-lyase activity."</div>
 
                     </li>
 
@@ -1955,6 +1991,29 @@
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PP_4348-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q88EV4" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pp_4348-curation-notes">PP_4348 curation notes</h1>
+<h2 id="go-term-status-verification">GO term status verification</h2>
+<p>Checked the EMBL-EBI QuickGO API on 2026-07-19:</p>
+<ul>
+<li><code>GO:0004121</code> returned <code>isObsolete: true</code> with the comment: "The reason for obsoletion is that this term is equivalent to GO:0047804 cysteine-S-conjugate beta-lyase activity."</li>
+<li><code>GO:0047804</code> returned <code>isObsolete: false</code> and lists "cystathionine beta-lyase activity" as a related synonym.</li>
+</ul>
+<p>API request: <code>https://www.ebi.ac.uk/QuickGO/services/ontology/go/terms/GO%3A0004121,GO%3A0047804</code></p>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
                     <h3 style="display: inline;">Fitness</h3>
                     <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PP_4348-fitness.md)</span>
                 </div>
@@ -2155,6 +2214,8 @@ existing_annotations:
       supporting_text: &#34;Reaction=L,L-cystathionine + H2O = L-homocysteine + pyruvate + NH4(+)&#34;
     - reference_id: file:PSEPK/PP_4348/PP_4348-goa.tsv
       supporting_text: &#34;GO:0047804\tcysteine-S-conjugate beta-lyase activity&#34;
+    - reference_id: file:PSEPK/PP_4348/PP_4348-notes.md
+      supporting_text: &#34;The reason for obsoletion is that this term is equivalent to GO:0047804 cysteine-S-conjugate beta-lyase activity.&#34;
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -2187,6 +2248,11 @@ references:
   - statement: OpenScientist confirmed PP_4348 as a MetC/cystathionine beta-lyase
       for the trans-sulfuration branch.
     supporting_text: &#34;PP_4348 (Q88EV4) of *Pseudomonas putida* KT2440 is a cytoplasmic, PLP-dependent **cystathionine β-lyase (MetC, EC 4.4.1.8)**&#34;
+- id: file:PSEPK/PP_4348/PP_4348-notes.md
+  title: PP_4348 manual curation notes
+  findings:
+  - statement: QuickGO confirms that GO:0004121 is obsolete because it is equivalent to the live GO:0047804 term.
+    supporting_text: &#34;The reason for obsoletion is that this term is equivalent to GO:0047804 cysteine-S-conjugate beta-lyase activity.&#34;
 core_functions:
 - description: Candidate PLP-dependent cystathionine beta-lyase that produces L-homocysteine
     in the trans-sulfuration branch of L-methionine biosynthesis.

--- a/genes/PSEPK/PP_4348/PP_4348-ai-review.yaml
+++ b/genes/PSEPK/PP_4348/PP_4348-ai-review.yaml
@@ -74,8 +74,11 @@ existing_annotations:
     summary: The beta-lyase activity captures the PP_4348 trans-sulfuration reaction.
     action: ACCEPT
     reason: UniProt records cystathionine beta-lyase catalytic activity producing
-      L-homocysteine, pyruvate, and ammonium from cystathionine, matching the module
-      need for a cystathionine-cleavage step.
+      L-homocysteine, pyruvate, and ammonium from cystathionine, matching the trans-sulfuration
+      cystathionine-cleavage reaction. The older GO:0004121 cystathionine beta-lyase
+      term is obsolete and equivalent to the current GO:0047804 term, so the valid
+      GOA molecular-function term is retained while the physiological cystathionine
+      substrate is stated explicitly.
     supported_by:
     - reference_id: file:PSEPK/PP_4348/PP_4348-uniprot.txt
       supporting_text: "Reaction=L,L-cystathionine + H2O = L-homocysteine + pyruvate + NH4(+)"

--- a/genes/PSEPK/PP_4348/PP_4348-ai-review.yaml
+++ b/genes/PSEPK/PP_4348/PP_4348-ai-review.yaml
@@ -84,6 +84,8 @@ existing_annotations:
       supporting_text: "Reaction=L,L-cystathionine + H2O = L-homocysteine + pyruvate + NH4(+)"
     - reference_id: file:PSEPK/PP_4348/PP_4348-goa.tsv
       supporting_text: "GO:0047804\tcysteine-S-conjugate beta-lyase activity"
+    - reference_id: file:PSEPK/PP_4348/PP_4348-notes.md
+      supporting_text: "The reason for obsoletion is that this term is equivalent to GO:0047804 cysteine-S-conjugate beta-lyase activity."
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -116,6 +118,11 @@ references:
   - statement: OpenScientist confirmed PP_4348 as a MetC/cystathionine beta-lyase
       for the trans-sulfuration branch.
     supporting_text: "PP_4348 (Q88EV4) of *Pseudomonas putida* KT2440 is a cytoplasmic, PLP-dependent **cystathionine β-lyase (MetC, EC 4.4.1.8)**"
+- id: file:PSEPK/PP_4348/PP_4348-notes.md
+  title: PP_4348 manual curation notes
+  findings:
+  - statement: QuickGO confirms that GO:0004121 is obsolete because it is equivalent to the live GO:0047804 term.
+    supporting_text: "The reason for obsoletion is that this term is equivalent to GO:0047804 cysteine-S-conjugate beta-lyase activity."
 core_functions:
 - description: Candidate PLP-dependent cystathionine beta-lyase that produces L-homocysteine
     in the trans-sulfuration branch of L-methionine biosynthesis.

--- a/genes/PSEPK/PP_4348/PP_4348-notes.md
+++ b/genes/PSEPK/PP_4348/PP_4348-notes.md
@@ -1,0 +1,10 @@
+# PP_4348 curation notes
+
+## GO term status verification
+
+Checked the EMBL-EBI QuickGO API on 2026-07-19:
+
+- `GO:0004121` returned `isObsolete: true` with the comment: "The reason for obsoletion is that this term is equivalent to GO:0047804 cysteine-S-conjugate beta-lyase activity."
+- `GO:0047804` returned `isObsolete: false` and lists "cystathionine beta-lyase activity" as a related synonym.
+
+API request: `https://www.ebi.ac.uk/QuickGO/services/ontology/go/terms/GO%3A0004121,GO%3A0047804`

--- a/genes/PSEPK/PP_4594/PP_4594-ai-review.html
+++ b/genes/PSEPK/PP_4594/PP_4594-ai-review.html
@@ -825,12 +825,12 @@
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q88E72" data-a="DESCRIPTION: PP_4594 encodes a PLP-dependent trans-sulfuration-..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q88E72" data-a="DESCRIPTION: PP_4594 encodes a PLP-dependent Cys/Met-metabolism..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>PP_4594 encodes a PLP-dependent trans-sulfuration-enzyme-family protein near the cysteine/methionine/selenocompound pathway boundary. Its sequence annotations conflict between cystathionine gamma-synthase product naming and cystathionine gamma-lyase GO/PANTHER assignments, so it is tracked as an adjacent unresolved paralog rather than a required methionine-biosynthesis module member.</p>
+        <p>PP_4594 encodes a PLP-dependent Cys/Met-metabolism enzyme near the cysteine, methionine, and selenocompound pathway boundary. Its sequence annotations place it near cystathionine gamma-synthase and cystathionine gamma-lyase family functions, leaving its physiological substrate and reaction direction unresolved.</p>
     </div>
 
 
@@ -1848,11 +1848,10 @@ taxon:
   id: NCBITaxon:160488
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950
     / KT2440)
-description: PP_4594 encodes a PLP-dependent trans-sulfuration-enzyme-family protein
-  near the cysteine/methionine/selenocompound pathway boundary. Its sequence annotations
-  conflict between cystathionine gamma-synthase product naming and cystathionine
-  gamma-lyase GO/PANTHER assignments, so it is tracked as an adjacent unresolved
-  paralog rather than a required methionine-biosynthesis module member.
+description: PP_4594 encodes a PLP-dependent Cys/Met-metabolism enzyme near the
+  cysteine, methionine, and selenocompound pathway boundary. Its sequence annotations
+  place it near cystathionine gamma-synthase and cystathionine gamma-lyase family
+  functions, leaving its physiological substrate and reaction direction unresolved.
 existing_annotations:
 - term:
     id: GO:0004123

--- a/genes/PSEPK/PP_4594/PP_4594-ai-review.yaml
+++ b/genes/PSEPK/PP_4594/PP_4594-ai-review.yaml
@@ -6,11 +6,10 @@ taxon:
   id: NCBITaxon:160488
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950
     / KT2440)
-description: PP_4594 encodes a PLP-dependent trans-sulfuration-enzyme-family protein
-  near the cysteine/methionine/selenocompound pathway boundary. Its sequence annotations
-  conflict between cystathionine gamma-synthase product naming and cystathionine
-  gamma-lyase GO/PANTHER assignments, so it is tracked as an adjacent unresolved
-  paralog rather than a required methionine-biosynthesis module member.
+description: PP_4594 encodes a PLP-dependent Cys/Met-metabolism enzyme near the
+  cysteine, methionine, and selenocompound pathway boundary. Its sequence annotations
+  place it near cystathionine gamma-synthase and cystathionine gamma-lyase family
+  functions, leaving its physiological substrate and reaction direction unresolved.
 existing_annotations:
 - term:
     id: GO:0004123

--- a/genes/PSEPK/PP_4637/PP_4637-ai-review.html
+++ b/genes/PSEPK/PP_4637/PP_4637-ai-review.html
@@ -830,7 +830,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>PP_4637 encodes a short MetE-like N-terminal barrel domain protein. Gene-level retrieval supports a plausible split-MetE model in which PP_4637 may partner with the C-terminal MetE-like PP_2698 subunit, but PP_4637 alone lacks the catalytic C-terminal zinc/homocysteine site and should not be annotated as independently enabling full cobalamin-independent methionine synthase activity.</p>
+        <p>PP_4637 encodes a short MetE-like N-terminal barrel-domain protein in the cobalamin-independent methionine synthase family. Domain evidence supports a possible role in a split or auxiliary MetE-like system, while the protein lacks the C-terminal catalytic zinc/homocysteine-binding barrel found in full-length MetE enzymes.</p>
     </div>
 
 
@@ -1454,11 +1454,11 @@ taxon:
   id: NCBITaxon:160488
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950
     / KT2440)
-description: PP_4637 encodes a short MetE-like N-terminal barrel domain protein.
-  Gene-level retrieval supports a plausible split-MetE model in which PP_4637 may
-  partner with the C-terminal MetE-like PP_2698 subunit, but PP_4637 alone lacks
-  the catalytic C-terminal zinc/homocysteine site and should not be annotated as
-  independently enabling full cobalamin-independent methionine synthase activity.
+description: PP_4637 encodes a short MetE-like N-terminal barrel-domain protein
+  in the cobalamin-independent methionine synthase family. Domain evidence supports
+  a possible role in a split or auxiliary MetE-like system, while the protein lacks
+  the C-terminal catalytic zinc/homocysteine-binding barrel found in full-length
+  MetE enzymes.
 existing_annotations:
 - term:
     id: GO:0003871

--- a/genes/PSEPK/PP_4637/PP_4637-ai-review.yaml
+++ b/genes/PSEPK/PP_4637/PP_4637-ai-review.yaml
@@ -6,11 +6,11 @@ taxon:
   id: NCBITaxon:160488
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950
     / KT2440)
-description: PP_4637 encodes a short MetE-like N-terminal barrel domain protein.
-  Gene-level retrieval supports a plausible split-MetE model in which PP_4637 may
-  partner with the C-terminal MetE-like PP_2698 subunit, but PP_4637 alone lacks
-  the catalytic C-terminal zinc/homocysteine site and should not be annotated as
-  independently enabling full cobalamin-independent methionine synthase activity.
+description: PP_4637 encodes a short MetE-like N-terminal barrel-domain protein
+  in the cobalamin-independent methionine synthase family. Domain evidence supports
+  a possible role in a split or auxiliary MetE-like system, while the protein lacks
+  the C-terminal catalytic zinc/homocysteine-binding barrel found in full-length
+  MetE enzymes.
 existing_annotations:
 - term:
     id: GO:0003871

--- a/genes/PSEPK/metB/metB-ai-review.html
+++ b/genes/PSEPK/metB/metB-ai-review.html
@@ -830,7 +830,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>metB (PP_0659) encodes a cytosolic PLP-dependent cystathionine gamma-synthase family enzyme. In the methionine-biosynthesis module it is the candidate first trans-sulfuration enzyme, forming cystathionine from activated homoserine and cysteine before a cystathionine beta-lyase releases homocysteine.</p>
+        <p>metB (PP_0659) encodes a cytosolic PLP-dependent cystathionine gamma-synthase family enzyme. It forms cystathionine from activated homoserine and cysteine in the trans-sulfuration route to L-homocysteine, upstream of cystathionine beta-lyase.</p>
     </div>
 
 
@@ -1991,9 +1991,9 @@ taxon:
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950
     / KT2440)
 description: metB (PP_0659) encodes a cytosolic PLP-dependent cystathionine gamma-synthase
-  family enzyme. In the methionine-biosynthesis module it is the candidate first
-  trans-sulfuration enzyme, forming cystathionine from activated homoserine and
-  cysteine before a cystathionine beta-lyase releases homocysteine.
+  family enzyme. It forms cystathionine from activated homoserine and cysteine
+  in the trans-sulfuration route to L-homocysteine, upstream of cystathionine
+  beta-lyase.
 existing_annotations:
 - term:
     id: GO:0003824

--- a/genes/PSEPK/metB/metB-ai-review.yaml
+++ b/genes/PSEPK/metB/metB-ai-review.yaml
@@ -7,9 +7,9 @@ taxon:
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950
     / KT2440)
 description: metB (PP_0659) encodes a cytosolic PLP-dependent cystathionine gamma-synthase
-  family enzyme. In the methionine-biosynthesis module it is the candidate first
-  trans-sulfuration enzyme, forming cystathionine from activated homoserine and
-  cysteine before a cystathionine beta-lyase releases homocysteine.
+  family enzyme. It forms cystathionine from activated homoserine and cysteine
+  in the trans-sulfuration route to L-homocysteine, upstream of cystathionine
+  beta-lyase.
 existing_annotations:
 - term:
     id: GO:0003824

--- a/modules/methionine_biosynthesis.yaml
+++ b/modules/methionine_biosynthesis.yaml
@@ -155,10 +155,16 @@ module:
                             gene:
                               preferred_term: metC (cystathionine beta-lyase)
                           function:
-                            preferred_term: cysteine-S-conjugate beta-lyase activity
+                            preferred_term: cystathionine beta-lyase activity
                             term:
                               id: GO:0047804
                               label: cysteine-S-conjugate beta-lyase activity
+                            evidence:
+                              - source_id: GO:0004121
+                                statement: >-
+                                  GO:0004121 cystathionine beta-lyase activity
+                                  is obsolete and equivalent to the current
+                                  GO:0047804 beta-lyase molecular-function term.
               - id: direct_sulfhydrylation
                 label: Direct sulfhydrylation of O-acetylhomoserine (metY)
                 module_type: REACTION

--- a/modules/methionine_biosynthesis.yaml
+++ b/modules/methionine_biosynthesis.yaml
@@ -160,11 +160,14 @@ module:
                               id: GO:0047804
                               label: cysteine-S-conjugate beta-lyase activity
                             evidence:
-                              - source_id: GO:0004121
+                              - source_id: file:PSEPK/PP_4348/PP_4348-notes.md
                                 statement: >-
-                                  GO:0004121 cystathionine beta-lyase activity
-                                  is obsolete and equivalent to the current
-                                  GO:0047804 beta-lyase molecular-function term.
+                                  QuickGO returned GO:0004121 with
+                                  isObsolete=true and states that it is
+                                  equivalent to the live GO:0047804
+                                  cysteine-S-conjugate beta-lyase activity term;
+                                  GO:0047804 also lists cystathionine beta-lyase
+                                  activity as a related synonym.
               - id: direct_sulfhydrylation
                 label: Direct sulfhydrylation of O-acetylhomoserine (metY)
                 module_type: REACTION

--- a/pages/modules/methionine_biosynthesis.html
+++ b/pages/modules/methionine_biosynthesis.html
@@ -894,7 +894,7 @@
             <span><strong>metC (cystathionine beta-lyase)</strong></span></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
-            <span><strong>cysteine-S-conjugate beta-lyase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047804" target="_blank" rel="noopener">GO:0047804</a></div></article>            </div>    </section>    </section>                    <section class="node-detail depth-2" id="node-direct_sulfhydrylation">
+            <span><strong>cystathionine beta-lyase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047804" target="_blank" rel="noopener">GO:0047804</a></div></article>            </div>    </section>    </section>                    <section class="node-detail depth-2" id="node-direct_sulfhydrylation">
         <div class="node-heading">
             <span class="node-title">Direct sulfhydrylation of O-acetylhomoserine (metY)</span><span class="pill type">Reaction</span><span class="pill">direct_sulfhydrylation</span>
         </div>            <p class="node-description">One enzyme, using free sulfide on O-acetyl-homoserine.</p>


### PR DESCRIPTION
## Summary
- remove curation/workflow framing from top-level descriptions for PP_2528, PP_4594, PP_4637, and metB
- clarify PP_4348 beta-lyase annotation rationale after checking QuickGO: `GO:0004121` is obsolete and equivalent to current `GO:0047804`, so the valid GOA term is retained
- update the methionine module MetC preferred term to display cystathionine beta-lyase while preserving the current valid GO term ID
- regenerate touched gene and module HTML pages

## Validation
- `just validate PSEPK PP_2528`
- `just validate PSEPK PP_4348`
- `just validate PSEPK PP_4594`
- `just validate PSEPK PP_4637`
- `just validate PSEPK metB`
- `uv run linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/methionine_biosynthesis.yaml`
- `uv run python -m ai_gene_review.validation.module_validator modules/methionine_biosynthesis.yaml`
- `just render PSEPK PP_2528`
- `just render PSEPK PP_4348`
- `just render PSEPK PP_4594`
- `just render PSEPK PP_4637`
- `just render PSEPK metB`
- `just render-module modules/methionine_biosynthesis.yaml`
- `git diff --check`