### PR TITLE
Heme degradation module (HMOX1/HMOX2 + BLVRA/BLVRB): heme → biliverdin → bilirubin

### DIFF
--- a/genes/human/BLVRA/BLVRA-ai-review.yaml
+++ b/genes/human/BLVRA/BLVRA-ai-review.yaml
@@ -557,34 +557,6 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
-- description: >-
-    Moonlighting dual-specificity Ser/Thr/Tyr protein kinase and signaling scaffold.
-    Human BVR-A participates in insulin/IGF1, PKC and MAPK signaling; it forms a
-    ternary MEK/ERK/BVR-A complex, activates MEK1 and ERK1/2, and acts as a nuclear
-    transporter of ERK required for Elk1-dependent transcription. This is a genuine
-    second function of the human protein, distinct from its reductase activity, and
-    is not captured in the curated GOA annotations.
-  supported_by:
-  - reference_id: PMID:18463290
-    supporting_text: >-
-      Human biliverdin reductase (hBVR) is a recently described Ser/Thr/Tyr kinase
-      in the MAPK insulin/insulin-like growth factor 1 (IGF1)-signaling cascade
-  - reference_id: PMID:18463290
-    supporting_text: >-
-      in the complex, hBVR functions as a scaffold
-  molecular_function:
-    id: GO:0004674
-    label: protein serine/threonine kinase activity
-  locations:
-  - id: GO:0005829
-    label: cytosol
-  knowledge_gaps:
-  - gap_statement: >-
-      Whether BVR-A's moonlighting Ser/Thr/Tyr kinase and MEK/ERK-scaffold activity
-      is quantitatively significant in vivo, and whether it is conserved beyond
-      human/mammalian BVR-A, is undetermined; the role has been characterized almost
-      entirely by one laboratory (Maines and colleagues) and needs independent
-      replication.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO

--- a/genes/human/BLVRA/BLVRA-ai-review.yaml
+++ b/genes/human/BLVRA/BLVRA-ai-review.yaml
@@ -1,0 +1,722 @@
+id: P53004
+gene_symbol: BLVRA
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: >-
+  BLVRA (biliverdin reductase A, BVR-A; EC 1.3.1.24) is a soluble cytosolic
+  NAD(P)H-dependent oxidoreductase that catalyzes the second and terminal step of
+  heme catabolism: reduction of the gamma-methene bridge of biliverdin IX-alpha to
+  bilirubin IX-alpha, the yellow, lipophilic, potently antioxidant bile pigment.
+  It acts downstream of heme oxygenase (HMOX1/HMOX2), which cleaves heme to
+  biliverdin. BVR-A is unusual among enzymes in having dual cofactor and dual pH
+  specificity: it uses NADH at acidic pH and NADPH at alkaline pH, with NADPH the
+  probable physiological electron donor. The enzyme is specific for the IX-alpha
+  isomer (the IX-beta isomer is handled by the paralog BLVRB) and adopts a
+  Gfo/Idh/MocA-family fold with an N-terminal NAD(P)-binding Rossmann domain. It is
+  broadly expressed, with high activity in liver. Beyond its metabolic role, human
+  BVR-A moonlights as a dual-specificity Ser/Thr/Tyr protein kinase and signaling
+  scaffold that participates in insulin/IGF1, PKC, PI3K and MAPK/ERK signaling,
+  functioning as an ERK activator and nuclear transporter and thereby linking
+  cytoplasmic signaling to gene regulation. Loss-of-function variants cause
+  hyperbiliverdinemia (green jaundice), a green discoloration of skin and body
+  fluids that typically manifests in the setting of obstructive cholestasis or
+  liver failure.
+existing_annotations:
+- term:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: >-
+      Core molecular function of BLVRA, propagated by phylogenetic inference from
+      the biliverdin reductase family tree (PANTHER PTN008681150). Fully consistent
+      with the direct experimental characterization of the human enzyme.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        Reduces the gamma-methene bridge of the open tetrapyrrole, biliverdin
+        IXalpha, to bilirubin with the concomitant oxidation of a NADH or NADPH
+        cofactor
+- term:
+    id: GO:0000166
+    label: nucleotide binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: >-
+      Generic InterPro-derived binding term reflecting the NAD(P)-binding Rossmann
+      domain. True but uninformative on its own; it describes a substructure of the
+      catalytic mechanism rather than a distinct function. Keep as non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        KM=3.2 uM for NADPH
+- term:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: >-
+      Electronic annotation of the core MF via InterPro/EC mapping (EC:1.3.1.24).
+      Agrees with the experimental IDA annotations; retained as core.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        Reduces the gamma-methene bridge of the open tetrapyrrole, biliverdin
+        IXalpha, to bilirubin with the concomitant oxidation of a NADH or NADPH
+        cofactor
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: >-
+      Correct but less specific than the experimentally supported cytosol
+      annotation. The enzyme is a soluble cytosolic protein; keep as non-core in
+      favor of the more precise GO:0005829 (cytosol).
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        Cytoplasm, cytosol
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: >-
+      Electronic subcellular-location annotation consistent with experimental IDA
+      evidence that BVR-A is a cytosolic enzyme. Retained as the functional location.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        Cytoplasm, cytosol
+- term:
+    id: GO:0008270
+    label: zinc ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: >-
+      BVR-A purified from human liver contains ~1 Zn per subunit and exogenous Zn
+      inhibits the NADPH-dependent (but not NADH-dependent) activity, so zinc
+      binding is real. However UniProt records the cofactor/binding assignment as an
+      inference (ECO:0000305/ECO:0000303) and the crystal structure (2H63) is
+      NADP-bound without a modeled zinc; its physiological requirement is not fully
+      established. Keep as a non-core cofactor-binding attribute rather than a core MF.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        Binds 1 zinc ion per subunit.
+- term:
+    id: GO:0042167
+    label: heme catabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core biological process: BVR-A performs the terminal reduction step of the
+      heme degradation pathway. Electronic annotation agrees with the experimental
+      IDA annotation to the same term.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        Porphyrin-containing compound metabolism; protoheme
+- term:
+    id: GO:0106276
+    label: biliberdin reductase (NADH) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: >-
+      NADH-specific child of the core biliverdin reductase activity. Electronic
+      (Rhea/ARBA) annotation matching the experimentally demonstrated NADH-dependent
+      activity at acidic pH; retained.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        Uses the reactants NADH or NADPH depending on the
+- term:
+    id: GO:0106277
+    label: biliverdin reductase (NADPH) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000116
+  qualifier: enables
+  review:
+    summary: >-
+      NADPH-specific child of the core activity (NADPH is the probable physiological
+      cofactor). Electronic Rhea annotation agreeing with experimental EXP/IDA
+      evidence; retained.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        NADPH, however, is the probable reactant in biological
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18463290
+  qualifier: enables
+  review:
+    summary: >-
+      IPI capturing the BVR-A interaction with MAPK1/ERK2 (UniProtKB:P28482), which
+      underlies the moonlighting ERK-scaffold function. Real and mechanistically
+      meaningful, but the bare "protein binding" term is uninformative; the specific
+      function is better represented by the protein serine/threonine kinase /
+      ERK-scaffold core function. Not removed (experimental IPI); flagged as
+      over-annotation of the generic term.
+    action: MARK_AS_OVER_ANNOTATED
+    supported_by:
+    - reference_id: PMID:18463290
+      supporting_text: >-
+        Human biliverdin reductase (hBVR) is a recently described Ser/Thr/Tyr kinase
+        in the MAPK insulin/insulin-like growth factor 1 (IGF1)-signaling cascade
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  qualifier: enables
+  review:
+    summary: >-
+      IPI from a large-scale human interactome map recording an interaction with
+      LNX1 (UniProtKB:Q8TBB1). Bare "protein binding" is uninformative and the
+      biological significance of this high-throughput interaction is unclear. Not
+      removed (experimental IPI); marked as over-annotation.
+    action: MARK_AS_OVER_ANNOTATED
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:29892012
+  qualifier: enables
+  review:
+    summary: >-
+      IPI from an interactome-perturbation study, again recording the LNX1
+      (Q8TBB1) interaction. Uninformative bare protein-binding term; not removed
+      (experimental IPI) but marked as over-annotation.
+    action: MARK_AS_OVER_ANNOTATED
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  qualifier: enables
+  review:
+    summary: >-
+      IPI from a large-scale variant-interaction study, LNX1 (Q8TBB1) partner.
+      Bare protein binding; not removed (experimental IPI) but marked as
+      over-annotation of an uninformative generic term.
+    action: MARK_AS_OVER_ANNOTATED
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: >-
+      Immunofluorescence-based (HPA) localization to the cytosol, consistent with
+      the biochemically established cytosolic localization of BVR-A. Accepted as the
+      functional location.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        Cytoplasm, cytosol
+- term:
+    id: GO:0106276
+    label: biliberdin reductase (NADH) activity
+  evidence_type: EXP
+  original_reference_id: PMID:10858451
+  qualifier: enables
+  review:
+    summary: >-
+      Experimental (EXP) support for the NADH-dependent biliverdin reductase
+      activity, from kinetic characterization of the human enzyme. Core catalytic
+      function; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        Uses the reactants NADH or NADPH depending on the
+- term:
+    id: GO:0106277
+    label: biliverdin reductase (NADPH) activity
+  evidence_type: EXP
+  original_reference_id: PMID:10858451
+  qualifier: enables
+  review:
+    summary: >-
+      Experimental support for the NADPH-dependent biliverdin reductase activity.
+      NADPH is the probable physiological cofactor. Core catalytic function; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        NADPH, however, is the probable reactant in biological
+- term:
+    id: GO:0106277
+    label: biliverdin reductase (NADPH) activity
+  evidence_type: EXP
+  original_reference_id: PMID:7929092
+  qualifier: enables
+  review:
+    summary: >-
+      Experimental support from purification of human liver biliverdin-IX alpha
+      reductase; NADPH assumed to be the physiological electron donor. Core
+      catalytic function; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:7929092
+      supporting_text: >-
+        It was assumed that NADPH rather than NADH was the
+- term:
+    id: GO:0106277
+    label: biliverdin reductase (NADPH) activity
+  evidence_type: EXP
+  original_reference_id: PMID:8424666
+  qualifier: enables
+  review:
+    summary: >-
+      Experimental support from purification/characterization of human biliverdin
+      reductase, showing dual cofactor use with NADPH preferred at alkaline pH.
+      Core catalytic function; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8424666
+      supporting_text: >-
+        At pH 6.0-7.0 the NADH was the more effective cofactor, whereas at pH
+- term:
+    id: GO:0106277
+    label: biliverdin reductase (NADPH) activity
+  evidence_type: EXP
+  original_reference_id: PMID:8631357
+  qualifier: enables
+  review:
+    summary: >-
+      Experimental support from characterization of purified and recombinant human
+      BVR-A, demonstrating dual pH/cofactor specificity including NADPH use. Core
+      catalytic function; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8631357
+      supporting_text: >-
+        BVR is unique among enzymes characterized to date in that it has dual
+        pH/cofactor (NADH, NADPH) specificity
+- term:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  evidence_type: IDA
+  original_reference_id: PMID:7929092
+  qualifier: enables
+  review:
+    summary: >-
+      Direct assay of purified human liver biliverdin-IX alpha reductase. This is a
+      primary line of experimental evidence for the core molecular function; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:7929092
+      supporting_text: >-
+        isozymes III and IV preferred biliverdin-IX
+- term:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  evidence_type: IDA
+  original_reference_id: PMID:8424666
+  qualifier: enables
+  review:
+    summary: >-
+      Direct experimental demonstration that the purified human liver enzyme
+      converts biliverdin to bilirubin. Core molecular function; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8424666
+      supporting_text: >-
+        Conversion of biliverdin to bilirubin is catalyzed by the cytosolic enzyme
+        biliverdin reductase
+- term:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  evidence_type: IDA
+  original_reference_id: PMID:8631357
+  qualifier: enables
+  review:
+    summary: >-
+      Direct assay of purified and E. coli-expressed human BVR-A converting
+      biliverdin to bilirubin. Core molecular function; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8631357
+      supporting_text: >-
+        Biliverdin IXalpha reductase (BVR) catalyzes the conversion of the heme b
+        degradation product, biliverdin, to bilirubin
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: PMID:7929092
+  qualifier: is_active_in
+  review:
+    summary: >-
+      BVR-A activity was isolated from human liver cytosolic fractions,
+      establishing the cytosol as the site of the catalytic activity
+      (is_active_in). Accepted as the functional location.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:7929092
+      supporting_text: >-
+        in human liver cytosolic
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: PMID:8424666
+  qualifier: is_active_in
+  review:
+    summary: >-
+      Experimental evidence that biliverdin-to-bilirubin conversion is catalyzed by
+      the cytosolic enzyme, supporting cytosol as the active-in location. Accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8424666
+      supporting_text: >-
+        catalyzed by the cytosolic enzyme
+- term:
+    id: GO:0106276
+    label: biliberdin reductase (NADH) activity
+  evidence_type: IDA
+  original_reference_id: PMID:7929092
+  qualifier: enables
+  review:
+    summary: >-
+      Direct evidence that the purified human enzyme uses NADH as an electron donor
+      for biliverdin reduction. NADH-specific child of the core activity; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:7929092
+      supporting_text: >-
+        The purified enzymes used NADPH and NADH as electron donors for the
+        reduction of biliverdin
+- term:
+    id: GO:0106276
+    label: biliberdin reductase (NADH) activity
+  evidence_type: IDA
+  original_reference_id: PMID:8424666
+  qualifier: enables
+  review:
+    summary: >-
+      Direct evidence for NADH-dependent activity (more effective cofactor at acidic
+      pH). NADH-specific child of the core biliverdin reductase activity; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8424666
+      supporting_text: >-
+        At pH 6.0-7.0 the NADH was the more effective cofactor
+- term:
+    id: GO:0106276
+    label: biliberdin reductase (NADH) activity
+  evidence_type: IDA
+  original_reference_id: PMID:8631357
+  qualifier: enables
+  review:
+    summary: >-
+      Direct evidence for NADH-dependent activity as part of the demonstrated dual
+      pH/cofactor specificity of human BVR-A. NADH-specific child of core activity;
+      accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8631357
+      supporting_text: >-
+        the human enzyme may also use NADH as cofactor
+- term:
+    id: GO:0042167
+    label: heme catabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:10858451
+  qualifier: involved_in
+  review:
+    summary: >-
+      BVR-A performs the terminal reduction step of heme catabolism, converting
+      biliverdin IX-alpha to bilirubin. Core biological process; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+      supporting_text: >-
+        Reduces the gamma-methene bridge of the open tetrapyrrole, biliverdin
+        IXalpha, to bilirubin
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  qualifier: located_in
+  review:
+    summary: >-
+      High-throughput MS detection of BVR-A in urinary exosomes. BVR-A is a soluble
+      cytosolic enzyme that is a common cargo of secreted vesicles; this does not
+      reflect a functional extracellular location. Keep as non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:19056867
+      supporting_text: >-
+        the analysis identified 1132 proteins unambiguously
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:20458337
+  qualifier: located_in
+  review:
+    summary: >-
+      High-throughput MS detection of BVR-A in B-cell-derived exosomes. As with the
+      urinary-exosome dataset, this reflects vesicular cargo rather than a functional
+      extracellular location. Keep as non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:20458337
+      supporting_text: >-
+        highly purified B cell-derived exosomes
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-189384
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome traceable-author-statement placing the BLVRA-catalyzed
+      biliverdin-to-bilirubin reaction in the cytosol. Consistent with experimental
+      localization; accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: Reactome:R-HSA-189384
+      supporting_text: >-
+        BIL is formed from the reduction of biliverdin (BV) by bilverdin reductases
+        BLVRA and BLVRB
+- term:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  evidence_type: IDA
+  original_reference_id: PMID:10858451
+  qualifier: enables
+  review:
+    summary: >-
+      Direct kinetic characterization of the human biliverdin-IX alpha reductase
+      substrate specificity, supporting the core molecular function. Accepted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10858451
+      supporting_text: >-
+        at least one "bridging propionate" is necessary for
+core_functions:
+- description: >-
+    Cytosolic NAD(P)H-dependent biliverdin reductase catalyzing the terminal step
+    of heme catabolism: reduction of biliverdin IX-alpha to bilirubin IX-alpha,
+    using NADH at acidic pH and NADPH (the probable physiological cofactor) at
+    alkaline pH. Specific for the IX-alpha isomer.
+  supported_by:
+  - reference_id: file:human/BLVRA/BLVRA-uniprot.txt
+    supporting_text: >-
+      Reduces the gamma-methene bridge of the open tetrapyrrole, biliverdin
+      IXalpha, to bilirubin with the concomitant oxidation of a NADH or NADPH
+      cofactor
+  - reference_id: PMID:8631357
+    supporting_text: >-
+      Biliverdin IXalpha reductase (BVR) catalyzes the conversion of the heme b
+      degradation product, biliverdin, to bilirubin
+  molecular_function:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  directly_involved_in:
+  - id: GO:0042167
+    label: heme catabolic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+- description: >-
+    Moonlighting dual-specificity Ser/Thr/Tyr protein kinase and signaling scaffold.
+    Human BVR-A participates in insulin/IGF1, PKC and MAPK signaling; it forms a
+    ternary MEK/ERK/BVR-A complex, activates MEK1 and ERK1/2, and acts as a nuclear
+    transporter of ERK required for Elk1-dependent transcription. This is a genuine
+    second function of the human protein, distinct from its reductase activity, and
+    is not captured in the curated GOA annotations.
+  supported_by:
+  - reference_id: PMID:18463290
+    supporting_text: >-
+      Human biliverdin reductase (hBVR) is a recently described Ser/Thr/Tyr kinase
+      in the MAPK insulin/insulin-like growth factor 1 (IGF1)-signaling cascade
+  - reference_id: PMID:18463290
+    supporting_text: >-
+      in the complex, hBVR functions as a scaffold
+  molecular_function:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  knowledge_gaps:
+  - gap_statement: >-
+      Whether BVR-A's moonlighting Ser/Thr/Tyr kinase and MEK/ERK-scaffold activity
+      is quantitatively significant in vivo, and whether it is conserved beyond
+      human/mammalian BVR-A, is undetermined; the role has been characterized almost
+      entirely by one laboratory (Maines and colleagues) and needs independent
+      replication.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000116
+  title: Automatic Gene Ontology annotation based on Rhea mapping
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10858451
+  title: Studies on the specificity of the tetrapyrrole substrate for human biliverdin-IXalpha
+    reductase and biliverdin-IXbeta reductase. Structure-activity relationships define
+    models for both active sites.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract-only in cache; establishes BVR-A IX-alpha isomer specificity (does
+      not reduce IX-beta) and active-site model. Supports the core reductase MF.
+- id: PMID:18463290
+  title: Human biliverdin reductase is an ERK activator; hBVR is an ERK nuclear transporter
+    and is required for MAPK signaling.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Full text available. Primary evidence for the moonlighting kinase/ERK-scaffold
+      function (MEK/ERK/hBVR ternary complex, ERK nuclear transport for Elk1). Also
+      the source of the MAPK1/ERK2 (P28482) IPI. Assays in 293A cells and in vitro.
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      High-throughput urinary-exosome proteome; BVR-A is a bulk cargo detection, not
+      a functional-location study. Supports only the non-core exosome annotation.
+- id: PMID:20458337
+  title: MHC class II-associated proteins in B-cell exosomes and potential functional
+    implications for exosome biogenesis.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      High-throughput B-cell exosome proteome; BVR-A is a bulk cargo detection.
+      Supports only the non-core exosome annotation.
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Large-scale interactome map; source of an LNX1 (Q8TBB1) IPI. Does not discuss
+      BLVRA specifically; supports only the uninformative bare protein-binding
+      annotation.
+- id: PMID:29892012
+  title: An interactome perturbation framework prioritizes damaging missense mutations
+    for developmental disorders.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Interactome-perturbation study; source of an LNX1 (Q8TBB1) IPI. High-throughput,
+      supports only the bare protein-binding annotation.
+- id: PMID:31515488
+  title: Extensive disruption of protein interactions by genetic variants across the
+    allele frequency spectrum in human populations.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Large-scale variant-interaction study; source of an LNX1 (Q8TBB1) IPI.
+      High-throughput; supports only the bare protein-binding annotation.
+- id: PMID:7929092
+  title: Biliverdin-IX alpha reductase and biliverdin-IX beta reductase from human
+    liver. Purification and characterization.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract-only in cache. Purification of human liver BVR-A; dual NADPH/NADH
+      cofactor use, NADPH assumed physiological, cytosolic localization, IX-alpha
+      isomer preference. Supports core reductase MF, cytosol location, and BP.
+- id: PMID:8424666
+  title: Purification and characterization of human biliverdin reductase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract-only in cache. Purified human liver reductase; cytosolic; dual
+      cofactor/dual pH (NADH at acidic pH, NADPH at alkaline pH). Supports core
+      reductase MF and cytosol location.
+- id: PMID:8631357
+  title: Human biliverdin IXalpha reductase is a zinc-metalloprotein. Characterization
+    of purified and Escherichia coli expressed enzymes.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract-only in cache. cDNA cloning + characterization of human BVR-A; dual
+      pH/cofactor specificity; ~1:1 Zn per subunit (Zn inhibits NADPH- but not
+      NADH-dependent activity). Supports core reductase MF and the zinc-binding
+      annotation.
+- id: Reactome:R-HSA-189384
+  title: BLVRA:Zn2+, BLVRB reduce BV to BIL
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Reactome reaction for the cytosolic biliverdin-to-bilirubin step catalyzed by
+      BLVRA (and BLVRB). Supports the core reductase MF, BP, and cytosol location.

--- a/genes/human/BLVRA/BLVRA-goa.tsv
+++ b/genes/human/BLVRA/BLVRA-goa.tsv
@@ -1,0 +1,33 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	P53004	BLVRA	enables	GO:0004074	biliverdin reductase [NAD(P)H] activity	molecular_function	ECO:0000318	IBA	GO_REF:0000033	MGI:MGI:88170|PANTHER:PTN008681150|RGD:620721|UniProtKB:P53004	9606	Homo sapiens	GO_Central	Biliverdin reductase A	20260530
+UniProtKB	P53004	BLVRA	enables	GO:0000166	nucleotide binding	molecular_function	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR000683	9606	Homo sapiens	InterPro	Biliverdin reductase A	20260706
+UniProtKB	P53004	BLVRA	enables	GO:0004074	biliverdin reductase [NAD(P)H] activity	molecular_function	ECO:0000501	IEA	GO_REF:0000120	InterPro:IPR015249|InterPro:IPR017094|EC:1.3.1.24	9606	Homo sapiens	UniProt	Biliverdin reductase A	20260706
+UniProtKB	P53004	BLVRA	located_in	GO:0005737	cytoplasm	cellular_component	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR017094	9606	Homo sapiens	InterPro	Biliverdin reductase A	20260706
+UniProtKB	P53004	BLVRA	located_in	GO:0005829	cytosol	cellular_component	ECO:0007322	IEA	GO_REF:0000044	UniProtKB-SubCell:SL-0091	9606	Homo sapiens	UniProt	Biliverdin reductase A	20260706
+UniProtKB	P53004	BLVRA	enables	GO:0008270	zinc ion binding	molecular_function	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR015249	9606	Homo sapiens	InterPro	Biliverdin reductase A	20260706
+UniProtKB	P53004	BLVRA	involved_in	GO:0042167	heme catabolic process	biological_process	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR015249|InterPro:IPR017094	9606	Homo sapiens	InterPro	Biliverdin reductase A	20260706
+UniProtKB	P53004	BLVRA	enables	GO:0106276	biliberdin reductase (NADH) activity	molecular_function	ECO:0000501	IEA	GO_REF:0000120	ARBA:ARBA00090830|RHEA:15797	9606	Homo sapiens	UniProt	Biliverdin reductase A	20260706
+UniProtKB	P53004	BLVRA	enables	GO:0106277	biliverdin reductase (NADPH) activity	molecular_function	ECO:0007322	IEA	GO_REF:0000116	RHEA:15793	9606	Homo sapiens	RHEA	Biliverdin reductase A	20260706
+UniProtKB	P53004	BLVRA	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:18463290	UniProtKB:P28482	9606	Homo sapiens	IntAct	Biliverdin reductase A	20260704
+UniProtKB	P53004	BLVRA	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:25416956	UniProtKB:Q8TBB1	9606	Homo sapiens	IntAct	Biliverdin reductase A	20260704
+UniProtKB	P53004	BLVRA	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:29892012	UniProtKB:Q8TBB1	9606	Homo sapiens	IntAct	Biliverdin reductase A	20260704
+UniProtKB	P53004	BLVRA	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:31515488	UniProtKB:Q8TBB1	9606	Homo sapiens	IntAct	Biliverdin reductase A	20260704
+UniProtKB	P53004	BLVRA	located_in	GO:0005829	cytosol	cellular_component	ECO:0000314	IDA	GO_REF:0000052		9606	Homo sapiens	HPA	Biliverdin reductase A	20251115
+UniProtKB	P53004	BLVRA	enables	GO:0106276	biliberdin reductase (NADH) activity	molecular_function	ECO:0000269	EXP	PMID:10858451		9606	Homo sapiens	UniProt	Biliverdin reductase A	20240916
+UniProtKB	P53004	BLVRA	enables	GO:0106277	biliverdin reductase (NADPH) activity	molecular_function	ECO:0000269	EXP	PMID:10858451		9606	Homo sapiens	UniProt	Biliverdin reductase A	20240916
+UniProtKB	P53004	BLVRA	enables	GO:0106277	biliverdin reductase (NADPH) activity	molecular_function	ECO:0000269	EXP	PMID:7929092		9606	Homo sapiens	UniProt	Biliverdin reductase A	20240916
+UniProtKB	P53004	BLVRA	enables	GO:0106277	biliverdin reductase (NADPH) activity	molecular_function	ECO:0000269	EXP	PMID:8424666		9606	Homo sapiens	UniProt	Biliverdin reductase A	20240916
+UniProtKB	P53004	BLVRA	enables	GO:0106277	biliverdin reductase (NADPH) activity	molecular_function	ECO:0000269	EXP	PMID:8631357		9606	Homo sapiens	UniProt	Biliverdin reductase A	20240916
+UniProtKB	P53004	BLVRA	enables	GO:0004074	biliverdin reductase [NAD(P)H] activity	molecular_function	ECO:0000314	IDA	PMID:7929092		9606	Homo sapiens	UniProt	Biliverdin reductase A	20211202
+UniProtKB	P53004	BLVRA	enables	GO:0004074	biliverdin reductase [NAD(P)H] activity	molecular_function	ECO:0000314	IDA	PMID:8424666		9606	Homo sapiens	UniProt	Biliverdin reductase A	20211202
+UniProtKB	P53004	BLVRA	enables	GO:0004074	biliverdin reductase [NAD(P)H] activity	molecular_function	ECO:0000314	IDA	PMID:8631357		9606	Homo sapiens	UniProt	Biliverdin reductase A	20211202
+UniProtKB	P53004	BLVRA	is_active_in	GO:0005829	cytosol	cellular_component	ECO:0000314	IDA	PMID:7929092		9606	Homo sapiens	UniProt	Biliverdin reductase A	20211202
+UniProtKB	P53004	BLVRA	is_active_in	GO:0005829	cytosol	cellular_component	ECO:0000314	IDA	PMID:8424666		9606	Homo sapiens	UniProt	Biliverdin reductase A	20211202
+UniProtKB	P53004	BLVRA	enables	GO:0106276	biliberdin reductase (NADH) activity	molecular_function	ECO:0000314	IDA	PMID:7929092		9606	Homo sapiens	UniProt	Biliverdin reductase A	20211202
+UniProtKB	P53004	BLVRA	enables	GO:0106276	biliberdin reductase (NADH) activity	molecular_function	ECO:0000314	IDA	PMID:8424666		9606	Homo sapiens	UniProt	Biliverdin reductase A	20211202
+UniProtKB	P53004	BLVRA	enables	GO:0106276	biliberdin reductase (NADH) activity	molecular_function	ECO:0000314	IDA	PMID:8631357		9606	Homo sapiens	UniProt	Biliverdin reductase A	20211202
+UniProtKB	P53004	BLVRA	involved_in	GO:0042167	heme catabolic process	biological_process	ECO:0000314	IDA	PMID:10858451		9606	Homo sapiens	UniProt	Biliverdin reductase A	20210121
+UniProtKB	P53004	BLVRA	located_in	GO:0070062	extracellular exosome	cellular_component	ECO:0007005	HDA	PMID:19056867		9606	Homo sapiens	UniProt	Biliverdin reductase A	20131024
+UniProtKB	P53004	BLVRA	located_in	GO:0070062	extracellular exosome	cellular_component	ECO:0007005	HDA	PMID:20458337		9606	Homo sapiens	UniProt	Biliverdin reductase A	20130829
+UniProtKB	P53004	BLVRA	located_in	GO:0005829	cytosol	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-189384		9606	Homo sapiens	Reactome	Biliverdin reductase A	20130729
+UniProtKB	P53004	BLVRA	enables	GO:0004074	biliverdin reductase [NAD(P)H] activity	molecular_function	ECO:0000314	IDA	PMID:10858451		9606	Homo sapiens	UniProt	Biliverdin reductase A	20060428

--- a/genes/human/BLVRA/BLVRA-notes.md
+++ b/genes/human/BLVRA/BLVRA-notes.md
@@ -1,0 +1,117 @@
+# BLVRA (Biliverdin reductase A) — review notes
+
+UniProt: P53004 (BIEA_HUMAN). Gene: BLVRA (HGNC:1062). Taxon: Homo sapiens (NCBITaxon:9606).
+EC 1.3.1.24. 296 aa; a Precursor (propeptide 1..2 removed, mature chain 3..296).
+
+## Canonical function (primary): biliverdin reductase A
+
+BLVRA catalyzes the **second step of heme catabolism**: reduction of the gamma-methene
+bridge of biliverdin IXalpha to bilirubin IXalpha, with concomitant oxidation of NADH or
+NADPH. It follows heme oxygenase (HMOX1/HMOX2), which opens the heme ring to biliverdin.
+
+- "Reduces the gamma-methene bridge of the open tetrapyrrole, biliverdin IXalpha, to
+  bilirubin with the concomitant oxidation of a NADH or NADPH cofactor"
+  [file:human/BLVRA/BLVRA-uniprot.txt FUNCTION, ECO:0000269 PubMed:10858451/7929092/8424666/8631357].
+- EC=1.3.1.24; Rhea RHEA:15797 (NAD+) and RHEA:15793 (NADP+); PhysiologicalDirection
+  right-to-left (i.e. biliverdin -> bilirubin) [file:human/BLVRA/BLVRA-uniprot.txt CATALYTIC ACTIVITY].
+- PATHWAY: "Porphyrin-containing compound metabolism; protoheme degradation"
+  [file:human/BLVRA/BLVRA-uniprot.txt PATHWAY].
+- Reactome R-HSA-189384 "BLVRA:Zn2+, BLVRB reduce BV to BIL": "BIL is formed from the
+  reduction of biliverdin (BV) by bilverdin reductases BLVRA and BLVRB"
+  [reactome:R-HSA-189384].
+
+### Dual cofactor / dual pH — unusual property
+- "BVR is unique among enzymes characterized to date in that it has dual pH/cofactor
+  (NADH, NADPH) specificity" [PMID:8631357 abstract].
+- "At pH 6.0-7.0 the NADH was the more effective cofactor, whereas at pH 8.5-8.75 NADPH
+  was the preferred cofactor" [PMID:8424666 abstract].
+- "It was assumed that NADPH rather than NADH was the physiological electron donor in the
+  intracellular reduction of biliverdin" [PMID:7929092 abstract]; UniProt: "NADPH,
+  however, is the probable reactant in biological systems (PubMed:7929092)".
+- KM: 3.2 uM for NADPH, 50 uM for NADH [file:human/BLVRA/BLVRA-uniprot.txt BIOPHYSICOCHEMICAL PROPERTIES].
+- Alpha-isomer specific: "as previously discussed for the rat and ox enzymes, it appears
+  that at least one 'bridging propionate' is necessary for optimal binding and catalytic
+  activity, whereas two are preferred" (BVR-A prefers IXalpha; BLVRB handles IXbeta)
+  [PMID:10858451 abstract]. "Does not reduce bilirubin IXbeta (PubMed:10858451)"
+  [file:human/BLVRA/BLVRA-uniprot.txt FUNCTION].
+
+### Zinc metalloprotein
+- "Atomic absorption spectroscopy indicates that the protein purified from human liver
+  contains Zn at an approximately 1:1 molar ratio" [PMID:8631357 abstract]; UniProt
+  COFACTOR "Binds 1 zinc ion per subunit" (Note is ECO:0000305, an inference)
+  [file:human/BLVRA/BLVRA-uniprot.txt COFACTOR]. FT BINDING residues 280/281/292/293 for Zn2+
+  are annotated with ECO:0000303 (from-statement in the paper), i.e. not a hard structural
+  determination. The physiological necessity of Zn is debated (the 2H63 crystal structure
+  is with NADP, monomer; no Zn in the FUNCTION statement). Treat zinc binding as
+  KEEP_AS_NON_CORE / accept-as-cofactor rather than a core catalytic MF.
+
+### Localization
+- Cytosol: "Conversion of biliverdin to bilirubin is catalyzed by the cytosolic enzyme
+  biliverdin reductase" [PMID:8424666 abstract]; enzyme isolated from "human liver
+  cytosolic fractions" [PMID:7929092 abstract]. UniProt SUBCELLULAR LOCATION "Cytoplasm,
+  cytosol" [file:human/BLVRA/BLVRA-uniprot.txt].
+- Tissue: Liver [file:human/BLVRA/BLVRA-uniprot.txt TISSUE SPECIFICITY]; HPA "Low tissue
+  specificity" (broadly expressed).
+- Extracellular exosome (HDA) from two large-scale exosome proteomics datasets
+  (PMID:19056867 urinary exosomes; PMID:20458337 B-cell exosomes). These are
+  high-throughput MS detections; the protein is a soluble cytosolic enzyme that is a
+  common exosome cargo — KEEP_AS_NON_CORE (not a functional location).
+
+## Moonlighting function (genuine second role): kinase / MAPK scaffold
+
+Human BVR-A is a well-documented dual-specificity Ser/Thr/Tyr kinase and signaling
+scaffold in insulin/IGF1/MAPK/PI3K and PKC pathways, and a transcriptional regulator
+(leucine-zipper) for HMOX1.
+
+- "Human biliverdin reductase (hBVR) is a recently described Ser/Thr/Tyr kinase in the
+  MAPK insulin/insulin-like growth factor 1 (IGF1)-signaling cascade" [PMID:18463290
+  abstract]. It forms a ternary MEK/ERK/hBVR complex, activates MEK1 and ERK1/2, is an
+  ERK nuclear transporter required for Elk1 transcriptional activity, and "in the complex,
+  hBVR functions as a scaffold" [PMID:18463290 full text, PMC2383961].
+- Also documented (in this paper's discussion) as an activator of PKCbetaII and PKCzeta
+  through protein-protein interaction [PMID:18463290].
+
+This role is not present in the curated GOA TSV (BLVRA-goa.tsv). It appears only as
+electronic IEA:Ensembl projections in the UniProt DR GO section
+(GO:0004674 protein serine/threonine kinase activity; GO:0000978 RNA Pol II CRM
+sequence-specific DNA binding; GO:0005634 nucleus; GO:0009986 cell surface). Because it
+is a genuine, experimentally described function of the human protein, it is captured as a
+**second core function** (protein serine/threonine kinase activity, GO:0004674), grounded
+in PMID:18463290, rather than being ignored. NB the kinase/scaffold role has been assayed
+almost entirely by one group (Maines lab); flag as an expert question.
+
+## Protein interactions (IPI, GO:0005515) — bare "protein binding"
+GOA has four IPI "protein binding" annotations. Per policy these are not removed (they are
+experimental IPI); marked MARK_AS_OVER_ANNOTATED because bare protein binding is
+uninformative. The with/from partners:
+- PMID:18463290 -> UniProtKB:P28482 (MAPK1/ERK2) — meaningful (the ERK-scaffold role);
+  UniProt INTERACTION lists P53004–P28482 MAPK1.
+- PMID:25416956 / PMID:29892012 / PMID:31515488 -> UniProtKB:Q8TBB1 (LNX1) — large-scale
+  Y2H/interactome maps; UniProt INTERACTION lists P53004–Q8TBB1 LNX1 (NbExp=5).
+  These interactome papers do not discuss BLVRA specifically in the cached text; they are
+  high-throughput screens. Kept as over-annotated bare protein binding.
+
+## Disease
+- Hyperbiliverdinemia (HBLVD, MIM:614156) / "green jaundice": "It is due to increased
+  biliverdin resulting from inefficient conversion to bilirubin. Affected individuals
+  appear to have symptoms only in the context of obstructive cholestasis and/or liver
+  failure" [file:human/BLVRA/BLVRA-uniprot.txt DISEASE, ECO:0000269 PubMed:19580635].
+
+## Family
+- Gfo/Idh/MocA family, Biliverdin reductase subfamily; NAD(P)-binding Rossmann-fold + C-terminal
+  cat domain [file:human/BLVRA/BLVRA-uniprot.txt SIMILARITY]. PANTHER PTHR43377 BILIVERDIN REDUCTASE A.
+
+## Annotation-review summary
+- Core MF: GO:0004074 biliverdin reductase [NAD(P)H] activity (ACCEPT experimental IDA;
+  the NADH- and NADPH-specific children GO:0106276/GO:0106277 are also experimentally
+  supported and ACCEPTed as they capture the dual-cofactor specificity).
+- Core BP: GO:0042167 heme catabolic process (ACCEPT IDA).
+- Second core MF (moonlighting): GO:0004674 protein serine/threonine kinase activity
+  (from PMID:18463290; not in GOA, added as core_function).
+- Cytosol IDA (GO:0005829) ACCEPT; cytoplasm IEA / cytosol IEA/TAS ACCEPT or non-core.
+- nucleotide binding (GO:0000166), zinc ion binding (GO:0008270): IEA cofactor/ligand-binding,
+  KEEP_AS_NON_CORE (real but sub-functional / part of the catalytic mechanism).
+- extracellular exosome (GO:0070062, HDA x2): KEEP_AS_NON_CORE (HTP cargo, not functional site).
+- protein binding IPI x4 (GO:0005515): MARK_AS_OVER_ANNOTATED (bare protein binding).
+- IEA biliverdin reductase duplicates (IBA/IEA of GO:0004074, GO:0106276, GO:0106277):
+  ACCEPT / KEEP as they agree with the experimental evidence.

--- a/genes/human/BLVRA/BLVRA-uniprot.txt
+++ b/genes/human/BLVRA/BLVRA-uniprot.txt
@@ -1,0 +1,537 @@
+ID   BIEA_HUMAN              Reviewed;         296 AA.
+AC   P53004; A8K747; O95019; Q86UX0; Q96QL4; Q9BRW8;
+DT   01-OCT-1996, integrated into UniProtKB/Swiss-Prot.
+DT   10-OCT-2002, sequence version 2.
+DT   10-JUN-2026, entry version 217.
+DE   RecName: Full=Biliverdin reductase A {ECO:0000303|PubMed:8631357};
+DE            Short=BVR A {ECO:0000303|PubMed:8631357};
+DE            EC=1.3.1.24 {ECO:0000269|PubMed:10858451, ECO:0000269|PubMed:7929092, ECO:0000269|PubMed:8424666, ECO:0000269|PubMed:8631357};
+DE   AltName: Full=Biliverdin-IX alpha-reductase {ECO:0000303|PubMed:8950184};
+DE   Flags: Precursor;
+GN   Name=BLVRA {ECO:0000312|HGNC:HGNC:1062};
+GN   Synonyms=BLVR, BVR {ECO:0000303|PubMed:8631357};
+OS   Homo sapiens (Human).
+OC   Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia;
+OC   Eutheria; Euarchontoglires; Primates; Haplorrhini; Catarrhini; Hominidae;
+OC   Homo.
+OX   NCBI_TaxID=9606;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [MRNA], AND VARIANT THR-3.
+RX   PubMed=8950184; DOI=10.1016/s0167-4781(96)00099-1;
+RA   Komuro A., Tobe T., Nakano Y., Yamaguchi T., Tomita M.;
+RT   "Cloning and characterization of the cDNA encoding human biliverdin-IX
+RT   alpha reductase.";
+RL   Biochim. Biophys. Acta 1309:89-99(1996).
+RN   [2]
+RP   NUCLEOTIDE SEQUENCE [MRNA], FUNCTION, CATALYTIC ACTIVITY,
+RP   BIOPHYSICOCHEMICAL PROPERTIES, AND COFACTOR.
+RC   TISSUE=Placenta;
+RX   PubMed=8631357; DOI=10.1111/j.1432-1033.1996.00372.x;
+RA   Maines M.D., Polevoda B.V., Huang T.-J., McCoubrey W.K. Jr.;
+RT   "Human biliverdin IXalpha reductase is a zinc-metalloprotein.
+RT   Characterization of purified and Escherichia coli expressed enzymes.";
+RL   Eur. J. Biochem. 235:372-381(1996).
+RN   [3]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA].
+RC   TISSUE=Skeletal muscle;
+RX   PubMed=14702039; DOI=10.1038/ng1285;
+RA   Ota T., Suzuki Y., Nishikawa T., Otsuki T., Sugiyama T., Irie R.,
+RA   Wakamatsu A., Hayashi K., Sato H., Nagai K., Kimura K., Makita H.,
+RA   Sekine M., Obayashi M., Nishi T., Shibahara T., Tanaka T., Ishii S.,
+RA   Yamamoto J., Saito K., Kawai Y., Isono Y., Nakamura Y., Nagahari K.,
+RA   Murakami K., Yasuda T., Iwayanagi T., Wagatsuma M., Shiratori A., Sudo H.,
+RA   Hosoiri T., Kaku Y., Kodaira H., Kondo H., Sugawara M., Takahashi M.,
+RA   Kanda K., Yokoi T., Furuya T., Kikkawa E., Omura Y., Abe K., Kamihara K.,
+RA   Katsuta N., Sato K., Tanikawa M., Yamazaki M., Ninomiya K., Ishibashi T.,
+RA   Yamashita H., Murakawa K., Fujimori K., Tanai H., Kimata M., Watanabe M.,
+RA   Hiraoka S., Chiba Y., Ishida S., Ono Y., Takiguchi S., Watanabe S.,
+RA   Yosida M., Hotuta T., Kusano J., Kanehori K., Takahashi-Fujii A., Hara H.,
+RA   Tanase T.-O., Nomura Y., Togiya S., Komai F., Hara R., Takeuchi K.,
+RA   Arita M., Imose N., Musashino K., Yuuki H., Oshima A., Sasaki N.,
+RA   Aotsuka S., Yoshikawa Y., Matsunawa H., Ichihara T., Shiohata N., Sano S.,
+RA   Moriya S., Momiyama H., Satoh N., Takami S., Terashima Y., Suzuki O.,
+RA   Nakagawa S., Senoh A., Mizoguchi H., Goto Y., Shimizu F., Wakebe H.,
+RA   Hishigaki H., Watanabe T., Sugiyama A., Takemoto M., Kawakami B.,
+RA   Yamazaki M., Watanabe K., Kumagai A., Itakura S., Fukuzumi Y., Fujimori Y.,
+RA   Komiyama M., Tashiro H., Tanigami A., Fujiwara T., Ono T., Yamada K.,
+RA   Fujii Y., Ozaki K., Hirao M., Ohmori Y., Kawabata A., Hikiji T.,
+RA   Kobatake N., Inagaki H., Ikema Y., Okamoto S., Okitani R., Kawakami T.,
+RA   Noguchi S., Itoh T., Shigeta K., Senba T., Matsumura K., Nakajima Y.,
+RA   Mizuno T., Morinaga M., Sasaki M., Togashi T., Oyama M., Hata H.,
+RA   Watanabe M., Komatsu T., Mizushima-Sugano J., Satoh T., Shirai Y.,
+RA   Takahashi Y., Nakagawa K., Okumura K., Nagase T., Nomura N., Kikuchi H.,
+RA   Masuho Y., Yamashita R., Nakai K., Yada T., Nakamura Y., Ohara O.,
+RA   Isogai T., Sugano S.;
+RT   "Complete sequencing and characterization of 21,243 full-length human
+RT   cDNAs.";
+RL   Nat. Genet. 36:40-45(2004).
+RN   [4]
+RP   NUCLEOTIDE SEQUENCE [GENOMIC DNA], AND VARIANTS THR-3; VAL-37 AND ARG-56.
+RG   NIEHS SNPs program;
+RL   Submitted (MAY-2004) to the EMBL/GenBank/DDBJ databases.
+RN   [5]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RX   PubMed=12853948; DOI=10.1038/nature01782;
+RA   Hillier L.W., Fulton R.S., Fulton L.A., Graves T.A., Pepin K.H.,
+RA   Wagner-McPherson C., Layman D., Maas J., Jaeger S., Walker R., Wylie K.,
+RA   Sekhon M., Becker M.C., O'Laughlin M.D., Schaller M.E., Fewell G.A.,
+RA   Delehaunty K.D., Miner T.L., Nash W.E., Cordes M., Du H., Sun H.,
+RA   Edwards J., Bradshaw-Cordum H., Ali J., Andrews S., Isak A., Vanbrunt A.,
+RA   Nguyen C., Du F., Lamar B., Courtney L., Kalicki J., Ozersky P.,
+RA   Bielicki L., Scott K., Holmes A., Harkins R., Harris A., Strong C.M.,
+RA   Hou S., Tomlinson C., Dauphin-Kohlberg S., Kozlowicz-Reilly A., Leonard S.,
+RA   Rohlfing T., Rock S.M., Tin-Wollam A.-M., Abbott A., Minx P., Maupin R.,
+RA   Strowmatt C., Latreille P., Miller N., Johnson D., Murray J.,
+RA   Woessner J.P., Wendl M.C., Yang S.-P., Schultz B.R., Wallis J.W.,
+RA   Spieth J., Bieri T.A., Nelson J.O., Berkowicz N., Wohldmann P.E.,
+RA   Cook L.L., Hickenbotham M.T., Eldred J., Williams D., Bedell J.A.,
+RA   Mardis E.R., Clifton S.W., Chissoe S.L., Marra M.A., Raymond C., Haugen E.,
+RA   Gillett W., Zhou Y., James R., Phelps K., Iadanoto S., Bubb K., Simms E.,
+RA   Levy R., Clendenning J., Kaul R., Kent W.J., Furey T.S., Baertsch R.A.,
+RA   Brent M.R., Keibler E., Flicek P., Bork P., Suyama M., Bailey J.A.,
+RA   Portnoy M.E., Torrents D., Chinwalla A.T., Gish W.R., Eddy S.R.,
+RA   McPherson J.D., Olson M.V., Eichler E.E., Green E.D., Waterston R.H.,
+RA   Wilson R.K.;
+RT   "The DNA sequence of human chromosome 7.";
+RL   Nature 424:157-164(2003).
+RN   [6]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA], AND VARIANT THR-3.
+RC   TISSUE=Brain, and Prostate;
+RX   PubMed=15489334; DOI=10.1101/gr.2596504;
+RG   The MGC Project Team;
+RT   "The status, quality, and expansion of the NIH full-length cDNA project:
+RT   the Mammalian Gene Collection (MGC).";
+RL   Genome Res. 14:2121-2127(2004).
+RN   [7]
+RP   PROTEIN SEQUENCE OF 3-36; 48-74 AND 228-248, FUNCTION, CATALYTIC ACTIVITY,
+RP   SUBCELLULAR LOCATION, AND TISSUE SPECIFICITY.
+RC   TISSUE=Liver;
+RX   PubMed=8424666; DOI=10.1006/abbi.1993.1044;
+RA   Maines M.D., Trakshel G.M.;
+RT   "Purification and characterization of human biliverdin reductase.";
+RL   Arch. Biochem. Biophys. 300:320-326(1993).
+RN   [8]
+RP   PROTEIN SEQUENCE OF 3-22, FUNCTION, CATALYTIC ACTIVITY, SUBCELLULAR
+RP   LOCATION, AND TISSUE SPECIFICITY.
+RC   TISSUE=Liver;
+RX   PubMed=7929092; DOI=10.1016/s0021-9258(19)51088-2;
+RA   Yamaguchi T., Komoda Y., Nakajima H.;
+RT   "Biliverdin-IX alpha reductase and biliverdin-IX beta reductase from human
+RT   liver. Purification and characterization.";
+RL   J. Biol. Chem. 269:24343-24348(1994).
+RN   [9]
+RP   FUNCTION, AND CATALYTIC ACTIVITY.
+RX   PubMed=10858451; DOI=10.1074/jbc.275.25.19009;
+RA   Cunningham O., Dunne A., Sabido P., Lightner D., Mantle T.J.;
+RT   "Studies on the specificity of the tetrapyrrole substrate for human
+RT   biliverdin-IXalpha reductase and biliverdin-IXbeta reductase. Structure-
+RT   activity relationships define models for both active sites.";
+RL   J. Biol. Chem. 275:19009-19017(2000).
+RN   [10]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-230, AND IDENTIFICATION BY
+RP   MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Cervix carcinoma;
+RX   PubMed=18669648; DOI=10.1073/pnas.0805139105;
+RA   Dephoure N., Zhou C., Villen J., Beausoleil S.A., Bakalarski C.E.,
+RA   Elledge S.J., Gygi S.P.;
+RT   "A quantitative atlas of mitotic phosphorylation.";
+RL   Proc. Natl. Acad. Sci. U.S.A. 105:10762-10767(2008).
+RN   [11]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=19413330; DOI=10.1021/ac9004309;
+RA   Gauci S., Helbig A.O., Slijper M., Krijgsveld J., Heck A.J., Mohammed S.;
+RT   "Lys-N and trypsin cover complementary parts of the phosphoproteome in a
+RT   refined SCX-based approach.";
+RL   Anal. Chem. 81:4493-4501(2009).
+RN   [12]
+RP   INVOLVEMENT IN HBLVD.
+RX   PubMed=19580635; DOI=10.1111/j.1478-3231.2009.02029.x;
+RA   Gafvels M., Holmstrom P., Somell A., Sjovall F., Svensson J.O., Stahle L.,
+RA   Broome U., Stal P.;
+RT   "A novel mutation in the biliverdin reductase-A gene combined with liver
+RT   cirrhosis results in hyperbiliverdinaemia (green jaundice).";
+RL   Liver Int. 29:1116-1124(2009).
+RN   [13]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT THR-174 AND SER-178, AND
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Leukemic T-cell;
+RX   PubMed=19690332; DOI=10.1126/scisignal.2000007;
+RA   Mayya V., Lundgren D.H., Hwang S.-I., Rezaul K., Wu L., Eng J.K.,
+RA   Rodionov V., Han D.K.;
+RT   "Quantitative phosphoproteomic analysis of T cell receptor signaling
+RT   reveals system-wide modulation of protein-protein interactions.";
+RL   Sci. Signal. 2:RA46-RA46(2009).
+RN   [14]
+RP   ACETYLATION [LARGE SCALE ANALYSIS] AT LYS-248 AND LYS-253, AND
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=19608861; DOI=10.1126/science.1175371;
+RA   Choudhary C., Kumar C., Gnad F., Nielsen M.L., Rehman M., Walther T.C.,
+RA   Olsen J.V., Mann M.;
+RT   "Lysine acetylation targets protein complexes and co-regulates major
+RT   cellular functions.";
+RL   Science 325:834-840(2009).
+RN   [15]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=21269460; DOI=10.1186/1752-0509-5-17;
+RA   Burkard T.R., Planyavsky M., Kaupe I., Breitwieser F.P., Buerckstuemmer T.,
+RA   Bennett K.L., Superti-Furga G., Colinge J.;
+RT   "Initial characterization of the human central proteome.";
+RL   BMC Syst. Biol. 5:17-17(2011).
+RN   [16]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Erythroleukemia;
+RX   PubMed=23186163; DOI=10.1021/pr300630k;
+RA   Zhou H., Di Palma S., Preisinger C., Peng M., Polat A.N., Heck A.J.,
+RA   Mohammed S.;
+RT   "Toward a comprehensive characterization of a human cancer cell
+RT   phosphoproteome.";
+RL   J. Proteome Res. 12:260-271(2013).
+RN   [17]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Liver;
+RX   PubMed=24275569; DOI=10.1016/j.jprot.2013.11.014;
+RA   Bian Y., Song C., Cheng K., Dong M., Wang F., Huang J., Sun D., Wang L.,
+RA   Ye M., Zou H.;
+RT   "An enzyme assisted RP-RPLC approach for in-depth analysis of human liver
+RT   phosphoproteome.";
+RL   J. Proteomics 96:253-262(2014).
+RN   [18]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=25944712; DOI=10.1002/pmic.201400617;
+RA   Vaca Jacome A.S., Rabilloud T., Schaeffer-Reiss C., Rompais M., Ayoub D.,
+RA   Lane L., Bairoch A., Van Dorsselaer A., Carapito C.;
+RT   "N-terminome analysis of the human mitochondrial proteome.";
+RL   Proteomics 15:2519-2524(2015).
+RN   [19] {ECO:0007744|PDB:2H63}
+RP   X-RAY CRYSTALLOGRAPHY (2.7 ANGSTROMS) OF 7-296 IN COMPLEX WITH NADP.
+RG   Structural genomics consortium (SGC);
+RT   "Crystal structure of human biliverdin reductase A.";
+RL   Submitted (FEB-2009) to the PDB data bank.
+CC   -!- FUNCTION: Reduces the gamma-methene bridge of the open tetrapyrrole,
+CC       biliverdin IXalpha, to bilirubin with the concomitant oxidation of a
+CC       NADH or NADPH cofactor (PubMed:10858451, PubMed:7929092,
+CC       PubMed:8424666, PubMed:8631357). Does not reduce bilirubin IXbeta
+CC       (PubMed:10858451). Uses the reactants NADH or NADPH depending on the
+CC       pH; NADH is used at the acidic pH range (6-6.9) and NADPH at the
+CC       alkaline range (8.5-8.7) (PubMed:7929092, PubMed:8424666,
+CC       PubMed:8631357). NADPH, however, is the probable reactant in biological
+CC       systems (PubMed:7929092). {ECO:0000269|PubMed:10858451,
+CC       ECO:0000269|PubMed:7929092, ECO:0000269|PubMed:8424666,
+CC       ECO:0000269|PubMed:8631357}.
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=(4Z,15Z)-bilirubin IXalpha + NAD(+) = biliverdin IXalpha +
+CC         NADH + H(+); Xref=Rhea:RHEA:15797, ChEBI:CHEBI:15378,
+CC         ChEBI:CHEBI:57540, ChEBI:CHEBI:57945, ChEBI:CHEBI:57977,
+CC         ChEBI:CHEBI:57991; EC=1.3.1.24;
+CC         Evidence={ECO:0000269|PubMed:10858451, ECO:0000269|PubMed:7929092,
+CC         ECO:0000269|PubMed:8424666, ECO:0000269|PubMed:8631357};
+CC       PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:15799;
+CC         Evidence={ECO:0000269|PubMed:10858451, ECO:0000269|PubMed:7929092,
+CC         ECO:0000269|PubMed:8424666, ECO:0000269|PubMed:8631357};
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=(4Z,15Z)-bilirubin IXalpha + NADP(+) = biliverdin IXalpha +
+CC         NADPH + H(+); Xref=Rhea:RHEA:15793, ChEBI:CHEBI:15378,
+CC         ChEBI:CHEBI:57783, ChEBI:CHEBI:57977, ChEBI:CHEBI:57991,
+CC         ChEBI:CHEBI:58349; EC=1.3.1.24;
+CC         Evidence={ECO:0000269|PubMed:10858451, ECO:0000269|PubMed:7929092,
+CC         ECO:0000269|PubMed:8424666, ECO:0000269|PubMed:8631357};
+CC       PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:15795;
+CC         Evidence={ECO:0000269|PubMed:10858451, ECO:0000269|PubMed:7929092,
+CC         ECO:0000269|PubMed:8424666, ECO:0000269|PubMed:8631357};
+CC   -!- COFACTOR:
+CC       Name=Zn(2+); Xref=ChEBI:CHEBI:29105;
+CC         Evidence={ECO:0000269|PubMed:8631357};
+CC       Note=Binds 1 zinc ion per subunit. {ECO:0000305|PubMed:8631357};
+CC   -!- BIOPHYSICOCHEMICAL PROPERTIES:
+CC       Kinetic parameters:
+CC         KM=3.2 uM for NADPH {ECO:0000269|PubMed:8631357};
+CC         KM=50 uM for NADH {ECO:0000269|PubMed:8631357};
+CC   -!- PATHWAY: Porphyrin-containing compound metabolism; protoheme
+CC       degradation.
+CC   -!- SUBUNIT: Monomer. {ECO:0000269|Ref.19}.
+CC   -!- INTERACTION:
+CC       P53004; Q8TBB1: LNX1; NbExp=5; IntAct=EBI-7410441, EBI-739832;
+CC       P53004; P28482: MAPK1; NbExp=2; IntAct=EBI-7410441, EBI-959949;
+CC   -!- SUBCELLULAR LOCATION: Cytoplasm, cytosol {ECO:0000269|PubMed:7929092,
+CC       ECO:0000269|PubMed:8424666}.
+CC   -!- TISSUE SPECIFICITY: Liver. {ECO:0000269|PubMed:7929092,
+CC       ECO:0000269|PubMed:8424666}.
+CC   -!- DISEASE: Hyperbiliverdinemia (HBLVD) [MIM:614156]: A condition
+CC       characterized by a green discoloration of the skin, urine, serum, and
+CC       other bodily fluids. It is due to increased biliverdin resulting from
+CC       inefficient conversion to bilirubin. Affected individuals appear to
+CC       have symptoms only in the context of obstructive cholestasis and/or
+CC       liver failure. In some cases, green jaundice can resolve after
+CC       resolution of obstructive cholestasis. {ECO:0000269|PubMed:19580635}.
+CC       Note=The disease is caused by variants affecting the gene represented
+CC       in this entry.
+CC   -!- SIMILARITY: Belongs to the Gfo/Idh/MocA family. Biliverdin reductase
+CC       subfamily. {ECO:0000305}.
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; U34877; AAC35588.1; -; mRNA.
+DR   EMBL; X93086; CAA63635.1; -; mRNA.
+DR   EMBL; AK291862; BAF84551.1; -; mRNA.
+DR   EMBL; AY616754; AAT11126.1; -; Genomic_DNA.
+DR   EMBL; AC005189; -; NOT_ANNOTATED_CDS; Genomic_DNA.
+DR   EMBL; AC004939; AAD05025.1; -; Genomic_DNA.
+DR   EMBL; AC004985; AAP21879.1; -; Genomic_DNA.
+DR   EMBL; BC005902; AAH05902.1; -; mRNA.
+DR   EMBL; BC008456; AAH08456.1; -; mRNA.
+DR   CCDS; CCDS5472.1; -.
+DR   PIR; G02066; G02066.
+DR   PIR; S62624; S62624.
+DR   RefSeq; NP_000703.2; NM_000712.3.
+DR   RefSeq; NP_001240752.1; NM_001253823.2.
+DR   RefSeq; XP_011513776.1; XM_011515474.3.
+DR   RefSeq; XP_016868009.1; XM_017012520.3.
+DR   RefSeq; XP_024302635.1; XM_024446867.2.
+DR   PDB; 2H63; X-ray; 2.70 A; A/B/C/D=7-296.
+DR   PDBsum; 2H63; -.
+DR   AlphaFoldDB; P53004; -.
+DR   SMR; P53004; -.
+DR   BioGRID; 107113; 98.
+DR   CORUM; P53004; -.
+DR   DIP; DIP-42180N; -.
+DR   FunCoup; P53004; 258.
+DR   IntAct; P53004; 60.
+DR   MINT; P53004; -.
+DR   NDEx; IQUERY-CP-BLVRA; 1 NDEx IQuery Curated Pathway.
+DR   STRING; 9606.ENSP00000385757; -.
+DR   DrugBank; DB00157; NADH.
+DR   DrugBank; DB14128; Nadide.
+DR   DrugBank; DB01586; Ursodeoxycholic acid.
+DR   GlyGen; P53004; 1 site, 1 O-linked glycan (1 site).
+DR   iPTMnet; P53004; -.
+DR   MetOSite; P53004; -.
+DR   PhosphoSitePlus; P53004; -.
+DR   SwissPalm; P53004; -.
+DR   BioMuta; BLVRA; -.
+DR   DMDM; 23830892; -.
+DR   OGP; P53004; -.
+DR   REPRODUCTION-2DPAGE; IPI00294158; -.
+DR   jPOST; P53004; -.
+DR   MassIVE; P53004; -.
+DR   PaxDb; 9606-ENSP00000385757; -.
+DR   PeptideAtlas; P53004; -.
+DR   ProteomicsDB; 56566; -.
+DR   Pumba; P53004; -.
+DR   Antibodypedia; 13185; 345 antibodies from 28 providers.
+DR   DNASU; 644; -.
+DR   Ensembl; ENST00000265523.9; ENSP00000265523.4; ENSG00000106605.12.
+DR   Ensembl; ENST00000402924.5; ENSP00000385757.1; ENSG00000106605.12.
+DR   Ensembl; ENST00000854106.1; ENSP00000524165.1; ENSG00000106605.12.
+DR   Ensembl; ENST00000854108.1; ENSP00000524167.1; ENSG00000106605.12.
+DR   Ensembl; ENST00000929414.1; ENSP00000599473.1; ENSG00000106605.12.
+DR   Ensembl; ENST00000940899.1; ENSP00000610958.1; ENSG00000106605.12.
+DR   GeneID; 644; -.
+DR   KEGG; hsa:644; -.
+DR   MANE-Select; ENST00000265523.9; ENSP00000265523.4; NM_000712.4; NP_000703.2.
+DR   UCSC; uc003tir.4; human.
+DR   AGR; HGNC:1062; -.
+DR   ClinPGx; PA25373; -.
+DR   CTD; 644; -.
+DR   DisGeNET; 644; -.
+DR   GeneCards; BLVRA; -.
+DR   HGNC; HGNC:1062; BLVRA.
+DR   HPA; ENSG00000106605; Low tissue specificity.
+DR   MalaCards; BLVRA; -.
+DR   MIM; 109750; gene.
+DR   MIM; 614156; phenotype.
+DR   OpenTargets; ENSG00000106605; -.
+DR   Orphanet; 276405; Hyperbiliverdinemia.
+DR   VEuPathDB; HostDB:ENSG00000106605; -.
+DR   eggNOG; ENOG502QTSZ; Eukaryota.
+DR   GeneTree; ENSGT00390000011072; -.
+DR   HOGENOM; CLU_053157_0_0_1; -.
+DR   InParanoid; P53004; -.
+DR   OMA; IQVAFIC; -.
+DR   OrthoDB; 2129491at2759; -.
+DR   PAN-GO; P53004; 1 GO annotation based on evolutionary models.
+DR   PhylomeDB; P53004; -.
+DR   BioCyc; MetaCyc:HS02928-MONOMER; -.
+DR   BRENDA; 1.3.1.24; 2681.
+DR   PathwayCommons; P53004; -.
+DR   Reactome; R-HSA-189483; Heme degradation.
+DR   Reactome; R-HSA-9707564; Cytoprotection by HMOX1.
+DR   SABIO-RK; P53004; -.
+DR   SignaLink; P53004; -.
+DR   SIGNOR; P53004; -.
+DR   UniPathway; UPA00684; -.
+DR   Agora; ENSG00000106605; -.
+DR   BioGRID-ORCS; 644; 12 hits in 1166 CRISPR screens.
+DR   ChiTaRS; BLVRA; human.
+DR   EvolutionaryTrace; P53004; -.
+DR   GenomeRNAi; 644; -.
+DR   Pharos; P53004; Tbio.
+DR   PRO; PR:P53004; -.
+DR   Proteomes; UP000005640; Chromosome 7.
+DR   RNAct; P53004; protein.
+DR   Bgee; ENSG00000106605; Expressed in monocyte and 205 other cell types or tissues.
+DR   ExpressionAtlas; P53004; baseline and differential.
+DR   GO; GO:0009986; C:cell surface; IEA:Ensembl.
+DR   GO; GO:0005829; C:cytosol; IDA:UniProtKB.
+DR   GO; GO:0070062; C:extracellular exosome; HDA:UniProtKB.
+DR   GO; GO:0005634; C:nucleus; IEA:Ensembl.
+DR   GO; GO:0106276; F:biliberdin reductase (NADH) activity; IDA:UniProtKB.
+DR   GO; GO:0106277; F:biliverdin reductase (NADPH) activity; IEA:RHEA.
+DR   GO; GO:0004074; F:biliverdin reductase [NAD(P)H] activity; IDA:UniProtKB.
+DR   GO; GO:0000166; F:nucleotide binding; IEA:InterPro.
+DR   GO; GO:0004674; F:protein serine/threonine kinase activity; IEA:Ensembl.
+DR   GO; GO:0000978; F:RNA polymerase II cis-regulatory region sequence-specific DNA binding; IEA:Ensembl.
+DR   GO; GO:0008270; F:zinc ion binding; IEA:InterPro.
+DR   GO; GO:0042167; P:heme catabolic process; IDA:UniProtKB.
+DR   FunFam; 3.30.360.10:FF:000020; Biliverdin reductase A; 1.
+DR   FunFam; 3.40.50.720:FF:000179; Biliverdin reductase A; 1.
+DR   Gene3D; 3.30.360.10; Dihydrodipicolinate Reductase, domain 2; 1.
+DR   Gene3D; 3.40.50.720; NAD(P)-binding Rossmann-like Domain; 1.
+DR   InterPro; IPR017094; Biliverdin_Rdtase_A.
+DR   InterPro; IPR015249; Biliverdin_Rdtase_cat.
+DR   InterPro; IPR000683; Gfo/Idh/MocA-like_OxRdtase_N.
+DR   InterPro; IPR051450; Gfo/Idh/MocA_Oxidoreductases.
+DR   InterPro; IPR036291; NAD(P)-bd_dom_sf.
+DR   PANTHER; PTHR43377; BILIVERDIN REDUCTASE A; 1.
+DR   PANTHER; PTHR43377:SF1; BILIVERDIN REDUCTASE A; 1.
+DR   Pfam; PF09166; Biliv-reduc_cat; 1.
+DR   Pfam; PF01408; GFO_IDH_MocA; 1.
+DR   PIRSF; PIRSF037032; Biliverdin_reductase_A; 1.
+DR   SUPFAM; SSF55347; Glyceraldehyde-3-phosphate dehydrogenase-like, C-terminal domain; 1.
+DR   SUPFAM; SSF51735; NAD(P)-binding Rossmann-fold domains; 1.
+PE   1: Evidence at protein level;
+KW   3D-structure; Acetylation; Cytoplasm; Direct protein sequencing;
+KW   Metal-binding; NAD; NADP; Oxidoreductase; Phosphoprotein;
+KW   Proteomics identification; Reference proteome; Zinc.
+FT   PROPEP          1..2
+FT                   /evidence="ECO:0000269|PubMed:7929092,
+FT                   ECO:0000269|PubMed:8424666"
+FT                   /id="PRO_0000010852"
+FT   CHAIN           3..296
+FT                   /note="Biliverdin reductase A"
+FT                   /evidence="ECO:0000269|PubMed:8631357"
+FT                   /id="PRO_0000010853"
+FT   BINDING         16..19
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|Ref.19, ECO:0007744|PDB:2H63"
+FT   BINDING         44..46
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|Ref.19, ECO:0007744|PDB:2H63"
+FT   BINDING         77..80
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|Ref.19, ECO:0007744|PDB:2H63"
+FT   BINDING         98
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|Ref.19, ECO:0007744|PDB:2H63"
+FT   BINDING         280
+FT                   /ligand="Zn(2+)"
+FT                   /ligand_id="ChEBI:CHEBI:29105"
+FT                   /evidence="ECO:0000303|PubMed:8631357"
+FT   BINDING         281
+FT                   /ligand="Zn(2+)"
+FT                   /ligand_id="ChEBI:CHEBI:29105"
+FT                   /evidence="ECO:0000303|PubMed:8631357"
+FT   BINDING         292
+FT                   /ligand="Zn(2+)"
+FT                   /ligand_id="ChEBI:CHEBI:29105"
+FT                   /evidence="ECO:0000303|PubMed:8631357"
+FT   BINDING         293
+FT                   /ligand="Zn(2+)"
+FT                   /ligand_id="ChEBI:CHEBI:29105"
+FT                   /evidence="ECO:0000303|PubMed:8631357"
+FT   MOD_RES         174
+FT                   /note="Phosphothreonine"
+FT                   /evidence="ECO:0007744|PubMed:19690332"
+FT   MOD_RES         178
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:19690332"
+FT   MOD_RES         230
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:18669648"
+FT   MOD_RES         248
+FT                   /note="N6-acetyllysine"
+FT                   /evidence="ECO:0007744|PubMed:19608861"
+FT   MOD_RES         253
+FT                   /note="N6-acetyllysine"
+FT                   /evidence="ECO:0007744|PubMed:19608861"
+FT   VARIANT         3
+FT                   /note="A -> T (in dbSNP:rs699512)"
+FT                   /evidence="ECO:0000269|PubMed:15489334,
+FT                   ECO:0000269|PubMed:8950184, ECO:0000269|Ref.4"
+FT                   /id="VAR_019230"
+FT   VARIANT         37
+FT                   /note="L -> V (in dbSNP:rs17245918)"
+FT                   /evidence="ECO:0000269|Ref.4"
+FT                   /id="VAR_019231"
+FT   VARIANT         56
+FT                   /note="Q -> R (in dbSNP:rs1050916)"
+FT                   /evidence="ECO:0000269|Ref.4"
+FT                   /id="VAR_014851"
+FT   CONFLICT        121
+FT                   /note="L -> S (in Ref. 6; AAH05902)"
+FT                   /evidence="ECO:0000305"
+FT   CONFLICT        154..155
+FT                   /note="AG -> SD (in Ref. 2; CAA63635)"
+FT                   /evidence="ECO:0000305"
+FT   CONFLICT        160
+FT                   /note="E -> D (in Ref. 2; CAA63635)"
+FT                   /evidence="ECO:0000305"
+FT   STRAND          9..14
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           18..28
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           33..36
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   STRAND          37..43
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   STRAND          50..53
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           59..64
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   STRAND          70..73
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           77..89
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   STRAND          93..98
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           104..117
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   STRAND          121..124
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           126..129
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           131..140
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   STRAND          145..154
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           159..162
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           165..168
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           170..180
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   STRAND          182..193
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   STRAND          198..207
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   STRAND          212..219
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   STRAND          226..235
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           241..243
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           250..262
+FT                   /evidence="ECO:0007829|PDB:2H63"
+FT   HELIX           268..290
+FT                   /evidence="ECO:0007829|PDB:2H63"
+SQ   SEQUENCE   296 AA;  33428 MW;  2CF2AA7F1CDDB707 CRC64;
+     MNAEPERKFG VVVVGVGRAG SVRMRDLRNP HPSSAFLNLI GFVSRRELGS IDGVQQISLE
+     DALSSQEVEV AYICSESSSH EDYIRQFLNA GKHVLVEYPM TLSLAAAQEL WELAEQKGKV
+     LHEEHVELLM EEFAFLKKEV VGKDLLKGSL LFTAGPLEEE RFGFPAFSGI SRLTWLVSLF
+     GELSLVSATL EERKEDQYMK MTVCLETEKK SPLSWIEEKG PGLKRNRYLS FHFKSGSLEN
+     VPNVGVNKNI FLKDQNIFVQ KLLGQFSEKE LAAEKKRILH CLGLAEEIQK YCCSRK
+//

--- a/genes/human/BLVRB/BLVRB-ai-review.yaml
+++ b/genes/human/BLVRB/BLVRB-ai-review.yaml
@@ -556,16 +556,6 @@ core_functions:
       a promiscuous enzyme catalysing the pyridine-nucleotide-dependent reduction of a variety
       of flavins, biliverdins, PQQ (pyrroloquinoline quinone) and ferric ion
 - description: >-
-    Binds NADPH as the preferred physiological electron-donor cofactor via a Rossmann-like
-    NAD(P)-binding fold, a structurally established feature required for its reductase activity.
-  molecular_function:
-    id: GO:0070402
-    label: NADPH binding
-  supported_by:
-  - reference_id: PMID:11224564
-    supporting_text: >-
-      The structure also explains the enzyme's preference for NADP(H) and its B-face stereospecificity.
-- description: >-
     SNO-CoA-assisted peptidyl-cysteine S-nitrosylase (SCAN) that transfers a nitric oxide
     group from S-nitroso-CoA to cysteine residues of target proteins, a molecular function
     distinct from its classical reductase activity.
@@ -575,16 +565,6 @@ core_functions:
   supported_by:
   - reference_id: PMID:38056462
     supporting_text: We conclude that BLVRB functions as a SNO-CoA-Assisted Nitrosylase (SCAN)
-- description: >-
-    Participates in heme catabolism as the biliverdin reductase that completes conversion
-    of biliverdin to bilirubin, especially in fetal liver.
-  molecular_function:
-    id: GO:0004074
-    label: biliverdin reductase [NAD(P)H] activity
-  supported_by:
-  - reference_id: PMID:7929092
-    supporting_text: >-
-      The purified enzymes used NADPH and NADH as electron donors for the reduction of biliverdin.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees

--- a/genes/human/BLVRB/BLVRB-ai-review.yaml
+++ b/genes/human/BLVRB/BLVRB-ai-review.yaml
@@ -1,0 +1,810 @@
+id: P30043
+gene_symbol: BLVRB
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: >-
+  BLVRB is a cytosolic, monomeric, broad-specificity NADPH-dependent oxidoreductase, also
+  known as flavin reductase (NADPH) (FR) and biliverdin reductase B (BVR-B). Using NADPH (preferred)
+  or NADH as electron donor, it reduces a range of substrates including flavins (FMN, FAD,
+  riboflavin), biliverdins, methemoglobin, pyrroloquinoline quinone (PQQ) and complexed ferric
+  iron. Its best-characterized physiological role is in fetal heme catabolism, where it reduces
+  biliverdin IX-beta to bilirubin IX-beta; biliverdin IX-beta is the major heme catabolite
+  in the fetus. BLVRB is isomer-selective, acting on biliverdin IX-beta, IX-gamma and IX-delta
+  but not IX-alpha (the substrate of the paralog BLVRA), and does not reduce bilirubin IX-alpha.
+  The protein adopts a Rossmann-like NAD(P)-binding fold with a single substrate-binding site
+  at which flavins and tetrapyrroles compete. Beyond its reductase activity, BLVRB is highly
+  expressed in liver and erythrocytes and has been implicated in redox homeostasis, hematopoiesis
+  and platelet production (megakaryocytopoiesis), and, through a distinct S-nitroso-CoA- dependent
+  nitrosyltransferase (SCAN) activity, in the S-nitrosylation of proteins such as the insulin
+  receptor and IRS1 that modulates insulin signaling.
+existing_annotations:
+- term:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: >-
+      Phylogenetic (IBA) assertion of the core biliverdin reductase molecular function. This
+      is the defining catalytic activity of BLVRB (reduction of biliverdin to bilirubin),
+      directly supported by biochemistry on the human enzyme and consistent across the family.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRB/BLVRB-uniprot.txt
+      supporting_text: >-
+        Contributes to fetal heme catabolism by catalyzing reduction of biliverdin IXbeta
+        into bilirubin IXbeta in the liver
+- term:
+    id: GO:0042602
+    label: riboflavin reductase (NADPH) activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: >-
+      Phylogenetic (IBA) assertion of NADPH-dependent riboflavin (flavin) reductase activity,
+      a core catalytic function of BLVRB directly measured on the human enzyme.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10620517
+      supporting_text: >-
+        The enzyme was shown to catalyse the reduction of FMN, FAD and riboflavin, with K(m)
+        values of 52 microM, 125 microM and 53 microM, respectively.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: >-
+      Electronic subcellular-location mapping to cytoplasm. Correct but general; BLVRB is
+      a soluble cytosolic enzyme, better represented by cytosol (GO:0005829). Consistent with
+      UniProt subcellular location.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRB/BLVRB-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm'
+- term:
+    id: GO:0030219
+    label: megakaryocyte differentiation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: >-
+      ARBA machine-learning transfer of a role in megakaryocyte differentiation. This is corroborated
+      experimentally in human by the BLVRB(S111L) redox mutation study, but it is a downstream
+      physiological role of the enzyme's redox activity rather than its molecular core function;
+      retained as non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:27207795
+      supporting_text: >-
+        identified a single loss-of-function mutation (BLVRB S111L) causally associated with
+        clonal and nonclonal disorders of enhanced platelet production
+- term:
+    id: GO:0042602
+    label: riboflavin reductase (NADPH) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: >-
+      Automated (Rhea/EC-based) assertion of riboflavin reductase (NADPH) activity, redundant
+      with the experimental IDA/EXP annotations to the same term. The molecular function is
+      correct.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRB/BLVRB-uniprot.txt
+      supporting_text: Reaction=reduced riboflavin + NADP(+) = riboflavin + NADPH + 2 H(+)
+- term:
+    id: GO:0052873
+    label: FMN reductase (NADPH) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000116
+  qualifier: enables
+  review:
+    summary: >-
+      Rhea-mapped FMN reductase (NADPH) activity, redundant with the experimental EXP annotation
+      (PMID:18241201) to the same term. The molecular function is correct and directly measured.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRB/BLVRB-uniprot.txt
+      supporting_text: Reaction=FMNH2 + NADP(+) = FMN + NADPH + 2 H(+)
+- term:
+    id: GO:0052874
+    label: FMN reductase (NADH) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000116
+  qualifier: enables
+  review:
+    summary: >-
+      Rhea-mapped FMN reductase (NADH) activity, redundant with the experimental EXP annotation
+      (PMID:18241201). BLVRB can use NADH as well as NADPH, although NADPH is the preferred
+      physiological cofactor.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRB/BLVRB-uniprot.txt
+      supporting_text: Reaction=FMNH2 + NAD(+) = FMN + NADH + 2 H(+)
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: >-
+      Bare "protein binding" from a high-throughput binary interactome screen (interactor
+      ANXA10, Q9UJ72). Uninformative as a molecular function and not indicative of a specific
+      biological role; kept per policy but flagged as over-annotated.
+    action: MARK_AS_OVER_ANNOTATED
+    supported_by:
+    - reference_id: file:human/BLVRB/BLVRB-uniprot.txt
+      supporting_text: 'P30043; Q9UJ72: ANXA10'
+- term:
+    id: GO:0035605
+    label: peptidyl-cysteine S-nitrosylase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: >-
+      ARBA transfer (from mouse ortholog Q923D2) of peptidyl-cysteine S-nitrosylase activity.
+      This is directly established experimentally for human BLVRB (SCAN activity), so the
+      molecular function is correct.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRB/BLVRB-uniprot.txt
+      supporting_text: >-
+        Acts as a protein nitrosyltransferase by catalyzing nitrosylation of cysteine residues
+        of target proteins, such as HMOX2, INSR and IRS1
+- term:
+    id: GO:0046627
+    label: negative regulation of insulin receptor signaling pathway
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: >-
+      ARBA transfer (from mouse ortholog Q923D2) of a role in negatively regulating insulin
+      receptor signaling. Corroborated experimentally in human (SCAN-mediated S-nitrosylation
+      of INSR/IRS1); a genuine but context-specific, non-core physiological role.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:38056462
+      supporting_text: S-nitrosylation of INSR/IRS1 by SCAN reduces insulin signaling physiologically
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: >-
+      Direct (immunofluorescence, HPA) localization to cytosol. This is the accurate, specific
+      compartment for this soluble reductase and is consistent with biochemical purification
+      from cytosolic fractions.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRB/BLVRB-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm'
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: EXP
+  original_reference_id: PMID:7929092
+  qualifier: located_in
+  review:
+    summary: >-
+      Experimental localization to cytoplasm; the enzyme was purified from human liver cytosolic
+      fractions. Correct but general relative to cytosol.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:7929092
+      supporting_text: >-
+        four forms of biliverdin reductase including two biliverdin-IX beta reductases and
+        two biliverdin-IX alpha reductases, designated isozymes I and II and isozymes III
+        and IV, respectively, in human liver cytosolic fractions
+- term:
+    id: GO:0042602
+    label: riboflavin reductase (NADPH) activity
+  evidence_type: EXP
+  original_reference_id: PMID:10620517
+  qualifier: enables
+  review:
+    summary: >-
+      Experimental (initial-rate kinetics) demonstration of NADPH-dependent flavin (including
+      riboflavin) reductase activity, with measured Km values. A core catalytic function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10620517
+      supporting_text: >-
+        The enzyme was shown to catalyse the reduction of FMN, FAD and riboflavin, with K(m)
+        values of 52 microM, 125 microM and 53 microM, respectively.
+- term:
+    id: GO:0042602
+    label: riboflavin reductase (NADPH) activity
+  evidence_type: EXP
+  original_reference_id: PMID:18241201
+  qualifier: enables
+  review:
+    summary: >-
+      Experimental confirmation of flavin (riboflavin/FMN) reductase activity in a study of
+      the BVR-B catalytic mechanism. Core catalytic function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:18241201
+      supporting_text: >-
+        a promiscuous enzyme catalysing the pyridine-nucleotide-dependent reduction of a variety
+        of flavins, biliverdins, PQQ (pyrroloquinoline quinone) and ferric ion
+- term:
+    id: GO:0052873
+    label: FMN reductase (NADPH) activity
+  evidence_type: EXP
+  original_reference_id: PMID:18241201
+  qualifier: enables
+  review:
+    summary: >-
+      Experimental demonstration of NADPH-dependent FMN reductase activity. Core catalytic
+      function of the broad-specificity flavin reductase.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:18241201
+      supporting_text: >-
+        a promiscuous enzyme catalysing the pyridine-nucleotide-dependent reduction of a variety
+        of flavins, biliverdins, PQQ (pyrroloquinoline quinone) and ferric ion
+- term:
+    id: GO:0052874
+    label: FMN reductase (NADH) activity
+  evidence_type: EXP
+  original_reference_id: PMID:18241201
+  qualifier: enables
+  review:
+    summary: >-
+      Experimental demonstration of NADH-dependent FMN reductase activity. BLVRB can use NADH
+      as a cofactor, though it prefers NADPH physiologically.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:18241201
+      supporting_text: >-
+        a promiscuous enzyme catalysing the pyridine-nucleotide-dependent reduction of a variety
+        of flavins, biliverdins, PQQ (pyrroloquinoline quinone) and ferric ion
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:38056462
+  qualifier: is_active_in
+  review:
+    summary: >-
+      Direct evidence that BLVRB is active in the cytoplasm; the SCAN/nitrosylase study localized
+      endogenous BLVRB mainly to the cytoplasm. Consistent with its cytosolic reductase role.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:38056462
+      supporting_text: BLVRB is mainly localized in the cytoplasm
+- term:
+    id: GO:0030219
+    label: megakaryocyte differentiation
+  evidence_type: IMP
+  original_reference_id: PMID:27207795
+  qualifier: involved_in
+  review:
+    summary: >-
+      Mutant-phenotype (IMP) evidence: the loss-of-function BLVRB(S111L) redox mutation is
+      causally associated with enhanced platelet production and alters terminal megakaryocytopoiesis
+      via ROS mishandling. A genuine physiological role, but downstream of the enzyme's redox
+      function rather than its molecular core; retained as non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:27207795
+      supporting_text: >-
+        implicate its activity and/or heme-regulated BV tetrapyrrole(s) in a unique redox-regulated
+        bioenergetic pathway governing terminal megakaryocytopoiesis
+- term:
+    id: GO:0035605
+    label: peptidyl-cysteine S-nitrosylase activity
+  evidence_type: IDA
+  original_reference_id: PMID:38056462
+  qualifier: enables
+  review:
+    summary: >-
+      Direct experimental evidence that BLVRB (SCAN) catalyzes S-nitrosylation of target-protein
+      cysteines using SNO-CoA as cofactor, via Cys-109/Cys-188 intermediates. A bona fide
+      second molecular function distinct from the classical NADPH reductase activity.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:38056462
+      supporting_text: We conclude that BLVRB functions as a SNO-CoA-Assisted Nitrosylase
+        (SCAN)
+- term:
+    id: GO:0042602
+    label: riboflavin reductase (NADPH) activity
+  evidence_type: IMP
+  original_reference_id: PMID:27207795
+  qualifier: enables
+  review:
+    summary: >-
+      Mutant-phenotype support for the flavin reductase activity: the S111L variant is a functionally
+      defective flavin/biliverdin redox coupler, confirming that wild-type BLVRB has this
+      NADPH-dependent flavin reductase activity. Core catalytic function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:27207795
+      supporting_text: >-
+        BLVRB S111L encompassed within the substrate/cofactor [α/β dinucleotide NAD(P)H] binding
+        fold is a functionally defective redox coupler using flavin and biliverdin (BV) IXβ
+        tetrapyrrole(s)
+- term:
+    id: GO:0046627
+    label: negative regulation of insulin receptor signaling pathway
+  evidence_type: IDA
+  original_reference_id: PMID:38056462
+  qualifier: involved_in
+  review:
+    summary: >-
+      Direct evidence that BLVRB/SCAN-mediated S-nitrosylation of INSR and IRS1 reduces insulin
+      signaling. A genuine, experimentally supported but context-specific (nitrosylation-dependent)
+      role; retained as non-core relative to the enzyme's core reductase functions.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:38056462
+      supporting_text: S-nitrosylation of INSR/IRS1 by SCAN reduces insulin signaling physiologically
+- term:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  evidence_type: IDA
+  original_reference_id: PMID:10858451
+  qualifier: enables
+  review:
+    summary: >-
+      Direct experimental evidence for biliverdin reductase activity, with substrate-specificity
+      analysis distinguishing the IX-beta-selective BLVRB active site from the IX-alpha-selective
+      BLVRA. Core catalytic function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10858451
+      supporting_text: >-
+        A comparison of the initial rate kinetics for human biliverdin-IXalpha reductase and
+        biliverdin-IXbeta reductase
+- term:
+    id: GO:0042167
+    label: heme catabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:10858451
+  qualifier: involved_in
+  review:
+    summary: >-
+      Direct evidence placing BLVRB's biliverdin reductase activity in the heme catabolic
+      pathway (biliverdin -> bilirubin). Core biological process.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/BLVRB/BLVRB-uniprot.txt
+      supporting_text: >-
+        Contributes to fetal heme catabolism by catalyzing reduction of biliverdin IXbeta
+        into bilirubin IXbeta in the liver
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  qualifier: located_in
+  review:
+    summary: >-
+      Detection in urinary exosomes by high-throughput proteomics. Abundant cytosolic enzymes
+      are routinely recovered in exosome/secretome datasets; this does not indicate a functional
+      extracellular localization. Flagged as over-annotated rather than a genuine site of
+      action.
+    action: MARK_AS_OVER_ANNOTATED
+    supported_by:
+    - reference_id: PMID:19056867
+      supporting_text: the analysis identified 1132 proteins unambiguously
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-189384
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome (TAS) placement of BLVRB in the cytosol as part of the biliverdin-to-bilirubin
+      reduction reaction. Accurate compartment for this soluble reductase.
+    action: ACCEPT
+    supported_by:
+    - reference_id: Reactome:R-HSA-189384
+      supporting_text: >-
+        BIL is formed from the reduction of biliverdin (BV) by bilverdin reductases BLVRA
+        and BLVRB
+- term:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  evidence_type: IDA
+  original_reference_id: PMID:7929092
+  qualifier: enables
+  review:
+    summary: >-
+      Direct evidence from purification and characterization of the human liver biliverdin-IX-beta
+      reductase, using NADPH/NADH to reduce biliverdin. Core catalytic function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:7929092
+      supporting_text: >-
+        The purified enzymes used NADPH and NADH as electron donors for the reduction of biliverdin.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: PMID:7929092
+  qualifier: located_in
+  review:
+    summary: >-
+      Direct evidence: the enzyme was purified from human liver cytosolic fractions, confirming
+      cytosolic localization.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:7929092
+      supporting_text: >-
+        biliverdin-IX alpha reductases, designated isozymes I and II and isozymes III and
+        IV, respectively, in human liver cytosolic fractions
+- term:
+    id: GO:0042167
+    label: heme catabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:7929092
+  qualifier: involved_in
+  review:
+    summary: >-
+      Direct evidence linking BLVRB's biliverdin reductase activity to heme catabolism (the
+      final step converting biliverdin to bilirubin). Core biological process.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:7929092
+      supporting_text: >-
+        The purified enzymes used NADPH and NADH as electron donors for the reduction of biliverdin.
+- term:
+    id: GO:0042602
+    label: riboflavin reductase (NADPH) activity
+  evidence_type: IDA
+  original_reference_id: PMID:11224564
+  qualifier: enables
+  review:
+    summary: >-
+      Structural/biochemical evidence (BVR-B crystal structures with FMN and lumichrome) supporting
+      flavin reductase activity and a single, broadly specific substrate-binding site. Core
+      catalytic function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:11224564
+      supporting_text: >-
+        human BVR-B has a single substrate binding site, to which substrates and inhibitors
+        bind primarily through hydrophobic interactions, explaining its broad specificity
+- term:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  evidence_type: TAS
+  original_reference_id: PMID:8117274
+  qualifier: enables
+  review:
+    summary: >-
+      Author-stated (TAS) biliverdin/flavin reductase activity from the cloning of the human
+      erythrocyte NADPH-flavin reductase, later shown to be identical to BVR-B. Core catalytic
+      function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8117274
+      supporting_text: A cDNA of human erythrocyte NADPH-flavin reductase was cloned
+- term:
+    id: GO:0070402
+    label: NADPH binding
+  evidence_type: IDA
+  original_reference_id: PMID:11224564
+  qualifier: enables
+  review:
+    summary: >-
+      Proposed new annotation. BLVRB binds NADP(H) as its cofactor via a Rossmann-like
+      NAD(P)-binding fold; the crystal structure with NADP+ establishes numerous
+      cofactor-binding residues and the enzyme's preference for NADP(H). NADPH binding is a
+      core, structurally established molecular function not currently captured in GOA.
+    action: NEW
+    supported_by:
+    - reference_id: PMID:11224564
+      supporting_text: >-
+        The structure also explains the enzyme's preference for NADP(H) and its B-face
+        stereospecificity.
+core_functions:
+- description: >-
+    NADPH-dependent biliverdin reductase that reduces biliverdin IX-beta (and IX-gamma/IX-delta,
+    but not IX-alpha) to the corresponding bilirubin, catalyzing the terminal step of fetal
+    heme catabolism.
+  molecular_function:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  supported_by:
+  - reference_id: PMID:10858451
+    supporting_text: >-
+      A comparison of the initial rate kinetics for human biliverdin-IXalpha reductase and
+      biliverdin-IXbeta reductase
+  - reference_id: file:human/BLVRB/BLVRB-uniprot.txt
+    supporting_text: >-
+      Contributes to fetal heme catabolism by catalyzing reduction of biliverdin IXbeta into
+      bilirubin IXbeta in the liver
+- description: >-
+    Broad-specificity NADPH-dependent flavin reductase that reduces riboflavin, FMN and FAD
+    (and can also use NADH), providing reduced flavins for cellular redox processes.
+  molecular_function:
+    id: GO:0042602
+    label: riboflavin reductase (NADPH) activity
+  supported_by:
+  - reference_id: PMID:10620517
+    supporting_text: >-
+      The enzyme was shown to catalyse the reduction of FMN, FAD and riboflavin, with K(m)
+      values of 52 microM, 125 microM and 53 microM, respectively.
+- description: >-
+    NADPH-dependent FMN reductase activity, part of the enzyme's broad pyridine-nucleotide-dependent
+    flavin reductase function.
+  molecular_function:
+    id: GO:0052873
+    label: FMN reductase (NADPH) activity
+  supported_by:
+  - reference_id: PMID:18241201
+    supporting_text: >-
+      a promiscuous enzyme catalysing the pyridine-nucleotide-dependent reduction of a variety
+      of flavins, biliverdins, PQQ (pyrroloquinoline quinone) and ferric ion
+- description: >-
+    Binds NADPH as the preferred physiological electron-donor cofactor via a Rossmann-like
+    NAD(P)-binding fold, a structurally established feature required for its reductase activity.
+  molecular_function:
+    id: GO:0070402
+    label: NADPH binding
+  supported_by:
+  - reference_id: PMID:11224564
+    supporting_text: >-
+      The structure also explains the enzyme's preference for NADP(H) and its B-face stereospecificity.
+- description: >-
+    SNO-CoA-assisted peptidyl-cysteine S-nitrosylase (SCAN) that transfers a nitric oxide
+    group from S-nitroso-CoA to cysteine residues of target proteins, a molecular function
+    distinct from its classical reductase activity.
+  molecular_function:
+    id: GO:0035605
+    label: peptidyl-cysteine S-nitrosylase activity
+  supported_by:
+  - reference_id: PMID:38056462
+    supporting_text: We conclude that BLVRB functions as a SNO-CoA-Assisted Nitrosylase (SCAN)
+- description: >-
+    Participates in heme catabolism as the biliverdin reductase that completes conversion
+    of biliverdin to bilirubin, especially in fetal liver.
+  molecular_function:
+    id: GO:0004074
+    label: biliverdin reductase [NAD(P)H] activity
+  supported_by:
+  - reference_id: PMID:7929092
+    supporting_text: >-
+      The purified enzymes used NADPH and NADH as electron donors for the reduction of biliverdin.
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: >-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000116
+  title: Automatic Gene Ontology annotation based on Rhea mapping
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10620517
+  title: >-
+    Initial-rate kinetics of the flavin reductase reaction catalysed by human biliverdin-IXbeta
+    reductase (BVR-B).
+  findings:
+  - statement: >-
+      Human BVR-B (flavin reductase) reduces FMN, FAD and riboflavin with Km values of 52,
+      125 and 53 microM respectively, and also exhibits ferric reductase activity requiring
+      NAD(P)H and FMN.
+    reference_section_type: ABSTRACT
+    supporting_text: >-
+      The enzyme was shown to catalyse the reduction of FMN, FAD and riboflavin, with K(m)
+      values of 52 microM, 125 microM and 53 microM, respectively.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Cached abstract directly documents NADPH-dependent flavin reductase kinetics of human
+      BVR-B; supports the flavin reductase MF annotations.
+- id: PMID:10858451
+  title: >-
+    Studies on the specificity of the tetrapyrrole substrate for human biliverdin-IXalpha
+    reductase and biliverdin-IXbeta reductase. Structure-activity relationships define models
+    for both active sites.
+  findings:
+  - statement: >-
+      Human biliverdin-IX-beta reductase (BLVRB) is isomer-selective and cannot tolerate a
+      bridging propionate; the flavin and tetrapyrrole substrates bind at a common site.
+    reference_section_type: ABSTRACT
+    supporting_text: the enzyme cannot tolerate even one propionate in the bridging position
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Supports biliverdin reductase activity and the IX-beta-selective active site distinct
+      from BLVRA.
+- id: PMID:11224564
+  title: >-
+    Structure of human biliverdin IXbeta reductase, an early fetal bilirubin IXbeta producing
+    enzyme.
+  findings:
+  - statement: >-
+      Crystal structure of human BVR-B (monomer, alpha/beta dinucleotide fold) with NADP+
+      and flavin/tetrapyrrole ligands reveals a single broadly specific substrate-binding
+      site and explains preference for NADP(H).
+    reference_section_type: ABSTRACT
+    supporting_text: >-
+      human BVR-B has a single substrate binding site, to which substrates and inhibitors
+      bind primarily through hydrophobic interactions, explaining its broad specificity
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Structural basis for broad flavin/biliverdin reductase activity and NADPH binding; supports
+      MF and cofactor-binding core functions.
+- id: PMID:18241201
+  title: >-
+    Computational and experimental studies on the catalytic mechanism of biliverdin-IXbeta
+    reductase.
+  findings:
+  - statement: >-
+      BVR-B (also known as flavin reductase) is a promiscuous enzyme reducing flavins, biliverdins,
+      PQQ and ferric ion; His-153 is not required for catalysis.
+    reference_section_type: ABSTRACT
+    supporting_text: >-
+      a promiscuous enzyme catalysing the pyridine-nucleotide-dependent reduction of a variety
+      of flavins, biliverdins, PQQ (pyrroloquinoline quinone) and ferric ion
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Directly supports the broad flavin/biliverdin reductase MF annotations.
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings:
+  - statement: >-
+      Large-scale proteomics of human urinary exosomes identified >1100 proteins, among which
+      BLVRB was detected; a high-throughput dataset, not a functional localization study.
+    reference_section_type: ABSTRACT
+    supporting_text: the analysis identified 1132 proteins unambiguously
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      HTP exosome proteomics; BLVRB detection is consistent with abundant cytosolic proteins
+      appearing in secretome datasets and does not establish a functional extracellular role.
+- id: PMID:27207795
+  title: >-
+    BLVRB redox mutation defines heme degradation in a metabolic pathway of enhanced thrombopoiesis
+    in humans.
+  findings:
+  - statement: >-
+      A loss-of-function redox mutation BLVRB(S111L), a defective flavin/BV IXbeta redox coupler,
+      is causally associated with enhanced platelet production and megakaryocytopoiesis via
+      ROS accumulation.
+    reference_section_type: ABSTRACT
+    supporting_text: >-
+      identified a single loss-of-function mutation (BLVRB S111L) causally associated with
+      clonal and nonclonal disorders of enhanced platelet production
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Full text available; defines the first physiological role of BLVRB in thrombopoiesis
+      and supports megakaryocyte-differentiation and flavin reductase (IMP) annotations.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings:
+  - statement: >-
+      BLVRB (P30043) was reported to interact with ANXA10 (Q9UJ72) in a high-throughput binary
+      interactome map.
+    reference_section_type: ABSTRACT
+    supporting_text: A reference map of the human binary protein interactome
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Systematic Y2H interactome; supports only a bare protein-binding annotation (ANXA10),
+      which is uninformative for function.
+- id: PMID:38056462
+  title: >-
+    An enzyme that selectively S-nitrosylates proteins to regulate insulin signaling.
+  findings:
+  - statement: >-
+      BLVRB functions as a SNO-CoA-assisted nitrosylase (SCAN) that S-nitrosylates target
+      proteins including INSR and IRS1, thereby reducing insulin signaling; BLVRB is mainly
+      cytoplasmic.
+    reference_section_type: RESULTS
+    supporting_text: We conclude that BLVRB functions as a SNO-CoA-Assisted Nitrosylase (SCAN)
+  - statement: >-
+      SCAN-mediated S-nitrosylation of INSR/IRS1 reduces insulin signaling physiologically.
+    reference_section_type: ABSTRACT
+    supporting_text: S-nitrosylation of INSR/IRS1 by SCAN reduces insulin signaling physiologically
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Full text available; establishes the S-nitrosylase MF and negative regulation of insulin
+      receptor signaling, and cytoplasmic localization.
+- id: PMID:7929092
+  title: >-
+    Biliverdin-IX alpha reductase and biliverdin-IX beta reductase from human liver. Purification
+    and characterization.
+  findings:
+  - statement: >-
+      Purification from human liver cytosol of biliverdin-IX-beta reductases (BLVRB, isozymes
+      I/II) that use NADPH/NADH to reduce biliverdin IX-beta, -gamma and -delta (but not IX-alpha);
+      higher relative activity in fetal than adult liver.
+    reference_section_type: ABSTRACT
+    supporting_text: >-
+      Isozymes I and II used biliverdin-IX beta, -IX gamma, and -IX delta as substrates but
+      not biliverdin-IX alpha
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Foundational biochemical characterization; supports biliverdin reductase MF, heme catabolism
+      BP, cytosolic localization, and IX-beta isomer selectivity.
+- id: PMID:8117274
+  title: >-
+    Cloning and nucleotide sequence of a cDNA of the human erythrocyte NADPH-flavin reductase.
+  findings:
+  - statement: >-
+      Cloning of the human erythrocyte NADPH-flavin reductase cDNA (206 aa), later shown to
+      be identical to biliverdin-IX-beta reductase (BVR-B).
+    reference_section_type: ABSTRACT
+    supporting_text: A cDNA of human erythrocyte NADPH-flavin reductase was cloned
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Cloning/sequence paper; TAS source for the biliverdin/flavin reductase activity.
+- id: Reactome:R-HSA-189384
+  title: BLVRA:Zn2+, BLVRB reduce BV to BIL
+  findings:
+  - statement: >-
+      Reactome reaction in which biliverdin reductases BLVRA and BLVRB reduce biliverdin to
+      bilirubin in the cytosol.
+    reference_section_type: OTHER
+    supporting_text: >-
+      BIL is formed from the reduction of biliverdin (BV) by bilverdin reductases BLVRA and
+      BLVRB
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Reactome pathway placing BLVRB's biliverdin reductase step in the cytosol.
+- id: file:human/BLVRB/BLVRB-uniprot.txt
+  title: UniProt P30043 (BLVRB_HUMAN)
+  findings:
+  - statement: >-
+      BLVRB is a broad-specificity NAD(P)H-dependent oxidoreductase reducing flavins, biliverdins,
+      methemoglobin and PQQ; contributes to fetal heme catabolism (biliverdin IXbeta -> bilirubin
+      IXbeta); does not reduce bilirubin IXalpha; also acts as a protein nitrosyltransferase
+      and is cytoplasmic.
+    reference_section_type: OTHER
+    supporting_text: >-
+      Has a broad specificity oxidoreductase activity by catalyzing the NAD(P)H-dependent
+      reduction of a variety of flavins, such as riboflavin, FAD or FMN, biliverdins, methemoglobin
+      and PQQ
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Authoritative UniProt record; source for description and multiple supporting quotes.

--- a/genes/human/BLVRB/BLVRB-goa.tsv
+++ b/genes/human/BLVRB/BLVRB-goa.tsv
@@ -1,0 +1,32 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	P30043	BLVRB	enables	GO:0004074	biliverdin reductase [NAD(P)H] activity	molecular_function	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN000385405|UniProtKB:P30043	9606	Homo sapiens	GO_Central	Flavin reductase (NADPH)	20220223
+UniProtKB	P30043	BLVRB	enables	GO:0042602	riboflavin reductase (NADPH) activity	molecular_function	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN000385405|UniProtKB:P30043	9606	Homo sapiens	GO_Central	Flavin reductase (NADPH)	20220223
+UniProtKB	P30043	BLVRB	located_in	GO:0005737	cytoplasm	cellular_component	ECO:0007322	IEA	GO_REF:0000044	UniProtKB-SubCell:SL-0086	9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20260706
+UniProtKB	P30043	BLVRB	involved_in	GO:0030219	megakaryocyte differentiation	biological_process	ECO:0000256	IEA	GO_REF:0000117	ARBA:ARBA00085624	9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20260706
+UniProtKB	P30043	BLVRB	enables	GO:0042602	riboflavin reductase (NADPH) activity	molecular_function	ECO:0000501	IEA	GO_REF:0000120	RHEA:19377|EC:1.5.1.30	9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20260706
+UniProtKB	P30043	BLVRB	enables	GO:0052873	FMN reductase (NADPH) activity	molecular_function	ECO:0007322	IEA	GO_REF:0000116	RHEA:21624	9606	Homo sapiens	RHEA	Flavin reductase (NADPH)	20260706
+UniProtKB	P30043	BLVRB	enables	GO:0052874	FMN reductase (NADH) activity	molecular_function	ECO:0007322	IEA	GO_REF:0000116	RHEA:21620	9606	Homo sapiens	RHEA	Flavin reductase (NADPH)	20260706
+UniProtKB	P30043	BLVRB	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9UJ72	9606	Homo sapiens	IntAct	Flavin reductase (NADPH)	20260704
+UniProtKB	P30043	BLVRB	enables	GO:0035605	peptidyl-cysteine S-nitrosylase activity	molecular_function	ECO:0000501	IEA	GO_REF:0000120	ARBA:ARBA00092976|UniProtKB:Q923D2|ensembl:ENSMUSP00000043092	9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20260629
+UniProtKB	P30043	BLVRB	involved_in	GO:0046627	negative regulation of insulin receptor signaling pathway	biological_process	ECO:0000501	IEA	GO_REF:0000120	ARBA:ARBA00092083|UniProtKB:Q923D2|ensembl:ENSMUSP00000043092	9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20260629
+UniProtKB	P30043	BLVRB	located_in	GO:0005829	cytosol	cellular_component	ECO:0000314	IDA	GO_REF:0000052		9606	Homo sapiens	HPA	Flavin reductase (NADPH)	20251115
+UniProtKB	P30043	BLVRB	located_in	GO:0005737	cytoplasm	cellular_component	ECO:0000269	EXP	PMID:7929092		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20240916
+UniProtKB	P30043	BLVRB	enables	GO:0042602	riboflavin reductase (NADPH) activity	molecular_function	ECO:0000269	EXP	PMID:10620517		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20240916
+UniProtKB	P30043	BLVRB	enables	GO:0042602	riboflavin reductase (NADPH) activity	molecular_function	ECO:0000269	EXP	PMID:18241201		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20240916
+UniProtKB	P30043	BLVRB	enables	GO:0052873	FMN reductase (NADPH) activity	molecular_function	ECO:0000269	EXP	PMID:18241201		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20240916
+UniProtKB	P30043	BLVRB	enables	GO:0052874	FMN reductase (NADH) activity	molecular_function	ECO:0000269	EXP	PMID:18241201		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20240916
+UniProtKB	P30043	BLVRB	is_active_in	GO:0005737	cytoplasm	cellular_component	ECO:0000314	IDA	PMID:38056462		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20231214
+UniProtKB	P30043	BLVRB	involved_in	GO:0030219	megakaryocyte differentiation	biological_process	ECO:0000315	IMP	PMID:27207795		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20231214
+UniProtKB	P30043	BLVRB	enables	GO:0035605	peptidyl-cysteine S-nitrosylase activity	molecular_function	ECO:0000314	IDA	PMID:38056462		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20231214
+UniProtKB	P30043	BLVRB	enables	GO:0035605	peptidyl-cysteine S-nitrosylase activity	molecular_function	ECO:0000314	IDA	PMID:38056462		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20231214
+UniProtKB	P30043	BLVRB	enables	GO:0042602	riboflavin reductase (NADPH) activity	molecular_function	ECO:0000315	IMP	PMID:27207795		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20231214
+UniProtKB	P30043	BLVRB	involved_in	GO:0046627	negative regulation of insulin receptor signaling pathway	biological_process	ECO:0000314	IDA	PMID:38056462		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20231214
+UniProtKB	P30043	BLVRB	enables	GO:0004074	biliverdin reductase [NAD(P)H] activity	molecular_function	ECO:0000314	IDA	PMID:10858451		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20231213
+UniProtKB	P30043	BLVRB	involved_in	GO:0042167	heme catabolic process	biological_process	ECO:0000314	IDA	PMID:10858451		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20231213
+UniProtKB	P30043	BLVRB	located_in	GO:0070062	extracellular exosome	cellular_component	ECO:0007005	HDA	PMID:19056867		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20131024
+UniProtKB	P30043	BLVRB	located_in	GO:0005829	cytosol	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-189384		9606	Homo sapiens	Reactome	Flavin reductase (NADPH)	20130528
+UniProtKB	P30043	BLVRB	enables	GO:0004074	biliverdin reductase [NAD(P)H] activity	molecular_function	ECO:0000314	IDA	PMID:7929092		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20100224
+UniProtKB	P30043	BLVRB	located_in	GO:0005829	cytosol	cellular_component	ECO:0000314	IDA	PMID:7929092		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20100224
+UniProtKB	P30043	BLVRB	involved_in	GO:0042167	heme catabolic process	biological_process	ECO:0000314	IDA	PMID:7929092		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20100224
+UniProtKB	P30043	BLVRB	enables	GO:0042602	riboflavin reductase (NADPH) activity	molecular_function	ECO:0000314	IDA	PMID:11224564		9606	Homo sapiens	UniProt	Flavin reductase (NADPH)	20100224
+UniProtKB	P30043	BLVRB	enables	GO:0004074	biliverdin reductase [NAD(P)H] activity	molecular_function	ECO:0000304	TAS	PMID:8117274		9606	Homo sapiens	PINC	Flavin reductase (NADPH)	20030904

--- a/genes/human/BLVRB/BLVRB-notes.md
+++ b/genes/human/BLVRB/BLVRB-notes.md
@@ -1,0 +1,89 @@
+# BLVRB (Flavin reductase (NADPH) / Biliverdin reductase B) — review notes
+
+UniProt: P30043 (BLVRB_HUMAN). HGNC:1063. 206 aa, cytosolic. Chromosome 19.
+Source of most claims below: `file:human/BLVRB/BLVRB-uniprot.txt` and cached publications.
+
+## Identity / nomenclature
+
+- Recommended name in UniProt is **Flavin reductase (NADPH)** (Short=FR); EC=1.5.1.30.
+  AltNames: **Biliverdin reductase B (BVR-B)**; **Biliverdin-IX beta-reductase** (EC=1.3.1.-);
+  Green heme-binding protein (GHBP); NADPH-dependent diaphorase; NADPH-flavin reductase (FLR);
+  S-nitroso-CoA-assisted nitrosyltransferase (SCAN), EC=2.6.99.-.
+  [file:human/BLVRB/BLVRB-uniprot.txt "RecName: Full=Flavin reductase (NADPH)"; "AltName: Full=Biliverdin reductase B"]
+- FR and BVR-B were shown to be the **same protein** [PMID:8687377, cited in UniProt RN[13] "Evidence that biliverdin-IX beta reductase and flavin reductase are identical."]
+
+## Core enzymology
+
+- Broad-specificity **NAD(P)H-dependent oxidoreductase**. UniProt FUNCTION:
+  "Has a broad specificity oxidoreductase activity by catalyzing the NAD(P)H-dependent reduction of a
+  variety of flavins, such as riboflavin, FAD or FMN, biliverdins, methemoglobin and PQQ (pyrroloquinoline quinone)"
+  [file:human/BLVRB/BLVRB-uniprot.txt].
+- **Biliverdin IXbeta -> bilirubin IXbeta** in fetal heme catabolism. UniProt: "Contributes to fetal heme
+  catabolism by catalyzing reduction of biliverdin IXbeta into bilirubin IXbeta in the liver"; "Biliverdin IXbeta,
+  which constitutes the major heme catabolite in the fetus is not present in adult"; "Does not reduce bilirubin IXalpha".
+  Kinetics: KM=0.3 uM for biliverdin IX-beta [file:human/BLVRB/BLVRB-uniprot.txt].
+- **Isomer specificity distinct from BLVRA**: BVR-B uses biliverdin IX-beta/-gamma/-delta but NOT IX-alpha;
+  BVR-A (BLVRA) prefers IX-alpha [PMID:7929092 "Isozymes I and II used biliverdin-IX beta, -IX gamma, and -IX
+  delta as substrates but not biliverdin-IX alpha, and isozymes III and IV preferred biliverdin-IX alpha"].
+- **Flavin reductase kinetics**: reduces FMN, FAD, riboflavin with KM 52, 125, 53 uM respectively
+  [PMID:10620517 "The enzyme was shown to catalyse the reduction of FMN, FAD and riboflavin, with K(m) values of
+  52 microM, 125 microM and 53 microM, respectively."].
+- **Ferric reductase** activity (NAD(P)H + FMN dependent) [PMID:10620517 "flavin reductase/biliverdin-IXbeta
+  reductase has also been shown to exhibit ferric reductase activity"; UniProt "Can also reduce the complexed
+  Fe(3+) iron to Fe(2+) in the presence of FMN and NADPH"].
+- Single substrate-binding site; flavin and tetrapyrrole compete for the same site
+  [PMID:11224564 "human BVR-B has a single substrate binding site, to which substrates and inhibitors bind
+  primarily through hydrophobic interactions, explaining its broad specificity"; PMID:10620517 mesobiliverdin is
+  a competitive inhibitor against FMN]. Monomer [PMID:11224564; UniProt SUBUNIT "Monomer."].
+- Prefers NADPH over NADH (KM NADP 36 uM vs NADH 5.6 mM) [file:human/BLVRB/BLVRB-uniprot.txt kinetics].
+- Catalytic mechanism: promiscuous; His-153 NOT required for catalysis (H153A/H153N retain activity)
+  [PMID:18241201 "site-directed mutagenesis studies with both the H153A and the H153N mutant reveal that
+  His(153) is not required for catalytic activity"].
+
+## Localization
+
+- **Cytosol / cytoplasm.** UniProt SUBCELLULAR LOCATION: "Cytoplasm" [file:human/BLVRB/BLVRB-uniprot.txt].
+  [PMID:38056462 "BLVRB is mainly localized in the cytoplasm"]. HPA IDA cytosol (GO_REF:0000052).
+  Detected in urinary exosomes in a large proteomics screen (non-specific; secreted/exosome contamination is
+  common for abundant cytosolic proteins) [PMID:19056867].
+
+## Physiological roles beyond fetal heme catabolism
+
+- **Thrombopoiesis / megakaryocytopoiesis.** A loss-of-function redox mutation BLVRB(S111L) is causally
+  associated with enhanced platelet production; BLVRB is a redox coupler whose defect causes ROS accumulation
+  driving megakaryocyte lineage commitment [PMID:27207795 "identified a single loss-of-function mutation
+  (BLVRB S111L) causally associated with clonal and nonclonal disorders of enhanced platelet production";
+  "define the first physiologically relevant function of BLVRB ... governing terminal megakaryocytopoiesis"].
+  This is an IMP for megakaryocyte differentiation (GO:0030219). BLVRB is a proposed thrombocytopenia drug target.
+- **S-nitrosylation / insulin signaling (SCAN activity).** BLVRB acts as a SNO-CoA-assisted nitrosylase (SCAN):
+  it transfers NO from SNO-CoA to target-protein cysteines (via BLVRB Cys-109/Cys-188 intermediates),
+  S-nitrosylating INSR and IRS1, thereby **inhibiting insulin signaling** [PMID:38056462
+  "uses SNO-CoA as its cofactor to S-nitrosylate multiple proteins"; "S-nitrosylation of INSR/IRS1 by SCAN
+  reduces insulin signaling physiologically"]. Note: UniProt encodes this as EC=2.6.99.- (a transferase /
+  nitrosyltransferase), and GO term GO:0035605 "peptidyl-cysteine S-nitrosylase activity" is the MF used.
+  These are recent (2023) findings; a distinct enzymatic mode from the classical NADPH reductase.
+- **Intermediary metabolism / stem-cell glutamine metabolism.** UniProt: "acts as a regulator of hematopoiesis,
+  intermediary metabolism (glutaminolysis, glycolysis, TCA cycle and pentose phosphate pathway)"
+  [file:human/BLVRB/BLVRB-uniprot.txt; PMID:29500232 (RN[23], FUNCTION)].
+
+## Annotation-review reasoning summary
+
+- Core MF: biliverdin reductase [NAD(P)H] activity (GO:0004074); riboflavin reductase (NADPH) activity
+  (GO:0042602); FMN reductase (NADPH) activity (GO:0052873); FMN reductase (NADH) activity (GO:0052874).
+  NADPH binding (GO:0070402) added as core (cofactor preference, structurally established).
+  peptidyl-cysteine S-nitrosylase activity (GO:0035605) is a real second, recently-characterized MF (IDA,
+  PMID:38056462) — kept as core but non-classical.
+- Core BP: heme catabolic process (GO:0042167). Megakaryocyte differentiation (GO:0030219) is a real, IMP-backed
+  downstream physiological role but not the enzyme's molecular core — KEEP_AS_NON_CORE. negative regulation of
+  insulin receptor signaling pathway (GO:0046627) is IDA (PMID:38056462), a genuine but non-core/context role —
+  KEEP_AS_NON_CORE.
+- Location: cytosol/cytoplasm ACCEPT. extracellular exosome (GO:0070062, HDA, PMID:19056867) is a
+  high-throughput proteomics detection typical of abundant cytosolic proteins — MARK_AS_OVER_ANNOTATED
+  (do not treat as a functional site).
+- Bare "protein binding" (GO:0005515, IPI, ANXA10) — MARK_AS_OVER_ANNOTATED (uninformative; policy: never REMOVE).
+- IEA duplicates of experimentally-supported MF terms (riboflavin/FMN reductase, S-nitrosylase, neg reg insulin):
+  the MF/BP is correct; where an experimental annotation to the same term exists, IEA is redundant but not wrong.
+  ARBA IEAs (megakaryocyte diff, neg reg insulin, S-nitrosylase) transferred from mouse ortholog Q923D2 — the
+  functions are corroborated experimentally in human, so KEEP (megakaryocyte/insulin as non-core) or ACCEPT
+  (S-nitrosylase MF).
+</content>

--- a/genes/human/BLVRB/BLVRB-uniprot.txt
+++ b/genes/human/BLVRB/BLVRB-uniprot.txt
@@ -1,0 +1,937 @@
+ID   BLVRB_HUMAN             Reviewed;         206 AA.
+AC   P30043; A6NKD8; B2R5C6; P32078; P53005; Q32LZ2;
+DT   01-APR-1993, integrated into UniProtKB/Swiss-Prot.
+DT   23-JAN-2007, sequence version 3.
+DT   10-JUN-2026, entry version 221.
+DE   RecName: Full=Flavin reductase (NADPH);
+DE            Short=FR;
+DE            EC=1.5.1.30 {ECO:0000269|PubMed:10620517, ECO:0000269|PubMed:18241201};
+DE   AltName: Full=Biliverdin reductase B {ECO:0000303|PubMed:10620517};
+DE            Short=BVR-B {ECO:0000303|PubMed:10620517};
+DE            EC=1.3.1.- {ECO:0000269|PubMed:10858451, ECO:0000269|PubMed:18241201, ECO:0000269|PubMed:7929092};
+DE   AltName: Full=Biliverdin-IX beta-reductase {ECO:0000303|PubMed:7929092};
+DE   AltName: Full=Green heme-binding protein;
+DE            Short=GHBP;
+DE   AltName: Full=NADPH-dependent diaphorase;
+DE   AltName: Full=NADPH-flavin reductase {ECO:0000303|PubMed:8117274};
+DE            Short=FLR {ECO:0000303|PubMed:8117274};
+DE   AltName: Full=S-nitroso-CoA-assisted nitrosyltransferase {ECO:0000303|PubMed:38056462};
+DE            Short=SNO-CoA-assisted nitrosyltransferase {ECO:0000303|PubMed:38056462};
+DE            EC=2.6.99.- {ECO:0000269|PubMed:38056462};
+GN   Name=BLVRB {ECO:0000312|HGNC:HGNC:1063};
+GN   Synonyms=FLR, SCAN {ECO:0000303|PubMed:38056462};
+OS   Homo sapiens (Human).
+OC   Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia;
+OC   Eutheria; Euarchontoglires; Primates; Haplorrhini; Catarrhini; Hominidae;
+OC   Homo.
+OX   NCBI_TaxID=9606;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [MRNA], AND PROTEIN SEQUENCE OF 2-34; 63-87 AND 98-206.
+RC   TISSUE=Erythrocyte, and Reticulocyte;
+RX   PubMed=8117274; DOI=10.1006/bbrc.1994.1165;
+RA   Chikuba K., Yubisui T., Shirabe K., Takeshita M.;
+RT   "Cloning and nucleotide sequence of a cDNA of the human erythrocyte NADPH-
+RT   flavin reductase.";
+RL   Biochem. Biophys. Res. Commun. 198:1170-1176(1994).
+RN   [2]
+RP   NUCLEOTIDE SEQUENCE [MRNA].
+RC   TISSUE=Liver;
+RX   PubMed=8799475; DOI=10.1248/bpb.19.796;
+RA   Komuro A., Tobe T., Hashimoto K., Nakano Y., Yamaguchi T., Nakajima H.,
+RA   Tomita M.;
+RT   "Molecular cloning and expression of human liver biliverdin-IXbeta
+RT   reductase.";
+RL   Biol. Pharm. Bull. 19:796-804(1996).
+RN   [3]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA].
+RC   TISSUE=Cerebellum;
+RX   PubMed=14702039; DOI=10.1038/ng1285;
+RA   Ota T., Suzuki Y., Nishikawa T., Otsuki T., Sugiyama T., Irie R.,
+RA   Wakamatsu A., Hayashi K., Sato H., Nagai K., Kimura K., Makita H.,
+RA   Sekine M., Obayashi M., Nishi T., Shibahara T., Tanaka T., Ishii S.,
+RA   Yamamoto J., Saito K., Kawai Y., Isono Y., Nakamura Y., Nagahari K.,
+RA   Murakami K., Yasuda T., Iwayanagi T., Wagatsuma M., Shiratori A., Sudo H.,
+RA   Hosoiri T., Kaku Y., Kodaira H., Kondo H., Sugawara M., Takahashi M.,
+RA   Kanda K., Yokoi T., Furuya T., Kikkawa E., Omura Y., Abe K., Kamihara K.,
+RA   Katsuta N., Sato K., Tanikawa M., Yamazaki M., Ninomiya K., Ishibashi T.,
+RA   Yamashita H., Murakawa K., Fujimori K., Tanai H., Kimata M., Watanabe M.,
+RA   Hiraoka S., Chiba Y., Ishida S., Ono Y., Takiguchi S., Watanabe S.,
+RA   Yosida M., Hotuta T., Kusano J., Kanehori K., Takahashi-Fujii A., Hara H.,
+RA   Tanase T.-O., Nomura Y., Togiya S., Komai F., Hara R., Takeuchi K.,
+RA   Arita M., Imose N., Musashino K., Yuuki H., Oshima A., Sasaki N.,
+RA   Aotsuka S., Yoshikawa Y., Matsunawa H., Ichihara T., Shiohata N., Sano S.,
+RA   Moriya S., Momiyama H., Satoh N., Takami S., Terashima Y., Suzuki O.,
+RA   Nakagawa S., Senoh A., Mizoguchi H., Goto Y., Shimizu F., Wakebe H.,
+RA   Hishigaki H., Watanabe T., Sugiyama A., Takemoto M., Kawakami B.,
+RA   Yamazaki M., Watanabe K., Kumagai A., Itakura S., Fukuzumi Y., Fujimori Y.,
+RA   Komiyama M., Tashiro H., Tanigami A., Fujiwara T., Ono T., Yamada K.,
+RA   Fujii Y., Ozaki K., Hirao M., Ohmori Y., Kawabata A., Hikiji T.,
+RA   Kobatake N., Inagaki H., Ikema Y., Okamoto S., Okitani R., Kawakami T.,
+RA   Noguchi S., Itoh T., Shigeta K., Senba T., Matsumura K., Nakajima Y.,
+RA   Mizuno T., Morinaga M., Sasaki M., Togashi T., Oyama M., Hata H.,
+RA   Watanabe M., Komatsu T., Mizushima-Sugano J., Satoh T., Shirai Y.,
+RA   Takahashi Y., Nakagawa K., Okumura K., Nagase T., Nomura N., Kikuchi H.,
+RA   Masuho Y., Yamashita R., Nakai K., Yada T., Nakamura Y., Ohara O.,
+RA   Isogai T., Sugano S.;
+RT   "Complete sequencing and characterization of 21,243 full-length human
+RT   cDNAs.";
+RL   Nat. Genet. 36:40-45(2004).
+RN   [4]
+RP   NUCLEOTIDE SEQUENCE [GENOMIC DNA], AND VARIANT GLN-46.
+RG   NIEHS SNPs program;
+RL   Submitted (JUL-2003) to the EMBL/GenBank/DDBJ databases.
+RN   [5]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RX   PubMed=15057824; DOI=10.1038/nature02399;
+RA   Grimwood J., Gordon L.A., Olsen A.S., Terry A., Schmutz J., Lamerdin J.E.,
+RA   Hellsten U., Goodstein D., Couronne O., Tran-Gyamfi M., Aerts A.,
+RA   Altherr M., Ashworth L., Bajorek E., Black S., Branscomb E., Caenepeel S.,
+RA   Carrano A.V., Caoile C., Chan Y.M., Christensen M., Cleland C.A.,
+RA   Copeland A., Dalin E., Dehal P., Denys M., Detter J.C., Escobar J.,
+RA   Flowers D., Fotopulos D., Garcia C., Georgescu A.M., Glavina T., Gomez M.,
+RA   Gonzales E., Groza M., Hammon N., Hawkins T., Haydu L., Ho I., Huang W.,
+RA   Israni S., Jett J., Kadner K., Kimball H., Kobayashi A., Larionov V.,
+RA   Leem S.-H., Lopez F., Lou Y., Lowry S., Malfatti S., Martinez D.,
+RA   McCready P.M., Medina C., Morgan J., Nelson K., Nolan M., Ovcharenko I.,
+RA   Pitluck S., Pollard M., Popkie A.P., Predki P., Quan G., Ramirez L.,
+RA   Rash S., Retterer J., Rodriguez A., Rogers S., Salamov A., Salazar A.,
+RA   She X., Smith D., Slezak T., Solovyev V., Thayer N., Tice H., Tsai M.,
+RA   Ustaszewska A., Vo N., Wagner M., Wheeler J., Wu K., Xie G., Yang J.,
+RA   Dubchak I., Furey T.S., DeJong P., Dickson M., Gordon D., Eichler E.E.,
+RA   Pennacchio L.A., Richardson P., Stubbs L., Rokhsar D.S., Myers R.M.,
+RA   Rubin E.M., Lucas S.M.;
+RT   "The DNA sequence and biology of human chromosome 19.";
+RL   Nature 428:529-535(2004).
+RN   [6]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RA   Mural R.J., Istrail S., Sutton G.G., Florea L., Halpern A.L., Mobarry C.M.,
+RA   Lippert R., Walenz B., Shatkay H., Dew I., Miller J.R., Flanigan M.J.,
+RA   Edwards N.J., Bolanos R., Fasulo D., Halldorsson B.V., Hannenhalli S.,
+RA   Turner R., Yooseph S., Lu F., Nusskern D.R., Shue B.C., Zheng X.H.,
+RA   Zhong F., Delcher A.L., Huson D.H., Kravitz S.A., Mouchard L., Reinert K.,
+RA   Remington K.A., Clark A.G., Waterman M.S., Eichler E.E., Adams M.D.,
+RA   Hunkapiller M.W., Myers E.W., Venter J.C.;
+RL   Submitted (JUL-2005) to the EMBL/GenBank/DDBJ databases.
+RN   [7]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA].
+RC   TISSUE=Pancreas;
+RX   PubMed=15489334; DOI=10.1101/gr.2596504;
+RG   The MGC Project Team;
+RT   "The status, quality, and expansion of the NIH full-length cDNA project:
+RT   the Mammalian Gene Collection (MGC).";
+RL   Genome Res. 14:2121-2127(2004).
+RN   [8]
+RP   PROTEIN SEQUENCE OF 2-205.
+RC   TISSUE=Liver;
+RX   PubMed=8280170; DOI=10.1006/bbrc.1993.2649;
+RA   Yamaguchi T., Komuro A., Nakano Y., Tomita M., Nakajima H.;
+RT   "Complete amino acid sequence of biliverdin-IX beta reductase from human
+RT   liver.";
+RL   Biochem. Biophys. Res. Commun. 197:1518-1523(1993).
+RN   [9]
+RP   PROTEIN SEQUENCE OF 2-21, FUNCTION, SUBUNIT, CATALYTIC ACTIVITY,
+RP   SUBCELLULAR LOCATION, BIOPHYSICOCHEMICAL PROPERTIES, AND TISSUE
+RP   SPECIFICITY.
+RC   TISSUE=Liver;
+RX   PubMed=7929092; DOI=10.1016/s0021-9258(19)51088-2;
+RA   Yamaguchi T., Komoda Y., Nakajima H.;
+RT   "Biliverdin-IX alpha reductase and biliverdin-IX beta reductase from human
+RT   liver. Purification and characterization.";
+RL   J. Biol. Chem. 269:24343-24348(1994).
+RN   [10]
+RP   PROTEIN SEQUENCE OF 2-11.
+RC   TISSUE=Liver;
+RX   PubMed=1286669; DOI=10.1002/elps.11501301201;
+RA   Hochstrasser D.F., Frutiger S., Paquet N., Bairoch A., Ravier F.,
+RA   Pasquali C., Sanchez J.-C., Tissot J.-D., Bjellqvist B., Vargas R.,
+RA   Appel R.D., Hughes G.J.;
+RT   "Human liver protein map: a reference database established by
+RT   microsequencing and gel comparison.";
+RL   Electrophoresis 13:992-1001(1992).
+RN   [11]
+RP   PROTEIN SEQUENCE OF 2-11.
+RC   TISSUE=Erythrocyte;
+RX   PubMed=8313871; DOI=10.1002/elps.11501401183;
+RA   Golaz O., Hughes G.J., Frutiger S., Paquet N., Bairoch A., Pasquali C.,
+RA   Sanchez J.-C., Tissot J.-D., Appel R.D., Walzer C., Balant L.,
+RA   Hochstrasser D.F.;
+RT   "Plasma and red blood cell protein maps: update 1993.";
+RL   Electrophoresis 14:1223-1231(1993).
+RN   [12]
+RP   PROTEIN SEQUENCE OF 40-92; 64-78; 106-124 AND 146-170, AND IDENTIFICATION
+RP   BY MASS SPECTROMETRY.
+RC   TISSUE=Brain, Cajal-Retzius cell, and Fetal brain cortex;
+RA   Lubec G., Vishwanath V., Chen W.-Q., Sun Y.;
+RL   Submitted (DEC-2008) to UniProtKB.
+RN   [13]
+RP   IDENTITY OF FR AND BVR-B.
+RX   PubMed=8687377; DOI=10.1042/bj3160385;
+RA   Shalloe F., Elliott G., Ennis O., Mantle T.J.;
+RT   "Evidence that biliverdin-IX beta reductase and flavin reductase are
+RT   identical.";
+RL   Biochem. J. 316:385-387(1996).
+RN   [14]
+RP   FUNCTION, ACTIVITY REGULATION, CATALYTIC ACTIVITY, AND BIOPHYSICOCHEMICAL
+RP   PROPERTIES.
+RX   PubMed=10620517; DOI=10.1042/bj3450393;
+RA   Cunningham O., Gore M.G., Mantle T.J.;
+RT   "Initial-rate kinetics of the flavin reductase reaction catalysed by human
+RT   biliverdin-IXbeta reductase (BVR-B).";
+RL   Biochem. J. 345:393-399(2000).
+RN   [15]
+RP   FUNCTION, AND CATALYTIC ACTIVITY.
+RX   PubMed=10858451; DOI=10.1074/jbc.275.25.19009;
+RA   Cunningham O., Dunne A., Sabido P., Lightner D., Mantle T.J.;
+RT   "Studies on the specificity of the tetrapyrrole substrate for human
+RT   biliverdin-IXalpha reductase and biliverdin-IXbeta reductase. Structure-
+RT   activity relationships define models for both active sites.";
+RL   J. Biol. Chem. 275:19009-19017(2000).
+RN   [16]
+RP   FUNCTION, CATALYTIC ACTIVITY, AND MUTAGENESIS OF HIS-153.
+RX   PubMed=18241201; DOI=10.1042/bj20071495;
+RA   Smith L.J., Browne S., Mulholland A.J., Mantle T.J.;
+RT   "Computational and experimental studies on the catalytic mechanism of
+RT   biliverdin-IXbeta reductase.";
+RL   Biochem. J. 411:475-484(2008).
+RN   [17]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=21269460; DOI=10.1186/1752-0509-5-17;
+RA   Burkard T.R., Planyavsky M., Kaupe I., Breitwieser F.P., Buerckstuemmer T.,
+RA   Bennett K.L., Superti-Furga G., Colinge J.;
+RT   "Initial characterization of the human central proteome.";
+RL   BMC Syst. Biol. 5:17-17(2011).
+RN   [18]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-82, AND IDENTIFICATION BY
+RP   MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Cervix carcinoma, and Erythroleukemia;
+RX   PubMed=23186163; DOI=10.1021/pr300630k;
+RA   Zhou H., Di Palma S., Preisinger C., Peng M., Polat A.N., Heck A.J.,
+RA   Mohammed S.;
+RT   "Toward a comprehensive characterization of a human cancer cell
+RT   phosphoproteome.";
+RL   J. Proteome Res. 12:260-271(2013).
+RN   [19]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-42, AND IDENTIFICATION BY
+RP   MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Liver;
+RX   PubMed=24275569; DOI=10.1016/j.jprot.2013.11.014;
+RA   Bian Y., Song C., Cheng K., Dong M., Wang F., Huang J., Sun D., Wang L.,
+RA   Ye M., Zou H.;
+RT   "An enzyme assisted RP-RPLC approach for in-depth analysis of human liver
+RT   phosphoproteome.";
+RL   J. Proteomics 96:253-262(2014).
+RN   [20]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=25944712; DOI=10.1002/pmic.201400617;
+RA   Vaca Jacome A.S., Rabilloud T., Schaeffer-Reiss C., Rompais M., Ayoub D.,
+RA   Lane L., Bairoch A., Van Dorsselaer A., Carapito C.;
+RT   "N-terminome analysis of the human mitochondrial proteome.";
+RL   Proteomics 15:2519-2524(2015).
+RN   [21]
+RP   FUNCTION, VARIANT LEU-111, AND CHARACTERIZATION OF VARIANT LEU-111.
+RX   PubMed=27207795; DOI=10.1182/blood-2016-02-696997;
+RA   Wu S., Li Z., Gnatenko D.V., Zhang B., Zhao L., Malone L.E., Markova N.,
+RA   Mantle T.J., Nesbitt N.M., Bahou W.F.;
+RT   "BLVRB redox mutation defines heme degradation in a metabolic pathway of
+RT   enhanced thrombopoiesis in humans.";
+RL   Blood 128:699-709(2016).
+RN   [22]
+RP   CHARACTERIZATION OF VARIANT LEU-111, AND MUTAGENESIS OF SER-111.
+RX   PubMed=27897348; DOI=10.1002/chem.201604517;
+RA   Chu W.T., Nesbitt N.M., Gnatenko D.V., Li Z., Zhang B., Seeliger M.A.,
+RA   Browne S., Mantle T.J., Bahou W.F., Wang J.;
+RT   "Enzymatic Activity and Thermodynamic Stability of Biliverdin IXbeta
+RT   Reductase Are Maintained by an Active Site Serine.";
+RL   Chemistry 23:1891-1900(2017).
+RN   [23]
+RP   FUNCTION.
+RX   PubMed=29500232; DOI=10.1042/bcj20180016;
+RA   Li Z., Nesbitt N.M., Malone L.E., Gnatenko D.V., Wu S., Wang D., Zhu W.,
+RA   Girnun G.D., Bahou W.F.;
+RT   "Heme degradation enzyme biliverdin IXbeta reductase is required for stem
+RT   cell glutamine metabolism.";
+RL   Biochem. J. 475:1211-1223(2018).
+RN   [24]
+RP   TISSUE SPECIFICITY, AND MUTAGENESIS OF ARG-78.
+RX   PubMed=29932944; DOI=10.1016/j.jmb.2018.06.015;
+RA   Paukovich N., Xue M., Elder J.R., Redzic J.S., Blue A., Pike H.,
+RA   Miller B.G., Pitts T.M., Pollock D.D., Hansen K., D'Alessandro A.,
+RA   Eisenmesser E.Z.;
+RT   "BiliveRDIN REDUCTAse B dynamics are coupled to coenzyme binding.";
+RL   J. Mol. Biol. 430:3234-3250(2018).
+RN   [25]
+RP   FUNCTION, CATALYTIC ACTIVITY, BIOPHYSICOCHEMICAL PROPERTIES, ACTIVE SITE,
+RP   SUBCELLULAR LOCATION, AND MUTAGENESIS OF 14-GLN--GLY-16; CYS-109 AND
+RP   CYS-188.
+RX   PubMed=38056462; DOI=10.1016/j.cell.2023.11.009;
+RA   Zhou H.L., Grimmett Z.W., Venetos N.M., Stomberski C.T., Qian Z.,
+RA   McLaughlin P.J., Bansal P.K., Zhang R., Reynolds J.D., Premont R.T.,
+RA   Stamler J.S.;
+RT   "An enzyme that selectively S-nitrosylates proteins to regulate insulin
+RT   signaling.";
+RL   Cell 0:0-0(2023).
+RN   [26] {ECO:0007744|PDB:1HDO, ECO:0007744|PDB:1HE2, ECO:0007744|PDB:1HE3, ECO:0007744|PDB:1HE4, ECO:0007744|PDB:1HE5}
+RP   X-RAY CRYSTALLOGRAPHY (1.15 ANGSTROMS) IN COMPLEXES WITH MESOBILIVERDIN;
+RP   BILIVERDIN; FLAVIN MONONUCLEOTIDE; LUMICHROME AND NADP, AND SUBUNIT.
+RX   PubMed=11224564; DOI=10.1038/84948;
+RA   Pereira P.J., Macedo-Ribeiro S., Parraga A., Perez-Luque R., Cunningham O.,
+RA   Darcy K., Mantle T.J., Coll M.;
+RT   "Structure of human biliverdin IXbeta reductase, an early fetal bilirubin
+RT   IXbeta producing enzyme.";
+RL   Nat. Struct. Biol. 8:215-220(2001).
+RN   [27] {ECO:0007744|PDB:5OOG, ECO:0007744|PDB:5OOH}
+RP   X-RAY CRYSTALLOGRAPHY (1.20 ANGSTROMS) IN COMPLEX WITH NADP(+), AND
+RP   ACTIVITY REGULATION.
+RX   PubMed=29487133; DOI=10.1074/jbc.ra118.001803;
+RA   Nesbitt N.M., Zheng X., Li Z., Manso J.A., Yen W.Y., Malone L.E.,
+RA   Ripoll-Rozada J., Pereira P.J.B., Mantle T.J., Wang J., Bahou W.F.;
+RT   "In silico and crystallographic studies identify key structural features of
+RT   biliverdin IXbeta reductase inhibitors having nanomolar potency.";
+RL   J. Biol. Chem. 293:5431-5446(2018).
+RN   [28] {ECO:0007744|PDB:6OPL}
+RP   X-RAY CRYSTALLOGRAPHY (1.37 ANGSTROMS) OF 1-205 IN COMPLEX WITH NADP(+),
+RP   AND MUTAGENESIS OF GLN-14 AND ARG-78.
+RX   PubMed=32246827; DOI=10.1093/jb/mvaa039;
+RA   Duff M.R., Redzic J.S., Ryan L.P., Paukovich N., Zhao R., Nix J.C.,
+RA   Pitts T.M., Agarwal P., Eisenmesser E.Z.;
+RT   "Structure, dynamics and function of the evolutionarily changing biliverdin
+RT   reductase B family.";
+RL   J. Biochem. 168:191-202(2020).
+RN   [29] {ECO:0007744|PDB:7ER6, ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8, ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA, ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC, ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE}
+RP   X-RAY CRYSTALLOGRAPHY (1.35 ANGSTROMS) IN COMPLEX WITH NADP(+), AND
+RP   ACTIVITY REGULATION.
+RX   PubMed=34957824; DOI=10.1021/acs.jmedchem.1c01664;
+RA   Kim M., Ha J.H., Choi J., Kim B.R., Gapsys V., Lee K.O., Jee J.G.,
+RA   Chakrabarti K.S., de Groot B.L., Griesinger C., Ryu K.S., Lee D.;
+RT   "Repositioning food and drug administration-approved drugs for inhibiting
+RT   biliverdin IXbeta reductase B as a novel thrombocytopenia therapeutic
+RT   target.";
+RL   J. Med. Chem. 65:2548-2557(2022).
+RN   [30] {ECO:0007744|PDB:8ELL, ECO:0007744|PDB:8ELM}
+RP   X-RAY CRYSTALLOGRAPHY (1.52 ANGSTROMS).
+RX   PubMed=37645217; DOI=10.3389/fmolb.2023.1244587;
+RA   Lee E., McLeod M.J., Redzic J.S., Marcolin B., Thorne R.E., Agarwal P.,
+RA   Eisenmesser E.Z.;
+RT   "Identifying structural and dynamic changes during the Biliverdin Reductase
+RT   B catalytic cycle.";
+RL   Front. Mol. Biosci. 10:1244587-1244587(2023).
+CC   -!- FUNCTION: Enzyme that can both act as a NAD(P)H-dependent reductase and
+CC       a S-nitroso-CoA-dependent nitrosyltransferase (PubMed:10620517,
+CC       PubMed:18241201, PubMed:27207795, PubMed:38056462, PubMed:7929092).
+CC       Promotes fetal heme degradation during development (PubMed:10858451,
+CC       PubMed:18241201, PubMed:7929092). Also expressed in adult tissues,
+CC       where it acts as a regulator of hematopoiesis, intermediary metabolism
+CC       (glutaminolysis, glycolysis, TCA cycle and pentose phosphate pathway)
+CC       and insulin signaling (PubMed:27207795, PubMed:29500232,
+CC       PubMed:38056462). Has a broad specificity oxidoreductase activity by
+CC       catalyzing the NAD(P)H-dependent reduction of a variety of flavins,
+CC       such as riboflavin, FAD or FMN, biliverdins, methemoglobin and PQQ
+CC       (pyrroloquinoline quinone) (PubMed:10620517, PubMed:18241201,
+CC       PubMed:7929092). Contributes to fetal heme catabolism by catalyzing
+CC       reduction of biliverdin IXbeta into bilirubin IXbeta in the liver
+CC       (PubMed:10858451, PubMed:18241201, PubMed:7929092). Biliverdin IXbeta,
+CC       which constitutes the major heme catabolite in the fetus is not present
+CC       in adult (PubMed:10858451, PubMed:18241201, PubMed:7929092). Does not
+CC       reduce bilirubin IXalpha (PubMed:10858451, PubMed:18241201,
+CC       PubMed:7929092). Can also reduce the complexed Fe(3+) iron to Fe(2+) in
+CC       the presence of FMN and NADPH (PubMed:10620517). Acts as a protein
+CC       nitrosyltransferase by catalyzing nitrosylation of cysteine residues of
+CC       target proteins, such as HMOX2, INSR and IRS1 (PubMed:38056462). S-
+CC       nitroso-CoA-dependent nitrosyltransferase activity is mediated via a
+CC       'ping-pong' mechanism: BLVRB first associates with both S-nitroso-CoA
+CC       and protein substrate, nitric oxide group is then transferred from S-
+CC       nitroso-CoA to Cys-109 and Cys-188 residues of BLVRB and from S-
+CC       nitroso-BLVRB to the protein substrate (PubMed:38056462). Inhibits
+CC       insulin signaling by mediating nitrosylation of INSR and IRS1, leading
+CC       to their inhibition (PubMed:38056462). {ECO:0000269|PubMed:10620517,
+CC       ECO:0000269|PubMed:10858451, ECO:0000269|PubMed:18241201,
+CC       ECO:0000269|PubMed:27207795, ECO:0000269|PubMed:29500232,
+CC       ECO:0000269|PubMed:38056462, ECO:0000269|PubMed:7929092}.
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=reduced riboflavin + NADP(+) = riboflavin + NADPH + 2 H(+);
+CC         Xref=Rhea:RHEA:19377, ChEBI:CHEBI:15378, ChEBI:CHEBI:17607,
+CC         ChEBI:CHEBI:57783, ChEBI:CHEBI:57986, ChEBI:CHEBI:58349; EC=1.5.1.30;
+CC         Evidence={ECO:0000269|PubMed:10620517, ECO:0000269|PubMed:18241201,
+CC         ECO:0000269|PubMed:27207795};
+CC       PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:19379;
+CC         Evidence={ECO:0000269|PubMed:10620517, ECO:0000269|PubMed:18241201,
+CC         ECO:0000269|PubMed:27207795};
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=bilirubin IXbeta + NADP(+) = biliverdin IXbeta + NADPH + H(+);
+CC         Xref=Rhea:RHEA:78395, ChEBI:CHEBI:15378, ChEBI:CHEBI:57783,
+CC         ChEBI:CHEBI:58349, ChEBI:CHEBI:136509, ChEBI:CHEBI:228295;
+CC         Evidence={ECO:0000269|PubMed:10858451, ECO:0000269|PubMed:18241201,
+CC         ECO:0000269|PubMed:7929092};
+CC       PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:78397;
+CC         Evidence={ECO:0000269|PubMed:10858451, ECO:0000269|PubMed:18241201,
+CC         ECO:0000269|PubMed:7929092};
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=FMNH2 + NAD(+) = FMN + NADH + 2 H(+); Xref=Rhea:RHEA:21620,
+CC         ChEBI:CHEBI:15378, ChEBI:CHEBI:57540, ChEBI:CHEBI:57618,
+CC         ChEBI:CHEBI:57945, ChEBI:CHEBI:58210;
+CC         Evidence={ECO:0000269|PubMed:18241201};
+CC       PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:21622;
+CC         Evidence={ECO:0000269|PubMed:18241201};
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=FMNH2 + NADP(+) = FMN + NADPH + 2 H(+); Xref=Rhea:RHEA:21624,
+CC         ChEBI:CHEBI:15378, ChEBI:CHEBI:57618, ChEBI:CHEBI:57783,
+CC         ChEBI:CHEBI:58210, ChEBI:CHEBI:58349;
+CC         Evidence={ECO:0000269|PubMed:18241201};
+CC       PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:21626;
+CC         Evidence={ECO:0000269|PubMed:18241201};
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=S-nitroso-CoA + L-cysteinyl-[protein] = S-nitroso-L-cysteinyl-
+CC         [protein] + CoA; Xref=Rhea:RHEA:78379, Rhea:RHEA-COMP:10131,
+CC         Rhea:RHEA-COMP:17091, ChEBI:CHEBI:29950, ChEBI:CHEBI:57287,
+CC         ChEBI:CHEBI:145546, ChEBI:CHEBI:149494;
+CC         Evidence={ECO:0000269|PubMed:38056462};
+CC       PhysiologicalDirection=left-to-right; Xref=Rhea:RHEA:78380;
+CC         Evidence={ECO:0000269|PubMed:38056462};
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=L-cysteinyl-[SCAN] + S-nitroso-CoA = S-nitroso-L-cysteinyl-
+CC         [SCAN] + CoA; Xref=Rhea:RHEA:78383, Rhea:RHEA-COMP:19068, Rhea:RHEA-
+CC         COMP:19069, ChEBI:CHEBI:29950, ChEBI:CHEBI:57287, ChEBI:CHEBI:145546,
+CC         ChEBI:CHEBI:149494; Evidence={ECO:0000269|PubMed:38056462};
+CC       PhysiologicalDirection=left-to-right; Xref=Rhea:RHEA:78384;
+CC         Evidence={ECO:0000269|PubMed:38056462};
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=S-nitroso-L-cysteinyl-[SCAN] + L-cysteinyl-[protein] = L-
+CC         cysteinyl-[SCAN] + S-nitroso-L-cysteinyl-[protein];
+CC         Xref=Rhea:RHEA:78387, Rhea:RHEA-COMP:10131, Rhea:RHEA-COMP:17091,
+CC         Rhea:RHEA-COMP:19068, Rhea:RHEA-COMP:19069, ChEBI:CHEBI:29950,
+CC         ChEBI:CHEBI:149494; Evidence={ECO:0000269|PubMed:38056462};
+CC       PhysiologicalDirection=left-to-right; Xref=Rhea:RHEA:78388;
+CC         Evidence={ECO:0000269|PubMed:38056462};
+CC   -!- ACTIVITY REGULATION: Mesobiliverdin acts as a competitive inhibitor for
+CC       flavin reduction, indicating that flavin and tetrapyrrole substrates
+CC       compete for the same site (PubMed:10620517). Inhibited by a wide range
+CC       of xanthene-based drugs, such as phloxine B, erythrosin B,
+CC       tamibarotene, sulfasalazine, olsalazine, febuxostat, ataluren (PTC124)
+CC       and deferasirox (PubMed:29487133, PubMed:34957824).
+CC       {ECO:0000269|PubMed:10620517, ECO:0000269|PubMed:29487133,
+CC       ECO:0000269|PubMed:34957824}.
+CC   -!- BIOPHYSICOCHEMICAL PROPERTIES:
+CC       Kinetic parameters:
+CC         KM=36 uM for NADP {ECO:0000269|PubMed:10620517,
+CC         ECO:0000269|PubMed:7929092};
+CC         KM=5.6 mM for NADH {ECO:0000269|PubMed:10620517,
+CC         ECO:0000269|PubMed:7929092};
+CC         KM=0.3 uM for biliverdin IX-beta {ECO:0000269|PubMed:10620517,
+CC         ECO:0000269|PubMed:7929092};
+CC         KM=52 uM for FMN {ECO:0000269|PubMed:10620517};
+CC         KM=125 uM for FAD {ECO:0000269|PubMed:10620517};
+CC         KM=53 uM for riboflavin {ECO:0000269|PubMed:10620517};
+CC         KM=4 uM for S-nitroso-CoA {ECO:0000269|PubMed:38056462};
+CC   -!- SUBUNIT: Monomer. {ECO:0000269|PubMed:11224564}.
+CC   -!- INTERACTION:
+CC       P30043; Q9UJ72: ANXA10; NbExp=5; IntAct=EBI-2837485, EBI-8648654;
+CC   -!- SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:38056462,
+CC       ECO:0000269|PubMed:7929092}.
+CC   -!- TISSUE SPECIFICITY: Predominantly expressed in liver and erythrocytes
+CC       (PubMed:7929092). At lower levels in heart, lung, adrenal gland and
+CC       cerebrum (PubMed:7929092). Expressed in adult red blood cells
+CC       (PubMed:29932944). {ECO:0000269|PubMed:29932944,
+CC       ECO:0000269|PubMed:7929092}.
+CC   -!- SIMILARITY: Belongs to the BLVRB family. {ECO:0000305}.
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; D26308; BAA05370.1; -; mRNA.
+DR   EMBL; D32143; BAA06874.1; -; mRNA.
+DR   EMBL; AK312137; BAG35073.1; -; mRNA.
+DR   EMBL; AY340485; AAP88933.1; -; Genomic_DNA.
+DR   EMBL; AC010271; -; NOT_ANNOTATED_CDS; Genomic_DNA.
+DR   EMBL; CH471126; EAW56969.1; -; Genomic_DNA.
+DR   EMBL; BC109371; AAI09372.1; -; mRNA.
+DR   CCDS; CCDS33029.1; -.
+DR   PIR; JC2070; JC2070.
+DR   RefSeq; NP_000704.1; NM_000713.3.
+DR   PDB; 1HDO; X-ray; 1.15 A; A=2-205.
+DR   PDB; 1HE2; X-ray; 1.20 A; A=2-205.
+DR   PDB; 1HE3; X-ray; 1.40 A; A=2-205.
+DR   PDB; 1HE4; X-ray; 1.40 A; A=2-205.
+DR   PDB; 1HE5; X-ray; 1.50 A; A=2-205.
+DR   PDB; 5OOG; X-ray; 1.33 A; A=1-206.
+DR   PDB; 5OOH; X-ray; 1.20 A; A=1-206.
+DR   PDB; 6OPL; X-ray; 1.37 A; A=1-205.
+DR   PDB; 7ER6; X-ray; 1.60 A; A/B=1-206.
+DR   PDB; 7ER7; X-ray; 1.70 A; A/B=1-206.
+DR   PDB; 7ER8; X-ray; 1.45 A; A/B=1-206.
+DR   PDB; 7ER9; X-ray; 1.45 A; A/B=1-206.
+DR   PDB; 7ERA; X-ray; 1.35 A; A/B=1-206.
+DR   PDB; 7ERB; X-ray; 1.50 A; A/B/C/D=1-206.
+DR   PDB; 7ERC; X-ray; 1.50 A; A/B=1-206.
+DR   PDB; 7ERD; X-ray; 2.00 A; A/B=1-206.
+DR   PDB; 7ERE; X-ray; 1.60 A; A/B/C/D=1-206.
+DR   PDB; 8ELL; X-ray; 1.52 A; A=1-206.
+DR   PDB; 8ELM; X-ray; 2.19 A; A=1-206.
+DR   PDB; 8K4K; X-ray; 1.70 A; A/B=1-206.
+DR   PDB; 9C16; X-ray; 1.58 A; A=1-206.
+DR   PDB; 9C17; X-ray; 1.63 A; A=1-206.
+DR   PDB; 9C18; X-ray; 1.90 A; A/B=1-206.
+DR   PDBsum; 1HDO; -.
+DR   PDBsum; 1HE2; -.
+DR   PDBsum; 1HE3; -.
+DR   PDBsum; 1HE4; -.
+DR   PDBsum; 1HE5; -.
+DR   PDBsum; 5OOG; -.
+DR   PDBsum; 5OOH; -.
+DR   PDBsum; 6OPL; -.
+DR   PDBsum; 7ER6; -.
+DR   PDBsum; 7ER7; -.
+DR   PDBsum; 7ER8; -.
+DR   PDBsum; 7ER9; -.
+DR   PDBsum; 7ERA; -.
+DR   PDBsum; 7ERB; -.
+DR   PDBsum; 7ERC; -.
+DR   PDBsum; 7ERD; -.
+DR   PDBsum; 7ERE; -.
+DR   PDBsum; 8ELL; -.
+DR   PDBsum; 8ELM; -.
+DR   PDBsum; 8K4K; -.
+DR   PDBsum; 9C16; -.
+DR   PDBsum; 9C17; -.
+DR   PDBsum; 9C18; -.
+DR   AlphaFoldDB; P30043; -.
+DR   SMR; P30043; -.
+DR   BioGRID; 107114; 58.
+DR   FunCoup; P30043; 997.
+DR   IntAct; P30043; 37.
+DR   NDEx; IQUERY-CP-BLVRB; 3 NDEx IQuery Curated Pathways.
+DR   STRING; 9606.ENSP00000263368; -.
+DR   BindingDB; P30043; -.
+DR   ChEMBL; CHEMBL5019; -.
+DR   DrugBank; DB02073; Biliverdine IX Alpha.
+DR   DrugBank; DB03247; Flavin mononucleotide.
+DR   DrugBank; DB04345; Lumichrome.
+DR   DrugBank; DB04363; Mesobiliverdin IV alpha.
+DR   DrugBank; DB09241; Methylene blue.
+DR   DrugBank; DB00157; NADH.
+DR   DrugBank; DB03461; Nicotinamide adenine dinucleotide phosphate.
+DR   DrugBank; DB00140; Riboflavin.
+DR   DrugCentral; P30043; -.
+DR   GlyGen; P30043; 1 site, 1 O-linked glycan (1 site).
+DR   iPTMnet; P30043; -.
+DR   MetOSite; P30043; -.
+DR   PhosphoSitePlus; P30043; -.
+DR   BioMuta; BLVRB; -.
+DR   DMDM; 1706870; -.
+DR   REPRODUCTION-2DPAGE; IPI00783862; -.
+DR   jPOST; P30043; -.
+DR   MassIVE; P30043; -.
+DR   PaxDb; 9606-ENSP00000263368; -.
+DR   PeptideAtlas; P30043; -.
+DR   ProteomicsDB; 54623; -.
+DR   Pumba; P30043; -.
+DR   TopDownProteomics; P30043; -.
+DR   Antibodypedia; 30531; 348 antibodies from 34 providers.
+DR   DNASU; 645; -.
+DR   Ensembl; ENST00000263368.9; ENSP00000263368.3; ENSG00000090013.12.
+DR   GeneID; 645; -.
+DR   KEGG; hsa:645; -.
+DR   MANE-Select; ENST00000263368.9; ENSP00000263368.3; NM_000713.3; NP_000704.1.
+DR   AGR; HGNC:1063; -.
+DR   ClinPGx; PA25374; -.
+DR   CTD; 645; -.
+DR   DisGeNET; 645; -.
+DR   GeneCards; BLVRB; -.
+DR   HGNC; HGNC:1063; BLVRB.
+DR   HPA; ENSG00000090013; Tissue enhanced (bone).
+DR   MIM; 600941; gene.
+DR   OpenTargets; ENSG00000090013; -.
+DR   VEuPathDB; HostDB:ENSG00000090013; -.
+DR   eggNOG; ENOG502RY9R; Eukaryota.
+DR   GeneTree; ENSGT00390000014810; -.
+DR   HOGENOM; CLU_025711_2_0_1; -.
+DR   InParanoid; P30043; -.
+DR   OMA; ACKKIAI; -.
+DR   OrthoDB; 419598at2759; -.
+DR   PAN-GO; P30043; 2 GO annotations based on evolutionary models.
+DR   PhylomeDB; P30043; -.
+DR   BRENDA; 1.3.1.24; 2681.
+DR   BRENDA; 1.5.1.30; 2681.
+DR   PathwayCommons; P30043; -.
+DR   Reactome; R-HSA-189483; Heme degradation.
+DR   Reactome; R-HSA-9707564; Cytoprotection by HMOX1.
+DR   SABIO-RK; P30043; -.
+DR   SignaLink; P30043; -.
+DR   SIGNOR; P30043; -.
+DR   Agora; ENSG00000090013; -.
+DR   BioGRID-ORCS; 645; 14 hits in 1175 CRISPR screens.
+DR   CD-CODE; FB4E32DD; Presynaptic clusters and postsynaptic densities.
+DR   ChiTaRS; BLVRB; human.
+DR   EvolutionaryTrace; P30043; -.
+DR   GenomeRNAi; 645; -.
+DR   Pharos; P30043; Tbio.
+DR   PRO; PR:P30043; -.
+DR   Proteomes; UP000005640; Chromosome 19.
+DR   RNAct; P30043; protein.
+DR   Bgee; ENSG00000090013; Expressed in trabecular bone tissue and 202 other cell types or tissues.
+DR   ExpressionAtlas; P30043; baseline and differential.
+DR   GO; GO:0005737; C:cytoplasm; IDA:UniProtKB.
+DR   GO; GO:0005829; C:cytosol; IDA:UniProtKB.
+DR   GO; GO:0070062; C:extracellular exosome; HDA:UniProtKB.
+DR   GO; GO:0004074; F:biliverdin reductase [NAD(P)H] activity; IDA:UniProtKB.
+DR   GO; GO:0052874; F:FMN reductase (NADH) activity; IEA:RHEA.
+DR   GO; GO:0052873; F:FMN reductase (NADPH) activity; IEA:RHEA.
+DR   GO; GO:0035605; F:peptidyl-cysteine S-nitrosylase activity; IDA:UniProtKB.
+DR   GO; GO:0042602; F:riboflavin reductase (NADPH) activity; IDA:UniProtKB.
+DR   GO; GO:0042167; P:heme catabolic process; IDA:UniProtKB.
+DR   GO; GO:0030219; P:megakaryocyte differentiation; IMP:UniProtKB.
+DR   GO; GO:0046627; P:negative regulation of insulin receptor signaling pathway; IDA:UniProtKB.
+DR   CDD; cd05244; BVR-B_like_SDR_a; 1.
+DR   FunFam; 3.40.50.720:FF:000369; flavin reductase (NADPH); 1.
+DR   Gene3D; 3.40.50.720; NAD(P)-binding Rossmann-like Domain; 1.
+DR   InterPro; IPR016040; NAD(P)-bd_dom.
+DR   InterPro; IPR036291; NAD(P)-bd_dom_sf.
+DR   InterPro; IPR051606; Polyketide_Oxido-like.
+DR   PANTHER; PTHR43355; FLAVIN REDUCTASE (NADPH); 1.
+DR   PANTHER; PTHR43355:SF2; FLAVIN REDUCTASE (NADPH); 1.
+DR   Pfam; PF13460; NAD_binding_10; 1.
+DR   SUPFAM; SSF51735; NAD(P)-binding Rossmann-fold domains; 1.
+PE   1: Evidence at protein level;
+KW   3D-structure; Cytoplasm; Direct protein sequencing; NADP; Oxidoreductase;
+KW   Phosphoprotein; Proteomics identification; Reference proteome; Transferase.
+FT   INIT_MET        1
+FT                   /note="Removed"
+FT                   /evidence="ECO:0000269|PubMed:1286669,
+FT                   ECO:0000269|PubMed:7929092, ECO:0000269|PubMed:8117274,
+FT                   ECO:0000269|PubMed:8280170, ECO:0000269|PubMed:8313871"
+FT   CHAIN           2..206
+FT                   /note="Flavin reductase (NADPH)"
+FT                   /id="PRO_0000064948"
+FT   ACT_SITE        109
+FT                   /note="S-nitroso-cysteine intermediate; for S-nitroso-CoA-
+FT                   dependent nitrosyltransferase activity"
+FT                   /evidence="ECO:0000269|PubMed:38056462"
+FT   ACT_SITE        188
+FT                   /note="S-nitroso-cysteine intermediate; for S-nitroso-CoA-
+FT                   dependent nitrosyltransferase activity"
+FT                   /evidence="ECO:0000269|PubMed:38056462"
+FT   BINDING         10
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:34957824,
+FT                   ECO:0007744|PDB:1HDO, ECO:0007744|PDB:5OOG,
+FT                   ECO:0007744|PDB:5OOH, ECO:0007744|PDB:7ER7"
+FT   BINDING         12
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:1HDO,
+FT                   ECO:0007744|PDB:1HE2, ECO:0007744|PDB:1HE3,
+FT                   ECO:0007744|PDB:1HE4, ECO:0007744|PDB:1HE5,
+FT                   ECO:0007744|PDB:5OOG, ECO:0007744|PDB:5OOH,
+FT                   ECO:0007744|PDB:6OPL, ECO:0007744|PDB:7ER6,
+FT                   ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   BINDING         13
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:32246827, ECO:0000269|PubMed:34957824,
+FT                   ECO:0007744|PDB:1HDO, ECO:0007744|PDB:1HE2,
+FT                   ECO:0007744|PDB:1HE3, ECO:0007744|PDB:1HE4,
+FT                   ECO:0007744|PDB:1HE5, ECO:0007744|PDB:5OOG,
+FT                   ECO:0007744|PDB:5OOH, ECO:0007744|PDB:6OPL,
+FT                   ECO:0007744|PDB:7ER6, ECO:0007744|PDB:7ER7,
+FT                   ECO:0007744|PDB:7ER8, ECO:0007744|PDB:7ER9,
+FT                   ECO:0007744|PDB:7ERA, ECO:0007744|PDB:7ERB,
+FT                   ECO:0007744|PDB:7ERC, ECO:0007744|PDB:7ERD,
+FT                   ECO:0007744|PDB:7ERE"
+FT   BINDING         14
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:34957824,
+FT                   ECO:0007744|PDB:1HDO, ECO:0007744|PDB:1HE2,
+FT                   ECO:0007744|PDB:1HE3, ECO:0007744|PDB:1HE4,
+FT                   ECO:0007744|PDB:1HE5, ECO:0007744|PDB:5OOG,
+FT                   ECO:0007744|PDB:5OOH, ECO:0007744|PDB:7ER6,
+FT                   ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   BINDING         15
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:1HDO,
+FT                   ECO:0007744|PDB:1HE2, ECO:0007744|PDB:1HE3,
+FT                   ECO:0007744|PDB:1HE4, ECO:0007744|PDB:1HE5,
+FT                   ECO:0007744|PDB:5OOG, ECO:0007744|PDB:5OOH,
+FT                   ECO:0007744|PDB:6OPL, ECO:0007744|PDB:7ER6,
+FT                   ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   BINDING         35
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:1HDO,
+FT                   ECO:0007744|PDB:1HE2, ECO:0007744|PDB:1HE3,
+FT                   ECO:0007744|PDB:1HE4, ECO:0007744|PDB:1HE5,
+FT                   ECO:0007744|PDB:5OOG, ECO:0007744|PDB:5OOH,
+FT                   ECO:0007744|PDB:6OPL, ECO:0007744|PDB:7ER6,
+FT                   ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   BINDING         38
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:34957824,
+FT                   ECO:0007744|PDB:7ER6, ECO:0007744|PDB:7ER9,
+FT                   ECO:0007744|PDB:7ERA, ECO:0007744|PDB:7ERB,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   BINDING         39
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:29487133,
+FT                   ECO:0000269|PubMed:32246827, ECO:0000269|PubMed:34957824,
+FT                   ECO:0007744|PDB:5OOH, ECO:0007744|PDB:6OPL,
+FT                   ECO:0007744|PDB:7ER6, ECO:0007744|PDB:7ER7,
+FT                   ECO:0007744|PDB:7ER8, ECO:0007744|PDB:7ER9,
+FT                   ECO:0007744|PDB:7ERA, ECO:0007744|PDB:7ERB,
+FT                   ECO:0007744|PDB:7ERC, ECO:0007744|PDB:7ERE"
+FT   BINDING         54
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:1HDO,
+FT                   ECO:0007744|PDB:1HE2, ECO:0007744|PDB:1HE3,
+FT                   ECO:0007744|PDB:1HE4, ECO:0007744|PDB:1HE5,
+FT                   ECO:0007744|PDB:5OOG, ECO:0007744|PDB:5OOH,
+FT                   ECO:0007744|PDB:6OPL, ECO:0007744|PDB:7ER6,
+FT                   ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   BINDING         55
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:1HDO,
+FT                   ECO:0007744|PDB:1HE2, ECO:0007744|PDB:1HE3,
+FT                   ECO:0007744|PDB:1HE4, ECO:0007744|PDB:1HE5,
+FT                   ECO:0007744|PDB:5OOG, ECO:0007744|PDB:5OOH,
+FT                   ECO:0007744|PDB:6OPL, ECO:0007744|PDB:7ER6,
+FT                   ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   BINDING         75
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:32246827, ECO:0000269|PubMed:34957824,
+FT                   ECO:0007744|PDB:1HDO, ECO:0007744|PDB:1HE2,
+FT                   ECO:0007744|PDB:1HE3, ECO:0007744|PDB:1HE4,
+FT                   ECO:0007744|PDB:1HE5, ECO:0007744|PDB:6OPL,
+FT                   ECO:0007744|PDB:7ER6, ECO:0007744|PDB:7ER7,
+FT                   ECO:0007744|PDB:7ER8, ECO:0007744|PDB:7ER9,
+FT                   ECO:0007744|PDB:7ERA, ECO:0007744|PDB:7ERB,
+FT                   ECO:0007744|PDB:7ERC, ECO:0007744|PDB:7ERD,
+FT                   ECO:0007744|PDB:7ERE"
+FT   BINDING         76
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:1HDO,
+FT                   ECO:0007744|PDB:1HE2, ECO:0007744|PDB:1HE3,
+FT                   ECO:0007744|PDB:1HE4, ECO:0007744|PDB:1HE5,
+FT                   ECO:0007744|PDB:5OOG, ECO:0007744|PDB:5OOH,
+FT                   ECO:0007744|PDB:6OPL, ECO:0007744|PDB:7ER6,
+FT                   ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   BINDING         78
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:1HDO,
+FT                   ECO:0007744|PDB:1HE2, ECO:0007744|PDB:1HE3,
+FT                   ECO:0007744|PDB:1HE4, ECO:0007744|PDB:1HE5,
+FT                   ECO:0007744|PDB:5OOG, ECO:0007744|PDB:5OOH,
+FT                   ECO:0007744|PDB:6OPL, ECO:0007744|PDB:7ER6,
+FT                   ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   BINDING         87
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:1HDO,
+FT                   ECO:0007744|PDB:1HE2, ECO:0007744|PDB:1HE3,
+FT                   ECO:0007744|PDB:1HE4, ECO:0007744|PDB:1HE5,
+FT                   ECO:0007744|PDB:5OOG, ECO:0007744|PDB:5OOH,
+FT                   ECO:0007744|PDB:6OPL, ECO:0007744|PDB:7ER6,
+FT                   ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   BINDING         109
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:1HDO,
+FT                   ECO:0007744|PDB:1HE2, ECO:0007744|PDB:1HE3,
+FT                   ECO:0007744|PDB:1HE4, ECO:0007744|PDB:1HE5,
+FT                   ECO:0007744|PDB:5OOH, ECO:0007744|PDB:6OPL,
+FT                   ECO:0007744|PDB:7ER6, ECO:0007744|PDB:7ER7,
+FT                   ECO:0007744|PDB:7ER8, ECO:0007744|PDB:7ER9,
+FT                   ECO:0007744|PDB:7ERA, ECO:0007744|PDB:7ERB,
+FT                   ECO:0007744|PDB:7ERC, ECO:0007744|PDB:7ERD,
+FT                   ECO:0007744|PDB:7ERE"
+FT   BINDING         132
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:1HE3,
+FT                   ECO:0007744|PDB:5OOG, ECO:0007744|PDB:5OOH,
+FT                   ECO:0007744|PDB:6OPL, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERB,
+FT                   ECO:0007744|PDB:7ERC"
+FT   BINDING         153
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:32246827,
+FT                   ECO:0000269|PubMed:34957824, ECO:0007744|PDB:6OPL,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERD"
+FT   BINDING         154
+FT                   /ligand="NADP(+)"
+FT                   /ligand_id="ChEBI:CHEBI:58349"
+FT                   /evidence="ECO:0000269|PubMed:11224564,
+FT                   ECO:0000269|PubMed:29487133, ECO:0000269|PubMed:34957824,
+FT                   ECO:0007744|PDB:1HDO, ECO:0007744|PDB:1HE2,
+FT                   ECO:0007744|PDB:1HE3, ECO:0007744|PDB:1HE4,
+FT                   ECO:0007744|PDB:1HE5, ECO:0007744|PDB:5OOG,
+FT                   ECO:0007744|PDB:5OOH, ECO:0007744|PDB:7ER6,
+FT                   ECO:0007744|PDB:7ER7, ECO:0007744|PDB:7ER8,
+FT                   ECO:0007744|PDB:7ER9, ECO:0007744|PDB:7ERA,
+FT                   ECO:0007744|PDB:7ERB, ECO:0007744|PDB:7ERC,
+FT                   ECO:0007744|PDB:7ERD, ECO:0007744|PDB:7ERE"
+FT   MOD_RES         42
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:24275569"
+FT   MOD_RES         82
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:23186163"
+FT   VARIANT         46
+FT                   /note="R -> Q (in dbSNP:rs11547746)"
+FT                   /evidence="ECO:0000269|Ref.4"
+FT                   /id="VAR_019168"
+FT   VARIANT         111
+FT                   /note="S -> L (risk factor for thrombocytosis; enhanced
+FT                   generation of reactive oxygen species (ROS) leading to
+FT                   impaired megakaryocyte differentiation; abolished
+FT                   NAD(P)H-dependent reductase activity; dbSNP:rs149698066)"
+FT                   /evidence="ECO:0000269|PubMed:27207795,
+FT                   ECO:0000269|PubMed:27897348"
+FT                   /id="VAR_088973"
+FT   MUTAGEN         14..16
+FT                   /note="QTG->NAA: Abolished binding to NAD(P)H and
+FT                   S-nitroso-CoA, leading to abolished NAD(P)H-dependent
+FT                   reductase and a S-nitroso-CoA-dependent nitrosyltransferase
+FT                   activities."
+FT                   /evidence="ECO:0000269|PubMed:38056462"
+FT   MUTAGEN         14
+FT                   /note="Q->R: Increased affinity for coenzyme A."
+FT                   /evidence="ECO:0000269|PubMed:32246827"
+FT   MUTAGEN         78
+FT                   /note="R->A: Induces both an increase in active site
+FT                   micro-millisecond motions and an increase in the rate
+FT                   constants of coenzyme-binding."
+FT                   /evidence="ECO:0000269|PubMed:29932944"
+FT   MUTAGEN         78
+FT                   /note="R->G: Decreased affinity for coenzyme A."
+FT                   /evidence="ECO:0000269|PubMed:32246827"
+FT   MUTAGEN         109
+FT                   /note="C->R: Abolished S-nitroso-CoA-dependent
+FT                   nitrosyltransferase activity; when associated with R-188."
+FT                   /evidence="ECO:0000269|PubMed:38056462"
+FT   MUTAGEN         111
+FT                   /note="S->A: Abolished NAD(P)H-dependent reductase
+FT                   activity."
+FT                   /evidence="ECO:0000269|PubMed:27897348"
+FT   MUTAGEN         153
+FT                   /note="H->A: Reduced affinity for biliverdin."
+FT                   /evidence="ECO:0000269|PubMed:18241201"
+FT   MUTAGEN         188
+FT                   /note="C->R: Abolished S-nitroso-CoA-dependent
+FT                   nitrosyltransferase activity; when associated with R-109."
+FT                   /evidence="ECO:0000269|PubMed:38056462"
+FT   CONFLICT        16
+FT                   /note="G -> C (in Ref. 9; AA sequence)"
+FT                   /evidence="ECO:0000305"
+FT   STRAND          5..10
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           14..25
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   STRAND          29..35
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           37..39
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   STRAND          42..44
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           45..47
+FT                   /evidence="ECO:0007829|PDB:7ERA"
+FT   STRAND          48..53
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           58..65
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   STRAND          69..73
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           86..101
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   STRAND          105..109
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           112..114
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           118..120
+FT                   /evidence="ECO:0007829|PDB:1HE2"
+FT   HELIX           123..125
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           126..141
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   STRAND          144..149
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   STRAND          152..155
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           157..159
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   STRAND          164..169
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   STRAND          174..177
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           178..187
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   HELIX           188..190
+FT                   /evidence="ECO:0007829|PDB:1HE2"
+FT   TURN            193..196
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+FT   STRAND          198..202
+FT                   /evidence="ECO:0007829|PDB:1HDO"
+SQ   SEQUENCE   206 AA;  22119 MW;  3057E6D69A9F9F9F CRC64;
+     MAVKKIAIFG ATGQTGLTTL AQAVQAGYEV TVLVRDSSRL PSEGPRPAHV VVGDVLQAAD
+     VDKTVAGQDA VIVLLGTRND LSPTTVMSEG ARNIVAAMKA HGVDKVVACT SAFLLWDPTK
+     VPPRLQAVTD DHIRMHKVLR ESGLKYVAVM PPHIGDQPLT GAYTVTLDGR GPSRVISKHD
+     LGHFMLRCLT TDEYDGHSTY PSHQYQ
+//

--- a/genes/human/HMOX1/HMOX1-ai-review.yaml
+++ b/genes/human/HMOX1/HMOX1-ai-review.yaml
@@ -816,12 +816,13 @@ existing_annotations:
     summary: >-
       HO-1 is a BMP4 target in pulmonary artery smooth muscle. The cited paper actually shows
       HO-1 inhibits proliferation; the direction here is questionable.
-    action: KEEP_AS_NON_CORE
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Context-specific smooth-muscle role. Note PMID:17600318 reports HO-1 overexpression
       inhibits SMC proliferation (growth-inhibitory), so a positive-regulation direction is not
-      well supported by this reference; retained as non-core pending clarification. Downstream of
-      the enzymatic function regardless.
+      well supported by this reference; marked as over-annotated because the cited evidence
+      contradicts the positive-regulation direction. Downstream of the enzymatic function
+      regardless.
 - term:
     id: GO:0048662
     label: negative regulation of smooth muscle cell proliferation
@@ -1299,7 +1300,7 @@ core_functions:
       enzyme in the oxidative degradation of heme to biliverdin.
   - reference_id: file:human/HMOX1/HMOX1-uniprot.txt
     supporting_text: >-
-      Catalyzes the oxidative cleavage of heme
+      axial binding residue
   locations:
   - id: GO:0005789
     label: endoplasmic reticulum membrane

--- a/genes/human/HMOX1/HMOX1-ai-review.yaml
+++ b/genes/human/HMOX1/HMOX1-ai-review.yaml
@@ -1,0 +1,1579 @@
+id: P09601
+gene_symbol: HMOX1
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: >-
+  Heme oxygenase 1 (HO-1 / HSP32) is the rate-limiting enzyme of heme catabolism. It is a
+  tail-anchored, single-pass type IV endoplasmic reticulum membrane protein whose catalytic
+  domain faces the cytosol. Using molecular oxygen and electrons donated by NADPH--cytochrome
+  P450 reductase, it oxidatively cleaves the alpha-methene bridge of heme b to produce
+  biliverdin IX-alpha, carbon monoxide (CO), and free ferrous iron (Fe2+); biliverdin is
+  subsequently reduced to bilirubin by biliverdin reductase. HO-1 is a highly inducible
+  cytoprotective, antioxidant and anti-inflammatory stress-response enzyme, strongly upregulated
+  by its heme substrate and by oxidative stress, heavy metals, hypoxia and UVA, largely through
+  the NRF2 (NFE2L2)-KEAP1/antioxidant response element pathway. Its cytoprotective actions are
+  mediated by its reaction products: the bilirubin/biliverdin antioxidant system, CO signaling,
+  and sequestration of released iron into ferritin. HO-1 forms homodimers/oligomers via its
+  C-terminal transmembrane anchor, which is required for stability and activity in the ER. In
+  humans, loss of HMOX1 causes heme oxygenase 1 deficiency, a severe systemic disorder with
+  intravascular hemolysis, erythrocyte fragmentation, endothelial injury and tissue iron
+  deposition.
+existing_annotations:
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: >-
+      Core molecular function of HMOX1, supported phylogenetically and by direct human
+      biochemistry. This is the rate-limiting activity of heme catabolism.
+    action: ACCEPT
+    reason: >-
+      Heme oxygenase activity is the defining, experimentally validated function of HMOX1
+      (also directly demonstrated in PMID:7703255, PMID:11121422, PMID:17915953). IBA correctly
+      propagates it across the heme oxygenase family.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: >-
+      HMOX1 is an ER-anchored enzyme, so the ER is a correct location. The more specific and
+      better-supported location is the ER membrane.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Correct but less specific than endoplasmic reticulum membrane (GO:0005789), which is the
+      experimentally supported core location. Retained as non-core.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: >-
+      Plasma membrane is not a substantiated location for human HO-1, which is an ER
+      tail-anchored protein. This IBA likely reflects a family-tree over-propagation.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      No experimental support for HMOX1 acting at the plasma membrane in human; the enzyme is
+      ER membrane-anchored (PubMed:19556236, 22419571, 27184847). Left as non-core rather than
+      removed (IBA), but it should not be treated as a real HO-1 location.
+- term:
+    id: GO:0006979
+    label: response to oxidative stress
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 is a canonical oxidative-stress-response enzyme; its induction and products protect
+      cells from oxidative injury.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      A genuine, well-established downstream physiological role (also IMP in PMID:9884342), but a
+      consequence of the heme oxygenase reaction rather than the core molecular function.
+- term:
+    id: GO:0020037
+    label: heme binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: >-
+      Heme is the substrate/cofactor of HO-1; heme binding is a core, experimentally validated
+      molecular function.
+    action: ACCEPT
+    reason: >-
+      Heme-binding residues are crystallographically resolved (PubMed:12842469) and binding is
+      directly characterized (PMID:17915953). Required for catalysis.
+- term:
+    id: GO:0042167
+    label: heme catabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core biological process: HMOX1 catalyzes the rate-limiting step of heme catabolism.
+    action: ACCEPT
+    reason: >-
+      Directly supported by human biochemistry (PMID:7703255, PMID:17915953) and appropriately
+      propagated by IBA.
+- term:
+    id: GO:0006788
+    label: heme oxidation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 oxidatively cleaves the heme ring; heme oxidation is a correct direct process term.
+    action: ACCEPT
+    reason: >-
+      Represents the oxidative chemistry of the core catalytic activity; also IDA in
+      PMID:17915953.
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: >-
+      Electronic assignment of the core catalytic activity via InterPro/EC/Rhea; correct.
+    action: ACCEPT
+    reason: >-
+      Consistent with the experimentally validated core function and the EC 1.14.14.18 /
+      RHEA:21764 catalytic reaction in UniProt.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: >-
+      Correct core location, derived from the UniProt Subcellular Location vocabulary mapping.
+    action: ACCEPT
+    reason: >-
+      HMOX1 is a tail-anchored ER membrane protein; multiple experimental annotations agree
+      (PubMed:19556236, 22419571, 27184847).
+- term:
+    id: GO:0006788
+    label: heme oxidation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: >-
+      InterPro2GO assignment of heme oxidation from the heme oxygenase domain; correct.
+    action: ACCEPT
+    reason: >-
+      Matches the core catalytic chemistry and the InterPro heme oxygenase signatures.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21044950
+  qualifier: enables
+  review:
+    summary: >-
+      Bare protein binding from a high-throughput YFP-complementation telomere-signaling screen
+      (interaction with POT1). Uninformative for HO-1 molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Generic protein binding from an HTP interactome screen; not indicative of a specific HO-1
+      molecular function and no defined biological role for a HO-1/POT1 interaction. Retained
+      (IPI) but flagged as over-annotation.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: >-
+      Bare protein binding from the HuRI reference binary interactome (many ER/membrane
+      partners). Uninformative for HO-1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      High-throughput systematic Y2H-style mapping; the numerous membrane-protein partners
+      largely reflect co-membership in ER/membrane compartments rather than a specific HO-1
+      molecular function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32353859
+  qualifier: enables
+  review:
+    summary: >-
+      Bare protein binding from a SARS-CoV-2 host-interactome map (ORF3a). Non-specific.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The HMOX1-ORF3a host-virus interaction is documented (see PMID:35239449), but the bare
+      protein binding term is uninformative; captured better as a host-virus interaction note.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32838362
+  qualifier: enables
+  review:
+    summary: >-
+      Bare protein binding from a virus-host interactome/proteomic survey (ORF3a). Non-specific.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      High-throughput host-virus interaction mapping; uninformative bare protein binding.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33060197
+  qualifier: enables
+  review:
+    summary: >-
+      Bare protein binding from a comparative coronavirus host-interactome network (ORF3a).
+      Non-specific.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      High-throughput host-virus interactome; uninformative bare protein binding.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:36217030
+  qualifier: enables
+  review:
+    summary: >-
+      Bare protein binding from a comprehensive SARS-CoV-2-human interactome (ORF3a).
+      Non-specific.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      High-throughput host-virus interactome; uninformative bare protein binding.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: >-
+      Nuclear localization by Ensembl orthology transfer from mouse. HO-1 nuclear translocation
+      of a cleaved fragment is reported under stress, but this is a secondary sub-pool.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Nuclear HO-1 is a context/stress-dependent sub-pool of a proteolytically processed form,
+      not the enzyme's primary location. Kept as non-core.
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: >-
+      ISS transfer of the core catalytic activity from mouse Hmox1; correct.
+    action: ACCEPT
+    reason: >-
+      Redundant with the directly demonstrated human activity; consistent and correct.
+- term:
+    id: GO:1900016
+    label: negative regulation of cytokine production involved in inflammatory response
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: >-
+      Anti-inflammatory role transferred by similarity from mouse Hmox1. Consistent with HO-1
+      being anti-inflammatory, but a downstream physiological consequence.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Genuine downstream effect of HO-1 products (CO, bilirubin) on inflammation, but not the
+      core molecular function; ISS-based.
+- term:
+    id: GO:0110076
+    label: negative regulation of ferroptosis
+  evidence_type: IMP
+  original_reference_id: PMID:26403645
+  qualifier: involved_in
+  review:
+    summary: >-
+      Knockdown of HO-1 (with NQO1 and FTH1), an NRF2 target, promoted ferroptosis in HCC cells,
+      supporting a protective role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      A downstream cytoprotective consequence of HO-1 (via iron handling/antioxidant products),
+      not the core molecular function. Note HO-1 can be context-dependent for ferroptosis, but
+      the cited experiment supports protection.
+    supported_by:
+    - reference_id: PMID:26403645
+      supporting_text: >-
+        Knockdown of p62, quinone oxidoreductase-1, heme oxygenase-1, and ferritin heavy
+        chain-1 by RNA interference in HCC cells promoted ferroptosis in response to erastin
+        and sorafenib.
+- term:
+    id: GO:0042167
+    label: heme catabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:7703255
+  qualifier: involved_in
+  review:
+    summary: >-
+      Direct demonstration that human HO-1 converts heme to biliverdin, defining its role in
+      heme catabolism. Core process.
+    action: ACCEPT
+    reason: >-
+      Truncated hHO-1 reconstituted with cytochrome P450 reductase converts heme to biliverdin.
+    supported_by:
+    - reference_id: PMID:7703255
+      supporting_text: >-
+        The purified, truncated hHO-1/heme complex is spectroscopically indistinguishable from
+        that of the rat enzyme and converts heme to biliverdin when reconstituted with rat liver
+        cytochrome P450 reductase.
+- term:
+    id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 is an enzyme, not a transcription factor. This ISS (transferred from rat P06762)
+      likely over-interprets nuclear-translocation observations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      There is no robust evidence that HO-1 directly regulates RNA polymerase II transcription;
+      any nuclear role is indirect/context-specific. Over-annotation via similarity transfer.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IMP
+  original_reference_id: PMID:19556236
+  qualifier: located_in
+  review:
+    summary: >-
+      Experimental support that HO-1 resides and functions in the ER membrane, with
+      oligomerization via its transmembrane segment. Core location.
+    action: ACCEPT
+    reason: >-
+      HO-1 is anchored in the ER by a single C-terminal transmembrane segment; oligomerization
+      is required for stability/function there.
+    supported_by:
+    - reference_id: PMID:19556236
+      supporting_text: >-
+        a stress-inducible enzyme anchored in the endoplasmic
+        reticulum (ER) by a single transmembrane segment (TMS) located at the C
+        terminus
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:27184847
+  qualifier: located_in
+  review:
+    summary: >-
+      APEX proximity fingerprinting confirmed the ER membrane localization and membrane topology
+      of HMOX1. Core location.
+    action: ACCEPT
+    reason: >-
+      Directly determined membrane protein topology of HMOX1 by APEX labeling.
+    supported_by:
+    - reference_id: PMID:27184847
+      supporting_text: >-
+        successfully elucidated the membrane protein topology of HMOX1
+- term:
+    id: GO:0006879
+    label: intracellular iron ion homeostasis
+  evidence_type: IDA
+  original_reference_id: PMID:17915953
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 releases free iron during heme degradation, contributing to cellular iron handling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      A downstream consequence of the heme oxygenase reaction (release of Fe2+ and rerouting to
+      ferritin), not the core molecular function.
+    supported_by:
+    - reference_id: PMID:17915953
+      supporting_text: >-
+        HO-1 receives the electrons necessary for catalysis from the
+        flavoprotein NADPH cytochrome P450 reductase (CPR), releasing free iron and carbon
+        monoxide.
+- term:
+    id: GO:0060586
+    label: multicellular organismal-level iron ion homeostasis
+  evidence_type: IMP
+  original_reference_id: PMID:9884342
+  qualifier: involved_in
+  review:
+    summary: >-
+      Human HO-1 deficiency causes systemic iron deposition and dysregulated iron handling,
+      supporting a role in organism-level iron homeostasis.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      An organism-level physiological consequence of losing heme catabolism, downstream of the
+      core enzymatic function.
+    supported_by:
+    - reference_id: PMID:9884342
+      supporting_text: >-
+        Iron deposition was noted in renal and hepatic tissue.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35239449
+  qualifier: enables
+  review:
+    summary: >-
+      Bare protein binding capturing the HMOX1-SARS-CoV-2 ORF3a interaction. The interaction is
+      real but the term is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      HMOX1 interacts with ORF3a and promotes ORF3a-induced autophagy (documented in UniProt),
+      but bare protein binding does not convey an informative HO-1 molecular function.
+- term:
+    id: GO:0050728
+    label: negative regulation of inflammatory response
+  evidence_type: ISS
+  original_reference_id: PMID:11447290
+  qualifier: involved_in
+  review:
+    summary: >-
+      Anti-inflammatory role transferred by similarity from rat Hmox1 (protection against
+      hypoxic pulmonary inflammation).
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      A genuine downstream anti-inflammatory effect of HO-1 activity/products, not the core
+      molecular function; ISS-based.
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: IMP
+  original_reference_id: PMID:11121422
+  qualifier: enables
+  review:
+    summary: >-
+      Mutagenesis of active-site Asp-140 abolishes heme oxygenase activity, directly confirming
+      the catalytic function. Core.
+    action: ACCEPT
+    reason: >-
+      D140A/F/L/H/N mutants lose heme oxygenase (biliverdin-forming) activity, establishing the
+      catalytic role of the residue and the enzyme.
+    supported_by:
+    - reference_id: PMID:11121422
+      supporting_text: >-
+        The D140A, D140H, and D140N mutants
+        retain a trace (<3%) of biliverdin forming activity, but the D140F and D140L mutants are
+        inactive in this respect.
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: IDA
+  original_reference_id: PMID:7703255
+  qualifier: enables
+  review:
+    summary: >-
+      Direct biochemical demonstration of human heme oxygenase activity (heme to biliverdin).
+      Core molecular function.
+    action: ACCEPT
+    reason: >-
+      Purified human HO-1 converts heme to biliverdin when reconstituted with cytochrome P450
+      reductase.
+    supported_by:
+    - reference_id: PMID:7703255
+      supporting_text: >-
+        converts
+        heme to biliverdin when reconstituted with rat liver cytochrome P450 reductase.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:22419571
+  qualifier: located_in
+  review:
+    summary: >-
+      Protease-protection assays show endogenous HO-1 is membrane-bound in the ER with its
+      active site facing the cytosol. Core location.
+    action: ACCEPT
+    reason: >-
+      Establishes ER-membrane anchoring and cytosolic-facing topology of HO-1.
+    supported_by:
+    - reference_id: PMID:22419571
+      supporting_text: >-
+        we
+        determined that heme-oxygenase 1 is membrane-bound and faces the cytosol in non-activated
+        macrophages in vivo.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9708558
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome models a stress-induced translocation of HO-1 from the ER to the mitochondrial
+      outer membrane. A secondary, context-dependent sub-pool.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Mitochondrial HO-1 has been reported under stress conditions but is not the primary
+      location; retained as non-core.
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9708536
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome models nuclear translocation of HO-1. A stress/context-dependent sub-pool of a
+      cleaved form, not the primary location.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Nuclear HO-1 is a secondary phenomenon tied to proteolytic processing under stress; kept
+      as non-core.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9609921
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome cytosol location, consistent with tail-anchored protein handling (SGTA/insertion
+      pathway) and the cytosol-facing catalytic domain / soluble cleaved form.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Consistent with the cytosol-facing active site and the soluble form; the primary anchored
+      location remains the ER membrane.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9708457
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome cytosol location associated with HM13-mediated cleavage of the HMOX1 dimer,
+      generating the soluble form.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Reflects the soluble/cleaved HO-1 form; non-core relative to the ER-membrane-anchored
+      enzyme.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9708536
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome cytosol location (precursor step to nuclear translocation).
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Context-dependent cytosolic pool; non-core relative to the ER-membrane location.
+- term:
+    id: GO:0005198
+    label: structural molecule activity
+  evidence_type: IMP
+  original_reference_id: PMID:19556236
+  qualifier: enables
+  review:
+    summary: >-
+      This annotation mis-types the homo-oligomerization observation of PMID:19556236. HO-1 is
+      an enzyme, not a structural molecule; the correct MF is protein homodimerization activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Structural molecule activity implies a scaffolding/structural role; HO-1's oligomerization
+      is better captured by protein homodimerization activity (GO:0042803, separately annotated).
+      The enzyme's function is catalytic, not structural.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19556236
+  qualifier: enables
+  review:
+    summary: >-
+      Captures HO-1 self-association. Better represented by the more informative protein
+      homodimerization activity term.
+    action: MODIFY
+    reason: >-
+      HO-1 forms homodimers/oligomers via its transmembrane segment; the specific MF
+      protein homodimerization activity (GO:0042803) is more informative than the generic
+      identical protein binding.
+    proposed_replacement_terms:
+    - id: GO:0042803
+      label: protein homodimerization activity
+    supported_by:
+    - reference_id: PMID:19556236
+      supporting_text: >-
+        here we showed that HO-1 forms
+        dimers/oligomers in the ER.
+- term:
+    id: GO:0090050
+    label: positive regulation of cell migration involved in sprouting angiogenesis
+  evidence_type: IGI
+  original_reference_id: PMID:24844779
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 acts in a hypoxia/miR-101-NRF2-HO-1/VEGF/eNOS angiogenic axis promoting angiogenesis.
+      A downstream, context-specific physiological role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Pro-angiogenic role of HO-1 in specific vascular contexts; downstream of its enzymatic
+      products (CO), not the core molecular function.
+- term:
+    id: GO:1903589
+    label: positive regulation of blood vessel endothelial cell proliferation involved
+      in sprouting angiogenesis
+  evidence_type: IGI
+  original_reference_id: PMID:24844779
+  qualifier: involved_in
+  review:
+    summary: >-
+      Same miR-101/HO-1/VEGF angiogenic axis; downstream endothelial proliferation phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Context-specific downstream physiological role of HO-1 in angiogenesis; not core.
+- term:
+    id: GO:0045766
+    label: positive regulation of angiogenesis
+  evidence_type: IDA
+  original_reference_id: PMID:21788589
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 is implicated in the pro-angiogenic response after myocardial infarction (miR-24
+      context). Downstream physiological role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Pro-angiogenic effect of HO-1 in the cardiovascular context; downstream of the enzymatic
+      function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21597468
+  qualifier: enables
+  review:
+    summary: >-
+      Bare protein binding in the context of eEF1Bdelta (eEF1BdeltaL) binding NRF2 and inducing
+      HO-1. Uninformative for HO-1 molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The paper concerns eEF1BdeltaL-driven NRF2-dependent HO-1 induction; a bare protein binding
+      annotation on HO-1 does not convey a specific molecular function.
+- term:
+    id: GO:0034605
+    label: cellular response to heat
+  evidence_type: IMP
+  original_reference_id: PMID:21597468
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 (HSP32) is a heat/stress-inducible protein; induction under heat-shock response is
+      consistent, but this is a stress-response consequence.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      HO-1 is induced as part of the heat-shock/stress response; a downstream physiological
+      role rather than the core molecular function.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IDA
+  original_reference_id: PMID:22503972
+  qualifier: located_in
+  review:
+    summary: >-
+      ER localization consistent with the anchored enzyme; less specific than ER membrane.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Correct but subsumed by the more specific ER membrane core location.
+- term:
+    id: GO:0048471
+    label: perinuclear region of cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:22503972
+  qualifier: located_in
+  review:
+    summary: >-
+      Perinuclear (ER-associated) staining reported alongside the STC2 complex study. A
+      plausible ER-adjacent distribution.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Consistent with the perinuclear ER distribution of HO-1; secondary to the ER membrane
+      location.
+- term:
+    id: GO:1902042
+    label: negative regulation of extrinsic apoptotic signaling pathway via death domain
+      receptors
+  evidence_type: IMP
+  original_reference_id: PMID:18202225
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 induction underlies resistance of AML cells to TNF-induced apoptosis; supports an
+      anti-apoptotic role in extrinsic death-receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      A genuine cytoprotective/anti-apoptotic downstream role of HO-1, not the core molecular
+      function.
+    supported_by:
+    - reference_id: PMID:18202225
+      supporting_text: >-
+        HO-1 was responsible for the resistance of AML
+        cells to the cytotoxic actions of TNF.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-189398
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome (heme cleavage reaction) places the HMOX1 dimer in the ER membrane. Core location.
+    action: ACCEPT
+    reason: >-
+      Consistent with the experimentally supported ER membrane location.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6797268
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome (HMOX1 expression) ER membrane location. Core location.
+    action: ACCEPT
+    reason: >-
+      Consistent with the ER membrane core location.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9707645
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome (HMOX1 dimer formation) ER membrane location. Core location.
+    action: ACCEPT
+    reason: >-
+      Consistent with the ER membrane core location.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9708457
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome (HM13 cleavage of HMOX1 dimer) ER membrane location. Core location.
+    action: ACCEPT
+    reason: >-
+      Consistent with the ER membrane core location.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9708558
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome (ER-to-mitochondria translocation step) ER membrane starting location. Core.
+    action: ACCEPT
+    reason: >-
+      Consistent with the ER membrane core location.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9759176
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome (NFE2L2-dependent HMOX1 expression) ER membrane location. Core.
+    action: ACCEPT
+    reason: >-
+      Consistent with the ER membrane core location.
+- term:
+    id: GO:0006879
+    label: intracellular iron ion homeostasis
+  evidence_type: IMP
+  original_reference_id: PMID:22989377
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 overexpression alters intracellular iron distribution, rerouting iron into ferritin
+      and reducing redox-active loose iron.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Downstream iron-handling consequence of heme degradation; supports cytoprotection but is
+      not the core molecular function.
+    supported_by:
+    - reference_id: PMID:22989377
+      supporting_text: >-
+        It appears that HO-1
+        overexpression leads to enhanced destruction of haem, consequent 2-3-fold
+        induction of ferritin
+- term:
+    id: GO:0048661
+    label: positive regulation of smooth muscle cell proliferation
+  evidence_type: IDA
+  original_reference_id: PMID:17600318
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 is a BMP4 target in pulmonary artery smooth muscle. The cited paper actually shows
+      HO-1 inhibits proliferation; the direction here is questionable.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Context-specific smooth-muscle role. Note PMID:17600318 reports HO-1 overexpression
+      inhibits SMC proliferation (growth-inhibitory), so a positive-regulation direction is not
+      well supported by this reference; retained as non-core pending clarification. Downstream of
+      the enzymatic function regardless.
+- term:
+    id: GO:0048662
+    label: negative regulation of smooth muscle cell proliferation
+  evidence_type: IDA
+  original_reference_id: PMID:17600318
+  qualifier: involved_in
+  review:
+    summary: >-
+      Consistent with the cited paper: HO-1 overexpression inhibits smooth muscle cell
+      proliferation.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Downstream anti-proliferative role of HO-1 in vascular smooth muscle; supported by the
+      reference, but not the core molecular function.
+    supported_by:
+    - reference_id: PMID:17600318
+      supporting_text: >-
+        overexpression of HO-1 in PASMCs inhibited serum-stimulated [3H]-thymidine
+        incorporation.
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: IMP
+  original_reference_id: PMID:19556236
+  qualifier: enables
+  review:
+    summary: >-
+      Mutagenesis affecting oligomerization reduces microsomal HO activity, supporting the
+      catalytic function. Core.
+    action: ACCEPT
+    reason: >-
+      The W270N mutation reduced HO enzymatic activity, confirming HO-1 catalytic activity in
+      the ER.
+    supported_by:
+    - reference_id: PMID:19556236
+      supporting_text: >-
+        the microsomal
+        HO activity of the W270N mutant was significantly lower than that of the wild
+        type.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IDA
+  original_reference_id: PMID:19556236
+  qualifier: located_in
+  review:
+    summary: >-
+      ER localization directly observed; less specific than ER membrane.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Correct but subsumed by the more specific ER membrane core location.
+- term:
+    id: GO:0042803
+    label: protein homodimerization activity
+  evidence_type: IDA
+  original_reference_id: PMID:19556236
+  qualifier: enables
+  review:
+    summary: >-
+      HO-1 forms homodimers/oligomers in the ER via its transmembrane segment; this is directly
+      demonstrated and required for stability/function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      A real, functionally important molecular property, but supportive of (not equivalent to)
+      the core catalytic function; retained as non-core.
+    supported_by:
+    - reference_id: PMID:19556236
+      supporting_text: >-
+        here we showed that HO-1 forms
+        dimers/oligomers in the ER.
+- term:
+    id: GO:0001525
+    label: angiogenesis
+  evidence_type: TAS
+  original_reference_id: PMID:12239590
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 contributes to prolactin-mediated endothelial proliferation and angiogenesis. A
+      downstream vascular role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Pleiotropic angiogenic role of HO-1; downstream of enzymatic products, not core.
+- term:
+    id: GO:0001935
+    label: endothelial cell proliferation
+  evidence_type: TAS
+  original_reference_id: PMID:12239590
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 promotes endothelial cell proliferation in the prolactin/angiogenesis context.
+      Downstream role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Context-specific downstream proliferative role; not core.
+- term:
+    id: GO:0002246
+    label: wound healing involved in inflammatory response
+  evidence_type: IMP
+  original_reference_id: PMID:9884342
+  qualifier: involved_in
+  review:
+    summary: >-
+      Human HO-1 deficiency is associated with impaired healing/tissue protection under
+      inflammatory stress. A downstream physiological role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Organism-level consequence of losing HO-1 cytoprotection; downstream of the enzymatic
+      function.
+- term:
+    id: GO:0002686
+    label: negative regulation of leukocyte migration
+  evidence_type: TAS
+  original_reference_id: PMID:14525760
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 inhibits leukocytic infiltration (anti-inflammatory) in the VEGF-induced context.
+      Downstream role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Anti-inflammatory downstream effect of HO-1; not the core molecular function.
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: IDA
+  original_reference_id: PMID:17915953
+  qualifier: enables
+  review:
+    summary: >-
+      Full-length human HO-1 directly degrades heme, releasing iron and CO. Core molecular
+      function.
+    action: ACCEPT
+    reason: >-
+      Purified full-length hHO-1 degrades heme at rates comparable to the WT enzyme.
+    supported_by:
+    - reference_id: PMID:17915953
+      supporting_text: >-
+        Heme oxygenase-1 (HO-1) is the chief regulatory
+        enzyme in the oxidative degradation of heme to biliverdin.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: PMID:18307065
+  qualifier: located_in
+  review:
+    summary: >-
+      Elevated HO-1 in maternal serum/decidua in pre-eclampsia; extracellular HO-1 is atypical
+      for an intracellular ER enzyme.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      HO-1 is an intracellular ER-membrane enzyme; extracellular detection is a context-specific
+      phenomenon (secretion/release), not a primary functional location.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: >-
+      Nuclear localization transferred by similarity from rat (P06762). Reflects a stress-induced
+      cleaved-fragment sub-pool.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Nuclear HO-1 is a secondary, context-dependent phenomenon; not the primary location.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: >-
+      ER localization by similarity; correct but less specific than ER membrane.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Subsumed by the more specific ER membrane core location.
+- term:
+    id: GO:0006788
+    label: heme oxidation
+  evidence_type: IDA
+  original_reference_id: PMID:17915953
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 oxidatively degrades heme; heme oxidation is a correct direct process term. Core.
+    action: ACCEPT
+    reason: >-
+      Reflects the oxidative chemistry of heme degradation directly demonstrated for human HO-1.
+    supported_by:
+    - reference_id: PMID:17915953
+      supporting_text: >-
+        Heme oxygenase-1 (HO-1) is the chief regulatory
+        enzyme in the oxidative degradation of heme to biliverdin.
+- term:
+    id: GO:0006979
+    label: response to oxidative stress
+  evidence_type: IMP
+  original_reference_id: PMID:9884342
+  qualifier: involved_in
+  review:
+    summary: >-
+      Cells from the HO-1-deficient patient are hypersensitive to oxidative/hemin-induced
+      injury, showing HO-1 protects against oxidative stress.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      A well-established downstream cytoprotective consequence of HO-1 activity, not the core
+      molecular function.
+    supported_by:
+    - reference_id: PMID:9884342
+      supporting_text: >-
+        An
+        LCL derived from the patient was extremely sensitive to hemin-induced cell
+        injury.
+- term:
+    id: GO:0014806
+    label: smooth muscle hyperplasia
+  evidence_type: TAS
+  original_reference_id: PMID:18289072
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 role in smooth-muscle/immune contexts from a review. A context-specific downstream
+      physiological process.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Pleiotropic downstream role; not the core molecular function.
+- term:
+    id: GO:0019899
+    label: enzyme binding
+  evidence_type: ISS
+  original_reference_id: PMID:15516695
+  qualifier: enables
+  review:
+    summary: >-
+      Reflects HO-1 functionally docking with NADPH-cytochrome P450 reductase (electron donor).
+      Generic term for a real, functionally central interaction.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      HO-1 partners with NADPH-CPR to receive catalytic electrons (PMID:15516695). The generic
+      enzyme binding term is uninformative on its own; the functionally specific interaction is
+      part of the catalytic mechanism. Retained as non-core.
+- term:
+    id: GO:0020037
+    label: heme binding
+  evidence_type: IDA
+  original_reference_id: PMID:17915953
+  qualifier: enables
+  review:
+    summary: >-
+      Direct heme binding by full-length human HO-1. Core molecular function.
+    action: ACCEPT
+    reason: >-
+      Heme is the substrate/cofactor; binding is required for catalysis and directly
+      characterized.
+    supported_by:
+    - reference_id: PMID:17915953
+      supporting_text: >-
+        the C-terminal 23 amino acids are essential for
+        maximal catalytic activity.
+- term:
+    id: GO:0032722
+    label: positive regulation of chemokine production
+  evidence_type: TAS
+  original_reference_id: PMID:17652371
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 modulates the anti-angiogenic chemokine CXCL10 in renal tubular epithelial cells.
+      Context-specific downstream role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Downstream immunomodulatory effect; not the core molecular function.
+- term:
+    id: GO:0034101
+    label: erythrocyte homeostasis
+  evidence_type: IMP
+  original_reference_id: PMID:9884342
+  qualifier: involved_in
+  review:
+    summary: >-
+      Human HO-1 deficiency causes hemolytic anemia with erythrocyte fragmentation, supporting a
+      role in erythrocyte homeostasis.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Organism-level physiological consequence of losing heme catabolism; downstream of the
+      enzymatic function.
+    supported_by:
+    - reference_id: PMID:9884342
+      supporting_text: >-
+        He has been suffering from persistent hemolytic anemia characterized by marked
+        erythrocyte fragmentation and intravascular hemolysis
+- term:
+    id: GO:0034383
+    label: low-density lipoprotein particle clearance
+  evidence_type: TAS
+  original_reference_id: PMID:9884342
+  qualifier: involved_in
+  review:
+    summary: >-
+      LDL clearance role attributed to HO-1 in the deficiency context. Context-specific
+      downstream physiological role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Downstream/indirect physiological role; not the core molecular function.
+- term:
+    id: GO:0035094
+    label: response to nicotine
+  evidence_type: IDA
+  original_reference_id: PMID:18205746
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 is induced by nicotine and plays a cytoprotective role against nicotine-induced
+      cytotoxicity in oral keratinocytes.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      A stress-response/cytoprotective consequence of HO-1 induction; not the core molecular
+      function.
+    supported_by:
+    - reference_id: PMID:18205746
+      supporting_text: >-
+        HO-1 plays a principal
+        role in the protective response to nicotine
+- term:
+    id: GO:0035556
+    label: intracellular signal transduction
+  evidence_type: TAS
+  original_reference_id: PMID:17652371
+  qualifier: involved_in
+  review:
+    summary: >-
+      Broad signaling role attributed to HO-1 (via CO/products). Very general downstream term.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      HO-1 products (notably CO) act as signaling molecules, but this generic term is a
+      downstream consequence, not the core function.
+- term:
+    id: GO:0042167
+    label: heme catabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:17915953
+  qualifier: involved_in
+  review:
+    summary: >-
+      Direct demonstration of heme degradation by human HO-1. Core biological process.
+    action: ACCEPT
+    reason: >-
+      Full-length human HO-1 degrades heme to biliverdin, releasing iron and CO.
+    supported_by:
+    - reference_id: PMID:17915953
+      supporting_text: >-
+        In the process of heme degradation, HO-1
+        receives the electrons necessary for catalysis from the flavoprotein NADPH
+        cytochrome P450 reductase (CPR), releasing free iron and carbon monoxide.
+- term:
+    id: GO:0042542
+    label: response to hydrogen peroxide
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 is induced by and protects against hydrogen peroxide/oxidative stress (transferred by
+      similarity from rat). Downstream stress-response role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      A genuine downstream oxidative-stress-response role; not the core molecular function.
+- term:
+    id: GO:0045765
+    label: regulation of angiogenesis
+  evidence_type: TAS
+  original_reference_id: PMID:17652371
+  qualifier: involved_in
+  review:
+    summary: >-
+      HO-1 modulates angiogenesis via CXCL10/chemokine effects. Context-specific downstream role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Pleiotropic angiogenic regulatory role; downstream of enzymatic products, not core.
+- term:
+    id: GO:0043123
+    label: positive regulation of canonical NF-kappaB signal transduction
+  evidence_type: HMP
+  original_reference_id: PMID:12761501
+  qualifier: involved_in
+  review:
+    summary: >-
+      HMOX1 cDNA scored as an NF-kappaB pathway activator in a large-scale overexpression
+      luciferase screen. High-throughput, overexpression-based inference.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Derived from a genome-scale overexpression reporter screen (HMP); HO-1 is generally
+      anti-inflammatory in physiological settings, so a positive-regulation-of-NF-kappaB role is
+      not well supported biologically. Retained but flagged as an over-annotation.
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: TAS
+  original_reference_id: PMID:9884342
+  qualifier: enables
+  review:
+    summary: >-
+      Author statement of HO-1's heme oxygenase activity in the deficiency case report. Core
+      molecular function.
+    action: ACCEPT
+    reason: >-
+      Consistent with the directly demonstrated core catalytic function.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: TAS
+  original_reference_id: PMID:3345742
+  qualifier: located_in
+  review:
+    summary: >-
+      Early author statement of ER localization; correct but less specific than ER membrane.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Subsumed by the more specific ER membrane core location.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: TAS
+  original_reference_id: PMID:3345742
+  qualifier: located_in
+  review:
+    summary: >-
+      Generic membrane location. Uninformative given the specific ER membrane annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The unspecific parent term membrane adds no information beyond the well-supported ER
+      membrane (GO:0005789) location.
+core_functions:
+- description: >-
+    Heme oxygenase (decyclizing) activity: HMOX1 catalyzes the rate-limiting, oxygen-dependent
+    oxidative cleavage of the alpha-methene bridge of heme b, using electrons from
+    NADPH--cytochrome P450 reductase, to produce biliverdin IX-alpha, carbon monoxide, and free
+    ferrous iron. This is the committed step of heme catabolism.
+  molecular_function:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  supported_by:
+  - reference_id: PMID:7703255
+    supporting_text: >-
+      converts
+      heme to biliverdin when reconstituted with rat liver cytochrome P450 reductase.
+  - reference_id: PMID:11121422
+    supporting_text: >-
+      The D140A, D140H, and D140N mutants
+      retain a trace (<3%) of biliverdin forming activity, but the D140F and D140L mutants are
+      inactive in this respect.
+  directly_involved_in:
+  - id: GO:0042167
+    label: heme catabolic process
+  - id: GO:0006788
+    label: heme oxidation
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+- description: >-
+    Heme binding: HMOX1 binds heme b as its substrate/cofactor via active-site residues
+    (including the axial His25 iron ligand and Asp140), positioning the porphyrin for
+    regiospecific oxidative cleavage.
+  molecular_function:
+    id: GO:0020037
+    label: heme binding
+  supported_by:
+  - reference_id: PMID:17915953
+    supporting_text: >-
+      Heme oxygenase-1 (HO-1) is the chief regulatory
+      enzyme in the oxidative degradation of heme to biliverdin.
+  - reference_id: file:human/HMOX1/HMOX1-uniprot.txt
+    supporting_text: >-
+      Catalyzes the oxidative cleavage of heme
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+- description: >-
+    Protein homodimerization activity: HMOX1 self-associates into homodimers/higher-order
+    oligomers through its C-terminal transmembrane segment; this oligomerization is required for
+    protein stability and catalytic function in the endoplasmic reticulum membrane.
+  molecular_function:
+    id: GO:0042803
+    label: protein homodimerization activity
+  supported_by:
+  - reference_id: PMID:19556236
+    supporting_text: >-
+      here we showed that HO-1 forms
+      dimers/oligomers in the ER.
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:11121422
+  title: Disruption of an active site hydrogen bond converts human heme oxygenase-1
+    into a peroxidase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Active-site Asp-140 mutagenesis abolishes heme oxygenase (biliverdin-forming) activity of
+      human HO-1, directly supporting the core catalytic function.
+- id: PMID:11447290
+  title: Targeted expression of heme oxygenase-1 prevents the pulmonary inflammatory
+    and vascular responses to hypoxia.
+  findings: []
+- id: PMID:12239590
+  title: Significance of heme oxygenase in prolactin-mediated cell proliferation and
+    angiogenesis in human endothelial cells.
+  findings: []
+- id: PMID:12761501
+  title: Large-scale identification and characterization of human genes that activate
+    NF-kappaB and MAPK signaling pathways.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Genome-scale overexpression luciferase screen; supports an NF-kappaB-activating signal from
+      HMOX1 cDNA only in that artificial context, hence the over-annotation flag.
+- id: PMID:14525760
+  title: 'Bifunctional role for VEGF-induced heme oxygenase-1 in vivo: induction of
+    angiogenesis and inhibition of leukocytic infiltration.'
+  findings: []
+- id: PMID:15516695
+  title: Involvement of NADPH in the interaction between heme oxygenase-1 and cytochrome
+    P450 reductase.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      Characterizes the functional HO-1/NADPH-CPR interaction (electron donor for catalysis);
+      supports the enzyme binding annotation.
+- id: PMID:17600318
+  title: BMP4 induces HO-1 via a Smad-independent, p38MAPK-dependent pathway in pulmonary
+    artery myocytes.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      Shows BMP4-induced HO-1 inhibits pulmonary artery SMC proliferation; supports the
+      negative-regulation-of-SMC-proliferation annotation but not the positive-regulation one.
+- id: PMID:17652371
+  title: Heme oxygenase-1 modulates the expression of the anti-angiogenic chemokine
+    CXCL-10 in renal tubular epithelial cells.
+  findings: []
+- id: PMID:17915953
+  title: 'Expression and characterization of full-length human heme oxygenase-1: the
+    presence of intact membrane-binding region leads to increased binding affinity
+    for NADPH cytochrome P450 reductase.'
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Direct biochemical characterization of full-length human HO-1 heme degradation and CPR
+      binding; supports the core catalytic function and heme binding.
+- id: PMID:18202225
+  title: HO-1 underlies resistance of AML cells to TNF-induced apoptosis.
+  findings: []
+- id: PMID:18205746
+  title: Differential induction of heme oxygenase-1 against nicotine-induced cytotoxicity
+    via the PI3K, MAPK, and NF-kappa B pathways in immortalized and malignant human
+    oral keratinocytes.
+  findings: []
+- id: PMID:18289072
+  title: 'The role of heme oxygenase-1 in T cell-mediated immunity: the all encompassing
+    enzyme.'
+  findings: []
+- id: PMID:18307065
+  title: Decidual expression and maternal serum levels of heme oxygenase 1 are increased
+    in pre-eclampsia.
+  findings: []
+- id: PMID:19556236
+  title: Oligomerization is crucial for the stability and function of heme oxygenase-1
+    in the endoplasmic reticulum.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Establishes ER-membrane anchoring, TM-driven homo-oligomerization, and its requirement for
+      HO-1 stability and enzymatic activity.
+- id: PMID:21044950
+  title: Genome-wide YFP fluorescence complementation screen identifies new regulators
+    for telomere signaling in human cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      High-throughput YFP-complementation telomere-signaling screen; the HO-1/POT1 hit is a
+      generic protein-binding observation without a defined HO-1 function.
+- id: PMID:21597468
+  title: Transformation of eEF1Bδ into heat-shock response transcription factor by
+    alternative splicing.
+  findings: []
+- id: PMID:21788589
+  title: MicroRNA-24 regulates vascularity after myocardial infarction.
+  findings: []
+- id: PMID:22419571
+  title: Endoplasmic reticulum anchored heme-oxygenase 1 faces the cytosol.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Protease-protection assays place endogenous HO-1 in the ER membrane with a cytosol-facing
+      active site; supports the core location and topology.
+- id: PMID:22503972
+  title: Stanniocalcin 2, forms a complex with heme oxygenase 1, binds hemin and is
+    a heat shock protein.
+  findings: []
+- id: PMID:22989377
+  title: Haem oxygenase-1 overexpression alters intracellular iron distribution.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      Shows HO-1 overexpression reroutes iron into ferritin and reduces redox-active loose iron;
+      supports the intracellular iron homeostasis annotation.
+- id: PMID:24844779
+  title: Hypoxia-responsive microRNA-101 promotes angiogenesis via heme oxygenase-1/vascular
+    endothelial growth factor axis by targeting cullin 3.
+  findings: []
+- id: PMID:26403645
+  title: Activation of the p62-Keap1-NRF2 pathway protects against ferroptosis in
+    hepatocellular carcinoma cells.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      HO-1 knockdown (with NQO1/FTH1) promoted ferroptosis; supports a protective
+      (negative-regulation-of-ferroptosis) role as an NRF2 target.
+- id: PMID:27184847
+  title: APEX Fingerprinting Reveals the Subcellular Localization of Proteins of Interest.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      APEX proximity fingerprinting directly resolved HMOX1 membrane topology/ER localization.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      High-throughput binary interactome (HuRI); numerous ER/membrane partners largely reflect
+      co-compartmentalization rather than specific HO-1 functions.
+- id: PMID:32353859
+  title: A SARS-CoV-2 protein interaction map reveals targets for drug repurposing.
+  findings: []
+- id: PMID:32838362
+  title: Virus-Host Interactome and Proteomic Survey Reveal Potential Virulence Factors
+    Influencing SARS-CoV-2 Pathogenesis.
+  findings: []
+- id: PMID:33060197
+  title: Comparative host-coronavirus protein interaction networks reveal pan-viral
+    disease mechanisms.
+  findings: []
+- id: PMID:3345742
+  title: Human heme oxygenase cDNA and induction of its mRNA by hemin.
+  findings: []
+- id: PMID:35239449
+  title: SARS-CoV-2 ORF3a induces RETREG1/FAM134B-dependent reticulophagy and triggers
+    sequential ER stress and inflammatory responses during SARS-CoV-2 infection.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Reports HMOX1-ORF3a interaction promoting ORF3a-induced autophagy during SARS-CoV-2
+      infection; a host-virus interaction, not a core HO-1 function.
+- id: PMID:36217030
+  title: A comprehensive SARS-CoV-2-human protein-protein interactome reveals COVID-19
+    pathobiology and potential host therapeutic targets.
+  findings: []
+- id: PMID:7703255
+  title: Expression and characterization of truncated human heme oxygenase (hHO-1)
+    and a fusion protein of hHO-1 with human cytochrome P450 reductase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Truncated human HO-1 converts heme to biliverdin with cytochrome P450 reductase; primary
+      evidence for the core catalytic function and the soluble form.
+- id: PMID:9884342
+  title: Oxidative stress causes enhanced endothelial cell injury in human heme oxygenase-1
+    deficiency.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      First human HMOX1-deficiency case; establishes the in vivo consequences (hemolysis,
+      erythrocyte fragmentation, iron deposition, oxidative-stress hypersensitivity).
+- id: Reactome:R-HSA-189398
+  title: HMOX1 dimer, HMOX2 cleave heme
+  findings: []
+- id: Reactome:R-HSA-6797268
+  title: Expression of HMOX1
+  findings: []
+- id: Reactome:R-HSA-9609921
+  title: SGTA binds Tail-anchored protein
+  findings: []
+- id: Reactome:R-HSA-9707645
+  title: HMOX1 gene produces HMOX1 dimer
+  findings: []
+- id: Reactome:R-HSA-9708457
+  title: HM13 cleaves HMOX1 dimer
+  findings: []
+- id: Reactome:R-HSA-9708536
+  title: HMOX1 translocates from the cytosol to the nucleoplasm
+  findings: []
+- id: Reactome:R-HSA-9708558
+  title: HMOX1 dimer translocates from ER membrane to mitochondrial outer membrane
+  findings: []
+- id: Reactome:R-HSA-9759176
+  title: NFE2L2-dependent HMOX1 gene expression
+  findings: []

--- a/genes/human/HMOX1/HMOX1-goa.tsv
+++ b/genes/human/HMOX1/HMOX1-goa.tsv
@@ -1,0 +1,108 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	P09601	HMOX1	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000318	IBA	GO_REF:0000033	CGD:CAL0000188588|FB:FBgn0037933|MGI:MGI:96163|PANTHER:PTN007456885|RGD:2806|RGD:67402|SGD:S000004195|UniProtKB:P09601|UniProtKB:P14791|UniProtKB:P30519|UniProtKB:P32394|UniProtKB:Q5E9F2|ZFIN:ZDB-GENE-030131-3102	9606	Homo sapiens	GO_Central	Heme oxygenase 1	20250902
+UniProtKB	P09601	HMOX1	is_active_in	GO:0005783	endoplasmic reticulum	cellular_component	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN002582051|RGD:2806|UniProtKB:P09601	9606	Homo sapiens	GO_Central	Heme oxygenase 1	20250415
+UniProtKB	P09601	HMOX1	is_active_in	GO:0005886	plasma membrane	cellular_component	ECO:0000318	IBA	GO_REF:0000033	CGD:CAL0000188588|PANTHER:PTN007456885|RGD:2806|UniProtKB:P30519	9606	Homo sapiens	GO_Central	Heme oxygenase 1	20250415
+UniProtKB	P09601	HMOX1	involved_in	GO:0006979	response to oxidative stress	biological_process	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN007456885|RGD:2806|RGD:67402|SGD:S000004195|UniProtKB:P09601	9606	Homo sapiens	GO_Central	Heme oxygenase 1	20250415
+UniProtKB	P09601	HMOX1	enables	GO:0020037	heme binding	molecular_function	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN007456885|RGD:2806|UniProtKB:P09601	9606	Homo sapiens	GO_Central	Heme oxygenase 1	20250415
+UniProtKB	P09601	HMOX1	involved_in	GO:0042167	heme catabolic process	biological_process	ECO:0000318	IBA	GO_REF:0000033	MGI:MGI:96163|PANTHER:PTN007456885|RGD:2806|SGD:S000004195|UniProtKB:P09601	9606	Homo sapiens	GO_Central	Heme oxygenase 1	20250415
+UniProtKB	P09601	HMOX1	involved_in	GO:0006788	heme oxidation	biological_process	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN000076492|UniProtKB:P09601	9606	Homo sapiens	GO_Central	Heme oxygenase 1	20170228
+UniProtKB	P09601	HMOX1	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000501	IEA	GO_REF:0000120	ARBA:ARBA00086726|InterPro:IPR002051|InterPro:IPR016053|InterPro:IPR018207|RHEA:21764|EC:1.14.14.18	9606	Homo sapiens	UniProt	Heme oxygenase 1	20260706
+UniProtKB	P09601	HMOX1	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0007322	IEA	GO_REF:0000044	UniProtKB-SubCell:SL-0097	9606	Homo sapiens	UniProt	Heme oxygenase 1	20260706
+UniProtKB	P09601	HMOX1	involved_in	GO:0006788	heme oxidation	biological_process	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR002051|InterPro:IPR016053	9606	Homo sapiens	InterPro	Heme oxygenase 1	20260706
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:21044950	UniProtKB:Q9NUX5	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:O60669	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:O75208	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P11912	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P49447	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q13113	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q13520	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q15800	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q16623	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q3SXY8	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q53TN4	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q5JX71	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q7Z7G2	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8N5M9	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8TBP5	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8TDT2	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q96DZ7	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q96KR6	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q96MV1	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9BUF7-2	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9BY50	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9GZR5	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9H5J4	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9NUH8	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9NYP7	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9Y282	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32353859	UniProtKB:P0DTC3	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32838362	UniProtKB:P0DTC3	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:33060197	UniProtKB:P0DTC3	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:36217030	UniProtKB:P0DTC3	9606	Homo sapiens	IntAct	Heme oxygenase 1	20260704
+UniProtKB	P09601	HMOX1	located_in	GO:0005634	nucleus	cellular_component	ECO:0000265	IEA	GO_REF:0000107	UniProtKB:P14901|ensembl:ENSMUSP00000005548	9606	Homo sapiens	Ensembl	Heme oxygenase 1	20260629
+UniProtKB	P09601	HMOX1	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000250	ISS	GO_REF:0000024	MGI:MGI:96163	9606	Homo sapiens	UniProt	Heme oxygenase 1	20241113
+UniProtKB	P09601	HMOX1	involved_in	GO:1900016	negative regulation of cytokine production involved in inflammatory response	biological_process	ECO:0000250	ISS	GO_REF:0000024	MGI:MGI:96163	9606	Homo sapiens	UniProt	Heme oxygenase 1	20241113
+UniProtKB	P09601	HMOX1	involved_in	GO:0110076	negative regulation of ferroptosis	biological_process	ECO:0000315	IMP	PMID:26403645		9606	Homo sapiens	UniProt	Heme oxygenase 1	20240405
+UniProtKB	P09601	HMOX1	involved_in	GO:0042167	heme catabolic process	biological_process	ECO:0000314	IDA	PMID:7703255		9606	Homo sapiens	UniProt	Heme oxygenase 1	20240222
+UniProtKB	P09601	HMOX1	involved_in	GO:0006357	regulation of transcription by RNA polymerase II	biological_process	ECO:0000250	ISS	GO_REF:0000024	UniProtKB:P06762	9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20231018
+UniProtKB	P09601	HMOX1	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000315	IMP	PMID:19556236		9606	Homo sapiens	UniProt	Heme oxygenase 1	20230619
+UniProtKB	P09601	HMOX1	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000314	IDA	PMID:27184847		9606	Homo sapiens	UniProt	Heme oxygenase 1	20230404
+UniProtKB	P09601	HMOX1	involved_in	GO:0006879	intracellular iron ion homeostasis	biological_process	ECO:0000314	IDA	PMID:17915953		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20221212
+UniProtKB	P09601	HMOX1	involved_in	GO:0060586	multicellular organismal-level iron ion homeostasis	biological_process	ECO:0000315	IMP	PMID:9884342		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20221212
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:35239449	UniProtKB:P0DTC3	9606	Homo sapiens	UniProt	Heme oxygenase 1	20220705
+UniProtKB	P09601	HMOX1	involved_in	GO:0050728	negative regulation of inflammatory response	biological_process	ECO:0000250	ISS	PMID:11447290	UniProtKB:P14901	9606	Homo sapiens	UniProt	Heme oxygenase 1	20220623
+UniProtKB	P09601	HMOX1	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000315	IMP	PMID:11121422		9606	Homo sapiens	UniProt	Heme oxygenase 1	20220214
+UniProtKB	P09601	HMOX1	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000314	IDA	PMID:7703255		9606	Homo sapiens	UniProt	Heme oxygenase 1	20220214
+UniProtKB	P09601	HMOX1	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000314	IDA	PMID:22419571		9606	Homo sapiens	UniProt	Heme oxygenase 1	20220214
+UniProtKB	P09601	HMOX1	located_in	GO:0005741	mitochondrial outer membrane	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-9708558		9606	Homo sapiens	Reactome	Heme oxygenase 1	20201203
+UniProtKB	P09601	HMOX1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-9708536		9606	Homo sapiens	Reactome	Heme oxygenase 1	20201130
+UniProtKB	P09601	HMOX1	located_in	GO:0005829	cytosol	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-9609921		9606	Homo sapiens	Reactome	Heme oxygenase 1	20201130
+UniProtKB	P09601	HMOX1	located_in	GO:0005829	cytosol	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-9708457		9606	Homo sapiens	Reactome	Heme oxygenase 1	20201130
+UniProtKB	P09601	HMOX1	located_in	GO:0005829	cytosol	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-9708536		9606	Homo sapiens	Reactome	Heme oxygenase 1	20201130
+UniProtKB	P09601	HMOX1	enables	GO:0005198	structural molecule activity	molecular_function	ECO:0000315	IMP	PMID:19556236		9606	Homo sapiens	UniProt	Heme oxygenase 1	20191121
+UniProtKB	P09601	HMOX1	enables	GO:0042802	identical protein binding	molecular_function	ECO:0000353	IPI	PMID:19556236	UniProtKB:P09601	9606	Homo sapiens	UniProt	Heme oxygenase 1	20191121
+UniProtKB	P09601	HMOX1	involved_in	GO:0090050	positive regulation of cell migration involved in sprouting angiogenesis	biological_process	ECO:0000316	IGI	PMID:24844779	RNAcentral:URS00001230A0_9606	9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20180119
+UniProtKB	P09601	HMOX1	involved_in	GO:1903589	positive regulation of blood vessel endothelial cell proliferation involved in sprouting angiogenesis	biological_process	ECO:0000316	IGI	PMID:24844779	RNAcentral:URS00001230A0_9606	9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20180119
+UniProtKB	P09601	HMOX1	involved_in	GO:0045766	positive regulation of angiogenesis	biological_process	ECO:0000314	IDA	PMID:21788589		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20171116
+UniProtKB	P09601	HMOX1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:21597468	UniProtKB:P29692-2	9606	Homo sapiens	UniProt	Heme oxygenase 1	20150122
+UniProtKB	P09601	HMOX1	involved_in	GO:0034605	cellular response to heat	biological_process	ECO:0000315	IMP	PMID:21597468		9606	Homo sapiens	UniProt	Heme oxygenase 1	20150121
+UniProtKB	P09601	HMOX1	located_in	GO:0005783	endoplasmic reticulum	cellular_component	ECO:0000314	IDA	PMID:22503972		9606	Homo sapiens	UniProt	Heme oxygenase 1	20140821
+UniProtKB	P09601	HMOX1	located_in	GO:0048471	perinuclear region of cytoplasm	cellular_component	ECO:0000314	IDA	PMID:22503972		9606	Homo sapiens	UniProt	Heme oxygenase 1	20140821
+UniProtKB	P09601	HMOX1	involved_in	GO:1902042	negative regulation of extrinsic apoptotic signaling pathway via death domain receptors	biological_process	ECO:0000315	IMP	PMID:18202225		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20130523
+UniProtKB	P09601	HMOX1	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-189398		9606	Homo sapiens	Reactome	Heme oxygenase 1	20130213
+UniProtKB	P09601	HMOX1	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-6797268		9606	Homo sapiens	Reactome	Heme oxygenase 1	20130213
+UniProtKB	P09601	HMOX1	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-9707645		9606	Homo sapiens	Reactome	Heme oxygenase 1	20130213
+UniProtKB	P09601	HMOX1	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-9708457		9606	Homo sapiens	Reactome	Heme oxygenase 1	20130213
+UniProtKB	P09601	HMOX1	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-9708558		9606	Homo sapiens	Reactome	Heme oxygenase 1	20130213
+UniProtKB	P09601	HMOX1	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-9759176		9606	Homo sapiens	Reactome	Heme oxygenase 1	20130213
+UniProtKB	P09601	HMOX1	involved_in	GO:0006879	intracellular iron ion homeostasis	biological_process	ECO:0000315	IMP	PMID:22989377		9606	Homo sapiens	CACAO	Heme oxygenase 1	20121031
+UniProtKB	P09601	HMOX1	involved_in	GO:0048661	positive regulation of smooth muscle cell proliferation	biological_process	ECO:0000314	IDA	PMID:17600318		9606	Homo sapiens	UniProt	Heme oxygenase 1	20100201
+UniProtKB	P09601	HMOX1	involved_in	GO:0048662	negative regulation of smooth muscle cell proliferation	biological_process	ECO:0000314	IDA	PMID:17600318		9606	Homo sapiens	UniProt	Heme oxygenase 1	20100201
+UniProtKB	P09601	HMOX1	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000315	IMP	PMID:19556236		9606	Homo sapiens	UniProt	Heme oxygenase 1	20091012
+UniProtKB	P09601	HMOX1	located_in	GO:0005783	endoplasmic reticulum	cellular_component	ECO:0000314	IDA	PMID:19556236		9606	Homo sapiens	UniProt	Heme oxygenase 1	20091012
+UniProtKB	P09601	HMOX1	enables	GO:0042803	protein homodimerization activity	molecular_function	ECO:0000314	IDA	PMID:19556236		9606	Homo sapiens	UniProt	Heme oxygenase 1	20091012
+UniProtKB	P09601	HMOX1	involved_in	GO:0001525	angiogenesis	biological_process	ECO:0000304	TAS	PMID:12239590		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0001935	endothelial cell proliferation	biological_process	ECO:0000304	TAS	PMID:12239590		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0002246	wound healing involved in inflammatory response	biological_process	ECO:0000315	IMP	PMID:9884342		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0002686	negative regulation of leukocyte migration	biological_process	ECO:0000304	TAS	PMID:14525760		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000314	IDA	PMID:17915953		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	located_in	GO:0005576	extracellular region	cellular_component	ECO:0000304	TAS	PMID:18307065		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	located_in	GO:0005634	nucleus	cellular_component	ECO:0000250	ISS	GO_REF:0000024	UniProtKB:P06762	9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	located_in	GO:0005783	endoplasmic reticulum	cellular_component	ECO:0000250	ISS	GO_REF:0000024	UniProtKB:P06762	9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0006788	heme oxidation	biological_process	ECO:0000314	IDA	PMID:17915953		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0006979	response to oxidative stress	biological_process	ECO:0000315	IMP	PMID:9884342		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0014806	smooth muscle hyperplasia	biological_process	ECO:0000304	TAS	PMID:18289072		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	enables	GO:0019899	enzyme binding	molecular_function	ECO:0000250	ISS	PMID:15516695	UniProtKB:P06762	9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	enables	GO:0020037	heme binding	molecular_function	ECO:0000314	IDA	PMID:17915953		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0032722	positive regulation of chemokine production	biological_process	ECO:0000304	TAS	PMID:17652371		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0034101	erythrocyte homeostasis	biological_process	ECO:0000315	IMP	PMID:9884342		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0034383	low-density lipoprotein particle clearance	biological_process	ECO:0000304	TAS	PMID:9884342		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0035094	response to nicotine	biological_process	ECO:0000314	IDA	PMID:18205746		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0035556	intracellular signal transduction	biological_process	ECO:0000304	TAS	PMID:17652371		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0042167	heme catabolic process	biological_process	ECO:0000314	IDA	PMID:17915953		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0042542	response to hydrogen peroxide	biological_process	ECO:0000250	ISS	GO_REF:0000024	UniProtKB:P06762	9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0045765	regulation of angiogenesis	biological_process	ECO:0000304	TAS	PMID:17652371		9606	Homo sapiens	BHF-UCL	Heme oxygenase 1	20080528
+UniProtKB	P09601	HMOX1	involved_in	GO:0043123	positive regulation of canonical NF-kappaB signal transduction	biological_process	ECO:0007001	HMP	PMID:12761501		9606	Homo sapiens	UniProt	Heme oxygenase 1	20040312
+UniProtKB	P09601	HMOX1	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000304	TAS	PMID:9884342		9606	Homo sapiens	PINC	Heme oxygenase 1	20030904
+UniProtKB	P09601	HMOX1	located_in	GO:0005783	endoplasmic reticulum	cellular_component	ECO:0000304	TAS	PMID:3345742		9606	Homo sapiens	PINC	Heme oxygenase 1	20030904
+UniProtKB	P09601	HMOX1	located_in	GO:0016020	membrane	cellular_component	ECO:0000304	TAS	PMID:3345742		9606	Homo sapiens	PINC	Heme oxygenase 1	20030904

--- a/genes/human/HMOX1/HMOX1-notes.md
+++ b/genes/human/HMOX1/HMOX1-notes.md
@@ -1,0 +1,125 @@
+# HMOX1 (Heme oxygenase 1 / HO-1 / HSP32) — review notes
+
+UniProt: P09601 (HMOX1_HUMAN), 288 aa, chromosome 22. HGNC:5013. EC 1.14.14.18.
+
+## Core biology (from UniProt P09601)
+
+- **Molecular function.** HMOX1 catalyzes the oxidative cleavage of heme at the alpha-methene
+  bridge carbon, released as carbon monoxide (CO), to generate biliverdin IXalpha, while
+  releasing the central heme iron chelate as ferrous iron
+  [file:human/HMOX1/HMOX1-uniprot.txt "Catalyzes the oxidative cleavage of heme at the alpha-methene bridge carbon, released as carbon monoxide (CO), to generate biliverdin IXalpha, while releasing the central heme iron chelate as ferrous iron"].
+  It is the **rate-limiting** enzyme of heme catabolism.
+- **Catalytic reaction (Rhea:RHEA:21764, EC 1.14.14.18).** heme b + 3 reduced [NADPH--hemoprotein
+  reductase] + 3 O2 = biliverdin IXalpha + CO + Fe(2+) + 3 oxidized [NADPH--hemoprotein reductase]
+  + 3 H2O + H(+). Electrons for catalysis are supplied by NADPH--cytochrome P450 reductase (CPR).
+- **Cytoprotection.** "Affords protection against programmed cell death and this cytoprotective
+  effect relies on its ability to catabolize free heme and prevent it from sensitizing cells to
+  undergo apoptosis" [file:human/HMOX1/HMOX1-uniprot.txt]. Downstream protective mediators:
+  biliverdin/bilirubin (antioxidant), CO (signaling/anti-apoptotic), and iron sequestration into
+  ferritin.
+- **Cofactor/substrate binding.** Heme b binding sites at residues 18, 25 (axial Fe ligand His25),
+  134, 183 (UniProt FT BINDING). Asp-140 is important for catalytic activity; D140 mutants are
+  inactive as heme oxygenase but gain peroxidase activity [PMID:11121422].
+- **Subcellular location.** Endoplasmic reticulum membrane; Single-pass type IV (tail-anchored)
+  membrane protein; C-terminal TM anchor (266–288); catalytic domain faces the **cytosol**
+  [file:human/HMOX1/HMOX1-uniprot.txt "Endoplasmic reticulum membrane ... Single-pass type IV membrane protein ... Cytoplasmic side"];
+  [PMID:22419571 "heme-oxygenase 1 is membrane-bound and faces the cytosol"]. A soluble ~30 kDa form
+  arises by proteolytic removal of the membrane anchor [PMID:7703255].
+- **Oligomerization.** Homodimer / higher-order homooligomer; oligomerization via the TM segment is
+  crucial for stability and function in the ER [PMID:19556236].
+- **Induction.** "Heme oxygenase 1 activity is highly inducible by its substrate heme and by various
+  non-heme substances such as heavy metals, bromobenzene, endotoxin, oxidizing agents and UVA"
+  [file:human/HMOX1/HMOX1-uniprot.txt]. Canonical inducer axis is NRF2 (NFE2L2)–KEAP1 via ARE in the
+  HO-1 promoter (e.g. [PMID:26403645], [PMID:18202225]).
+- **Disease.** Heme oxygenase 1 deficiency (HMOX1D, MIM:614034): persistent hemolytic anemia with
+  marked erythrocyte fragmentation and intravascular hemolysis, endothelial damage, iron deposition,
+  asplenia, nephritis, growth retardation. First human case [PMID:9884342].
+
+## Evidence for specific GO annotations
+
+- **heme oxygenase (decyclizing) activity (GO:0004392).** Directly demonstrated for human HO-1:
+  truncated hHO-1 "converts heme to biliverdin when reconstituted with rat liver cytochrome P450
+  reductase" [PMID:7703255]; full-length hHO-1 degrades heme releasing free iron and CO
+  [PMID:17915953]; D140 mutagenesis abolishes heme oxygenase activity [PMID:11121422]. This is the
+  well-supported CORE molecular function.
+- **heme binding (GO:0020037).** Substrate/cofactor; heme-binding sites resolved crystallographically
+  [PMID:12842469 via UniProt FT]; direct binding characterized [PMID:17915953]. CORE.
+- **heme catabolic process (GO:0042167) / heme oxidation (GO:0006788).** Direct process terms for the
+  catalytic activity; well supported [PMID:7703255, PMID:17915953]. CORE BP.
+- **protein homodimerization activity (GO:0042803) / structural molecule activity (GO:0005198) /
+  identical protein binding (GO:0042802).** All from [PMID:19556236] (homo-oligomerization via TM
+  segment). Homodimerization is real and functionally relevant (stability in ER). `structural
+  molecule activity` (GO:0005198) is a mis-typing of the oligomerization observation — HO-1 is an
+  enzyme, not a structural/scaffolding molecule; MARK_AS_OVER_ANNOTATED. Homodimerization kept as
+  non-core.
+- **intracellular iron ion homeostasis (GO:0006879).** HO-1 releases Fe2+ from heme and its
+  overexpression reroutes iron into ferritin, reducing redox-active "loose" iron [PMID:22989377,
+  PMID:17915953]. Reasonable downstream consequence; KEEP_AS_NON_CORE.
+- **negative regulation of ferroptosis (GO:0110076).** IMP from [PMID:26403645]: knockdown of HO-1
+  (with NQO1/FTH1) promoted ferroptosis; NRF2 target. Note HO-1 can be double-edged for ferroptosis
+  (iron release), but the cited paper supports a protective role. KEEP_AS_NON_CORE.
+- **response to oxidative stress (GO:0006979).** IMP [PMID:9884342] (patient LCL hypersensitive to
+  oxidative injury) + IBA. Core stress-response consequence; KEEP_AS_NON_CORE (it is a downstream
+  physiological role, not the MF).
+- **Angiogenesis / smooth-muscle / leukocyte / chemokine / NF-kB / LDL / nicotine / heat / wound
+  healing terms.** These are pleiotropic downstream physiological consequences of HO-1
+  induction/products (CO, biliverdin, iron) in specific cell/disease contexts. Mostly TAS/IDA/IMP/IGI
+  from individual papers. Keep as NON_CORE (they are genuine observations but not the enzyme's core
+  molecular role). `structural molecule activity` and `regulation of transcription by RNA polymerase
+  II` are over-annotations (HO-1 is not a transcription factor; the ISS to P06762/rat is a weak
+  transfer).
+- **enzyme binding (GO:0019899).** ISS from rat HO-1 (P06762) re CPR interaction [PMID:15516695];
+  HO-1 does functionally dock with NADPH-CPR. Generic; KEEP_AS_NON_CORE (the specific, informative MF
+  would be an oxidoreductase/electron-acceptor interaction with CPR). Could support a proposed
+  more-specific term but kept conservatively.
+
+## Protein-binding (GO:0005515) IPI annotations — over-annotation flags
+
+- Many bare `protein binding` IPI annotations from high-throughput interactome screens:
+  - PMID:21044950 (POT1, YFP-complementation telomere screen) — HTP; not an informative function.
+  - PMID:32296183 (HuRI reference binary interactome) — 25 partners (AQP6, ARL13B, CD79A, COQ9,
+    CPLX4, CRB3, CYB561, CYBRD1, ELOVL4/5/6, ERGIC3, FAM174A, FAM209A, FAM210B, GPR152, JAGN1,
+    MSMO1, PDZK1IP1, SEC11C, SLC16A7, STX1A, TLCD4, TM4SF19, TMEM14B). Most are ER/membrane proteins
+    co-detected in the assay; likely reflect membrane co-localization, not specific function.
+  - PMID:32353859, PMID:32838362, PMID:33060197, PMID:36217030, PMID:35239449 — SARS-CoV-2 ORF3a
+    (P0DTC3) interactome studies. HMOX1–ORF3a interaction is real and reported in UniProt
+    (host-virus), promotes ORF3a-induced autophagy [PMID:35239449]. Non-core; MARK_AS_OVER_ANNOTATED
+    the bare `protein binding` (the specific host-virus interaction is captured in notes/UniProt).
+  - PMID:21597468 (eEF1Bδ, P29692-2) — eEF1BδL binds NRF2 and induces HO-1; the IPI captures a
+    HO-1/eEF1Bδ association context. Non-core.
+  All bare `protein binding` IPIs: MARK_AS_OVER_ANNOTATED (never REMOVE per policy).
+- `identical protein binding (GO:0042802)` [PMID:19556236]: real homo-oligomerization — MODIFY toward
+  the more informative `protein homodimerization activity` (GO:0042803), which is separately
+  annotated. Keep non-core.
+
+## Localization annotations
+
+- ER membrane (GO:0005789) — strongly supported experimental core location [PMID:19556236,
+  PMID:27184847, PMID:22419571]; ACCEPT/KEEP.
+- ER (GO:0005783) — parent of ER membrane; KEEP_AS_NON_CORE (less specific).
+- perinuclear region of cytoplasm (GO:0048471) [PMID:22503972] — IDA; plausible ER-associated
+  perinuclear staining; non-core.
+- nucleus / nucleoplasm (GO:0005634, GO:0005654) — reported nuclear translocation of a cleaved HO-1
+  fragment under stress (sub-pool). ISS from rat (P06762) and Ensembl/Reactome. KEEP_AS_NON_CORE
+  (secondary, context-specific).
+- mitochondrial outer membrane (GO:0005741) — Reactome TAS; reported stress relocalization sub-pool;
+  KEEP_AS_NON_CORE.
+- cytosol (GO:0005829) — Reactome TAS; the soluble/cleaved form and the cytosol-facing active site
+  are consistent with this; KEEP_AS_NON_CORE.
+- plasma membrane (GO:0005886) IBA — not a substantiated HO-1 location for human; likely PANTHER
+  tree artifact (some family members). Weak; KEEP_AS_NON_CORE (not removing IBA).
+- extracellular region / extracellular space (GO:0005576) TAS [PMID:18307065] — pre-eclampsia serum
+  HO-1; HO-1 is intracellular, secretion is atypical/context-specific; KEEP_AS_NON_CORE.
+- membrane (GO:0016020) TAS [PMID:3345742] — generic parent of ER membrane; MARK_AS_OVER_ANNOTATED
+  (uninformative given specific ER membrane annotations).
+
+## Core function summary
+
+1. Heme oxygenase (decyclizing) activity (GO:0004392) — rate-limiting oxidative cleavage of heme to
+   biliverdin IXalpha + CO + Fe2+, using O2 and electrons from NADPH-CPR. MF core; BP: heme catabolic
+   process (GO:0042167) / heme oxidation (GO:0006788); location: ER membrane (GO:0005789).
+2. Heme binding (GO:0020037) — substrate/cofactor binding required for catalysis.
+3. Protein homodimerization activity (GO:0042803) — homo-oligomerization via the C-terminal TM anchor,
+   required for stability/function in the ER (structural/enzymatic support role, non-core but real).
+</content>
+</invoke>

--- a/genes/human/HMOX1/HMOX1-uniprot.txt
+++ b/genes/human/HMOX1/HMOX1-uniprot.txt
@@ -1,0 +1,636 @@
+ID   HMOX1_HUMAN             Reviewed;         288 AA.
+AC   P09601;
+DT   01-JUL-1989, integrated into UniProtKB/Swiss-Prot.
+DT   01-JUL-1989, sequence version 1.
+DT   10-JUN-2026, entry version 234.
+DE   RecName: Full=Heme oxygenase 1;
+DE            Short=HO-1;
+DE            EC=1.14.14.18 {ECO:0000269|PubMed:11121422, ECO:0000269|PubMed:19556236, ECO:0000269|PubMed:7703255};
+DE   Contains:
+DE     RecName: Full=Heme oxygenase 1 soluble form {ECO:0000303|PubMed:7703255};
+GN   Name=HMOX1; Synonyms=HO, HO1;
+OS   Homo sapiens (Human).
+OC   Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia;
+OC   Eutheria; Euarchontoglires; Primates; Haplorrhini; Catarrhini; Hominidae;
+OC   Homo.
+OX   NCBI_TaxID=9606;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [MRNA], AND INDUCTION.
+RX   PubMed=3345742; DOI=10.1111/j.1432-1033.1988.tb13811.x;
+RA   Yoshida T., Biro P., Cohen T., Mueller R.M., Shibahara S.;
+RT   "Human heme oxygenase cDNA and induction of its mRNA by hemin.";
+RL   Eur. J. Biochem. 171:457-461(1988).
+RN   [2]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA].
+RX   PubMed=15461802; DOI=10.1186/gb-2004-5-10-r84;
+RA   Collins J.E., Wright C.L., Edwards C.A., Davis M.P., Grinham J.A.,
+RA   Cole C.G., Goward M.E., Aguado B., Mallya M., Mokrab Y., Huckle E.J.,
+RA   Beare D.M., Dunham I.;
+RT   "A genome annotation-driven approach to cloning the human ORFeome.";
+RL   Genome Biol. 5:R84.1-R84.11(2004).
+RN   [3]
+RP   NUCLEOTIDE SEQUENCE [GENOMIC DNA], AND VARIANT HIS-7.
+RG   SeattleSNPs variation discovery resource;
+RL   Submitted (NOV-2003) to the EMBL/GenBank/DDBJ databases.
+RN   [4]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RX   PubMed=10591208; DOI=10.1038/990031;
+RA   Dunham I., Hunt A.R., Collins J.E., Bruskiewich R., Beare D.M., Clamp M.,
+RA   Smink L.J., Ainscough R., Almeida J.P., Babbage A.K., Bagguley C.,
+RA   Bailey J., Barlow K.F., Bates K.N., Beasley O.P., Bird C.P., Blakey S.E.,
+RA   Bridgeman A.M., Buck D., Burgess J., Burrill W.D., Burton J., Carder C.,
+RA   Carter N.P., Chen Y., Clark G., Clegg S.M., Cobley V.E., Cole C.G.,
+RA   Collier R.E., Connor R., Conroy D., Corby N.R., Coville G.J., Cox A.V.,
+RA   Davis J., Dawson E., Dhami P.D., Dockree C., Dodsworth S.J., Durbin R.M.,
+RA   Ellington A.G., Evans K.L., Fey J.M., Fleming K., French L., Garner A.A.,
+RA   Gilbert J.G.R., Goward M.E., Grafham D.V., Griffiths M.N.D., Hall C.,
+RA   Hall R.E., Hall-Tamlyn G., Heathcott R.W., Ho S., Holmes S., Hunt S.E.,
+RA   Jones M.C., Kershaw J., Kimberley A.M., King A., Laird G.K., Langford C.F.,
+RA   Leversha M.A., Lloyd C., Lloyd D.M., Martyn I.D., Mashreghi-Mohammadi M.,
+RA   Matthews L.H., Mccann O.T., Mcclay J., Mclaren S., McMurray A.A.,
+RA   Milne S.A., Mortimore B.J., Odell C.N., Pavitt R., Pearce A.V., Pearson D.,
+RA   Phillimore B.J.C.T., Phillips S.H., Plumb R.W., Ramsay H., Ramsey Y.,
+RA   Rogers L., Ross M.T., Scott C.E., Sehra H.K., Skuce C.D., Smalley S.,
+RA   Smith M.L., Soderlund C., Spragon L., Steward C.A., Sulston J.E.,
+RA   Swann R.M., Vaudin M., Wall M., Wallis J.M., Whiteley M.N., Willey D.L.,
+RA   Williams L., Williams S.A., Williamson H., Wilmer T.E., Wilming L.,
+RA   Wright C.L., Hubbard T., Bentley D.R., Beck S., Rogers J., Shimizu N.,
+RA   Minoshima S., Kawasaki K., Sasaki T., Asakawa S., Kudoh J., Shintani A.,
+RA   Shibuya K., Yoshizaki Y., Aoki N., Mitsuyama S., Roe B.A., Chen F., Chu L.,
+RA   Crabtree J., Deschamps S., Do A., Do T., Dorman A., Fang F., Fu Y., Hu P.,
+RA   Hua A., Kenton S., Lai H., Lao H.I., Lewis J., Lewis S., Lin S.-P., Loh P.,
+RA   Malaj E., Nguyen T., Pan H., Phan S., Qi S., Qian Y., Ray L., Ren Q.,
+RA   Shaull S., Sloan D., Song L., Wang Q., Wang Y., Wang Z., White J.,
+RA   Willingham D., Wu H., Yao Z., Zhan M., Zhang G., Chissoe S., Murray J.,
+RA   Miller N., Minx P., Fulton R., Johnson D., Bemis G., Bentley D.,
+RA   Bradshaw H., Bourne S., Cordes M., Du Z., Fulton L., Goela D., Graves T.,
+RA   Hawkins J., Hinds K., Kemp K., Latreille P., Layman D., Ozersky P.,
+RA   Rohlfing T., Scheet P., Walker C., Wamsley A., Wohldmann P., Pepin K.,
+RA   Nelson J., Korf I., Bedell J.A., Hillier L.W., Mardis E., Waterston R.,
+RA   Wilson R., Emanuel B.S., Shaikh T., Kurahashi H., Saitta S., Budarf M.L.,
+RA   McDermid H.E., Johnson A., Wong A.C.C., Morrow B.E., Edelmann L., Kim U.J.,
+RA   Shizuya H., Simon M.I., Dumanski J.P., Peyrard M., Kedra D., Seroussi E.,
+RA   Fransson I., Tapia I., Bruder C.E., O'Brien K.P., Wilkinson P.,
+RA   Bodenteich A., Hartman K., Hu X., Khan A.S., Lane L., Tilahun Y.,
+RA   Wright H.;
+RT   "The DNA sequence of human chromosome 22.";
+RL   Nature 402:489-495(1999).
+RN   [5]
+RP   NUCLEOTIDE SEQUENCE [MRNA] OF 1-103, AND INDUCTION.
+RC   TISSUE=Foreskin;
+RX   PubMed=2911585; DOI=10.1073/pnas.86.1.99;
+RA   Keyse S.M., Tyrrell R.M.;
+RT   "Heme oxygenase is the major 32-kDa stress protein induced in human skin
+RT   fibroblasts by UVA radiation, hydrogen peroxide, and sodium arsenite.";
+RL   Proc. Natl. Acad. Sci. U.S.A. 86:99-103(1989).
+RN   [6]
+RP   NUCLEOTIDE SEQUENCE [GENOMIC DNA] OF 1-7.
+RX   PubMed=2537723; DOI=10.1111/j.1432-1033.1989.tb14583.x;
+RA   Shibahara S., Sato M., Muller R.M., Yoshida T.;
+RT   "Structural organization of the human heme oxygenase gene and the function
+RT   of its promoter.";
+RL   Eur. J. Biochem. 179:557-563(1989).
+RN   [7]
+RP   FUNCTION, CATALYTIC ACTIVITY, BIOPHYSICOCHEMICAL PROPERTIES, AND
+RP   PROTEOLYTIC CLEAVAGE.
+RX   PubMed=7703255; DOI=10.1021/bi00013a034;
+RA   Wilks A., Black S.M., Miller W.L., Ortiz de Montellano P.R.;
+RT   "Expression and characterization of truncated human heme oxygenase (hHO-1)
+RT   and a fusion protein of hHO-1 with human cytochrome P450 reductase.";
+RL   Biochemistry 34:4421-4427(1995).
+RN   [8]
+RP   INVOLVEMENT IN HMOX1D.
+RX   PubMed=9884342; DOI=10.1172/jci4165;
+RA   Yachie A., Niida Y., Wada T., Igarashi N., Kaneda H., Toma T., Ohta K.,
+RA   Kasahara Y., Koizumi S.;
+RT   "Oxidative stress causes enhanced endothelial cell injury in human heme
+RT   oxygenase-1 deficiency.";
+RL   J. Clin. Invest. 103:129-135(1999).
+RN   [9]
+RP   FUNCTION, CATALYTIC ACTIVITY, MUTAGENESIS OF ASP-140, AND SITE.
+RX   PubMed=11121422; DOI=10.1074/jbc.m010349200;
+RA   Lightning L.K., Huang H., Moenne-Loccoz P., Loehr T.M., Schuller D.J.,
+RA   Poulos T.L., de Montellano P.R.;
+RT   "Disruption of an active site hydrogen bond converts human heme oxygenase-1
+RT   into a peroxidase.";
+RL   J. Biol. Chem. 276:10612-10619(2001).
+RN   [10]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Cervix carcinoma;
+RX   PubMed=17081983; DOI=10.1016/j.cell.2006.09.026;
+RA   Olsen J.V., Blagoev B., Gnad F., Macek B., Kumar C., Mortensen P., Mann M.;
+RT   "Global, in vivo, and site-specific phosphorylation dynamics in signaling
+RT   networks.";
+RL   Cell 127:635-648(2006).
+RN   [11]
+RP   FUNCTION, CATALYTIC ACTIVITY, SUBCELLULAR LOCATION, SUBUNIT, DOMAIN, AND
+RP   MUTAGENESIS OF TRP-270.
+RX   PubMed=19556236; DOI=10.1074/jbc.m109.028001;
+RA   Hwang H.W., Lee J.R., Chou K.Y., Suen C.S., Hwang M.J., Chen C.,
+RA   Shieh R.C., Chau L.Y.;
+RT   "Oligomerization is crucial for the stability and function of heme
+RT   oxygenase-1 in the endoplasmic reticulum.";
+RL   J. Biol. Chem. 284:22672-22679(2009).
+RN   [12]
+RP   REVIEW ON ANTIAPOPTOTIC FUNCTION.
+RX   PubMed=20055707; DOI=10.1146/annurev.pharmtox.010909.105600;
+RA   Gozzelino R., Jeney V., Soares M.P.;
+RT   "Mechanisms of cell protection by heme oxygenase-1.";
+RL   Annu. Rev. Pharmacol. Toxicol. 50:323-354(2010).
+RN   [13]
+RP   TISSUE SPECIFICITY.
+RX   PubMed=20855888; DOI=10.1074/jbc.m110.170324;
+RA   Datta D., Banerjee P., Gasser M., Waaga-Gasser A.M., Pal S.;
+RT   "CXCR3-B can mediate growth-inhibitory signals in human renal cancer cells
+RT   by down-regulating the expression of heme oxygenase-1.";
+RL   J. Biol. Chem. 285:36842-36848(2010).
+RN   [14]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-229, AND IDENTIFICATION BY
+RP   MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Cervix carcinoma;
+RX   PubMed=20068231; DOI=10.1126/scisignal.2000475;
+RA   Olsen J.V., Vermeulen M., Santamaria A., Kumar C., Miller M.L.,
+RA   Jensen L.J., Gnad F., Cox J., Jensen T.S., Nigg E.A., Brunak S., Mann M.;
+RT   "Quantitative phosphoproteomics reveals widespread full phosphorylation
+RT   site occupancy during mitosis.";
+RL   Sci. Signal. 3:RA3-RA3(2010).
+RN   [15]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=21269460; DOI=10.1186/1752-0509-5-17;
+RA   Burkard T.R., Planyavsky M., Kaupe I., Breitwieser F.P., Buerckstuemmer T.,
+RA   Bennett K.L., Superti-Furga G., Colinge J.;
+RT   "Initial characterization of the human central proteome.";
+RL   BMC Syst. Biol. 5:17-17(2011).
+RN   [16]
+RP   SUBCELLULAR LOCATION, AND TOPOLOGY.
+RX   PubMed=22419571; DOI=10.3324/haematol.2012.063651;
+RA   Gottlieb Y., Truman M., Cohen L.A., Leichtmann-Bardoogo Y.,
+RA   Meyron-Holtz E.G.;
+RT   "Endoplasmic reticulum anchored heme-oxygenase 1 faces the cytosol.";
+RL   Haematologica 97:1489-1493(2012).
+RN   [17]
+RP   FUNCTION (MICROBIAL INFECTION), AND INTERACTION WITH SARS-COV-2 ORF3A.
+RX   PubMed=35239449; DOI=10.1080/15548627.2022.2039992;
+RA   Zhang X., Yang Z., Pan T., Long X., Sun Q., Wang P.H., Li X., Kuang E.;
+RT   "SARS-CoV-2 ORF3a induces RETREG1/FAM134B-dependent reticulophagy and
+RT   triggers sequential ER stress and inflammatory responses during SARS-CoV-2
+RT   infection.";
+RL   Autophagy 0:0-0(2022).
+RN   [18]
+RP   SUBCELLULAR LOCATION.
+RX   PubMed=27184847; DOI=10.1016/j.celrep.2016.04.064;
+RA   Lee S.Y., Kang M.G., Park J.S., Lee G., Ting A.Y., Rhee H.W.;
+RT   "APEX Fingerprinting Reveals the Subcellular Localization of Proteins of
+RT   Interest.";
+RL   Cell Rep. 15:1837-1847(2016).
+RN   [19]
+RP   X-RAY CRYSTALLOGRAPHY (2.08 ANGSTROMS).
+RX   PubMed=10467099; DOI=10.1038/12319;
+RA   Schuller D.J., Wilks A., Ortiz de Montellano P.R., Poulos T.L.;
+RT   "Crystal structure of human heme oxygenase-1.";
+RL   Nat. Struct. Biol. 6:860-867(1999).
+RN   [20]
+RP   X-RAY CRYSTALLOGRAPHY (1.55 ANGSTROMS) OF 1-233 OF MUTANT ALA-140,
+RP   HEME-BINDING SITES, AND MUTAGENESIS OF ASP-140.
+RX   PubMed=12842469; DOI=10.1016/s0022-2836(03)00578-3;
+RA   Lad L., Wang J., Li H., Friedman J., Bhaskar B., Ortiz de Montellano P.R.,
+RA   Poulos T.L.;
+RT   "Crystal structures of the ferric, ferrous, and ferrous-NO forms of the
+RT   Asp140Ala mutant of human heme oxygenase-1: catalytic implications.";
+RL   J. Mol. Biol. 330:527-538(2003).
+CC   -!- FUNCTION: [Heme oxygenase 1]: Catalyzes the oxidative cleavage of heme
+CC       at the alpha-methene bridge carbon, released as carbon monoxide (CO),
+CC       to generate biliverdin IXalpha, while releasing the central heme iron
+CC       chelate as ferrous iron (PubMed:11121422, PubMed:19556236,
+CC       PubMed:7703255). Affords protection against programmed cell death and
+CC       this cytoprotective effect relies on its ability to catabolize free
+CC       heme and prevent it from sensitizing cells to undergo apoptosis
+CC       (PubMed:20055707). {ECO:0000269|PubMed:11121422,
+CC       ECO:0000269|PubMed:19556236, ECO:0000269|PubMed:7703255,
+CC       ECO:0000303|PubMed:20055707}.
+CC   -!- FUNCTION: [Heme oxygenase 1]: (Microbial infection) During SARS-COV-2
+CC       infection, promotes SARS-CoV-2 ORF3A-mediated autophagy but is unlikely
+CC       to be required for ORF3A-mediated induction of reticulophagy.
+CC       {ECO:0000269|PubMed:35239449}.
+CC   -!- FUNCTION: [Heme oxygenase 1 soluble form]: Catalyzes the oxidative
+CC       cleavage of heme at the alpha-methene bridge carbon, released as carbon
+CC       monoxide (CO), to generate biliverdin IXalpha, while releasing the
+CC       central heme iron chelate as ferrous iron.
+CC       {ECO:0000269|PubMed:7703255}.
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=heme b + 3 reduced [NADPH--hemoprotein reductase] + 3 O2 =
+CC         biliverdin IXalpha + CO + Fe(2+) + 3 oxidized [NADPH--hemoprotein
+CC         reductase] + 3 H2O + H(+); Xref=Rhea:RHEA:21764, Rhea:RHEA-
+CC         COMP:11964, Rhea:RHEA-COMP:11965, ChEBI:CHEBI:15377,
+CC         ChEBI:CHEBI:15378, ChEBI:CHEBI:15379, ChEBI:CHEBI:17245,
+CC         ChEBI:CHEBI:29033, ChEBI:CHEBI:57618, ChEBI:CHEBI:57991,
+CC         ChEBI:CHEBI:58210, ChEBI:CHEBI:60344; EC=1.14.14.18;
+CC         Evidence={ECO:0000269|PubMed:11121422, ECO:0000269|PubMed:19556236,
+CC         ECO:0000269|PubMed:7703255};
+CC       PhysiologicalDirection=left-to-right; Xref=Rhea:RHEA:21765;
+CC         Evidence={ECO:0000305|PubMed:7703255};
+CC   -!- BIOPHYSICOCHEMICAL PROPERTIES: [Heme oxygenase 1]:
+CC       Kinetic parameters:
+CC         KM=6 uM for heme b {ECO:0000269|PubMed:7703255};
+CC         Vmax=102 nmol/h/mg enzyme for heme b {ECO:0000269|PubMed:7703255};
+CC   -!- BIOPHYSICOCHEMICAL PROPERTIES: [Heme oxygenase 1 soluble form]:
+CC       Kinetic parameters:
+CC         KM=3 uM for heme b {ECO:0000269|PubMed:7703255};
+CC         Vmax=40 nmol/h/mg enzyme for heme b {ECO:0000269|PubMed:7703255};
+CC   -!- SUBUNIT: (Microbial infection) Interacts with SARS-CoV-2 ORF3A protein;
+CC       the interaction promotes ORF3A-induced autophagy but is unlikely to be
+CC       involved in ORF3A-mediated induction of reticulophagy.
+CC       {ECO:0000269|PubMed:35239449}.
+CC   -!- SUBUNIT: Homodimer and higher order homooligomer (PubMed:19556236).
+CC       Oligomerization is crucial for its stability and function in the
+CC       endoplasmic reticulum (PubMed:19556236). Interacts with FLVCR2; this
+CC       interaction is potentiated in the presence of heme.
+CC       {ECO:0000250|UniProtKB:P14901, ECO:0000269|PubMed:19556236}.
+CC   -!- INTERACTION:
+CC       P09601; Q13520: AQP6; NbExp=3; IntAct=EBI-2806151, EBI-13059134;
+CC       P09601; Q3SXY8: ARL13B; NbExp=3; IntAct=EBI-2806151, EBI-11343438;
+CC       P09601; P11912: CD79A; NbExp=3; IntAct=EBI-2806151, EBI-7797864;
+CC       P09601; O75208: COQ9; NbExp=3; IntAct=EBI-2806151, EBI-724524;
+CC       P09601; Q7Z7G2: CPLX4; NbExp=3; IntAct=EBI-2806151, EBI-18013275;
+CC       P09601; Q9BUF7-2: CRB3; NbExp=3; IntAct=EBI-2806151, EBI-17233035;
+CC       P09601; P49447: CYB561; NbExp=3; IntAct=EBI-2806151, EBI-8646596;
+CC       P09601; Q53TN4: CYBRD1; NbExp=3; IntAct=EBI-2806151, EBI-8637742;
+CC       P09601; Q9GZR5: ELOVL4; NbExp=3; IntAct=EBI-2806151, EBI-18535450;
+CC       P09601; Q9NYP7: ELOVL5; NbExp=3; IntAct=EBI-2806151, EBI-11037623;
+CC       P09601; Q9H5J4: ELOVL6; NbExp=3; IntAct=EBI-2806151, EBI-12821617;
+CC       P09601; Q9Y282: ERGIC3; NbExp=3; IntAct=EBI-2806151, EBI-781551;
+CC       P09601; Q8TBP5: FAM174A; NbExp=3; IntAct=EBI-2806151, EBI-18636064;
+CC       P09601; Q5JX71: FAM209A; NbExp=3; IntAct=EBI-2806151, EBI-18304435;
+CC       P09601; Q96KR6: FAM210B; NbExp=3; IntAct=EBI-2806151, EBI-18938272;
+CC       P09601; Q8TDT2: GPR152; NbExp=3; IntAct=EBI-2806151, EBI-13345167;
+CC       P09601; Q8N5M9: JAGN1; NbExp=3; IntAct=EBI-2806151, EBI-10266796;
+CC       P09601; Q15800: MSMO1; NbExp=3; IntAct=EBI-2806151, EBI-949102;
+CC       P09601; Q13113: PDZK1IP1; NbExp=3; IntAct=EBI-2806151, EBI-716063;
+CC       P09601; Q9NUX5: POT1; NbExp=2; IntAct=EBI-2806151, EBI-752420;
+CC       P09601; Q9BY50: SEC11C; NbExp=3; IntAct=EBI-2806151, EBI-2855401;
+CC       P09601; O60669: SLC16A7; NbExp=3; IntAct=EBI-2806151, EBI-3921243;
+CC       P09601; Q16623: STX1A; NbExp=4; IntAct=EBI-2806151, EBI-712466;
+CC       P09601; Q96MV1: TLCD4; NbExp=3; IntAct=EBI-2806151, EBI-12947623;
+CC       P09601; Q96DZ7: TM4SF19; NbExp=3; IntAct=EBI-2806151, EBI-6448756;
+CC       P09601; Q9NUH8: TMEM14B; NbExp=3; IntAct=EBI-2806151, EBI-8638294;
+CC       P09601; P0DTC3: 3a; Xeno; NbExp=4; IntAct=EBI-2806151, EBI-25475894;
+CC   -!- SUBCELLULAR LOCATION: Endoplasmic reticulum membrane
+CC       {ECO:0000269|PubMed:19556236, ECO:0000269|PubMed:22419571,
+CC       ECO:0000269|PubMed:27184847}; Single-pass type IV membrane protein
+CC       {ECO:0000255}; Cytoplasmic side {ECO:0000269|PubMed:22419571}.
+CC   -!- TISSUE SPECIFICITY: Expressed at higher levels in renal cancer tissue
+CC       than in normal tissue (at protein level).
+CC       {ECO:0000269|PubMed:20855888}.
+CC   -!- INDUCTION: Heme oxygenase 1 activity is highly inducible by its
+CC       substrate heme and by various non-heme substances such as heavy metals,
+CC       bromobenzene, endotoxin, oxidizing agents and UVA.
+CC       {ECO:0000269|PubMed:2911585, ECO:0000269|PubMed:3345742}.
+CC   -!- DOMAIN: The transmembrane domain is necessary for its oligomerization.
+CC       {ECO:0000269|PubMed:19556236}.
+CC   -!- PTM: A soluble form arises by proteolytic removal of the membrane
+CC       anchor. {ECO:0000305|PubMed:7703255}.
+CC   -!- DISEASE: Heme oxygenase 1 deficiency (HMOX1D) [MIM:614034]: A disease
+CC       characterized by impaired stress hematopoiesis, resulting in marked
+CC       erythrocyte fragmentation and intravascular hemolysis, coagulation
+CC       abnormalities, endothelial damage, and iron deposition in renal and
+CC       hepatic tissues. Clinical features include persistent hemolytic anemia,
+CC       asplenia, nephritis, generalized erythematous rash, growth retardation
+CC       and hepatomegaly. {ECO:0000269|PubMed:9884342}. Note=The disease is
+CC       caused by variants affecting the gene represented in this entry.
+CC   -!- SIMILARITY: Belongs to the heme oxygenase family. {ECO:0000305}.
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; X06985; CAA30045.1; -; mRNA.
+DR   EMBL; CR456505; CAG30391.1; -; mRNA.
+DR   EMBL; AY460337; AAR23262.1; -; Genomic_DNA.
+DR   EMBL; Z82244; -; NOT_ANNOTATED_CDS; Genomic_DNA.
+DR   EMBL; M23041; AAA50403.1; -; mRNA.
+DR   EMBL; X14782; CAA32886.1; -; Genomic_DNA.
+DR   CCDS; CCDS13914.1; -.
+DR   PIR; S00325; S00325.
+DR   RefSeq; NP_002124.1; NM_002133.3.
+DR   PDB; 1N3U; X-ray; 2.58 A; A/B=1-233.
+DR   PDB; 1N45; X-ray; 1.50 A; A/B=1-233.
+DR   PDB; 1NI6; X-ray; 2.10 A; A/B/C/D=1-224.
+DR   PDB; 1OYK; X-ray; 2.59 A; A/B=1-233.
+DR   PDB; 1OYL; X-ray; 1.59 A; A/B=1-233.
+DR   PDB; 1OZE; X-ray; 2.19 A; A/B=1-233.
+DR   PDB; 1OZL; X-ray; 1.58 A; A/B=1-233.
+DR   PDB; 1OZR; X-ray; 1.74 A; A/B=1-233.
+DR   PDB; 1OZW; X-ray; 1.55 A; A/B=1-233.
+DR   PDB; 1S13; X-ray; 2.29 A; A/B=1-233.
+DR   PDB; 1S8C; X-ray; 2.19 A; A/B/C/D=1-233.
+DR   PDB; 1T5P; X-ray; 2.11 A; A/B=1-233.
+DR   PDB; 1TWN; X-ray; 2.20 A; A/B=1-233.
+DR   PDB; 1TWR; X-ray; 2.10 A; A/B=1-233.
+DR   PDB; 1XJZ; X-ray; 1.88 A; A/B=1-233.
+DR   PDB; 1XK0; X-ray; 2.18 A; A/B=1-233.
+DR   PDB; 1XK1; X-ray; 2.08 A; A/B=1-233.
+DR   PDB; 1XK2; X-ray; 2.20 A; A/B=1-233.
+DR   PDB; 1XK3; X-ray; 2.08 A; A/B=1-233.
+DR   PDB; 3CZY; X-ray; 1.54 A; A/B=1-233.
+DR   PDB; 3HOK; X-ray; 2.19 A; A/B=1-233.
+DR   PDB; 3K4F; X-ray; 2.17 A; A/B=1-233.
+DR   PDB; 3TGM; X-ray; 2.85 A; A/B=1-233.
+DR   PDB; 4WD4; X-ray; 2.95 A; A/B/C/D=1-288.
+DR   PDB; 5BTQ; X-ray; 2.08 A; A/B=1-233.
+DR   PDB; 6EHA; X-ray; 2.00 A; A/B=1-288.
+DR   PDBsum; 1N3U; -.
+DR   PDBsum; 1N45; -.
+DR   PDBsum; 1NI6; -.
+DR   PDBsum; 1OYK; -.
+DR   PDBsum; 1OYL; -.
+DR   PDBsum; 1OZE; -.
+DR   PDBsum; 1OZL; -.
+DR   PDBsum; 1OZR; -.
+DR   PDBsum; 1OZW; -.
+DR   PDBsum; 1S13; -.
+DR   PDBsum; 1S8C; -.
+DR   PDBsum; 1T5P; -.
+DR   PDBsum; 1TWN; -.
+DR   PDBsum; 1TWR; -.
+DR   PDBsum; 1XJZ; -.
+DR   PDBsum; 1XK0; -.
+DR   PDBsum; 1XK1; -.
+DR   PDBsum; 1XK2; -.
+DR   PDBsum; 1XK3; -.
+DR   PDBsum; 3CZY; -.
+DR   PDBsum; 3HOK; -.
+DR   PDBsum; 3K4F; -.
+DR   PDBsum; 3TGM; -.
+DR   PDBsum; 4WD4; -.
+DR   PDBsum; 5BTQ; -.
+DR   PDBsum; 6EHA; -.
+DR   AlphaFoldDB; P09601; -.
+DR   SMR; P09601; -.
+DR   BioGRID; 109405; 168.
+DR   FunCoup; P09601; 791.
+DR   IntAct; P09601; 126.
+DR   MINT; P09601; -.
+DR   NDEx; IQUERY-CP-HMOX1; 24 NDEx IQuery Curated Pathways.
+DR   STRING; 9606.ENSP00000216117; -.
+DR   BindingDB; P09601; -.
+DR   ChEMBL; CHEMBL2823; -.
+DR   DrugBank; DB07342; 1-(adamantan-1-yl)-2-(1H-imidazol-1-yl)ethanone.
+DR   DrugBank; DB06914; 1-({2-[2-(4-CHLOROPHENYL)ETHYL]-1,3-DIOXOLAN-2-YL}METHYL)-1H-IMIDAZOLE.
+DR   DrugBank; DB02468; 12-Phenylheme.
+DR   DrugBank; DB03906; 2-Phenylheme.
+DR   DrugBank; DB14001; alpha-Tocopherol succinate.
+DR   DrugBank; DB02073; Biliverdine IX Alpha.
+DR   DrugBank; DB14002; D-alpha-Tocopherol acetate.
+DR   DrugBank; DB18267; Ferroheme.
+DR   DrugBank; DB01942; Formic acid.
+DR   DrugBank; DB02325; Isopropyl alcohol.
+DR   DrugBank; DB00157; NADH.
+DR   DrugBank; DB09221; Polaprezinc.
+DR   DrugBank; DB04912; Stannsoporfin.
+DR   DrugBank; DB04803; Verdoheme.
+DR   DrugBank; DB00163; Vitamin E.
+DR   GuidetoPHARMACOLOGY; 1441; -.
+DR   TCDB; 8.A.252.1.1; the heme oxidase (ho) family.
+DR   GlyGen; P09601; 1 site, 1 O-linked glycan (1 site).
+DR   iPTMnet; P09601; -.
+DR   PhosphoSitePlus; P09601; -.
+DR   BioMuta; HMOX1; -.
+DR   DMDM; 123446; -.
+DR   jPOST; P09601; -.
+DR   MassIVE; P09601; -.
+DR   PaxDb; 9606-ENSP00000216117; -.
+DR   PeptideAtlas; P09601; -.
+DR   ProteomicsDB; 52249; -.
+DR   Pumba; P09601; -.
+DR   Antibodypedia; 266; 1113 antibodies from 47 providers.
+DR   DNASU; 3162; -.
+DR   Ensembl; ENST00000216117.9; ENSP00000216117.8; ENSG00000100292.18.
+DR   GeneID; 3162; -.
+DR   KEGG; hsa:3162; -.
+DR   MANE-Select; ENST00000216117.9; ENSP00000216117.8; NM_002133.3; NP_002124.1.
+DR   AGR; HGNC:5013; -.
+DR   CIViC; 3162; 1 evidence item across 2 molecular profiles.
+DR   ClinPGx; PA29341; -.
+DR   CTD; 3162; -.
+DR   DisGeNET; 3162; -.
+DR   GeneCards; HMOX1; -.
+DR   HGNC; HGNC:5013; HMOX1.
+DR   HPA; ENSG00000100292; Tissue enriched (lymphoid).
+DR   MalaCards; HMOX1; -.
+DR   MIM; 141250; gene.
+DR   MIM; 614034; phenotype.
+DR   OpenTargets; ENSG00000100292; -.
+DR   Orphanet; 586; Cystic fibrosis.
+DR   Orphanet; 562509; Heme oxygenase-1 deficiency.
+DR   VEuPathDB; HostDB:ENSG00000100292; -.
+DR   eggNOG; KOG4480; Eukaryota.
+DR   GeneTree; ENSGT00390000017673; -.
+DR   HOGENOM; CLU_057050_0_0_1; -.
+DR   InParanoid; P09601; -.
+DR   OMA; TEQLWFV; -.
+DR   OrthoDB; 652091at2759; -.
+DR   PAN-GO; P09601; 7 GO annotations based on evolutionary models.
+DR   PhylomeDB; P09601; -.
+DR   BioCyc; MetaCyc:HS02027-MONOMER; -.
+DR   BRENDA; 1.14.14.18; 2681.
+DR   PathwayCommons; P09601; -.
+DR   Reactome; R-HSA-189483; Heme degradation.
+DR   Reactome; R-HSA-6785807; Interleukin-4 and Interleukin-13 signaling.
+DR   Reactome; R-HSA-844456; The NLRP3 inflammasome.
+DR   Reactome; R-HSA-917937; Iron uptake and transport.
+DR   Reactome; R-HSA-9609523; Insertion of tail-anchored proteins into the endoplasmic reticulum membrane.
+DR   Reactome; R-HSA-9660826; Purinergic signaling in leishmaniasis infection.
+DR   Reactome; R-HSA-9707564; Cytoprotection by HMOX1.
+DR   Reactome; R-HSA-9707587; Regulation of HMOX1 expression and activity.
+DR   Reactome; R-HSA-9707616; Heme signaling.
+DR   Reactome; R-HSA-9818027; NFE2L2 regulating anti-oxidant/detoxification enzymes.
+DR   SignaLink; P09601; -.
+DR   SIGNOR; P09601; -.
+DR   Agora; ENSG00000100292; -.
+DR   BioGRID-ORCS; 3162; 17 hits in 1173 CRISPR screens.
+DR   ChiTaRS; HMOX1; human.
+DR   EvolutionaryTrace; P09601; -.
+DR   GeneWiki; HMOX1; -.
+DR   GenomeRNAi; 3162; -.
+DR   Pharos; P09601; Tchem.
+DR   PRO; PR:P09601; -.
+DR   Proteomes; UP000005640; Chromosome 22.
+DR   RNAct; P09601; protein.
+DR   Bgee; ENSG00000100292; Expressed in cartilage tissue and 147 other cell types or tissues.
+DR   ExpressionAtlas; P09601; baseline and differential.
+DR   GO; GO:0005829; C:cytosol; TAS:Reactome.
+DR   GO; GO:0005783; C:endoplasmic reticulum; IDA:UniProtKB.
+DR   GO; GO:0005789; C:endoplasmic reticulum membrane; IDA:UniProtKB.
+DR   GO; GO:0005615; C:extracellular space; TAS:BHF-UCL.
+DR   GO; GO:0016020; C:membrane; TAS:ProtInc.
+DR   GO; GO:0005741; C:mitochondrial outer membrane; TAS:Reactome.
+DR   GO; GO:0005654; C:nucleoplasm; TAS:Reactome.
+DR   GO; GO:0005634; C:nucleus; ISS:BHF-UCL.
+DR   GO; GO:0048471; C:perinuclear region of cytoplasm; IDA:UniProtKB.
+DR   GO; GO:0005886; C:plasma membrane; IBA:GO_Central.
+DR   GO; GO:0019899; F:enzyme binding; ISS:BHF-UCL.
+DR   GO; GO:0020037; F:heme binding; IDA:BHF-UCL.
+DR   GO; GO:0004392; F:heme oxygenase (decyclizing) activity; IDA:UniProtKB.
+DR   GO; GO:0042802; F:identical protein binding; IPI:UniProtKB.
+DR   GO; GO:0046872; F:metal ion binding; IEA:UniProtKB-KW.
+DR   GO; GO:0042803; F:protein homodimerization activity; IDA:UniProtKB.
+DR   GO; GO:0005198; F:structural molecule activity; IMP:UniProtKB.
+DR   GO; GO:0001525; P:angiogenesis; TAS:BHF-UCL.
+DR   GO; GO:0006915; P:apoptotic process; IEA:UniProtKB-KW.
+DR   GO; GO:0034605; P:cellular response to heat; IMP:UniProtKB.
+DR   GO; GO:0001935; P:endothelial cell proliferation; TAS:BHF-UCL.
+DR   GO; GO:0034101; P:erythrocyte homeostasis; IMP:BHF-UCL.
+DR   GO; GO:0042167; P:heme catabolic process; IDA:BHF-UCL.
+DR   GO; GO:0006788; P:heme oxidation; IDA:BHF-UCL.
+DR   GO; GO:0006879; P:intracellular iron ion homeostasis; IDA:BHF-UCL.
+DR   GO; GO:0035556; P:intracellular signal transduction; TAS:BHF-UCL.
+DR   GO; GO:0034383; P:low-density lipoprotein particle clearance; TAS:BHF-UCL.
+DR   GO; GO:0060586; P:multicellular organismal-level iron ion homeostasis; IMP:BHF-UCL.
+DR   GO; GO:1900016; P:negative regulation of cytokine production involved in inflammatory response; IEA:Ensembl.
+DR   GO; GO:1902042; P:negative regulation of extrinsic apoptotic signaling pathway via death domain receptors; IMP:BHF-UCL.
+DR   GO; GO:0110076; P:negative regulation of ferroptosis; IMP:UniProtKB.
+DR   GO; GO:0002686; P:negative regulation of leukocyte migration; TAS:BHF-UCL.
+DR   GO; GO:0048662; P:negative regulation of smooth muscle cell proliferation; IDA:UniProtKB.
+DR   GO; GO:0045766; P:positive regulation of angiogenesis; IDA:BHF-UCL.
+DR   GO; GO:1903589; P:positive regulation of blood vessel endothelial cell proliferation involved in sprouting angiogenesis; IGI:BHF-UCL.
+DR   GO; GO:0043123; P:positive regulation of canonical NF-kappaB signal transduction; HMP:UniProtKB.
+DR   GO; GO:0090050; P:positive regulation of cell migration involved in sprouting angiogenesis; IGI:BHF-UCL.
+DR   GO; GO:0032722; P:positive regulation of chemokine production; TAS:BHF-UCL.
+DR   GO; GO:0048661; P:positive regulation of smooth muscle cell proliferation; IDA:UniProtKB.
+DR   GO; GO:0045765; P:regulation of angiogenesis; TAS:BHF-UCL.
+DR   GO; GO:0006357; P:regulation of transcription by RNA polymerase II; ISS:BHF-UCL.
+DR   GO; GO:0042542; P:response to hydrogen peroxide; ISS:BHF-UCL.
+DR   GO; GO:0035094; P:response to nicotine; IDA:BHF-UCL.
+DR   GO; GO:0006979; P:response to oxidative stress; IMP:BHF-UCL.
+DR   GO; GO:0014806; P:smooth muscle hyperplasia; TAS:BHF-UCL.
+DR   GO; GO:0002246; P:wound healing involved in inflammatory response; IMP:BHF-UCL.
+DR   CDD; cd00232; HemeO-like; 1.
+DR   FunFam; 1.20.910.10:FF:000001; Heme oxygenase 1; 1.
+DR   Gene3D; 1.20.910.10; Heme oxygenase-like; 1.
+DR   InterPro; IPR002051; Haem_Oase.
+DR   InterPro; IPR016053; Haem_Oase-like.
+DR   InterPro; IPR016084; Haem_Oase-like_multi-hlx.
+DR   InterPro; IPR018207; Haem_oxygenase_CS.
+DR   PANTHER; PTHR10720; HEME OXYGENASE; 1.
+DR   PANTHER; PTHR10720:SF1; HEME OXYGENASE 1; 1.
+DR   Pfam; PF01126; Heme_oxygenase; 1.
+DR   PIRSF; PIRSF000343; Haem_Oase; 1.
+DR   PRINTS; PR00088; HAEMOXYGNASE.
+DR   SUPFAM; SSF48613; Heme oxygenase-like; 1.
+DR   PROSITE; PS00593; HEME_OXYGENASE; 1.
+PE   1: Evidence at protein level;
+KW   3D-structure; Apoptosis; Endoplasmic reticulum; Heme;
+KW   Host-virus interaction; Iron; Membrane; Metal-binding; Oxidoreductase;
+KW   Phosphoprotein; Proteomics identification; Reference proteome;
+KW   Transmembrane; Transmembrane helix.
+FT   CHAIN           1..288
+FT                   /note="Heme oxygenase 1"
+FT                   /id="PRO_0000209687"
+FT   CHAIN           1..265
+FT                   /note="Heme oxygenase 1 soluble form"
+FT                   /evidence="ECO:0000305|PubMed:7703255"
+FT                   /id="PRO_0000455621"
+FT   TOPO_DOM        1..265
+FT                   /note="Cytoplasmic"
+FT                   /evidence="ECO:0000305|PubMed:22419571"
+FT   TRANSMEM        266..288
+FT                   /note="Helical; Anchor for type IV membrane protein"
+FT                   /evidence="ECO:0000255"
+FT   REGION          223..260
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   BINDING         18
+FT                   /ligand="heme b"
+FT                   /ligand_id="ChEBI:CHEBI:60344"
+FT                   /evidence="ECO:0000269|PubMed:12842469,
+FT                   ECO:0007744|PDB:1OZW"
+FT   BINDING         25
+FT                   /ligand="heme b"
+FT                   /ligand_id="ChEBI:CHEBI:60344"
+FT                   /ligand_part="Fe"
+FT                   /ligand_part_id="ChEBI:CHEBI:18248"
+FT                   /note="axial binding residue"
+FT                   /evidence="ECO:0000269|PubMed:12842469,
+FT                   ECO:0007744|PDB:1OZW"
+FT   BINDING         134
+FT                   /ligand="heme b"
+FT                   /ligand_id="ChEBI:CHEBI:60344"
+FT                   /evidence="ECO:0000269|PubMed:12842469,
+FT                   ECO:0007744|PDB:1OZW"
+FT   BINDING         183
+FT                   /ligand="heme b"
+FT                   /ligand_id="ChEBI:CHEBI:60344"
+FT                   /evidence="ECO:0000269|PubMed:12842469,
+FT                   ECO:0007744|PDB:1OZW"
+FT   SITE            140
+FT                   /note="Important for catalytic activity"
+FT                   /evidence="ECO:0000269|PubMed:11121422"
+FT   MOD_RES         229
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:20068231"
+FT   VARIANT         7
+FT                   /note="D -> H (in dbSNP:rs2071747)"
+FT                   /evidence="ECO:0000269|Ref.3"
+FT                   /id="VAR_019165"
+FT   VARIANT         106
+FT                   /note="P -> L (in dbSNP:rs9282702)"
+FT                   /id="VAR_022156"
+FT   MUTAGEN         140
+FT                   /note="D->A,H,N,F,L: Inactive as a heme oxygenase but
+FT                   active as a peroxidase."
+FT                   /evidence="ECO:0000269|PubMed:11121422,
+FT                   ECO:0000269|PubMed:12842469"
+FT   MUTAGEN         270
+FT                   /note="W->A: No effect on catalytic activity,
+FT                   oligomerization and localization to the endoplasmic
+FT                   reticulum."
+FT                   /evidence="ECO:0000269|PubMed:19556236"
+FT   MUTAGEN         270
+FT                   /note="W->N: Significant reduction in catalytic activity,
+FT                   reduced oligomerization, reduced endoplasmic reticulum
+FT                   localization with cytoplasmic mislocalization."
+FT                   /evidence="ECO:0000269|PubMed:19556236"
+FT   HELIX           6..8
+FT                   /evidence="ECO:0007829|PDB:1NI6"
+FT   HELIX           13..20
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           22..30
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           32..38
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           44..68
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   TURN            72..74
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           75..77
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           80..83
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           86..97
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           101..103
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           109..124
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           126..128
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           129..133
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           134..138
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           139..155
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   STRAND          159..161
+FT                   /evidence="ECO:0007829|PDB:3CZY"
+FT   HELIX           165..167
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           175..188
+FT                   /evidence="ECO:0007829|PDB:1N45"
+FT   HELIX           193..220
+FT                   /evidence="ECO:0007829|PDB:1N45"
+SQ   SEQUENCE   288 AA;  32819 MW;  AB47827778694064 CRC64;
+     MERPQPDSMP QDLSEALKEA TKEVHTQAEN AEFMRNFQKG QVTRDGFKLV MASLYHIYVA
+     LEEEIERNKE SPVFAPVYFP EELHRKAALE QDLAFWYGPR WQEVIPYTPA MQRYVKRLHE
+     VGRTEPELLV AHAYTRYLGD LSGGQVLKKI AQKALDLPSS GEGLAFFTFP NIASATKFKQ
+     LYRSRMNSLE MTPAVRQRVI EEAKTAFLLN IQLFEELQEL LTHDTKDQSP SRAPGLRQRA
+     SNKVQDSAPV ETPRGKPPLN TRSQAPLLRW VLTLSFLVAT VAVGLYAM
+//

--- a/genes/human/HMOX2/HMOX2-ai-review.yaml
+++ b/genes/human/HMOX2/HMOX2-ai-review.yaml
@@ -1,0 +1,638 @@
+id: P30519
+gene_symbol: HMOX2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: >-
+  HMOX2 encodes heme oxygenase 2 (HO-2), the constitutively expressed heme
+  oxygenase isozyme (in contrast to the stress-inducible HMOX1/HO-1) and the
+  predominant heme oxygenase in brain, testis and vascular endothelium. HO-2 is
+  a single-pass endoplasmic reticulum (microsomal) membrane protein anchored by a
+  C-terminal type IV transmembrane helix, with its catalytic domain on the
+  cytoplasmic face. It catalyzes the oxidative cleavage of heme b at the
+  alpha-methene bridge carbon, using molecular O2 and reducing equivalents from
+  NADPH--cytochrome P450 (hemoprotein) reductase, to yield biliverdin IXalpha,
+  carbon monoxide (CO) and free ferrous iron (Fe2+); it thereby provides
+  constitutive heme turnover and is a major physiological source of endogenous CO.
+  HO-2 binds one heme b as substrate through an axial histidine and additional
+  heme contacts. Distinctive from HO-1, HO-2 carries C-terminal heme-regulatory
+  Cys-Pro motifs (HRMs) and participates in oxygen sensing: HO-2-derived CO
+  modulates large-conductance calcium-activated (BK) potassium channels, a
+  mechanism important in carotid body and neuronal responses to hypoxia. The
+  enzyme is inhibited by metalloporphyrins such as Sn- and Zn-protoporphyrin.
+alternative_products:
+- name: '1'
+  id: P30519-1
+- name: '2'
+  id: P30519-2
+  sequence_note: VSP_055031
+existing_annotations:
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: >-
+      Core molecular function. HO-2 is a heme oxygenase that oxidatively cleaves heme;
+      the phylogenetic (IBA) inference is fully consistent with direct biochemical
+      evidence for the human enzyme.
+    action: ACCEPT
+    reason: >-
+      Heme oxygenase (decyclizing) activity is the defining catalytic function of HO-2 and
+      is supported directly by IDA evidence (PMID:7890772, PMID:1575508) in addition to the
+      family-level IBA inference across HMOX orthologs.
+    supported_by:
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Catalyzes the oxidative cleavage of heme
+    - reference_id: PMID:7890772
+      supporting_text: enzymatic activity for conversion of heme to biliverdin
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: >-
+      Plasma-membrane localization is over-general relative to the ER-membrane core; HO-2 is
+      detected at the plasma membrane mainly in the BK-channel/O2-sensing context.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      HO-2 is an ER/microsomal membrane enzyme (its authoritative core location). Plasma-membrane
+      residence reflects recruitment into the BK potassium channel complex (PMID:15528406) in a
+      heterologous system rather than a generic constitutive plasma-membrane location; the IBA
+      is_active_in plasma membrane row over-states this. Not removed (family-supported IBA), but
+      flagged as over-annotated relative to the ER core.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      - CONTEXT_OR_TISSUE_MISMATCH
+      source_entities:
+      - source_id: UniProtKB:P30519
+        source_label: HMOX2 (human)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: HO-2 plasma-membrane detection is specific to the BK-channel/O2-sensing complex context (PMID:15528406), not a constitutive plasma-membrane residence; the enzyme's catalytic location is the ER membrane.
+      - source_id: RGD:2806
+        source_label: Hmox2 (rat)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Rodent ortholog contributes the is_active_in plasma membrane IBA seed, but the general plasma-membrane scoping over-states HO-2's ER-membrane core location.
+    supported_by:
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+    - reference_id: PMID:15528406
+      supporting_text: is part of the BK channel complex and
+- term:
+    id: GO:0006979
+    label: response to oxidative stress
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: >-
+      Plausible family-level role, but antioxidant/oxidative-stress response is primarily an HO-1
+      (inducible) function; retained as non-core for HO-2.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Response to oxidative stress is a well-established role of the inducible paralog HMOX1; the IBA
+      transfer to constitutive HO-2 is reasonable (heme/CO/biliverdin chemistry has antioxidant
+      consequences) but is secondary to HO-2's constitutive heme-catabolic and CO-producing core.
+      Kept as a non-core biological-process context.
+    supported_by:
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Catalyzes the oxidative cleavage of heme
+- term:
+    id: GO:0020037
+    label: heme binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: >-
+      Core molecular function. HO-2 binds one heme b as substrate via an axial histidine; supported
+      by biochemistry and crystallography of the human enzyme.
+    action: ACCEPT
+    reason: >-
+      Heme binding is required for HO-2 catalysis and is directly demonstrated: the purified human
+      HO-2 fragment bound one equivalent of heme with a histidine proximal ligand (PMID:7890772), and
+      the crystal structure defined the heme-binding residues (His45 axial; UniProt BINDING features).
+    supported_by:
+    - reference_id: PMID:7890772
+      supporting_text: bound one equivalent of heme to form a
+    - reference_id: PMID:7890772
+      supporting_text: appears to be similar to that of heme oxygenase-1
+- term:
+    id: GO:0042167
+    label: heme catabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core biological process. HO-2 degrades heme constitutively; heme catabolic process is the
+      pathway-level counterpart of its enzymatic activity.
+    action: ACCEPT
+    reason: >-
+      Heme catabolism is the biological process HO-2 carries out; the constitutive (non-inducible)
+      HO-2 contributes to endogenous heme turnover and CO production.
+    supported_by:
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: at the alpha-methene bridge carbon, released as carbon monoxide (CO),
+    - reference_id: PMID:7890772
+      supporting_text: enzymatic activity for conversion of heme to biliverdin
+- term:
+    id: GO:0006788
+    label: heme oxidation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core biological process. Heme oxidation is the mechanistic sub-step of HO-2-mediated heme
+      cleavage.
+    action: ACCEPT
+    reason: >-
+      HO-2 oxidizes heme (using O2 and reductase-supplied electrons) as the first committed step of
+      heme ring cleavage; this term directly reflects the enzyme's chemistry.
+    supported_by:
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Catalyzes the oxidative cleavage of heme
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: >-
+      Core molecular function (automated IEA duplicate of the experimentally supported heme oxygenase
+      activity).
+    action: ACCEPT
+    reason: >-
+      This IEA (multiple-methods; InterPro/EC/Rhea mapping to EC 1.14.14.18, RHEA:21764) correctly
+      assigns heme oxygenase (decyclizing) activity, matching the direct IDA evidence for HO-2.
+    supported_by:
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Catalyzes the oxidative cleavage of heme
+    - reference_id: PMID:1575508
+      supporting_text: significant heme oxygenase
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: >-
+      Core cellular location. HO-2 is an ER/microsomal membrane protein.
+    action: ACCEPT
+    reason: >-
+      UniProt Subcellular Location keyword mapping correctly places HO-2 at the ER membrane, its
+      authoritative catalytic location as a single-pass type IV membrane protein with a cytoplasmic
+      catalytic domain.
+    supported_by:
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Microsome membrane
+- term:
+    id: GO:0006788
+    label: heme oxidation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core biological process (InterPro2GO IEA duplicate of the heme-oxidation step).
+    action: ACCEPT
+    reason: >-
+      InterPro heme-oxygenase domain-to-GO mapping (IPR002051, IPR016053) correctly infers the
+      heme-oxidation process for HO-2, consistent with its enzymatic mechanism.
+    supported_by:
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Catalyzes the oxidative cleavage of heme
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: >-
+      High-throughput binary-interactome (HuRI) protein binding; uninformative generic MF term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      This is a bare GO:0005515 protein binding IPI from a systematic binary interactome screen
+      (HuRI, PMID:32296183) reporting many heterogeneous, mostly ER/membrane partners. It carries no
+      specific molecular function and is uninformative about HO-2's activity. Per policy, IPI protein
+      binding is marked as over-annotated rather than removed.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: A reference map of the human binary protein interactome
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  qualifier: enables
+  review:
+    summary: >-
+      High-throughput yeast two-hybrid neurodegeneration interactome protein binding; uninformative
+      generic MF term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Bare GO:0005515 protein binding IPI from a systematic Y2H neurodegenerative-disease interactome
+      screen (PMID:32814053). No specific molecular function is conveyed. Per policy, IPI protein
+      binding is marked as over-annotated rather than removed.
+    supported_by:
+    - reference_id: PMID:32814053
+      supporting_text: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: >-
+      Core cellular location (ISS transfer from the HMOX1 ortholog to the shared ER-membrane
+      location).
+    action: ACCEPT
+    reason: >-
+      Sequence-similarity transfer (from UniProtKB:P09601/HMOX1) correctly assigns ER-membrane
+      localization, matching HO-2's own microsomal/ER-membrane residence.
+    supported_by:
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: IDA
+  original_reference_id: PMID:7890772
+  qualifier: enables
+  review:
+    summary: >-
+      Core molecular function, directly demonstrated. Purified recombinant human HO-2 converts heme
+      to biliverdin using NADPH-cytochrome P450 reductase.
+    action: ACCEPT
+    reason: >-
+      Direct assay of the purified human HO-2 tryptic fragment showed it accepts electrons from
+      NADPH-cytochrome P-450 reductase and converts heme to biliverdin, with a catalytic mechanism
+      like HO-1. This is a strong experimental anchor for the core catalytic function.
+    supported_by:
+    - reference_id: PMID:7890772
+      supporting_text: enzymatic activity for conversion of heme to biliverdin
+    - reference_id: PMID:7890772
+      supporting_text: appears to be similar to that of heme oxygenase-1
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6799350
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome neutrophil specific-granule exocytosis context places HO-2 at the plasma membrane;
+      over-general relative to the ER-membrane core.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      This TAS row comes from the Reactome Exocytosis of specific granule membrane proteins
+      pathway (neutrophil degranulation), in which granule membrane cargo becomes surface/plasma
+      membrane. It is a specialized cell-type context and does not represent HO-2's constitutive
+      catalytic location at the ER membrane. Retained but flagged as over-annotated.
+    supported_by:
+    - reference_id: Reactome:R-HSA-6799350
+      supporting_text: Exocytosis of specific granule membrane proteins
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0035579
+    label: specific granule membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6799350
+  qualifier: located_in
+  review:
+    summary: >-
+      Reactome places HO-2 among neutrophil specific-granule membrane proteins; a specialized
+      non-core location.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      HO-2 appears in the Reactome neutrophil specific-granule/degranulation cargo set. This is a
+      legitimate cell-type-specific localization but peripheral to the enzyme's core ER-membrane
+      heme-catabolic role; kept as non-core.
+    supported_by:
+    - reference_id: Reactome:R-HSA-6799350
+      supporting_text: Exocytosis of specific granule membrane proteins
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: >-
+      Generic membrane localization from a high-throughput NK-cell membrane-proteome MS study;
+      correct but uninformative.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      HO-2 was identified in an NK-cell membrane proteome by mass spectrometry (PMID:19946888). This
+      is consistent with HO-2 being a membrane-anchored protein but the term membrane is too general
+      to represent the specific ER-membrane core location; kept as non-core.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: Defining the membrane proteome of NK cells
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-189398
+  qualifier: located_in
+  review:
+    summary: >-
+      Core cellular location (Reactome heme-degradation reaction places HO-2 at the ER membrane).
+    action: ACCEPT
+    reason: >-
+      The Reactome HMOX1 dimer, HMOX2 cleave heme reaction (heme degradation) localizes the heme
+      oxygenases to the ER membrane, matching HO-2's authoritative catalytic location.
+    supported_by:
+    - reference_id: Reactome:R-HSA-189398
+      supporting_text: HMOX1 dimer, HMOX2 cleave heme
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0001666
+    label: response to hypoxia
+  evidence_type: IDA
+  original_reference_id: PMID:15528406
+  qualifier: involved_in
+  review:
+    summary: >-
+      Well-evidenced physiological role: HO-2 is an O2 sensor whose CO product modulates BK potassium
+      channels during hypoxia. Secondary to the heme-catabolic core but experimentally supported.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Direct evidence (PMID:15528406) shows HO-2 is part of the BK channel complex and acts as an
+      oxygen sensor controlling channel activity during oxygen deprivation, with CO (an HO-2 product)
+      rescuing channel function. This O2-sensing/hypoxia-response role is a genuine, distinctive HO-2
+      function but is a downstream physiological consequence of its CO-producing catalytic activity
+      rather than the primary heme-catabolic core; retained as non-core.
+    supported_by:
+    - reference_id: PMID:15528406
+      supporting_text: HO-2 is an oxygen sensor that controls channel activity during oxygen
+    - reference_id: PMID:15528406
+      supporting_text: carbon monoxide, a product of HO-2 activity
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:15528406
+  qualifier: enables
+  review:
+    summary: >-
+      Bare protein binding IPI capturing the HO-2 / BK-channel alpha-subunit (KCNMA1, Q12791)
+      interaction; biologically real but the generic MF term is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      This IPI (WITH UniProtKB:Q12791, the BK channel alpha subunit KCNMA1) records the physiologically
+      important HO-2 / BK-channel interaction underlying O2 sensing (PMID:15528406). The interaction is
+      meaningful and is captured in the O2-sensing context, but the bare GO:0005515 protein binding term
+      conveys no specific molecular function. Per policy, IPI protein binding is marked over-annotated
+      rather than removed.
+    supported_by:
+    - reference_id: PMID:15528406
+      supporting_text: is part of the BK channel complex and
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IDA
+  original_reference_id: PMID:15528406
+  qualifier: located_in
+  review:
+    summary: >-
+      HO-2 detected at the plasma membrane in the BK-channel/O2-sensing context; over-general relative
+      to the ER-membrane core.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      In PMID:15528406 HO-2 is found in the BK channel complex, which localizes to the plasma membrane
+      in the heterologous expression system used. This plasma-membrane detection reflects the specific
+      channel-complex context, not HO-2's constitutive catalytic residence at the ER membrane; flagged
+      as over-annotated (experimental annotation retained, not removed).
+    supported_by:
+    - reference_id: PMID:15528406
+      supporting_text: is part of the BK channel complex and
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  evidence_type: IDA
+  original_reference_id: PMID:1575508
+  qualifier: enables
+  review:
+    summary: >-
+      Core molecular function, directly demonstrated. Recombinant human HO-2 showed heme oxygenase
+      activity inhibited by Zn-/Sn-protoporphyrins.
+    action: ACCEPT
+    reason: >-
+      The E. coli-expressed human HO-2 fusion protein displayed significant heme oxygenase activity,
+      inhibited by Zn- and Sn-protoporphyrins (classic heme oxygenase inhibitors), providing direct
+      evidence for the core catalytic function.
+    supported_by:
+    - reference_id: PMID:1575508
+      supporting_text: significant heme oxygenase
+    - reference_id: PMID:1575508
+      supporting_text: which was inhibited by Zn- and
+    - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+      supporting_text: Inhibited by metalloporphyrins such as Sn- and Zn-
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:15528406
+  title: Hemoxygenase-2 is an oxygen sensor for a calcium-sensitive potassium channel.
+  findings:
+  - statement: HO-2 is part of the BK potassium channel complex and acts as an oxygen sensor; CO produced by HO-2 modulates channel activity, and HO-2 controls channel activity during oxygen deprivation (carotid body / hypoxia response).
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract-only cache (full_text_available false). PubMed-verified Science 2004 paper on HO-2
+      as an O2 sensor for BK channels; directly supports the GO:0001666 response to hypoxia IDA and
+      the HO-2/KCNMA1 (Q12791) interaction. Supports a genuine, distinctive HO-2 physiological role
+      (kept as non-core relative to the heme-catabolic core).
+- id: PMID:1575508
+  title: 'Human heme oxygenase-2: characterization and expression of a full-length
+    cDNA and evidence suggesting that the two HO-2 transcripts may differ by choice
+    of polyadenylation signal.'
+  findings:
+  - statement: Recombinant human HO-2 fusion protein displayed significant heme oxygenase activity that was inhibited by Zn- and Sn-protoporphyrins; predicted 36 kDa protein matching HO-2 in human testis microsomes.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract-only cache. PubMed-verified 1992 characterization of the human HO-2 cDNA and enzyme;
+      supports the GO:0004392 heme oxygenase activity IDA and metalloporphyrin inhibition (ACTIVITY
+      REGULATION). Directly about HMOX2 (HO-2).
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings:
+  - statement: HO-2 was identified by mass spectrometry in an NK-cell membrane proteome; supports generic membrane localization (GO:0016020) but not a specific compartment.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract-only cache. High-throughput membrane-proteome MS study; the HO-2 identification supports
+      a generic membrane HDA row only and is not informative about the specific ER-membrane location.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings:
+  - statement: Systematic binary interactome (HuRI) reporting many HO-2 protein-protein interactions; supports only a generic GO:0005515 protein binding row.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      High-throughput binary-interactome screen. Interactions are numerous and heterogeneous and
+      yield only uninformative bare protein binding; over-annotated as MF.
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
+    and Uncovers Widespread Protein Aggregation in Affected Brains.
+  findings:
+  - statement: Systematic Y2H neurodegeneration interactome reporting HO-2 protein-protein interactions; supports only a generic GO:0005515 protein binding row.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      High-throughput Y2H interactome; HO-2 partners are generic and yield only uninformative bare
+      protein binding; over-annotated as MF.
+- id: PMID:7890772
+  title: Heme oxygenase-2. Properties of the heme complex of the purified tryptic
+    fragment of recombinant human heme oxygenase-2.
+  findings:
+  - statement: Purified recombinant human HO-2 fragment accepts electrons from NADPH-cytochrome P-450 reductase, converts heme to biliverdin, binds one equivalent of heme with a histidine proximal ligand, and has a catalytic mechanism similar to HO-1.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract-only cache. PubMed-verified biochemical/spectroscopic characterization of purified human
+      HO-2; strong direct support for GO:0004392 heme oxygenase activity and GO:0020037 heme binding.
+- id: Reactome:R-HSA-189398
+  title: HMOX1 dimer, HMOX2 cleave heme
+  findings:
+  - statement: Reactome reaction for heme degradation localizing the heme oxygenases (including non-inducible HMOX2) to the ER membrane, cleaving heme at the alpha-methene bridge and forming the endogenous source of CO.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Reactome curated reaction; supports the ER-membrane location (GO:0005789 TAS) and the
+      heme-catabolic/CO-producing core of HO-2.
+- id: Reactome:R-HSA-6799350
+  title: Exocytosis of specific granule membrane proteins
+  findings:
+  - statement: Reactome neutrophil specific-granule exocytosis pathway that includes HO-2 as specific-granule membrane cargo, underlying the specific granule membrane (GO:0035579) and plasma membrane (GO:0005886) TAS rows.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Reactome neutrophil-degranulation pathway; a specialized cell-type context. Supports the
+      specific-granule-membrane / plasma-membrane TAS rows but is peripheral to HO-2's core ER-membrane
+      heme-catabolic function.
+- id: file:human/HMOX2/HMOX2-uniprot.txt
+  title: UniProtKB record for human HMOX2 (P30519)
+  findings:
+  - statement: HO-2 is a constitutive ER/microsomal single-pass type IV membrane heme oxygenase that catalyzes oxidative cleavage of heme b at the alpha-methene bridge to biliverdin IXalpha + CO + Fe2+ (EC 1.14.14.18), binds heme b via an axial histidine, is inhibited by Sn-/Zn-protoporphyrins, carries C-terminal heme-regulatory motifs, and is S-nitrosylated by BLVRB.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Authoritative UniProt record for HMOX2; primary source for the description and core-function calls.
+core_functions:
+- description: >-
+    HO-2 is a heme oxygenase that catalyzes the oxidative cleavage of heme b at the alpha-methene
+    bridge (using O2 and NADPH--cytochrome P450 reductase electrons) to biliverdin IXalpha, carbon
+    monoxide and ferrous iron, binding one heme b as substrate. This constitutive heme catabolism is
+    HO-2's core molecular function and a major physiological source of endogenous CO.
+  molecular_function:
+    id: GO:0004392
+    label: heme oxygenase (decyclizing) activity
+  directly_involved_in:
+  - id: GO:0042167
+    label: heme catabolic process
+  - id: GO:0006788
+    label: heme oxidation
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+    supporting_text: Catalyzes the oxidative cleavage of heme
+  - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+    supporting_text: at the alpha-methene bridge carbon, released as carbon monoxide (CO),
+  - reference_id: PMID:7890772
+    supporting_text: enzymatic activity for conversion of heme to biliverdin
+  - reference_id: PMID:1575508
+    supporting_text: significant heme oxygenase
+- description: >-
+    HO-2 binds heme b as its catalytic substrate through an axial histidine and additional
+    heme-b contacts, a molecular function required for its heme oxygenase activity.
+  molecular_function:
+    id: GO:0020037
+    label: heme binding
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:7890772
+    supporting_text: bound one equivalent of heme to form a
+  - reference_id: file:human/HMOX2/HMOX2-uniprot.txt
+    supporting_text: Belongs to the heme oxygenase family.
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Should HO-2's O2-sensing / CO-mediated BK-channel modulation (currently captured as response to
+    hypoxia plus a bare protein-binding IPI to KCNMA1) be curated with a more specific
+    process/regulation term rather than a generic protein-binding annotation?
+  experts:
+  - GO ion-channel / signaling editors
+  - carotid body / O2-sensing physiologists
+- question: >-
+    Do HO-2's C-terminal heme-regulatory motifs (HRMs) and their S-nitrosylation warrant a specific
+    regulatory-heme-binding or redox-sensing annotation distinct from substrate heme binding?
+  experts:
+  - heme biology curators
+  - UniProt curators
+suggested_experiments:
+- description: >-
+    Reconstitute purified full-length human HO-2 with NADPH-cytochrome P450 reductase and measure
+    heme cleavage, CO and biliverdin production, comparing wild-type with HRM (Cys265/Cys282) and
+    axial-His45 variants.
+  hypothesis: >-
+    Substrate heme binding and catalysis depend on His45, while the HRMs/Cys residues modulate
+    activity (e.g. via S-nitrosylation or thiol redox) rather than substrate turnover.
+- description: >-
+    In carotid body glomus cells or a BK-channel-expressing system, test whether HO-2 catalytic
+    activity (CO output) versus mere HO-2/KCNMA1 physical association is required for hypoxic BK-channel
+    modulation, using catalytically dead HO-2 and CO donors.
+  hypothesis: >-
+    HO-2's O2-sensing role requires its CO-producing catalytic activity, not just complex formation
+    with the BK channel.

--- a/genes/human/HMOX2/HMOX2-goa.tsv
+++ b/genes/human/HMOX2/HMOX2-goa.tsv
@@ -1,0 +1,77 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	P30519	HMOX2	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000318	IBA	GO_REF:0000033	CGD:CAL0000188588|FB:FBgn0037933|MGI:MGI:96163|PANTHER:PTN007456885|RGD:2806|RGD:67402|SGD:S000004195|UniProtKB:P09601|UniProtKB:P14791|UniProtKB:P30519|UniProtKB:P32394|UniProtKB:Q5E9F2|ZFIN:ZDB-GENE-030131-3102	9606	Homo sapiens	GO_Central	Heme oxygenase 2	20250902
+UniProtKB	P30519	HMOX2	is_active_in	GO:0005886	plasma membrane	cellular_component	ECO:0000318	IBA	GO_REF:0000033	CGD:CAL0000188588|PANTHER:PTN007456885|RGD:2806|UniProtKB:P30519	9606	Homo sapiens	GO_Central	Heme oxygenase 2	20250415
+UniProtKB	P30519	HMOX2	involved_in	GO:0006979	response to oxidative stress	biological_process	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN007456885|RGD:2806|RGD:67402|SGD:S000004195|UniProtKB:P09601	9606	Homo sapiens	GO_Central	Heme oxygenase 2	20250415
+UniProtKB	P30519	HMOX2	enables	GO:0020037	heme binding	molecular_function	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN007456885|RGD:2806|UniProtKB:P09601	9606	Homo sapiens	GO_Central	Heme oxygenase 2	20250415
+UniProtKB	P30519	HMOX2	involved_in	GO:0042167	heme catabolic process	biological_process	ECO:0000318	IBA	GO_REF:0000033	MGI:MGI:96163|PANTHER:PTN007456885|RGD:2806|SGD:S000004195|UniProtKB:P09601	9606	Homo sapiens	GO_Central	Heme oxygenase 2	20250415
+UniProtKB	P30519	HMOX2	involved_in	GO:0006788	heme oxidation	biological_process	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN000076492|UniProtKB:P09601	9606	Homo sapiens	GO_Central	Heme oxygenase 2	20170228
+UniProtKB	P30519	HMOX2	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000501	IEA	GO_REF:0000120	ARBA:ARBA00086726|InterPro:IPR002051|InterPro:IPR016053|InterPro:IPR018207|RHEA:21764|EC:1.14.14.18	9606	Homo sapiens	UniProt	Heme oxygenase 2	20260706
+UniProtKB	P30519	HMOX2	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0007322	IEA	GO_REF:0000044	UniProtKB-SubCell:SL-0097	9606	Homo sapiens	UniProt	Heme oxygenase 2	20260706
+UniProtKB	P30519	HMOX2	involved_in	GO:0006788	heme oxidation	biological_process	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR002051|InterPro:IPR016053	9606	Homo sapiens	InterPro	Heme oxygenase 2	20260706
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:O00258	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:O14880	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:O95470	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P07307-3	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P11912	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P21579	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P27105	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P48051	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q13520	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q13571	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q15125	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q3SXY8	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q3ZAQ7	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q5JX71	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q6P5S7	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q86VR2	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8IWU4	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8TDT2	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8TED1	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8WWF3	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q96KR6	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9BUF7-2	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9BXK5	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9GZR5	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9NR31	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9NUH8	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9NYP7	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9Y282	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9Y320	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:A0A0A0MR05	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:O00257-3	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:O00472	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P05067	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P06241	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P36639-4	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P36954	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P49459	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P54274-2	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q13573	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q14032	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q3SX64	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q53FD0-2	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q66K80	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q66PJ3-4	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q6DHV7-2	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q6IN84-2	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q6NXT2	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q6PJW8-3	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q7Z3B4	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q86WT6-2	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q8IYG6	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q96BD6	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q96BR5	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q9H2U1-3	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q9NQ89	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q9NSI6-4	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:Q9NTN9-3	9606	Homo sapiens	IntAct	Heme oxygenase 2	20260704
+UniProtKB	P30519	HMOX2	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000250	ISS	GO_REF:0000024	UniProtKB:P09601	9606	Homo sapiens	UniProt	Heme oxygenase 2	20241126
+UniProtKB	P30519	HMOX2	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000314	IDA	PMID:7890772		9606	Homo sapiens	UniProt	Heme oxygenase 2	20220214
+UniProtKB	P30519	HMOX2	located_in	GO:0005886	plasma membrane	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-6799350		9606	Homo sapiens	Reactome	Heme oxygenase 2	20160716
+UniProtKB	P30519	HMOX2	located_in	GO:0035579	specific granule membrane	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-6799350		9606	Homo sapiens	Reactome	Heme oxygenase 2	20160716
+UniProtKB	P30519	HMOX2	located_in	GO:0016020	membrane	cellular_component	ECO:0007005	HDA	PMID:19946888		9606	Homo sapiens	UniProt	Heme oxygenase 2	20140627
+UniProtKB	P30519	HMOX2	located_in	GO:0005789	endoplasmic reticulum membrane	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-189398		9606	Homo sapiens	Reactome	Heme oxygenase 2	20130213
+UniProtKB	P30519	HMOX2	involved_in	GO:0001666	response to hypoxia	biological_process	ECO:0000314	IDA	PMID:15528406		9606	Homo sapiens	UniProt	Heme oxygenase 2	20080520
+UniProtKB	P30519	HMOX2	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:15528406	UniProtKB:Q12791	9606	Homo sapiens	UniProt	Heme oxygenase 2	20080520
+UniProtKB	P30519	HMOX2	located_in	GO:0005886	plasma membrane	cellular_component	ECO:0000314	IDA	PMID:15528406		9606	Homo sapiens	UniProt	Heme oxygenase 2	20080520
+UniProtKB	P30519	HMOX2	enables	GO:0004392	heme oxygenase (decyclizing) activity	molecular_function	ECO:0000314	IDA	PMID:1575508		9606	Homo sapiens	UniProt	Heme oxygenase 2	20060419

--- a/genes/human/HMOX2/HMOX2-notes.md
+++ b/genes/human/HMOX2/HMOX2-notes.md
@@ -1,0 +1,141 @@
+# HMOX2 (Heme oxygenase 2, HO-2) review notes
+
+UniProt: P30519 (HMOX2_HUMAN), 316 aa, human (NCBITaxon:9606). HGNC:5014. EC 1.14.14.18.
+
+## Core biology
+
+HMOX2 encodes heme oxygenase 2 (HO-2), one of the two mammalian heme oxygenase
+isozymes. Unlike the stress-inducible HMOX1 (HO-1), HO-2 is **constitutively**
+expressed and is the predominant isoform in brain, testis and vascular
+endothelium. It is a heme-degrading oxidoreductase anchored in the endoplasmic
+reticulum (microsomal) membrane by a single C-terminal transmembrane helix, with
+the catalytic domain facing the cytoplasm.
+
+### Molecular function / catalytic activity
+
+HO-2 catalyzes the oxidative cleavage of heme at the alpha-methene bridge carbon,
+using O2 and reducing equivalents delivered by NADPH--cytochrome P450 (hemoprotein)
+reductase, to produce biliverdin IXalpha, carbon monoxide (CO) and free ferrous
+iron (Fe2+).
+
+- UniProt FUNCTION: "Catalyzes the oxidative cleavage of heme" ... "at the
+  alpha-methene bridge carbon, released as carbon monoxide (CO)," ... "to generate
+  biliverdin IXalpha, while releasing the central heme iron chelate as ferrous iron"
+  [file:human/HMOX2/HMOX2-uniprot.txt, ECO:0000269|PubMed:1575508, ECO:0000269|PubMed:7890772].
+- CATALYTIC ACTIVITY / Rhea RHEA:21764, EC=1.14.14.18: heme b + 3 reduced
+  [NADPH--hemoprotein reductase] + 3 O2 = biliverdin IXalpha + CO + Fe(2+) + ...
+  [file:human/HMOX2/HMOX2-uniprot.txt].
+- HO-2 heme oxygenase activity was demonstrated directly for the purified recombinant
+  human protein: the tryptic fragment "retained the ability to accept electrons from
+  NADPH-cytochrome P-450 reductase and the enzymatic activity for conversion of heme to
+  biliverdin" [PMID:7890772 "retained the ability to accept electrons from
+  NADPH-cytochrome P-450 reductase and the enzymatic activity for conversion of heme to
+  biliverdin"]. The catalytic mechanism is similar to HO-1: "the catalytic mechanism of
+  heme oxygenase-2 appears to be similar to that of heme oxygenase-1" [PMID:7890772].
+- The E. coli-expressed human HO-2 fusion protein "displayed significant heme oxygenase
+  activity, which was inhibited by Zn- and Sn-protoporphyrins, known inhibitors of
+  eukaryotic heme oxygenase" [PMID:1575508]. UniProt ACTIVITY REGULATION: "Inhibited by
+  metalloporphyrins such as Sn- and Zn-" protoporphyrins
+  [file:human/HMOX2/HMOX2-uniprot.txt].
+
+Supporting IDA GO annotations: GO:0004392 heme oxygenase (decyclizing) activity
+from both PMID:7890772 and PMID:1575508 (both ECO:0000314 IDA).
+
+### Heme binding
+
+HO-2 binds one heme b as substrate; the crystal structure of a truncated human HO-2
+(PMID:17965015) defined heme-binding sites, with His45 as the axial (proximal)
+iron-binding residue and additional heme-b contacts at residues 154, 199, 203
+[file:human/HMOX2/HMOX2-uniprot.txt, BINDING features]. The purified tryptic fragment
+"bound one equivalent of heme to form a substrate-enzyme complex" and spectroscopy
+indicated "a neutral imidazole of a histidine residue served as the proximal ligand"
+[PMID:7890772]. GO:0020037 heme binding (IBA) is well supported.
+
+Note on heme-regulatory motifs: UniProt annotates two HRM repeats (residues 264-269
+"HRM 1", 281-286 "HRM 2") [file:human/HMOX2/HMOX2-uniprot.txt, REPEAT features]. These
+Cys-Pro motifs are a distinctive feature of HO-2 (absent from HO-1) and are proposed to
+confer thiol/heme redox and CO/O2-sensing regulation, but the current GOA set does not
+carry a specific HRM/regulatory-heme-binding annotation.
+
+### Biological process
+
+- Heme catabolism: GO:0042167 heme catabolic process and GO:0006788 heme oxidation
+  (both from the enzymatic reaction). HO-2 is the constitutive contributor to endogenous
+  heme turnover and is the physiological source of CO. Reactome R-HSA-189398 "HMOX1
+  dimer, HMOX2 cleave heme" / R-HSA-189483 "Heme degradation": "Heme oxygenases (HMOXs)
+  cleaves the heme ring at the alpha-methene bridge to form bilverdin. This reaction
+  forms the only endogenous source of carbon monoxide. ... HMOX2 is non-inducible."
+  [reactome/R-HSA-189398.md].
+
+- O2 sensing / response to hypoxia: HO-2 acts as an oxygen sensor for large-conductance
+  calcium-activated (BK) K+ channels. "We demonstrate that hemoxygenase-2 (HO-2) is part
+  of the BK channel complex and enhances channel activity in normoxia. Knockdown of HO-2
+  expression reduced channel activity, and carbon monoxide, a product of HO-2 activity,
+  rescued this loss of function." and "HO-2 is an oxygen sensor that controls channel
+  activity during oxygen deprivation" [PMID:15528406]. This underpins the GO:0001666
+  response to hypoxia IDA annotation and the GO:0005515 protein binding IPI to the BK
+  channel alpha subunit (KCNMA1, UniProtKB:Q12791). The plasma-membrane IDA
+  (GO:0005886) in the same paper reflects HO-2 being detected in / recruited to the BK
+  channel complex at the plasma membrane in the heterologous HEK293 system, not the
+  enzyme's principal ER-membrane residence.
+
+- Response to oxidative stress: GO:0006979 (IBA) is a family-level inference. It is more
+  strongly established for HO-1 (the inducible, cytoprotective antioxidant isoform); for
+  HO-2 the antioxidant/cytoprotective role is real but secondary to its constitutive
+  catabolic/CO-producing role. Kept as non-core.
+
+### Subcellular location
+
+- Endoplasmic reticulum / microsomal membrane, single-pass type IV membrane protein,
+  cytoplasmic side [file:human/HMOX2/HMOX2-uniprot.txt SUBCELLULAR LOCATION: "Microsome
+  membrane" ... "Endoplasmic reticulum membrane" ... "Single-pass type IV membrane
+  protein" ... "Cytoplasmic side"]. This is the core catalytic location.
+  GO:0005789 endoplasmic reticulum membrane (ISS, IEA, TAS) — ACCEPT/core.
+- GO:0016020 membrane (HDA, PMID:19946888) — a large-scale NK-cell membrane-proteome MS
+  study; correct but generic; kept as non-core.
+- GO:0005886 plasma membrane (IBA; IDA PMID:15528406; TAS Reactome) — HO-2 can be found
+  at the plasma membrane in the BK channel complex context; the IBA/TAS generic
+  plasma-membrane rows are over-general relative to the ER-membrane core; treated as
+  non-core / over-annotation.
+- GO:0035579 specific granule membrane (TAS Reactome R-HSA-6799350, neutrophil
+  degranulation) — Reactome places HO-2 in the neutrophil specific-granule / degranulation
+  cargo set; peripheral relative to the enzyme's ER function; kept as non-core.
+
+### S-nitrosylation / post-translational regulation
+
+HO-2 is S-nitrosylated at Cys265 and Cys282 (within/near the HRM region) by BLVRB
+[file:human/HMOX2/HMOX2-uniprot.txt PTM: "S-nitrosylated by BLVRB",
+ECO:0000269|PubMed:38056462]. A soluble form arises by proteolytic removal of the
+membrane anchor [file:human/HMOX2/HMOX2-uniprot.txt PTM].
+
+## Protein-binding (IPI) annotations
+
+Three GO:0005515 protein binding IPI sources:
+- PMID:15528406 (WITH UniProtKB:Q12791 = KCNMA1/BK channel alpha) — biologically
+  meaningful HO-2 interaction underpinning O2 sensing. Per policy, bare protein binding
+  IPI is marked MARK_AS_OVER_ANNOTATED (uninformative MF term) but the interaction itself
+  is real and captured in core-function context (BK channel / O2 sensing).
+- PMID:32296183 (HuRI, systematic binary interactome) and PMID:32814053 (neurodegenerative
+  disease interactome Y2H) — high-throughput interactome screens producing long,
+  heterogeneous partner lists (many ER/membrane proteins, e.g. GET1/O00258, MGST3/O14880,
+  SGPL1/O95470, etc.). These are generic "protein binding" rows with no specific functional
+  MF; MARK_AS_OVER_ANNOTATED (never REMOVE per policy for IPI protein binding).
+
+## Distinctions from HMOX1 (paralog)
+
+- HMOX1 (HO-1): stress-inducible, cytoprotective/antioxidant, broadly expressed on
+  induction; forms ER dimers/oligomers.
+- HMOX2 (HO-2): constitutive, abundant in brain/testis/endothelium, harbors HRMs,
+  functions in physiological CO production and O2 sensing. Same catalytic reaction.
+  Reactome: "HMOX1 is inducible ... HMOX2 is non-inducible." [reactome/R-HSA-189398.md].
+
+## Core function summary
+
+- MF: GO:0004392 heme oxygenase (decyclizing) activity (with GO:0020037 heme binding).
+- BP: GO:0042167 heme catabolic process; GO:0006788 heme oxidation.
+- CC: GO:0005789 endoplasmic reticulum membrane.
+- Additional physiological role: O2 sensing via CO production and BK-channel modulation
+  (GO:0001666 response to hypoxia), retained as a secondary/non-core but well-evidenced
+  function.
+</content>
+</invoke>

--- a/genes/human/HMOX2/HMOX2-uniprot.txt
+++ b/genes/human/HMOX2/HMOX2-uniprot.txt
@@ -1,0 +1,625 @@
+ID   HMOX2_HUMAN             Reviewed;         316 AA.
+AC   P30519; A8MT35; D3DUD5; I3L430; O60605;
+DT   01-APR-1993, integrated into UniProtKB/Swiss-Prot.
+DT   01-NOV-1995, sequence version 2.
+DT   10-JUN-2026, entry version 224.
+DE   RecName: Full=Heme oxygenase 2;
+DE            Short=HO-2;
+DE            EC=1.14.14.18 {ECO:0000269|PubMed:1575508, ECO:0000269|PubMed:7890772};
+DE   Contains:
+DE     RecName: Full=Heme oxygenase 2 soluble form {ECO:0000303|PubMed:7890772};
+GN   Name=HMOX2; Synonyms=HO2;
+OS   Homo sapiens (Human).
+OC   Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia;
+OC   Eutheria; Euarchontoglires; Primates; Haplorrhini; Catarrhini; Hominidae;
+OC   Homo.
+OX   NCBI_TaxID=9606;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [MRNA] (ISOFORM 1), PROTEIN SEQUENCE OF 30-49,
+RP   FUNCTION, CATALYTIC ACTIVITY, SUBCELLULAR LOCATION, AND PROTEOLYTIC
+RP   CLEAVAGE.
+RC   TISSUE=Placenta;
+RX   PubMed=7890772; DOI=10.1074/jbc.270.11.6345;
+RA   Ishikawa K.;
+RT   "Heme oxygenase-2. Properties of the heme complex of the purified tryptic
+RT   fragment of recombinant human heme oxygenase-2.";
+RL   J. Biol. Chem. 270:6345-6350(1995).
+RN   [2]
+RP   NUCLEOTIDE SEQUENCE [MRNA] (ISOFORM 1), FUNCTION, CATALYTIC ACTIVITY, AND
+RP   ACTIVITY REGULATION.
+RC   TISSUE=Kidney;
+RX   PubMed=1575508; DOI=10.1016/0003-9861(92)90481-b;
+RA   McCoubrey W.K. Jr., Ewing J.F., Maines M.D.;
+RT   "Human heme oxygenase-2: characterization and expression of a full-length
+RT   cDNA and evidence suggesting that the two HO-2 transcripts may differ by
+RT   choice of polyadenylation signal.";
+RL   Arch. Biochem. Biophys. 295:13-20(1992).
+RN   [3]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA] (ISOFORM 1).
+RA   Kalnine N., Chen X., Rolfs A., Halleck A., Hines L., Eisenstein S.,
+RA   Koundinya M., Raphael J., Moreira D., Kelley T., LaBaer J., Lin Y.,
+RA   Phelan M., Farmer A.;
+RT   "Cloning of human full-length CDSs in BD Creator(TM) system donor vector.";
+RL   Submitted (OCT-2004) to the EMBL/GenBank/DDBJ databases.
+RN   [4]
+RP   NUCLEOTIDE SEQUENCE [GENOMIC DNA], AND VARIANTS GLN-137 AND LEU-146.
+RG   NIEHS SNPs program;
+RL   Submitted (OCT-2004) to the EMBL/GenBank/DDBJ databases.
+RN   [5]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RX   PubMed=15616553; DOI=10.1038/nature03187;
+RA   Martin J., Han C., Gordon L.A., Terry A., Prabhakar S., She X., Xie G.,
+RA   Hellsten U., Chan Y.M., Altherr M., Couronne O., Aerts A., Bajorek E.,
+RA   Black S., Blumer H., Branscomb E., Brown N.C., Bruno W.J., Buckingham J.M.,
+RA   Callen D.F., Campbell C.S., Campbell M.L., Campbell E.W., Caoile C.,
+RA   Challacombe J.F., Chasteen L.A., Chertkov O., Chi H.C., Christensen M.,
+RA   Clark L.M., Cohn J.D., Denys M., Detter J.C., Dickson M.,
+RA   Dimitrijevic-Bussod M., Escobar J., Fawcett J.J., Flowers D., Fotopulos D.,
+RA   Glavina T., Gomez M., Gonzales E., Goodstein D., Goodwin L.A., Grady D.L.,
+RA   Grigoriev I., Groza M., Hammon N., Hawkins T., Haydu L., Hildebrand C.E.,
+RA   Huang W., Israni S., Jett J., Jewett P.B., Kadner K., Kimball H.,
+RA   Kobayashi A., Krawczyk M.-C., Leyba T., Longmire J.L., Lopez F., Lou Y.,
+RA   Lowry S., Ludeman T., Manohar C.F., Mark G.A., McMurray K.L., Meincke L.J.,
+RA   Morgan J., Moyzis R.K., Mundt M.O., Munk A.C., Nandkeshwar R.D.,
+RA   Pitluck S., Pollard M., Predki P., Parson-Quintana B., Ramirez L., Rash S.,
+RA   Retterer J., Ricke D.O., Robinson D.L., Rodriguez A., Salamov A.,
+RA   Saunders E.H., Scott D., Shough T., Stallings R.L., Stalvey M.,
+RA   Sutherland R.D., Tapia R., Tesmer J.G., Thayer N., Thompson L.S., Tice H.,
+RA   Torney D.C., Tran-Gyamfi M., Tsai M., Ulanovsky L.E., Ustaszewska A.,
+RA   Vo N., White P.S., Williams A.L., Wills P.L., Wu J.-R., Wu K., Yang J.,
+RA   DeJong P., Bruce D., Doggett N.A., Deaven L., Schmutz J., Grimwood J.,
+RA   Richardson P., Rokhsar D.S., Eichler E.E., Gilna P., Lucas S.M.,
+RA   Myers R.M., Rubin E.M., Pennacchio L.A.;
+RT   "The sequence and analysis of duplication-rich human chromosome 16.";
+RL   Nature 432:988-994(2004).
+RN   [6]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RA   Mural R.J., Istrail S., Sutton G.G., Florea L., Halpern A.L., Mobarry C.M.,
+RA   Lippert R., Walenz B., Shatkay H., Dew I., Miller J.R., Flanigan M.J.,
+RA   Edwards N.J., Bolanos R., Fasulo D., Halldorsson B.V., Hannenhalli S.,
+RA   Turner R., Yooseph S., Lu F., Nusskern D.R., Shue B.C., Zheng X.H.,
+RA   Zhong F., Delcher A.L., Huson D.H., Kravitz S.A., Mouchard L., Reinert K.,
+RA   Remington K.A., Clark A.G., Waterman M.S., Eichler E.E., Adams M.D.,
+RA   Hunkapiller M.W., Myers E.W., Venter J.C.;
+RL   Submitted (SEP-2005) to the EMBL/GenBank/DDBJ databases.
+RN   [7]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA] (ISOFORM 1).
+RC   TISSUE=Lung;
+RX   PubMed=15489334; DOI=10.1101/gr.2596504;
+RG   The MGC Project Team;
+RT   "The status, quality, and expansion of the NIH full-length cDNA project:
+RT   the Mammalian Gene Collection (MGC).";
+RL   Genome Res. 14:2121-2127(2004).
+RN   [8]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA] OF 1-148 (ISOFORM 2).
+RA   Hillier L., Clark N., Dubuque T., Elliston K., Hawkins M., Holman M.,
+RA   Hultman M., Kucaba T., Le M., Lennon G., Marra M., Parsons J., Rifkin L.,
+RA   Rohlfing T., Soares M., Tan F., Trevaskis E., Waterston R., Williamson A.,
+RA   Wohldmann P., Wilson R.;
+RT   "The WashU-Merck EST project.";
+RL   Submitted (MAR-2000) to the EMBL/GenBank/DDBJ databases.
+RN   [9]
+RP   PROTEIN SEQUENCE OF 2-17; 30-38; 48-59; 138-168; 206-214 AND 219-246,
+RP   CLEAVAGE OF INITIATOR METHIONINE, ACETYLATION AT SER-2, AND IDENTIFICATION
+RP   BY MASS SPECTROMETRY.
+RC   TISSUE=Colon carcinoma, and Ovarian carcinoma;
+RA   Bienvenut W.V., Bilsland A.E., Keith W.N.;
+RL   Submitted (JAN-2010) to UniProtKB.
+RN   [10]
+RP   NUCLEOTIDE SEQUENCE [MRNA] OF 10-166.
+RC   TISSUE=Intestine;
+RA   Follett J., Ahn J.-Y.;
+RL   Submitted (FEB-1998) to the EMBL/GenBank/DDBJ databases.
+RN   [11]
+RP   ACETYLATION [LARGE SCALE ANALYSIS] AT SER-2, CLEAVAGE OF INITIATOR
+RP   METHIONINE [LARGE SCALE ANALYSIS], AND IDENTIFICATION BY MASS SPECTROMETRY
+RP   [LARGE SCALE ANALYSIS].
+RX   PubMed=19413330; DOI=10.1021/ac9004309;
+RA   Gauci S., Helbig A.O., Slijper M., Krijgsveld J., Heck A.J., Mohammed S.;
+RT   "Lys-N and trypsin cover complementary parts of the phosphoproteome in a
+RT   refined SCX-based approach.";
+RL   Anal. Chem. 81:4493-4501(2009).
+RN   [12]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=21269460; DOI=10.1186/1752-0509-5-17;
+RA   Burkard T.R., Planyavsky M., Kaupe I., Breitwieser F.P., Buerckstuemmer T.,
+RA   Bennett K.L., Superti-Furga G., Colinge J.;
+RT   "Initial characterization of the human central proteome.";
+RL   BMC Syst. Biol. 5:17-17(2011).
+RN   [13]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-2, AND IDENTIFICATION BY MASS
+RP   SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Erythroleukemia;
+RX   PubMed=23186163; DOI=10.1021/pr300630k;
+RA   Zhou H., Di Palma S., Preisinger C., Peng M., Polat A.N., Heck A.J.,
+RA   Mohammed S.;
+RT   "Toward a comprehensive characterization of a human cancer cell
+RT   phosphoproteome.";
+RL   J. Proteome Res. 12:260-271(2013).
+RN   [14]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Liver;
+RX   PubMed=24275569; DOI=10.1016/j.jprot.2013.11.014;
+RA   Bian Y., Song C., Cheng K., Dong M., Wang F., Huang J., Sun D., Wang L.,
+RA   Ye M., Zou H.;
+RT   "An enzyme assisted RP-RPLC approach for in-depth analysis of human liver
+RT   phosphoproteome.";
+RL   J. Proteomics 96:253-262(2014).
+RN   [15]
+RP   ACETYLATION [LARGE SCALE ANALYSIS] AT SER-2, CLEAVAGE OF INITIATOR
+RP   METHIONINE [LARGE SCALE ANALYSIS], AND IDENTIFICATION BY MASS SPECTROMETRY
+RP   [LARGE SCALE ANALYSIS].
+RX   PubMed=25944712; DOI=10.1002/pmic.201400617;
+RA   Vaca Jacome A.S., Rabilloud T., Schaeffer-Reiss C., Rompais M., Ayoub D.,
+RA   Lane L., Bairoch A., Van Dorsselaer A., Carapito C.;
+RT   "N-terminome analysis of the human mitochondrial proteome.";
+RL   Proteomics 15:2519-2524(2015).
+RN   [16]
+RP   S-NITROSYLATION AT CYS-265 AND CYS-282, AND MUTAGENESIS OF CYS-265 AND
+RP   CYS-282.
+RX   PubMed=38056462; DOI=10.1016/j.cell.2023.11.009;
+RA   Zhou H.L., Grimmett Z.W., Venetos N.M., Stomberski C.T., Qian Z.,
+RA   McLaughlin P.J., Bansal P.K., Zhang R., Reynolds J.D., Premont R.T.,
+RA   Stamler J.S.;
+RT   "An enzyme that selectively S-nitrosylates proteins to regulate insulin
+RT   signaling.";
+RL   Cell 0:0-0(2023).
+RN   [17]
+RP   X-RAY CRYSTALLOGRAPHY (2.4 ANGSTROMS) OF 1-264, AND HEME-BINDING SITES.
+RX   PubMed=17965015; DOI=10.1074/jbc.m707396200;
+RA   Bianchetti C.M., Yi L., Ragsdale S.W., Phillips G.N. Jr.;
+RT   "Comparison of apo- and heme-bound crystal structures of a truncated human
+RT   heme oxygenase-2.";
+RL   J. Biol. Chem. 282:37624-37631(2007).
+CC   -!- FUNCTION: [Heme oxygenase 2]: Catalyzes the oxidative cleavage of heme
+CC       at the alpha-methene bridge carbon, released as carbon monoxide (CO),
+CC       to generate biliverdin IXalpha, while releasing the central heme iron
+CC       chelate as ferrous iron. {ECO:0000269|PubMed:1575508,
+CC       ECO:0000269|PubMed:7890772}.
+CC   -!- FUNCTION: [Heme oxygenase 2 soluble form]: Catalyzes the oxidative
+CC       cleavage of heme at the alpha-methene bridge carbon, released as carbon
+CC       monoxide (CO), to generate biliverdin IXalpha, while releasing the
+CC       central heme iron chelate as ferrous iron.
+CC       {ECO:0000269|PubMed:7890772}.
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=heme b + 3 reduced [NADPH--hemoprotein reductase] + 3 O2 =
+CC         biliverdin IXalpha + CO + Fe(2+) + 3 oxidized [NADPH--hemoprotein
+CC         reductase] + 3 H2O + H(+); Xref=Rhea:RHEA:21764, Rhea:RHEA-
+CC         COMP:11964, Rhea:RHEA-COMP:11965, ChEBI:CHEBI:15377,
+CC         ChEBI:CHEBI:15378, ChEBI:CHEBI:15379, ChEBI:CHEBI:17245,
+CC         ChEBI:CHEBI:29033, ChEBI:CHEBI:57618, ChEBI:CHEBI:57991,
+CC         ChEBI:CHEBI:58210, ChEBI:CHEBI:60344; EC=1.14.14.18;
+CC         Evidence={ECO:0000269|PubMed:1575508, ECO:0000269|PubMed:7890772};
+CC       PhysiologicalDirection=left-to-right; Xref=Rhea:RHEA:21765;
+CC         Evidence={ECO:0000305|PubMed:7890772};
+CC   -!- ACTIVITY REGULATION: Inhibited by metalloporphyrins such as Sn- and Zn-
+CC       protoporphyrins. {ECO:0000269|PubMed:1575508}.
+CC   -!- INTERACTION:
+CC       P30519; Q6DHV7-2: ADAL; NbExp=3; IntAct=EBI-712096, EBI-18899653;
+CC       P30519; P05067: APP; NbExp=3; IntAct=EBI-712096, EBI-77613;
+CC       P30519; Q13520: AQP6; NbExp=3; IntAct=EBI-712096, EBI-13059134;
+CC       P30519; Q3SXY8: ARL13B; NbExp=3; IntAct=EBI-712096, EBI-11343438;
+CC       P30519; Q66PJ3-4: ARL6IP4; NbExp=3; IntAct=EBI-712096, EBI-5280499;
+CC       P30519; P07307-3: ASGR2; NbExp=3; IntAct=EBI-712096, EBI-12808270;
+CC       P30519; Q14032: BAAT; NbExp=3; IntAct=EBI-712096, EBI-8994378;
+CC       P30519; Q9BXK5: BCL2L13; NbExp=3; IntAct=EBI-712096, EBI-747430;
+CC       P30519; Q9NSI6-4: BRWD1; NbExp=3; IntAct=EBI-712096, EBI-10693038;
+CC       P30519; Q3SXR2: C3orf36; NbExp=3; IntAct=EBI-712096, EBI-18036948;
+CC       P30519; O00257-3: CBX4; NbExp=3; IntAct=EBI-712096, EBI-4392727;
+CC       P30519; P11912: CD79A; NbExp=3; IntAct=EBI-712096, EBI-7797864;
+CC       P30519; Q3SX64: CIMAP1D; NbExp=3; IntAct=EBI-712096, EBI-6660184;
+CC       P30519; Q6PJW8-3: CNST; NbExp=3; IntAct=EBI-712096, EBI-25836090;
+CC       P30519; Q96BR5: COA7; NbExp=3; IntAct=EBI-712096, EBI-6269632;
+CC       P30519; Q9BUF7-2: CRB3; NbExp=3; IntAct=EBI-712096, EBI-17233035;
+CC       P30519; Q9H2U1-3: DHX36; NbExp=3; IntAct=EBI-712096, EBI-25868628;
+CC       P30519; Q15125: EBP; NbExp=3; IntAct=EBI-712096, EBI-3915253;
+CC       P30519; O00472: ELL2; NbExp=3; IntAct=EBI-712096, EBI-395274;
+CC       P30519; Q9GZR5: ELOVL4; NbExp=3; IntAct=EBI-712096, EBI-18535450;
+CC       P30519; Q9NYP7: ELOVL5; NbExp=3; IntAct=EBI-712096, EBI-11037623;
+CC       P30519; Q9Y282: ERGIC3; NbExp=3; IntAct=EBI-712096, EBI-781551;
+CC       P30519; Q5JX71: FAM209A; NbExp=3; IntAct=EBI-712096, EBI-18304435;
+CC       P30519; Q96KR6: FAM210B; NbExp=3; IntAct=EBI-712096, EBI-18938272;
+CC       P30519; Q9NQ89: FERRY3; NbExp=3; IntAct=EBI-712096, EBI-11090973;
+CC       P30519; P06241: FYN; NbExp=3; IntAct=EBI-712096, EBI-515315;
+CC       P30519; O00258: GET1; NbExp=3; IntAct=EBI-712096, EBI-18908258;
+CC       P30519; Q8TDT2: GPR152; NbExp=3; IntAct=EBI-712096, EBI-13345167;
+CC       P30519; Q8TED1: GPX8; NbExp=3; IntAct=EBI-712096, EBI-11721746;
+CC       P30519; Q6NXT2: H3-5; NbExp=3; IntAct=EBI-712096, EBI-2868501;
+CC       P30519; P48051: KCNJ6; NbExp=3; IntAct=EBI-712096, EBI-12017638;
+CC       P30519; Q13571: LAPTM5; NbExp=3; IntAct=EBI-712096, EBI-2865663;
+CC       P30519; Q8IYG6: LRRC56; NbExp=3; IntAct=EBI-712096, EBI-14752528;
+CC       P30519; O14880: MGST3; NbExp=3; IntAct=EBI-712096, EBI-724754;
+CC       P30519; A0A0A0MR05: MLST8; NbExp=3; IntAct=EBI-712096, EBI-25835557;
+CC       P30519; Q6IN84-2: MRM1; NbExp=3; IntAct=EBI-712096, EBI-25835707;
+CC       P30519; P36639-4: NUDT1; NbExp=3; IntAct=EBI-712096, EBI-25834643;
+CC       P30519; Q7Z3B4: NUP54; NbExp=3; IntAct=EBI-712096, EBI-741048;
+CC       P30519; P36954: POLR2I; NbExp=3; IntAct=EBI-712096, EBI-395202;
+CC       P30519; Q86VR2: RETREG3; NbExp=3; IntAct=EBI-712096, EBI-10192441;
+CC       P30519; Q6P5S7: RNASEK; NbExp=3; IntAct=EBI-712096, EBI-18397230;
+CC       P30519; Q66K80: RUSC1-AS1; NbExp=3; IntAct=EBI-712096, EBI-10248967;
+CC       P30519; Q9NR31: SAR1A; NbExp=3; IntAct=EBI-712096, EBI-3920694;
+CC       P30519; Q9NTN9-3: SEMA4G; NbExp=3; IntAct=EBI-712096, EBI-9089805;
+CC       P30519; O95470: SGPL1; NbExp=3; IntAct=EBI-712096, EBI-1046170;
+CC       P30519; Q8IWU4: SLC30A8; NbExp=3; IntAct=EBI-712096, EBI-10262251;
+CC       P30519; Q13573: SNW1; NbExp=3; IntAct=EBI-712096, EBI-632715;
+CC       P30519; Q96BD6: SPSB1; NbExp=3; IntAct=EBI-712096, EBI-2659201;
+CC       P30519; Q8WWF3: SSMEM1; NbExp=3; IntAct=EBI-712096, EBI-17280858;
+CC       P30519; P27105: STOM; NbExp=3; IntAct=EBI-712096, EBI-1211440;
+CC       P30519; P21579: SYT1; NbExp=3; IntAct=EBI-712096, EBI-524909;
+CC       P30519; P54274-2: TERF1; NbExp=3; IntAct=EBI-712096, EBI-711018;
+CC       P30519; Q9NUH8: TMEM14B; NbExp=3; IntAct=EBI-712096, EBI-8638294;
+CC       P30519; Q9Y320: TMX2; NbExp=3; IntAct=EBI-712096, EBI-6447886;
+CC       P30519; Q86WT6-2: TRIM69; NbExp=3; IntAct=EBI-712096, EBI-11525489;
+CC       P30519; P49459: UBE2A; NbExp=3; IntAct=EBI-712096, EBI-2339348;
+CC       P30519; Q3ZAQ7: VMA21; NbExp=3; IntAct=EBI-712096, EBI-1055364;
+CC       P30519; Q53FD0-2: ZC2HC1C; NbExp=3; IntAct=EBI-712096, EBI-14104088;
+CC   -!- SUBCELLULAR LOCATION: Microsome membrane {ECO:0000305|PubMed:7890772};
+CC       Single-pass type IV membrane protein {ECO:0000255}; Cytoplasmic side
+CC       {ECO:0000250|UniProtKB:P09601}. Endoplasmic reticulum membrane
+CC       {ECO:0000250|UniProtKB:P09601}; Single-pass type IV membrane protein
+CC       {ECO:0000255}; Cytoplasmic side {ECO:0000250|UniProtKB:P09601}.
+CC   -!- ALTERNATIVE PRODUCTS:
+CC       Event=Alternative splicing; Named isoforms=2;
+CC       Name=1;
+CC         IsoId=P30519-1; Sequence=Displayed;
+CC       Name=2;
+CC         IsoId=P30519-2; Sequence=VSP_055031;
+CC   -!- PTM: A soluble form arises by proteolytic removal of the membrane
+CC       anchor. {ECO:0000305|PubMed:7890772}.
+CC   -!- PTM: S-nitrosylated by BLVRB. {ECO:0000269|PubMed:38056462}.
+CC   -!- SIMILARITY: Belongs to the heme oxygenase family. {ECO:0000305}.
+CC   -!- SEQUENCE CAUTION:
+CC       Sequence=W38932; Type=Frameshift; Evidence={ECO:0000305};
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; D21243; BAA04789.1; -; mRNA.
+DR   EMBL; S34389; AAB22110.2; -; mRNA.
+DR   EMBL; BT019788; AAV38591.1; -; mRNA.
+DR   EMBL; AY771350; AAV28730.1; -; Genomic_DNA.
+DR   EMBL; AC007606; -; NOT_ANNOTATED_CDS; Genomic_DNA.
+DR   EMBL; CH471112; EAW85299.1; -; Genomic_DNA.
+DR   EMBL; CH471112; EAW85300.1; -; Genomic_DNA.
+DR   EMBL; BC002396; AAH02396.1; -; mRNA.
+DR   EMBL; W38932; -; NOT_ANNOTATED_CDS; mRNA.
+DR   EMBL; AF051306; AAC05297.1; -; mRNA.
+DR   CCDS; CCDS10517.1; -. [P30519-1]
+DR   CCDS; CCDS66931.1; -. [P30519-2]
+DR   PIR; I60119; I60119.
+DR   PIR; S21700; S21700.
+DR   RefSeq; NP_001120676.1; NM_001127204.2. [P30519-1]
+DR   RefSeq; NP_001120677.1; NM_001127205.2. [P30519-1]
+DR   RefSeq; NP_001120678.1; NM_001127206.3. [P30519-1]
+DR   RefSeq; NP_001273196.1; NM_001286267.1.
+DR   RefSeq; NP_001273197.1; NM_001286268.2. [P30519-1]
+DR   RefSeq; NP_001273198.1; NM_001286269.2. [P30519-1]
+DR   RefSeq; NP_001273199.1; NM_001286270.2. [P30519-1]
+DR   RefSeq; NP_001273200.1; NM_001286271.2. [P30519-2]
+DR   RefSeq; NP_002125.3; NM_002134.3. [P30519-1]
+DR   RefSeq; XP_016878685.1; XM_017023196.3. [P30519-1]
+DR   RefSeq; XP_024306018.1; XM_024450250.2. [P30519-1]
+DR   RefSeq; XP_054185152.1; XM_054329177.1. [P30519-1]
+DR   RefSeq; XP_054185153.1; XM_054329178.1. [P30519-1]
+DR   RefSeq; XP_054236180.1; XM_054380205.1. [P30519-1]
+DR   RefSeq; XP_054236181.1; XM_054380206.1. [P30519-1]
+DR   PDB; 2Q32; X-ray; 2.40 A; A/B=1-264.
+DR   PDB; 2QPP; X-ray; 2.61 A; A/B=1-264.
+DR   PDB; 2RGZ; X-ray; 2.61 A; A/B=1-264.
+DR   PDB; 4WMH; X-ray; 2.50 A; A=31-237.
+DR   PDB; 5UC8; X-ray; 2.00 A; A/B/C/D=30-242.
+DR   PDB; 5UC9; X-ray; 1.90 A; A/B/C/D=30-242.
+DR   PDB; 5UCA; X-ray; 2.12 A; A/B/C/D=30-242.
+DR   PDBsum; 2Q32; -.
+DR   PDBsum; 2QPP; -.
+DR   PDBsum; 2RGZ; -.
+DR   PDBsum; 4WMH; -.
+DR   PDBsum; 5UC8; -.
+DR   PDBsum; 5UC9; -.
+DR   PDBsum; 5UCA; -.
+DR   AlphaFoldDB; P30519; -.
+DR   SMR; P30519; -.
+DR   BioGRID; 109406; 363.
+DR   DIP; DIP-53564N; -.
+DR   FunCoup; P30519; 864.
+DR   IntAct; P30519; 214.
+DR   MINT; P30519; -.
+DR   NDEx; IQUERY-CP-HMOX2; 1 NDEx IQuery Curated Pathway.
+DR   STRING; 9606.ENSP00000477572; -.
+DR   BindingDB; P30519; -.
+DR   ChEMBL; CHEMBL2546; -.
+DR   DrugBank; DB00157; NADH.
+DR   DrugBank; DB04912; Stannsoporfin.
+DR   GlyCosmos; P30519; 2 sites, 1 glycan.
+DR   GlyGen; P30519; 3 sites, 1 O-linked glycan (3 sites).
+DR   iPTMnet; P30519; -.
+DR   MetOSite; P30519; -.
+DR   PhosphoSitePlus; P30519; -.
+DR   SwissPalm; P30519; -.
+DR   BioMuta; HMOX2; -.
+DR   DMDM; 1170328; -.
+DR   jPOST; P30519; -.
+DR   MassIVE; P30519; -.
+DR   PaxDb; 9606-ENSP00000477572; -.
+DR   PeptideAtlas; P30519; -.
+DR   ProteomicsDB; 47391; -.
+DR   ProteomicsDB; 54710; -. [P30519-1]
+DR   Pumba; P30519; -.
+DR   Antibodypedia; 11116; 641 antibodies from 39 providers.
+DR   DNASU; 3163; -.
+DR   Ensembl; ENST00000219700.10; ENSP00000219700.6; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000398595.7; ENSP00000381595.3; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000406590.6; ENSP00000385100.2; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000414777.5; ENSP00000391637.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000458134.7; ENSP00000394103.3; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000570646.6; ENSP00000459214.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000575120.5; ENSP00000460926.1; ENSG00000103415.13. [P30519-2]
+DR   Ensembl; ENST00000612525.4; ENSP00000481295.1; ENSG00000277424.4. [P30519-1]
+DR   Ensembl; ENST00000615778.4; ENSP00000484422.1; ENSG00000277424.4. [P30519-1]
+DR   Ensembl; ENST00000619528.4; ENSP00000484423.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000619913.4; ENSP00000484467.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000620445.3; ENSP00000478785.1; ENSG00000277424.4. [P30519-1]
+DR   Ensembl; ENST00000621065.4; ENSP00000481811.1; ENSG00000277424.4. [P30519-1]
+DR   Ensembl; ENST00000622146.4; ENSP00000483319.2; ENSG00000277424.4. [P30519-1]
+DR   Ensembl; ENST00000631540.1; ENSP00000487673.1; ENSG00000277424.4. [P30519-1]
+DR   Ensembl; ENST00000631677.1; ENSP00000488579.1; ENSG00000277424.4. [P30519-1]
+DR   Ensembl; ENST00000632458.1; ENSP00000488880.1; ENSG00000277424.4. [P30519-1]
+DR   Ensembl; ENST00000633319.1; ENSP00000488769.1; ENSG00000277424.4. [P30519-2]
+DR   Ensembl; ENST00000905894.1; ENSP00000575953.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905895.1; ENSP00000575954.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905896.1; ENSP00000575955.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905897.1; ENSP00000575956.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905898.1; ENSP00000575957.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905899.1; ENSP00000575958.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905900.1; ENSP00000575959.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905901.1; ENSP00000575960.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905902.1; ENSP00000575961.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905903.1; ENSP00000575962.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905904.1; ENSP00000575963.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000905905.1; ENSP00000575964.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000938913.1; ENSP00000608972.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000938914.1; ENSP00000608973.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000938916.1; ENSP00000608975.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000938917.1; ENSP00000608976.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964450.1; ENSP00000634509.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964451.1; ENSP00000634510.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964452.1; ENSP00000634511.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964453.1; ENSP00000634512.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964454.1; ENSP00000634513.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964455.1; ENSP00000634514.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964456.1; ENSP00000634515.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964457.1; ENSP00000634516.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964458.1; ENSP00000634517.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964459.1; ENSP00000634518.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964460.1; ENSP00000634519.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964461.1; ENSP00000634520.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964462.1; ENSP00000634521.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964463.1; ENSP00000634522.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964464.1; ENSP00000634523.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964465.1; ENSP00000634524.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964466.1; ENSP00000634525.1; ENSG00000103415.13. [P30519-1]
+DR   Ensembl; ENST00000964467.1; ENSP00000634526.1; ENSG00000103415.13. [P30519-1]
+DR   GeneID; 3163; -.
+DR   KEGG; hsa:3163; -.
+DR   MANE-Select; ENST00000570646.6; ENSP00000459214.1; NM_002134.4; NP_002125.3.
+DR   UCSC; uc002cwq.5; human. [P30519-1]
+DR   AGR; HGNC:5014; -.
+DR   ClinPGx; PA29342; -.
+DR   CTD; 3163; -.
+DR   DisGeNET; 3163; -.
+DR   GeneCards; HMOX2; -.
+DR   HGNC; HGNC:5014; HMOX2.
+DR   HPA; ENSG00000103415; Low tissue specificity.
+DR   MIM; 141251; gene.
+DR   OpenTargets; ENSG00000103415; -.
+DR   VEuPathDB; HostDB:ENSG00000103415; -.
+DR   eggNOG; KOG4480; Eukaryota.
+DR   GeneTree; ENSGT00390000017673; -.
+DR   HOGENOM; CLU_057050_0_1_1; -.
+DR   InParanoid; P30519; -.
+DR   OMA; NRAFEYN; -.
+DR   OrthoDB; 652091at2759; -.
+DR   PAN-GO; P30519; 6 GO annotations based on evolutionary models.
+DR   PhylomeDB; P30519; -.
+DR   BRENDA; 1.14.14.18; 2681.
+DR   PathwayCommons; P30519; -.
+DR   Reactome; R-HSA-189483; Heme degradation.
+DR   Reactome; R-HSA-6798695; Neutrophil degranulation.
+DR   Reactome; R-HSA-8980692; RHOA GTPase cycle.
+DR   Reactome; R-HSA-917937; Iron uptake and transport.
+DR   Reactome; R-HSA-9707564; Cytoprotection by HMOX1.
+DR   SignaLink; P30519; -.
+DR   SIGNOR; P30519; -.
+DR   Agora; ENSG00000103415; -.
+DR   BioGRID-ORCS; 3163; 19 hits in 1171 CRISPR screens.
+DR   CD-CODE; FB4E32DD; Presynaptic clusters and postsynaptic densities.
+DR   ChiTaRS; HMOX2; human.
+DR   EvolutionaryTrace; P30519; -.
+DR   GeneWiki; HMOX2; -.
+DR   GenomeRNAi; 3163; -.
+DR   Pharos; P30519; Tchem.
+DR   PRO; PR:P30519; -.
+DR   Proteomes; UP000005640; Chromosome 16.
+DR   RNAct; P30519; protein.
+DR   Bgee; ENSG00000103415; Expressed in right testis and 97 other cell types or tissues.
+DR   ExpressionAtlas; P30519; baseline and differential.
+DR   GO; GO:0005789; C:endoplasmic reticulum membrane; TAS:Reactome.
+DR   GO; GO:0016020; C:membrane; HDA:UniProtKB.
+DR   GO; GO:0005886; C:plasma membrane; IDA:UniProtKB.
+DR   GO; GO:0035579; C:specific granule membrane; TAS:Reactome.
+DR   GO; GO:0020037; F:heme binding; IBA:GO_Central.
+DR   GO; GO:0004392; F:heme oxygenase (decyclizing) activity; IDA:UniProtKB.
+DR   GO; GO:0046872; F:metal ion binding; IEA:UniProtKB-KW.
+DR   GO; GO:0042167; P:heme catabolic process; IBA:GO_Central.
+DR   GO; GO:0006788; P:heme oxidation; IBA:GO_Central.
+DR   GO; GO:0001666; P:response to hypoxia; IDA:UniProtKB.
+DR   GO; GO:0006979; P:response to oxidative stress; IBA:GO_Central.
+DR   CDD; cd19165; HemeO; 1.
+DR   DisProt; DP04179; -.
+DR   FunFam; 1.20.910.10:FF:000001; Heme oxygenase 1; 1.
+DR   Gene3D; 1.20.910.10; Heme oxygenase-like; 1.
+DR   InterPro; IPR002051; Haem_Oase.
+DR   InterPro; IPR016053; Haem_Oase-like.
+DR   InterPro; IPR016084; Haem_Oase-like_multi-hlx.
+DR   InterPro; IPR018207; Haem_oxygenase_CS.
+DR   PANTHER; PTHR10720; HEME OXYGENASE; 1.
+DR   PANTHER; PTHR10720:SF2; HEME OXYGENASE 2; 1.
+DR   Pfam; PF01126; Heme_oxygenase; 1.
+DR   PIRSF; PIRSF000343; Haem_Oase; 1.
+DR   PRINTS; PR00088; HAEMOXYGNASE.
+DR   SUPFAM; SSF48613; Heme oxygenase-like; 1.
+DR   PROSITE; PS00593; HEME_OXYGENASE; 1.
+PE   1: Evidence at protein level;
+KW   3D-structure; Acetylation; Alternative splicing; Direct protein sequencing;
+KW   Endoplasmic reticulum; Heme; Iron; Membrane; Metal-binding; Microsome;
+KW   Oxidoreductase; Phosphoprotein; Proteomics identification;
+KW   Reference proteome; Repeat; S-nitrosylation; Transmembrane;
+KW   Transmembrane helix.
+FT   INIT_MET        1
+FT                   /note="Removed"
+FT                   /evidence="ECO:0000269|Ref.9, ECO:0007744|PubMed:19413330,
+FT                   ECO:0007744|PubMed:25944712"
+FT   CHAIN           2..316
+FT                   /note="Heme oxygenase 2"
+FT                   /id="PRO_0000209691"
+FT   CHAIN           2..295
+FT                   /note="Heme oxygenase 2 soluble form"
+FT                   /evidence="ECO:0000305|PubMed:7890772"
+FT                   /id="PRO_0000455626"
+FT   TOPO_DOM        2..295
+FT                   /note="Cytoplasmic"
+FT                   /evidence="ECO:0000250|UniProtKB:P09601"
+FT   TRANSMEM        296..316
+FT                   /note="Helical; Anchor for type IV membrane protein"
+FT                   /evidence="ECO:0000255"
+FT   REPEAT          264..269
+FT                   /note="HRM 1"
+FT   REPEAT          281..286
+FT                   /note="HRM 2"
+FT   REGION          1..29
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        1..12
+FT                   /note="Acidic residues"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        13..27
+FT                   /note="Basic and acidic residues"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   BINDING         45
+FT                   /ligand="heme b"
+FT                   /ligand_id="ChEBI:CHEBI:60344"
+FT                   /ligand_part="Fe"
+FT                   /ligand_part_id="ChEBI:CHEBI:18248"
+FT                   /note="axial binding residue"
+FT                   /evidence="ECO:0000269|PubMed:17965015,
+FT                   ECO:0007744|PDB:2QPP"
+FT   BINDING         154
+FT                   /ligand="heme b"
+FT                   /ligand_id="ChEBI:CHEBI:60344"
+FT                   /evidence="ECO:0000269|PubMed:17965015,
+FT                   ECO:0007744|PDB:2QPP"
+FT   BINDING         199
+FT                   /ligand="heme b"
+FT                   /ligand_id="ChEBI:CHEBI:60344"
+FT                   /evidence="ECO:0000269|PubMed:17965015,
+FT                   ECO:0007744|PDB:2QPP"
+FT   BINDING         203
+FT                   /ligand="heme b"
+FT                   /ligand_id="ChEBI:CHEBI:60344"
+FT                   /evidence="ECO:0000269|PubMed:17965015,
+FT                   ECO:0007744|PDB:2QPP"
+FT   SITE            160
+FT                   /note="Important for catalytic activity"
+FT                   /evidence="ECO:0000250|UniProtKB:P09601"
+FT   MOD_RES         2
+FT                   /note="N-acetylserine"
+FT                   /evidence="ECO:0000269|Ref.9, ECO:0007744|PubMed:19413330,
+FT                   ECO:0007744|PubMed:25944712"
+FT   MOD_RES         2
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:23186163"
+FT   MOD_RES         265
+FT                   /note="S-nitrosocysteine"
+FT                   /evidence="ECO:0000269|PubMed:38056462"
+FT   MOD_RES         282
+FT                   /note="S-nitrosocysteine"
+FT                   /evidence="ECO:0000269|PubMed:38056462"
+FT   VAR_SEQ         1..29
+FT                   /note="Missing (in isoform 2)"
+FT                   /evidence="ECO:0000303|Ref.8"
+FT                   /id="VSP_055031"
+FT   VARIANT         137
+FT                   /note="R -> Q (in dbSNP:rs17884623)"
+FT                   /evidence="ECO:0000269|Ref.4"
+FT                   /id="VAR_021067"
+FT   VARIANT         146
+FT                   /note="P -> L (in dbSNP:rs17880805)"
+FT                   /evidence="ECO:0000269|Ref.4"
+FT                   /id="VAR_021068"
+FT   MUTAGEN         265
+FT                   /note="C->R: Abolished S-nitrosylation; when associated
+FT                   with R-282."
+FT                   /evidence="ECO:0000269|PubMed:38056462"
+FT   MUTAGEN         282
+FT                   /note="C->R: Abolished S-nitrosylation; when associated
+FT                   with R-265."
+FT                   /evidence="ECO:0000269|PubMed:38056462"
+FT   CONFLICT        107
+FT                   /note="E -> T (in Ref. 8; W38932)"
+FT                   /evidence="ECO:0000305"
+FT   CONFLICT        165..166
+FT                   /note="QV -> KC (in Ref. 10; AAC05297)"
+FT                   /evidence="ECO:0000305"
+FT   CONFLICT        222
+FT                   /note="Missing (in Ref. 2; AAB22110)"
+FT                   /evidence="ECO:0000305"
+FT   CONFLICT        276
+FT                   /note="Missing (in Ref. 2; AAB22110)"
+FT                   /evidence="ECO:0000305"
+FT   CONFLICT        281..288
+FT                   /note="SCPFRTAM -> LSLPTSY (in Ref. 2; AAB22110)"
+FT                   /evidence="ECO:0000305"
+FT   HELIX           33..49
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           52..58
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           64..87
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   TURN            88..90
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   TURN            92..94
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           95..97
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           100..103
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           106..117
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           121..124
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           129..144
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           146..148
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           149..153
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           154..158
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           159..175
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           185..187
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           195..207
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   HELIX           213..238
+FT                   /evidence="ECO:0007829|PDB:5UC9"
+FT   TURN            243..247
+FT                   /evidence="ECO:0007829|PDB:2Q32"
+SQ   SEQUENCE   316 AA;  36033 MW;  BF4B6A341F1A81AC CRC64;
+     MSAEVETSEG VDESEKKNSG ALEKENQMRM ADLSELLKEG TKEAHDRAEN TQFVKDFLKG
+     NIKKELFKLA TTALYFTYSA LEEEMERNKD HPAFAPLYFP MELHRKEALT KDMEYFFGEN
+     WEEQVQCPKA AQKYVERIHY IGQNEPELLV AHAYTRYMGD LSGGQVLKKV AQRALKLPST
+     GEGTQFYLFE NVDNAQQFKQ LYRARMNALD LNMKTKERIV EEANKAFEYN MQIFNELDQA
+     GSTLARETLE DGFPVHDGKG DMRKCPFYAA EQDKGALEGS SCPFRTAMAV LRKPSLQFIL
+     AAGVALAAGL LAWYYM
+//

--- a/interpro/panther/PTHR10720/PTHR10720-entries.csv
+++ b/interpro/panther/PTHR10720/PTHR10720-entries.csv
@@ -1,0 +1,24 @@
+id,name,entry_type,source_tax_id,source_tax_name,full_tax_name,gene,length,subfamily,subfamily_name,in_alphafold
+O19998,Heme oxygenase,protein,2801,Rhodella violacea,Rhodella violacea (Red alga),pbsA,235,PTHR10720:SF0,HEME OXYGENASE,True
+O70252,Heme oxygenase 2,protein,10090,Mus musculus,Mus musculus (Mouse),Hmox2,315,PTHR10720:SF2,HEME OXYGENASE 2,True
+O70453,Putative heme oxygenase 3,protein,10116,Rattus norvegicus,Rattus norvegicus (Rat),Hmox3,290,PTHR10720:SF2,HEME OXYGENASE 2,True
+O73688,Heme oxygenase,protein,31033,Takifugu rubripes,Takifugu rubripes (Japanese pufferfish),hmox,277,PTHR10720:SF1,HEME OXYGENASE 1,True
+O78497,Heme oxygenase,protein,55529,Guillardia theta,Guillardia theta (Cryptophyte),pbsA,237,PTHR10720:SF0,HEME OXYGENASE,True
+P06762,Heme oxygenase 1,protein,10116,Rattus norvegicus,Rattus norvegicus (Rat),Hmox1,289,PTHR10720:SF1,HEME OXYGENASE 1,True
+P09601,Heme oxygenase 1,protein,9606,Homo sapiens,Homo sapiens (Human),HMOX1,288,PTHR10720:SF1,HEME OXYGENASE 1,True
+P14791,Heme oxygenase 1,protein,9031,Gallus gallus,Gallus gallus (Chicken),HMOX1,296,PTHR10720:SF1,HEME OXYGENASE 1,True
+P14901,Heme oxygenase 1,protein,10090,Mus musculus,Mus musculus (Mouse),Hmox1,289,PTHR10720:SF1,HEME OXYGENASE 1,True
+P23711,Heme oxygenase 2,protein,10116,Rattus norvegicus,Rattus norvegicus (Rat),Hmox2,315,PTHR10720:SF2,HEME OXYGENASE 2,True
+P30519,Heme oxygenase 2,protein,9606,Homo sapiens,Homo sapiens (Human),HMOX2,316,PTHR10720:SF2,HEME OXYGENASE 2,True
+P32339,Heme-binding protein HMX1,protein,559292,Saccharomyces cerevisiae (strain ATCC 204508 / S288c),Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast),HMX1,317,PTHR10720:SF0,HEME OXYGENASE,True
+P32394,Heme oxygenase 1,protein,9823,Sus scrofa,Sus scrofa (Pig),HMOX1,288,PTHR10720:SF1,HEME OXYGENASE 1,True
+P43242,Heme oxygenase 2,protein,9986,Oryctolagus cuniculus,Oryctolagus cuniculus (Rabbit),HMOX2,312,PTHR10720:SF2,HEME OXYGENASE 2,True
+P51271,Heme oxygenase,protein,2787,Porphyra purpurea,Porphyra purpurea (Red seaweed),pbsA,236,PTHR10720:SF0,HEME OXYGENASE,True
+P71119,Heme oxygenase,protein,257309,Corynebacterium diphtheriae (strain ATCC 700971 / NCTC 13129 / Biotype gravis),Corynebacterium diphtheriae (strain ATCC 700971 / NCTC 13129 / Biotype gravis),hmuO,215,PTHR10720:SF0,HEME OXYGENASE,True
+P72849,Heme oxygenase 1,protein,1111708,Synechocystis sp. (strain ATCC 27184 / PCC 6803 / Kazusa),Synechocystis sp. (strain ATCC 27184 / PCC 6803 / Kazusa),ho1,240,PTHR10720:SF0,HEME OXYGENASE,True
+P74133,Heme oxygenase 2,protein,1111708,Synechocystis sp. (strain ATCC 27184 / PCC 6803 / Kazusa),Synechocystis sp. (strain ATCC 27184 / PCC 6803 / Kazusa),ho2,250,PTHR10720:SF0,HEME OXYGENASE,True
+Q1XDL5,Heme oxygenase,protein,2788,Pyropia yezoensis,Pyropia yezoensis (Susabi-nori),pbsA,238,PTHR10720:SF0,HEME OXYGENASE,True
+Q2PG53,Heme oxygenase 2,protein,9541,Macaca fascicularis,Macaca fascicularis (Crab-eating macaque),HMOX2,316,PTHR10720:SF2,HEME OXYGENASE 2,True
+Q5E9F2,Heme oxygenase 1,protein,9913,Bos taurus,Bos taurus (Bovine),HMOX1,289,PTHR10720:SF1,HEME OXYGENASE 1,True
+Q5R7E3,Heme oxygenase 1,protein,9601,Pongo abelii,Pongo abelii (Sumatran orangutan),HMOX1,288,PTHR10720:SF1,HEME OXYGENASE 1,True
+Q8YVS7,Heme oxygenase,protein,103690,Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576),Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576),ho,238,PTHR10720:SF0,HEME OXYGENASE,True

--- a/interpro/panther/PTHR10720/PTHR10720-metadata.yaml
+++ b/interpro/panther/PTHR10720/PTHR10720-metadata.yaml
@@ -1,0 +1,45 @@
+metadata:
+  accession: PTHR10720
+  entry_id: null
+  type: family
+  go_terms: null
+  source_database: panther
+  member_databases: null
+  integrated: IPR002051
+  hierarchy: null
+  name:
+    name: HEME OXYGENASE
+    short: null
+  description: null
+  wikipedia: null
+  literature: null
+  set_info: null
+  overlaps_with: null
+  counters:
+    subfamilies: 4
+    domain_architectures: 0
+    interactions: 0
+    matches: 6831
+    pathways: 0
+    proteins: 6831
+    proteomes: 4857
+    sets: 0
+    structural_models:
+      alphafold: 5121
+    structures: 87
+    taxa: 9617
+  entry_annotations:
+    hmm: 0
+    logo: 0
+  cross_references: {}
+  is_llm: false
+  is_reviewed_llm: false
+  is_updated_llm: false
+  representative_structure:
+    accession: 6eha
+    name: Heme oxygenase 1 in complex with inhibitor
+_fetch_info:
+  fetched_date: '2026-07-14T05:00:25.643118'
+  api_endpoint: https://www.ebi.ac.uk/interpro/api/entry/panther/PTHR10720/
+  database: panther
+  family_id: PTHR10720

--- a/interpro/panther/PTHR43355/PTHR43355-entries.csv
+++ b/interpro/panther/PTHR43355/PTHR43355-entries.csv
@@ -1,0 +1,12 @@
+id,name,entry_type,source_tax_id,source_tax_name,full_tax_name,gene,length,subfamily,subfamily_name,in_alphafold
+M2XHE6,Averufin oxidase A,protein,675120,Dothistroma septosporum (strain NZE10 / CBS 128990),Dothistroma septosporum (strain NZE10 / CBS 128990) (Red band needle blight fungus),avfA,284,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True
+O07548,Uncharacterized protein YheG,protein,224308,Bacillus subtilis (strain 168),Bacillus subtilis (strain 168),yheG,206,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True
+P30043,Flavin reductase (NADPH),protein,9606,Homo sapiens,Homo sapiens (Human),BLVRB,206,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True
+P52556,Flavin reductase (NADPH),protein,9913,Bos taurus,Bos taurus (Bovine),BLVRB,206,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True
+P71037,Uncharacterized protein YwnB,protein,224308,Bacillus subtilis (strain 168),Bacillus subtilis (strain 168),ywnB,213,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True
+P9WEZ2,Reductase pytE,protein,33178,Aspergillus terreus,Aspergillus terreus,pytE,263,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True
+Q00710,Averufin oxidase stcO,protein,227321,Emericella nidulans (strain FGSC A4 / ATCC 38163 / CBS 112.46 / NRRL 194 / M139),Emericella nidulans (strain FGSC A4 / ATCC 38163 / CBS 112.46 / NRRL 194 / M139),stcO,297,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True
+Q12437,Averufin oxidase A,protein,1403190,Aspergillus parasiticus (strain ATCC 56775 / NRRL 5862 / SRRC 143 / SU-1),Aspergillus parasiticus (strain ATCC 56775 / NRRL 5862 / SRRC 143 / SU-1),aflI,285,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True
+Q30DW7,Averufin oxidase A,protein,64363,Dothistroma septosporum,Dothistroma septosporum (Red band needle blight fungus),avfA,301,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True
+Q923D2,Flavin reductase (NADPH),protein,10090,Mus musculus,Mus musculus (Mouse),Blvrb,206,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True
+Q9P8Z9,Averufin oxidase A,protein,332952,Aspergillus flavus (strain ATCC 200026 / FGSC A1120 / IAM 13836 / NRRL 3357 / JCM 12722 / SRRC 167),Aspergillus flavus (strain ATCC 200026 / FGSC A1120 / IAM 13836 / NRRL 3357 / JCM 12722 / SRRC 167),avfA,282,PTHR43355:SF2,FLAVIN REDUCTASE (NADPH),True

--- a/interpro/panther/PTHR43355/PTHR43355-metadata.yaml
+++ b/interpro/panther/PTHR43355/PTHR43355-metadata.yaml
@@ -1,0 +1,58 @@
+metadata:
+  accession: PTHR43355
+  entry_id: null
+  type: family
+  go_terms: null
+  source_database: panther
+  member_databases: null
+  integrated: IPR051606
+  hierarchy: null
+  name:
+    name: Polyketide Oxidoreductase-like
+    short: Polyketide_Oxido-like
+  description:
+  - text: This family of proteins includes oxidoreductases that play a crucial role
+      in the biosynthesis of various secondary metabolites, including mycotoxins such
+      as aflatoxins and sterigmatocystin, as well as other polyketide-derived compounds.
+      Members of this family are involved in specific oxidation steps within the biosynthetic
+      pathways. These enzymes typically catalyze the conversion of intermediate compounds
+      to more complex structures, contributing to the formation of key functional
+      groups and rings essential for the biological activity of the final products.
+      The family also includes proteins that are involved in the reduction of various
+      flavins and other substrates, indicating a broad specificity and a role in diverse
+      metabolic processes.
+    llm: true
+    checked: false
+    updated: false
+  wikipedia: null
+  literature: null
+  set_info: null
+  overlaps_with: null
+  counters:
+    subfamilies: 2
+    domain_architectures: 0
+    interactions: 0
+    matches: 16730
+    pathways: 0
+    proteins: 16730
+    proteomes: 9530
+    sets: 0
+    structural_models:
+      alphafold: 10894
+    structures: 34
+    taxa: 15457
+  entry_annotations:
+    hmm: 0
+    logo: 0
+  cross_references: {}
+  is_llm: true
+  is_reviewed_llm: false
+  is_updated_llm: false
+  representative_structure:
+    accession: 1hdo
+    name: 'Human biliverdin IX beta reductase: NADP complex'
+_fetch_info:
+  fetched_date: '2026-07-14T05:02:01.511347'
+  api_endpoint: https://www.ebi.ac.uk/interpro/api/entry/panther/PTHR43355/
+  database: panther
+  family_id: PTHR43355

--- a/interpro/panther/PTHR43377/PTHR43377-entries.csv
+++ b/interpro/panther/PTHR43377/PTHR43377-entries.csv
@@ -1,0 +1,13 @@
+id,name,entry_type,source_tax_id,source_tax_name,full_tax_name,gene,length,subfamily,subfamily_name,in_alphafold
+A7B558,"2,7-anhydro-N-acetylneuraminate hydratase",protein,411470,Mediterraneibacter gnavus (strain ATCC 29149 / DSM 114966 / JCM 6515 / VPI C7-9),Mediterraneibacter gnavus (strain ATCC 29149 / DSM 114966 / JCM 6515 / VPI C7-9),RUMGNA_02695,374,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True
+B7JA34,UDP-N-acetylglucosamine 3-dehydrogenase,protein,243159,Acidithiobacillus ferrooxidans (strain ATCC 23270 / DSM 14882 / CIP 104768 / NCIMB 8455),Acidithiobacillus ferrooxidans (strain ATCC 23270 / DSM 14882 / CIP 104768 / NCIMB 8455),gnnA,313,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True
+O34371,Putative oxidoreductase YteT,protein,224308,Bacillus subtilis (strain 168),Bacillus subtilis (strain 168),yteT,428,PTHR43377:SF2,"BINDING ROSSMANN FOLD OXIDOREDUCTASE, PUTATIVE (AFU_ORTHOLOGUE AFUA_4G00560)-RELATED",True
+P39353,"2,7-anhydro-N-acetylneuraminate hydratase",protein,83333,Escherichia coli (strain K12),Escherichia coli (strain K12),nanY,372,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True
+P46844,Biliverdin reductase A,protein,10116,Rattus norvegicus,Rattus norvegicus (Rat),Blvra,295,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True
+P53004,Biliverdin reductase A,protein,9606,Homo sapiens,Homo sapiens (Human),BLVRA,296,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True
+P55609,Uncharacterized protein y4oX,protein,394,Sinorhizobium fredii (strain NBRC 101917 / NGR234),Sinorhizobium fredii (strain NBRC 101917 / NGR234),NGR_a02120,360,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True
+Q05184,"Putative 4,5-dihydroxyphthalate dehydrogenase",protein,303,Pseudomonas putida,Pseudomonas putida,pht4,410,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True
+Q54728,Uncharacterized oxidoreductase SP_1686,protein,170187,Streptococcus pneumoniae serotype 4 (strain ATCC BAA-334 / TIGR4),Streptococcus pneumoniae serotype 4 (strain ATCC BAA-334 / TIGR4),SP_1686,367,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True
+Q6M0B9,UDP-N-acetylglucosamine 3-dehydrogenase,protein,267377,Methanococcus maripaludis (strain DSM 14266 / JCM 13030 / NBRC 101832 / S2 / LL),Methanococcus maripaludis (strain DSM 14266 / JCM 13030 / NBRC 101832 / S2 / LL),MMP0352,311,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True
+Q7BUE1,Putative UDP-kanosamine synthase oxidoreductase subunit,protein,713604,Amycolatopsis mediterranei (strain S699),Amycolatopsis mediterranei (strain S699),rifL,358,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True
+Q9CY64,Biliverdin reductase A,protein,10090,Mus musculus,Mus musculus (Mouse),Blvra,295,PTHR43377:SF1,BILIVERDIN REDUCTASE A,True

--- a/interpro/panther/PTHR43377/PTHR43377-metadata.yaml
+++ b/interpro/panther/PTHR43377/PTHR43377-metadata.yaml
@@ -1,0 +1,58 @@
+metadata:
+  accession: PTHR43377
+  entry_id: null
+  type: family
+  go_terms: null
+  source_database: panther
+  member_databases: null
+  integrated: IPR051450
+  hierarchy: null
+  name:
+    name: Gfo/Idh/MocA Oxidoreductases
+    short: Gfo/Idh/MocA_Oxidoreductases
+  description:
+  - text: This family of proteins includes enzymes that are involved in various oxidation-reduction
+      (redox) reactions, which are critical for cellular metabolism. Members of this
+      family are characterized by their ability to catalyze the transfer of electrons
+      from one molecule to another, often using NADH or NADPH as cofactors. Functions
+      attributed to this family range from the degradation of plant cell wall components
+      and the reduction of biliverdin to bilirubin, to the specific oxidation of UDP-GlcNAc
+      and the transformation of 4,5-dihydroxyphthalate. Some members are also implicated
+      in the degradation of protocatechuate via specific pathways. The enzymes in
+      this family display a variety of substrate specificities and are involved in
+      distinct metabolic pathways, reflecting their diverse roles in cellular physiology.
+    llm: true
+    checked: false
+    updated: false
+  wikipedia: null
+  literature: null
+  set_info: null
+  overlaps_with: null
+  counters:
+    subfamilies: 6
+    domain_architectures: 0
+    interactions: 0
+    matches: 28365
+    pathways: 0
+    proteins: 28365
+    proteomes: 12624
+    sets: 0
+    structural_models:
+      alphafold: 18975
+    structures: 24
+    taxa: 21011
+  entry_annotations:
+    hmm: 0
+    logo: 0
+  cross_references: {}
+  is_llm: true
+  is_reviewed_llm: false
+  is_updated_llm: false
+  representative_structure:
+    accession: 1lc0
+    name: Structure of Biliverdin Reductase and the Enzyme-NADH Complex
+_fetch_info:
+  fetched_date: '2026-07-14T05:01:12.924551'
+  api_endpoint: https://www.ebi.ac.uk/interpro/api/entry/panther/PTHR43377/
+  database: panther
+  family_id: PTHR43377

--- a/modules/heme_degradation.yaml
+++ b/modules/heme_degradation.yaml
@@ -1,0 +1,216 @@
+id: MODULE:heme_degradation
+title: Heme degradation (heme -> biliverdin -> bilirubin)
+description: >-
+  Heme (iron-protoporphyrin IX), released chiefly from senescent-erythrocyte hemoglobin, is both an
+  essential cofactor and, when free, a pro-oxidant; its controlled catabolism recovers iron, produces the
+  signalling gas carbon monoxide, and generates the antioxidant bile pigments. Degradation proceeds in two
+  enzymatic steps. First, heme oxygenase — the highly inducible, cytoprotective HMOX1 (HO-1/HSP32) and the
+  constitutive HMOX2 (HO-2, an oxygen sensor in brain and vasculature) — uses molecular O2 and electrons
+  from NADPH--cytochrome P450 reductase to oxidatively cleave the alpha-methene bridge of heme, releasing
+  biliverdin IX-alpha, carbon monoxide (CO) and free ferrous iron (Fe2+); this is the rate-limiting step,
+  and the iron is recaptured by ferritin while CO acts as a vasodilatory/anti-inflammatory messenger.
+  Second, biliverdin reductase reduces the green biliverdin to the yellow, lipophilic, potently antioxidant
+  bilirubin: the cytosolic NAD(P)H-dependent BLVRA acts on the major IX-alpha isomer (and additionally
+  moonlights as a signalling kinase/scaffold), while the broad-specificity NADPH flavin reductase BLVRB
+  reduces the IX-beta isomer (prominent in fetal heme catabolism) as well as flavins and other substrates.
+  Bilirubin is subsequently glucuronidated (UGT1A1) for biliary excretion. Inherited defects cause severe
+  systemic inflammation with hemolysis (HMOX1 deficiency) and green jaundice / hyperbiliverdinemia (BLVRA
+  deficiency).
+status: DRAFT
+evidence:
+  - source_id: GO:0042167
+    title: heme catabolic process
+    statement: HMOX1/HMOX2 and BLVRA/BLVRB together carry out heme catabolism (GO:0042167).
+  - source_id: GO:0006788
+    title: heme oxidation
+    statement: HMOX1/HMOX2 oxidise heme to biliverdin + CO + Fe2+ (GO:0006788).
+  - source_id: file:human/HMOX1/HMOX1-ai-review.yaml
+    title: HMOX1 gene review (human)
+    statement: The inducible heme->biliverdin+CO+Fe step (UniProtKB:P09601, GO:0004392) matches the completed human HMOX1 review.
+  - source_id: file:human/HMOX2/HMOX2-ai-review.yaml
+    title: HMOX2 gene review (human)
+    statement: The constitutive heme->biliverdin+CO+Fe step (UniProtKB:P30519, GO:0004392) matches the completed human HMOX2 review.
+  - source_id: file:human/BLVRA/BLVRA-ai-review.yaml
+    title: BLVRA gene review (human)
+    statement: The biliverdin IX-alpha -> bilirubin step (UniProtKB:P53004, GO:0004074) matches the completed human BLVRA review.
+  - source_id: file:human/BLVRB/BLVRB-ai-review.yaml
+    title: BLVRB gene review (human)
+    statement: The biliverdin IX-beta / flavin reduction step (UniProtKB:P30043, GO:0004074) matches the completed human BLVRB review.
+module:
+  id: heme_degradation
+  label: Heme degradation (heme -> biliverdin -> bilirubin)
+  module_type: METABOLIC_PATHWAY
+  concepts:
+    - preferred_term: heme catabolic process
+      term:
+        id: GO:0042167
+        label: heme catabolic process
+      description: Two-step degradation of heme to bilirubin, releasing CO and iron.
+    - preferred_term: heme oxidation
+      term:
+        id: GO:0006788
+        label: heme oxidation
+      description: Heme-oxygenase cleavage of heme to biliverdin + CO + Fe2+.
+  context:
+    cellular_components:
+      - preferred_term: endoplasmic reticulum membrane
+        term:
+          id: GO:0005789
+          label: endoplasmic reticulum membrane
+        description: HMOX1/HMOX2 are tail-anchored ER-membrane enzymes.
+      - preferred_term: cytosol
+        term:
+          id: GO:0005829
+          label: cytosol
+        description: BLVRA and BLVRB are cytosolic reductases.
+  parts:
+    - order: 1
+      role: heme oxidation to biliverdin (rate-limiting)
+      node:
+        id: heme_oxidation
+        label: Heme oxygenase (HMOX1/HMOX2)
+        module_type: REACTION
+        annotons:
+          - id: hmox_activity
+            label: "HMOX1/HMOX2: heme oxygenase"
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: heme oxygenase family
+                term:
+                  id: PANTHER:PTHR10720
+                  label: HEME OXYGENASE
+                representative_members:
+                  - preferred_term: HMOX1 (human)
+                    term:
+                      id: UniProtKB:P09601
+                      label: Heme oxygenase 1
+                  - preferred_term: HMOX2 (human)
+                    term:
+                      id: UniProtKB:P30519
+                      label: Heme oxygenase 2
+            function:
+              preferred_term: heme oxygenase (decyclizing) activity
+              term:
+                id: GO:0004392
+                label: heme oxygenase (decyclizing) activity
+              substrates:
+                - preferred_term: heme (protoporphyrin IX-Fe)
+                - preferred_term: O2 (electrons from NADPH--cytochrome P450 reductase)
+              products:
+                - preferred_term: biliverdin IX-alpha
+                - preferred_term: carbon monoxide (CO) + Fe2+
+              evidence:
+                - source_id: file:human/HMOX1/HMOX1-ai-review.yaml
+                  statement: HMOX1 (inducible, NRF2-driven, cytoprotective) and HMOX2 (constitutive, O2 sensor) cleave the heme alpha-methene bridge to biliverdin IX-alpha + CO + Fe2+; rate-limiting step; HMOX1 deficiency = systemic inflammation/hemolysis
+            locations:
+              - preferred_term: endoplasmic reticulum membrane
+                term:
+                  id: GO:0005789
+                  label: endoplasmic reticulum membrane
+            role_description: Oxidatively cleave heme to biliverdin IX-alpha + CO + Fe2+.
+    - order: 2
+      role: biliverdin IX-alpha reduction to bilirubin
+      node:
+        id: biliverdin_alpha_reduction
+        label: Biliverdin reductase A (BLVRA)
+        module_type: REACTION
+        annotons:
+          - id: blvra_activity
+            label: "BLVRA: biliverdin reductase A"
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: BLVRA / biliverdin reductase A family
+                term:
+                  id: PANTHER:PTHR43377
+                  label: BILIVERDIN REDUCTASE A
+                representative_members:
+                  - preferred_term: BLVRA (human)
+                    term:
+                      id: UniProtKB:P53004
+                      label: Biliverdin reductase A
+            function:
+              preferred_term: biliverdin reductase [NAD(P)H] activity
+              term:
+                id: GO:0004074
+                label: biliverdin reductase [NAD(P)H] activity
+              substrates:
+                - preferred_term: biliverdin IX-alpha
+                - preferred_term: NAD(P)H
+              products:
+                - preferred_term: bilirubin IX-alpha (antioxidant)
+                - preferred_term: NAD(P)+
+              evidence:
+                - source_id: file:human/BLVRA/BLVRA-ai-review.yaml
+                  statement: Cytosolic dual-cofactor (NADH acidic / NADPH alkaline) reductase converting biliverdin IX-alpha to bilirubin IX-alpha; also moonlights as a Ser/Thr/Tyr kinase-scaffold (GO:0004674); deficiency = green jaundice/hyperbiliverdinemia
+            locations:
+              - preferred_term: cytosol
+                term:
+                  id: GO:0005829
+                  label: cytosol
+            role_description: Reduce biliverdin IX-alpha to bilirubin IX-alpha (main isomer).
+    - order: 3
+      role: biliverdin IX-beta / flavin reduction
+      node:
+        id: biliverdin_beta_reduction
+        label: Biliverdin reductase B / flavin reductase (BLVRB)
+        module_type: REACTION
+        annotons:
+          - id: blvrb_activity
+            label: "BLVRB: biliverdin reductase B (flavin reductase)"
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: BLVRB / flavin reductase (NADPH) family
+                term:
+                  id: PANTHER:PTHR43355
+                  label: FLAVIN REDUCTASE
+                representative_members:
+                  - preferred_term: BLVRB (human)
+                    term:
+                      id: UniProtKB:P30043
+                      label: Flavin reductase (NADPH)
+            function:
+              preferred_term: biliverdin reductase [NAD(P)H] activity
+              term:
+                id: GO:0004074
+                label: biliverdin reductase [NAD(P)H] activity
+              substrates:
+                - preferred_term: biliverdin IX-beta (and flavins FMN/FAD/riboflavin)
+                - preferred_term: NADPH
+              products:
+                - preferred_term: bilirubin IX-beta (or reduced flavin)
+                - preferred_term: NADP+
+              evidence:
+                - source_id: file:human/BLVRB/BLVRB-ai-review.yaml
+                  statement: Broad-specificity cytosolic NADPH reductase; reduces the biliverdin IX-beta isomer (prominent in fetal heme catabolism) and flavins (GO:0042602/GO:0052873), methemoglobin and other substrates
+            locations:
+              - preferred_term: cytosol
+                term:
+                  id: GO:0005829
+                  label: cytosol
+            role_description: Reduce biliverdin IX-beta (fetal isomer) and flavins.
+  connections:
+    - source: heme_oxidation
+      target: biliverdin_alpha_reduction
+      connection_type: PROVIDES_INPUT_FOR
+      description: The biliverdin IX-alpha produced by heme oxygenase is reduced to bilirubin IX-alpha by BLVRA.
+    - source: heme_oxidation
+      target: biliverdin_beta_reduction
+      connection_type: PROVIDES_INPUT_FOR
+      description: >-
+        The minor biliverdin IX-beta isomer (prominent in fetal heme catabolism) is reduced by the
+        flavin/biliverdin reductase BLVRB.
+  notes: >-
+    Heme degradation (GO:0042167 heme catabolic + GO:0006788 heme oxidation), grounded to four completed
+    human gene reviews. STEP 1 (ER membrane, rate-limiting): heme oxygenases HMOX1 (P09601, inducible/NRF2,
+    cytoprotective; deficiency = systemic inflammation/hemolysis) + HMOX2 (P30519, constitutive, O2 sensor)
+    share PTHR10720, GO:0004392 — cleave heme with O2 + NADPH-cytochrome-P450-reductase electrons to
+    biliverdin IX-alpha + CO + Fe2+ (CO = signalling gas, Fe -> ferritin). STEP 2 (cytosol): biliverdin
+    reductases, both GO:0004074 but DIFFERENT families/isomer specificity — BLVRA (P53004 PTHR43377, IX-alpha,
+    dual NADH/NADPH; also a moonlighting Ser/Thr/Tyr kinase-scaffold GO:0004674) and BLVRB (P30043 PTHR43355,
+    the broad NADPH flavin reductase, prefers IX-beta / fetal, also reduces FMN/FAD/riboflavin/methemoglobin).
+    Bilirubin is a potent antioxidant, then glucuronidated by UGT1A1 (curated separately) for excretion. GO
+    term ids/labels verified against the local go.db. Disorders: HMOX1 deficiency; BLVRA green jaundice /
+    hyperbiliverdinemia; BLVRB links to thrombopoiesis.

--- a/publications/PMID_10620517.md
+++ b/publications/PMID_10620517.md
@@ -1,0 +1,67 @@
+---
+pmid: '10620517'
+title: Initial-rate kinetics of the flavin reductase reaction catalysed by human biliverdin-IXbeta
+  reductase (BVR-B).
+authors:
+- Cunningham O
+- Gore MG
+- Mantle TJ
+journal: Biochem J
+year: '2000'
+full_text_available: false
+pmcid: PMC1220769
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Initial-rate kinetics of the flavin reductase reaction catalysed by human biliverdin-IXbeta reductase (BVR-B).
+**Authors:** Cunningham O, Gore MG, Mantle TJ
+**Journal:** Biochem J (2000)
+**PMC:** [PMC1220769](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1220769/)
+
+## Abstract
+
+1. Biochem J. 2000 Jan 15;345 Pt 2(Pt 2):393-9.
+
+Initial-rate kinetics of the flavin reductase reaction catalysed by human 
+biliverdin-IXbeta reductase (BVR-B).
+
+Cunningham O(1), Gore MG, Mantle TJ.
+
+Author information:
+(1)Department of Biochemistry, Trinity College, Dublin 2, Ireland. 
+cunningo@mail.tcd.ie
+
+The initial-rate kinetics of the flavin reductase reaction catalysed by 
+biliverdin-IXbeta reductase at pH 7.5 are consistent with a rapid-equilibrium 
+ordered mechanism, with the pyridine nucleotide binding first. NADPH binding to 
+the free enzyme was characterized using stopped-flow fluorescence quenching, and 
+a K(d) of 15.8 microM was calculated. Equilibrium fluorescence quenching 
+experiments indicated a K(d) of 0.55 microM, suggesting that an enzyme-NADPH 
+encounter complex (K(d) 15.8 microM) isomerizes to a more stable 
+'nucleotide-induced' conformation. The enzyme was shown to catalyse the 
+reduction of FMN, FAD and riboflavin, with K(m) values of 52 microM, 125 microM 
+and 53 microM, respectively. Lumichrome was shown to be a competitive inhibitor 
+against FMN, with a K(i) of 76 microM, indicating that interactions with the 
+isoalloxazine ring are probably sufficient for binding. During initial 
+experiments it was observed that both the flavin reductase and biliverdin 
+reductase activities of the enzyme exhibit a sharp optimum at pH 5 in citrate 
+buffer. An initial-rate study indicated that the enzyme obeys a steady-state 
+ordered mechanism in this buffer. The initial-rate kinetics in sodium acetate at 
+pH 5 are consistent with a rapid-equilibrium ordered mechanism, indicating that 
+citrate may directly affect the enzyme's behaviour at pH 5. Mesobiliverdin 
+XIIIalpha, a synthetic biliverdin which binds to flavin reductase but does not 
+act as a substrate for the enzyme, exhibits competitive kinetics with FMN (K(i) 
+0.59 microM) and mixed-inhibition kinetics with NADPH. This is consistent with a 
+single pyridine nucleotide site and competition by FMN and biliverdin for a 
+second site. Interestingly, flavin reductase/biliverdin-IXbeta reductase has 
+also been shown to exhibit ferric reductase activity, with an apparent K(m) of 
+2.5 microM for the ferric iron. The ferric reductase reaction requires NAD(P)H 
+and FMN. This activity is intriguing, as haem cleavage in the foetus produces 
+non-alpha isomers of biliverdin and ferric iron, both of which are substrates 
+for flavin reductase/biliverdin-IXbeta reductase.
+
+PMCID: PMC1220769
+PMID: 10620517 [Indexed for MEDLINE]

--- a/publications/PMID_10858451.md
+++ b/publications/PMID_10858451.md
@@ -1,0 +1,64 @@
+---
+pmid: '10858451'
+title: Studies on the specificity of the tetrapyrrole substrate for human biliverdin-IXalpha
+  reductase and biliverdin-IXbeta reductase. Structure-activity relationships define
+  models for both active sites.
+authors:
+- Cunningham O
+- Dunne A
+- Sabido P
+- Lightner D
+- Mantle TJ
+journal: J Biol Chem
+year: '2000'
+full_text_available: false
+doi: 10.1074/jbc.275.25.19009
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Studies on the specificity of the tetrapyrrole substrate for human biliverdin-IXalpha reductase and biliverdin-IXbeta reductase. Structure-activity relationships define models for both active sites.
+**Authors:** Cunningham O, Dunne A, Sabido P, Lightner D, Mantle TJ
+**Journal:** J Biol Chem (2000)
+**DOI:** [10.1074/jbc.275.25.19009](https://doi.org/10.1074/jbc.275.25.19009)
+
+## Abstract
+
+1. J Biol Chem. 2000 Jun 23;275(25):19009-17. doi: 10.1074/jbc.275.25.19009.
+
+Studies on the specificity of the tetrapyrrole substrate for human 
+biliverdin-IXalpha reductase and biliverdin-IXbeta reductase. Structure-activity 
+relationships define models for both active sites.
+
+Cunningham O(1), Dunne A, Sabido P, Lightner D, Mantle TJ.
+
+Author information:
+(1)Department of Biochemistry, Trinity College, Dublin 2, Ireland and the 
+Departments of Chemistry & Biochemistry, University of Nevada, Reno, Nevada 
+89557-0020, USA.
+
+A comparison of the initial rate kinetics for human biliverdin-IXalpha reductase 
+and biliverdin-IXbeta reductase with a series of synthetic biliverdins with 
+propionate side chains "moving" from a bridging position across the central 
+methene bridge (alpha isomers) to a "gamma-configuration" reveals characteristic 
+behavior that allows us to propose distinct models for the two active sites. For 
+human biliverdin-IXalpha reductase, as previously discussed for the rat and ox 
+enzymes, it appears that at least one "bridging propionate" is necessary for 
+optimal binding and catalytic activity, whereas two are preferred. All other 
+configurations studied were substrates for human biliverdin-IXalpha reductase, 
+albeit poor ones. In the case of mesobiliverdin-XIIIalpha, extending the 
+propionate side chains to hexanoate resulted in a significant loss of activity, 
+whereas the butyrate derivative retained high activity. For human 
+biliverdin-IXalpha reductase, we suggest that a pair of positively charged side 
+chains play a key role in optimally binding the IXalpha isomers. In the case of 
+human biliverdin-IXbeta reductase, the enzyme cannot tolerate even one 
+propionate in the bridging position, suggesting that two negatively charged 
+residues on the enzyme surface may preclude productive binding in this case. The 
+flavin reductase activity of biliverdin-IXbeta reductase is potently inhibited 
+by mesobiliverdin-XIIIalpha and protohemin, which is consistent with the 
+hypothesis that the tetrapyrrole and flavin substrate bind at a common site.
+
+DOI: 10.1074/jbc.275.25.19009
+PMID: 10858451 [Indexed for MEDLINE]

--- a/publications/PMID_11121422.md
+++ b/publications/PMID_11121422.md
@@ -1,0 +1,63 @@
+---
+pmid: '11121422'
+title: Disruption of an active site hydrogen bond converts human heme oxygenase-1
+  into a peroxidase.
+authors:
+- Lightning LK
+- Huang H
+- Moenne-Loccoz P
+- Loehr TM
+- Schuller DJ
+- Poulos TL
+- de Montellano PR
+journal: J Biol Chem
+year: '2001'
+full_text_available: false
+doi: 10.1074/jbc.M010349200
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+- Research Support, U.S. Gov't, P.H.S.
+publication_type: PRIMARY_RESEARCH
+---
+
+# Disruption of an active site hydrogen bond converts human heme oxygenase-1 into a peroxidase.
+**Authors:** Lightning LK, Huang H, Moenne-Loccoz P, Loehr TM, Schuller DJ, Poulos TL, de Montellano PR
+**Journal:** J Biol Chem (2001)
+**DOI:** [10.1074/jbc.M010349200](https://doi.org/10.1074/jbc.M010349200)
+
+## Abstract
+
+1. J Biol Chem. 2001 Apr 6;276(14):10612-9. doi: 10.1074/jbc.M010349200. Epub
+2000  Dec 19.
+
+Disruption of an active site hydrogen bond converts human heme oxygenase-1 into 
+a peroxidase.
+
+Lightning LK(1), Huang H, Moenne-Loccoz P, Loehr TM, Schuller DJ, Poulos TL, de 
+Montellano PR.
+
+Author information:
+(1)Department of Pharmaceutical Chemistry, University of California, San 
+Francisco, California 94143-0446, USA.
+
+The crystal structure of heme oxygenase-1 suggests that Asp-140 may participate 
+in a hydrogen bonding network involving ligands coordinated to the heme iron 
+atom. To examine this possibility, Asp-140 was mutated to an alanine, 
+phenylalanine, histidine, leucine, or asparagine, and the properties of the 
+purified proteins were investigated. UV-visible and resonance Raman spectroscopy 
+indicate that the distal water ligand is lost from the iron in all the mutants 
+except, to some extent, the D140N mutant. In the D140H mutant, the distal water 
+ligand is replaced by the new His-140 as the sixth iron ligand, giving a 
+bis-histidine complex. The D140A, D140H, and D140N mutants retain a trace (<3%) 
+of biliverdin forming activity, but the D140F and D140L mutants are inactive in 
+this respect. However, the two latter mutants retain a low ability to form 
+verdoheme, an intermediate in the reaction sequence. All the Asp-140 mutants 
+exhibit a new peroxidase activity. The results indicate that disruption of the 
+distal hydrogen bonding environment by mutation of Asp-140 destabilizes the 
+ferrous dioxygen complex and promotes conversion of the ferrous hydroperoxy 
+intermediate obtained by reduction of the ferrous dioxygen complex to a ferryl 
+species at the expense of its normal reaction with the porphyrin ring.
+
+DOI: 10.1074/jbc.M010349200
+PMID: 11121422 [Indexed for MEDLINE]

--- a/publications/PMID_11224564.md
+++ b/publications/PMID_11224564.md
@@ -1,0 +1,66 @@
+---
+pmid: '11224564'
+title: Structure of human biliverdin IXbeta reductase, an early fetal bilirubin IXbeta
+  producing enzyme.
+authors:
+- Pereira PJ
+- Macedo-Ribeiro S
+- Párraga A
+- Pérez-Luque R
+- Cunningham O
+- Darcy K
+- Mantle TJ
+- Coll M
+journal: Nat Struct Biol
+year: '2001'
+full_text_available: false
+doi: 10.1038/84948
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Structure of human biliverdin IXbeta reductase, an early fetal bilirubin IXbeta producing enzyme.
+**Authors:** Pereira PJ, Macedo-Ribeiro S, Párraga A, Pérez-Luque R, Cunningham O, Darcy K, Mantle TJ, Coll M
+**Journal:** Nat Struct Biol (2001)
+**DOI:** [10.1038/84948](https://doi.org/10.1038/84948)
+
+## Abstract
+
+1. Nat Struct Biol. 2001 Mar;8(3):215-20. doi: 10.1038/84948.
+
+Structure of human biliverdin IXbeta reductase, an early fetal bilirubin IXbeta 
+producing enzyme.
+
+Pereira PJ(1), Macedo-Ribeiro S, Párraga A, Pérez-Luque R, Cunningham O, Darcy 
+K, Mantle TJ, Coll M.
+
+Author information:
+(1)Instituto de Biologia Molecular de Barcelona, Consejo Superior de 
+Investigaciones Científicas, Jordi Girona, 18-26, 08034 Barcelona, Spain.
+
+Comment in
+    Nat Struct Biol. 2001 Mar;8(3):198-200. doi: 10.1038/84915.
+
+Biliverdin IXbeta reductase (BVR-B) catalyzes the pyridine nucleotide-dependent 
+production of bilirubin-IXbeta, the major heme catabolite during early fetal 
+development. BVR-B displays a preference for biliverdin isomers without 
+propionates straddling the C10 position, in contrast to biliverdin IXalpha 
+reductase (BVR-A), the major form of BVR in adult human liver. In addition to 
+its tetrapyrrole clearance role in the fetus, BVR-B has flavin and ferric 
+reductase activities in the adult. We have solved the structure of human BVR-B 
+in complex with NADP+ at 1.15 A resolution. Human BVR-B is a monomer displaying 
+an alpha/beta dinucleotide binding fold. The structures of ternary complexes 
+with mesobiliverdin IValpha, biliverdin IXalpha, FMN and lumichrome show that 
+human BVR-B has a single substrate binding site, to which substrates and 
+inhibitors bind primarily through hydrophobic interactions, explaining its broad 
+specificity. The reducible atom of both biliverdin and flavin substrates lies 
+above the reactive C4 of the cofactor, an appropriate position for direct 
+hydride transfer. BVR-B discriminates against the biliverdin IXalpha isomer 
+through steric hindrance at the bilatriene side chain binding pockets. The 
+structure also explains the enzyme's preference for NADP(H) and its B-face 
+stereospecificity.
+
+DOI: 10.1038/84948
+PMID: 11224564 [Indexed for MEDLINE]

--- a/publications/PMID_11447290.md
+++ b/publications/PMID_11447290.md
@@ -1,0 +1,84 @@
+---
+pmid: '11447290'
+title: Targeted expression of heme oxygenase-1 prevents the pulmonary inflammatory
+  and vascular responses to hypoxia.
+authors:
+- Minamino T
+- Christou H
+- Hsieh CM
+- Liu Y
+- Dhawan V
+- Abraham NG
+- Perrella MA
+- Mitsialis SA
+- Kourembanas S
+journal: Proc Natl Acad Sci U S A
+year: '2001'
+full_text_available: true
+full_text_extraction_method: html
+pmcid: PMC37515
+doi: 10.1073/pnas.161272598
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+- Research Support, U.S. Gov't, P.H.S.
+publication_type: PRIMARY_RESEARCH
+---
+
+# Targeted expression of heme oxygenase-1 prevents the pulmonary inflammatory and vascular responses to hypoxia.
+**Authors:** Minamino T, Christou H, Hsieh CM, Liu Y, Dhawan V, Abraham NG, Perrella MA, Mitsialis SA, Kourembanas S
+**Journal:** Proc Natl Acad Sci U S A (2001)
+**DOI:** [10.1073/pnas.161272598](https://doi.org/10.1073/pnas.161272598)
+**PMC:** [PMC37515](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC37515/)
+
+## Abstract
+
+1. Proc Natl Acad Sci U S A. 2001 Jul 17;98(15):8798-803. doi: 
+10.1073/pnas.161272598. Epub 2001 Jul 10.
+
+Targeted expression of heme oxygenase-1 prevents the pulmonary inflammatory and 
+vascular responses to hypoxia.
+
+Minamino T(1), Christou H, Hsieh CM, Liu Y, Dhawan V, Abraham NG, Perrella MA, 
+Mitsialis SA, Kourembanas S.
+
+Author information:
+(1)Department of Medicine, Division of Newborn Medicine, Children's Hospital, 
+Harvard Medical School, Boston, MA 02115, USA.
+
+Chronic hypoxia causes pulmonary hypertension with smooth muscle cell 
+proliferation and matrix deposition in the wall of the pulmonary arterioles. We 
+demonstrate here that hypoxia also induces a pronounced inflammation in the lung 
+before the structural changes of the vessel wall. The proinflammatory action of 
+hypoxia is mediated by the induction of distinct cytokines and chemokines and is 
+independent of tumor necrosis factor-alpha signaling. We have previously 
+proposed a crucial role for heme oxygenase-1 (HO-1) in protecting cardiomyocytes 
+from hypoxic stress, and potent anti-inflammatory properties of HO-1 have been 
+reported in models of tissue injury. We thus established transgenic mice that 
+constitutively express HO-1 in the lung and exposed them to chronic hypoxia. 
+HO-1 transgenic mice were protected from the development of both pulmonary 
+inflammation as well as hypertension and vessel wall hypertrophy induced by 
+hypoxia. Significantly, the hypoxic induction of proinflammatory cytokines and 
+chemokines was suppressed in HO-1 transgenic mice. Our findings suggest an 
+important protective function of enzymatic products of HO-1 activity as 
+inhibitors of hypoxia-induced vasoconstrictive and proinflammatory pathways.
+
+DOI: 10.1073/pnas.161272598
+PMCID: PMC37515
+PMID: 11447290 [Indexed for MEDLINE]
+
+## Full Text
+
+Abstract
+
+Chronic hypoxia causes pulmonary hypertension with smooth muscle cell proliferation and matrix deposition in the wall of the pulmonary arterioles. We demonstrate here that hypoxia also induces a pronounced inflammation in the lung before the structural changes of the vessel wall. The proinflammatory action of hypoxia is mediated by the induction of distinct cytokines and chemokines and is independent of tumor necrosis factor-α signaling. We have previously proposed a crucial role for heme oxygenase-1 (HO-1) in protecting cardiomyocytes from hypoxic stress, and potent anti-inflammatory properties of HO-1 have been reported in models of tissue injury. We thus established transgenic mice that constitutively express HO-1 in the lung and exposed them to chronic hypoxia. HO-1 transgenic mice were protected from the development of both pulmonary inflammation as well as hypertension and vessel wall hypertrophy induced by hypoxia. Significantly, the hypoxic induction of proinflammatory cytokines and chemokines was suppressed in HO-1 transgenic mice. Our findings suggest an important protective function of enzymatic products of HO-1 activity as inhibitors of hypoxia-induced vasoconstrictive and proinflammatory pathways.
+
+Discussion
+
+Chronic hypoxia is well known to cause hypertension and vascular remodeling in the pulmonary vasculature in various animal models of human pathophysiology. Shorter, more pronounced hypoxic exposure (6% O 2 for 4–8 h) leads to induction of tissue factor and results in fibrin deposition and thrombosis in the pulmonary vasculature of mice ( 20 ). In the present study, we observed that less severe hypoxia (8–10% O 2 for 48 h to 5 days) lead to a marked induction of proinflammatory cytokines and chemokines in association with pulmonary inflammation that preceded the development of pulmonary hypertension. Moreover, we demonstrated that overexpression of HO-1 in the lung inhibited cytokine gene expression and protected against both pulmonary inflammation as well as pulmonary hypertension induced by hypoxia.
+
+In the process of pulmonary inflammation, cytokines are produced and amplified manyfold by target cells, such as monocytes, endothelial cells, and epithelial cells, leading to the recruitment of leukocytes that release a variety of pro-oxidants and proteolytic enzymes capable of causing vasoconstriction and lung injury ( 17 , 21 ). In addition, proinflammatory cytokines and chemokines directly induce changes in vascular permeability and thrombogenicity ( 22 , 23 ), processes implicated in the pathogenesis of pulmonary hypertension. These cytokines were also reported to promote proliferation and migration of VSMC in vitro ( 18 , 19 ), and disruption of the CCR2 chemokine receptor gene decreased vascular remodeling in a model of atherosclerosis in vivo ( 24 ). Moreover, it was demonstrated that administration of an IL-1 receptor antagonist or anti-MCP-1 antibody protected against monocrotaline-induced pulmonary hypertension ( 25 , 26 ). Together with our data of pronounced cytokine and chemokine induction in hypoxic pulmonary hypertension, these findings suggest a crucial role for proinflammatory cytokines and chemokines in the development of pulmonary vascular remodeling. Cytokine induction and cellular infiltration peak at 48 h and decrease by 2 weeks of hypoxia, yet RVH and vascular remodeling persist for several weeks of continued hypoxia. It is possible that these cytokines initiate a cascade of events leading to VSMC proliferation that is later amplified by the release of vasoactive mediators and growth factors that alter vessel wall structure and function. For example, the initial injury and loss of endothelial barrier function can lead to extravasation of serum and activation of endogenous elastolytic activity from vascular smooth muscle cells ( 27 , 28 ). Increased serine elastase activity results in proteolytic degradation of extracellular matrix and the release of matrix-bound growth factors amplifying smooth muscle cell proliferation and remodeling of the pulmonary arterioles ( 27 , 29 ). Indeed, treatment of rats with elastase inhibitors completely reversed malignant pulmonary hypertension induced by monocrotaline ( 30 ). In this report, we demonstrate a pronounced neutrophil and macrophage infiltration in the lungs of hypoxic mice that is linked with pulmonary hypertension. It is possible that neutrophil elastase as well as other proteolytic enzymes may trigger similar molecular events in the hypoxic setting. Future studies will determine whether inhibition of inflammation can prevent hypoxia-induced pulmonary hypertension.
+
+The mechanism of protection provided by HO-1 may depend on its enzymatic product, CO, to function as a vasodilator against vasoconstriction and bilirubin as an antioxidant against the reactive oxygen species that are generated under hypoxic conditions ( 31 ). Because the recruitment of leukocytes was greatly suppressed in the hypoxic lungs of HO-1 transgenic mice, inhibition of cytokine induction may be another important mechanism by which HO-1 activity imparts protection against the development of pulmonary hypertension induced by hypoxia. In two recent studies, HO-1 activity and, in particular, CO, were reported to have potent anti-inflammatory properties in models of vascular injury ( 11 , 32 ). The anti-inflammatory properties of CO were mediated by the inhibition of proinflammatory cytokines, TNFα, IL1-β, and MIP-1β, in the model of lipopolysaccharide-induced systemic inflammation ( 32 ). HO-1 was also shown to have protective effects in hyperoxic lung injury as well as ischemia–reperfusion in the liver, two well known models of inflammation-mediated injury ( 33 , 34 ). In this report, we demonstrate a previously unrecognized inflammatory response induced by hypoxia. The mechanisms underlying the induction of cytokines by hypoxia are most likely different from other models of systemic or pulmonary inflammation. For example, in endotoxin-induced pulmonary inflammation models, early response cytokines, such as TNFα, are rapidly induced (within 6 h), and this early response leads to the activation of cytokine networks including the induction of IL-6, MCP-1, and MIP-2 ( 21 ). In contrast, induction of TNFα was not detected in the lungs 3, 6, and 18 h after hypoxia (Fig. 6 and data not shown), indicating that the hypoxic induction of IL-6, MCP-1, and MIP-2 is not secondary to that of this early response cytokine. Similarly, IL-6 has been suggested to function as an anti-inflammatory cytokine in endotoxin-induced pulmonary inflammation because IL-6 deficiency resulted in an increase in proinflammatory cytokines, including TNFα and IL-1β ( 35 ). However, despite reduced IL-6 expression in the hypoxic lungs of transgenic mice, we did not observe increased expression of other proinflammatory cytokines. In addition, treatment with lipopolysaccharide induced expression of the anti-inflammatory cytokine IL-10, whereas we did not find increased IL-10 expression under hypoxia. Hypoxia, therefore, induces a network of cytokines and chemokines that is distinct from other inflammatory pathways such as those induced by lipopolysaccharide.
+
+In summary, we demonstrate that hypoxia induced an early inflammatory response in the lung before the development of pulmonary hypertension. HO-1 overexpression effectively inhibited pulmonary inflammation and prevented pulmonary hypertension induced by hypoxia. HO-1 may be an important therapeutic target to inhibit hypoxia-induced cytokine signaling and prevent the inflammatory pathways that may lead to pulmonary hypertension.

--- a/publications/PMID_12239590.md
+++ b/publications/PMID_12239590.md
@@ -1,0 +1,60 @@
+---
+pmid: '12239590'
+title: Significance of heme oxygenase in prolactin-mediated cell proliferation and
+  angiogenesis in human endothelial cells.
+authors:
+- Malaguarnera L
+- Pilastro MR
+- Quan S
+- Ghattas MH
+- Yang L
+- Mezentsev AV
+- Kushida T
+- Abraham NG
+- Kappas A
+journal: Int J Mol Med
+year: '2002'
+full_text_available: false
+pubmed_publication_types:
+- Journal Article
+publication_type: PRIMARY_RESEARCH
+---
+
+# Significance of heme oxygenase in prolactin-mediated cell proliferation and angiogenesis in human endothelial cells.
+**Authors:** Malaguarnera L, Pilastro MR, Quan S, Ghattas MH, Yang L, Mezentsev AV, Kushida T, Abraham NG, Kappas A
+**Journal:** Int J Mol Med (2002)
+
+## Abstract
+
+1. Int J Mol Med. 2002 Oct;10(4):433-40.
+
+Significance of heme oxygenase in prolactin-mediated cell proliferation and 
+angiogenesis in human endothelial cells.
+
+Malaguarnera L(1), Pilastro MR, Quan S, Ghattas MH, Yang L, Mezentsev AV, 
+Kushida T, Abraham NG, Kappas A.
+
+Author information:
+(1)Department of Pharmacology, New York Medical College, Valhalla, NY 10595, 
+USA.
+
+Our objectives were to determine whether heme oxygenase-1 is a second messenger 
+for prolactin-mediated angiogenesis. Endothelial cell proliferation and 
+angiogenesis assay demonstrated that cell number and capillary formation were 
+increased by prolactin (10 and 25 ng/ml). Both protein synthesis and mRNA 
+analysis confirmed that HO-1 expression was induced by prolactin in cultured 
+endothelial cells and occurred in a concentration-dependent manner. Endothelial 
+cells transduced with retrovirus-mediated delivery of HO-1 gene in sense and 
+antisense orientation were used to further determine whether HO-1 overexpression 
+or underexpression modulated prolactin-mediated endothelial cell proliferation 
+and angiogenesis. Incubation of human microvessel endothelial cells transduced 
+with HO-1 in sense orientation resulted in enhancement of prolactin-mediated 
+increase in endothelial cell proliferation and angiogenesis, whereas inhibition 
+of HO-1 by transduction of HO-1 in antisense orientation prevented prolactin 
+increase in endothelial cell proliferation. Similarly, addition of stannic 
+mesoporphyrin, the inhibitor of HO activity, prevented PRL-mediated increase in 
+endothelial cell proliferation. Our results demonstrated for the first time, 
+that prolactin-mediated angiogenesis and cell proliferation was dependent on 
+HO-1 gene expression.
+
+PMID: 12239590 [Indexed for MEDLINE]

--- a/publications/PMID_14525760.md
+++ b/publications/PMID_14525760.md
@@ -1,0 +1,68 @@
+---
+pmid: '14525760'
+title: 'Bifunctional role for VEGF-induced heme oxygenase-1 in vivo: induction of
+  angiogenesis and inhibition of leukocytic infiltration.'
+authors:
+- Bussolati B
+- Ahmed A
+- Pemberton H
+- Landis RC
+- Di Carlo F
+- Haskard DO
+- Mason JC
+journal: Blood
+year: '2004'
+full_text_available: false
+doi: 10.1182/blood-2003-06-1974
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Bifunctional role for VEGF-induced heme oxygenase-1 in vivo: induction of angiogenesis and inhibition of leukocytic infiltration.
+**Authors:** Bussolati B, Ahmed A, Pemberton H, Landis RC, Di Carlo F, Haskard DO, Mason JC
+**Journal:** Blood (2004)
+**DOI:** [10.1182/blood-2003-06-1974](https://doi.org/10.1182/blood-2003-06-1974)
+
+## Abstract
+
+1. Blood. 2004 Feb 1;103(3):761-6. doi: 10.1182/blood-2003-06-1974. Epub 2003 Oct
+ 2.
+
+Bifunctional role for VEGF-induced heme oxygenase-1 in vivo: induction of 
+angiogenesis and inhibition of leukocytic infiltration.
+
+Bussolati B(1), Ahmed A, Pemberton H, Landis RC, Di Carlo F, Haskard DO, Mason 
+JC.
+
+Author information:
+(1)Department of Reproductive and Vascular Biology, The Medical School, 
+University of Birmingham, Edgbaston, Birmingham, B12 2TG, United Kingdom. 
+benedetta.bussolati@unito.it
+
+Heme-oxygenases (HOs) catalyze the conversion of heme into carbon monoxide and 
+biliverdin. HO-1 is induced during hypoxia, ischemia/reperfusion, and 
+inflammation, providing cytoprotection and inhibiting leukocyte migration to 
+inflammatory sites. Although in vitro studies have suggested an additional role 
+for HO-1 in angiogenesis, the relevance of this in vivo remains unknown. We 
+investigated the involvement of HO-1 in angiogenesis in vitro and in vivo. 
+Vascular endothelial growth factor (VEGF) induced prolonged HO-1 expression and 
+activity in human endothelial cells and HO-1 inhibition abrogated VEGF-driven 
+angiogenesis. Two murine models of angiogenesis were used: (1) angiogenesis 
+initiated by addition of VEGF to Matrigel and (2) a lipopolysaccharide 
+(LPS)-induced model of inflammatory angiogenesis in which angiogenesis is 
+secondary to leukocyte invasion. Pharmacologic inhibition of HO-1 induced marked 
+leukocytic infiltration that enhanced VEGF-induced angiogenesis. However, in the 
+presence of an anti-CD18 monoclonal antibody (mAb) to block leukocyte migration, 
+VEGF-induced angiogenesis was significantly inhibited by HO-1 antagonists. 
+Furthermore, in the LPS-induced model of inflammatory angiogenesis, induction of 
+HO-1 with cobalt protoporphyrin significantly inhibited leukocyte invasion into 
+LPS-conditioned Matrigel and thus prevented the subsequent angiogenesis. We 
+therefore propose that during chronic inflammation HO-1 has 2 roles: first, an 
+anti-inflammatory action inhibiting leukocyte infiltration; and second, 
+promotion of VEGF-driven noninflammatory angiogenesis that facilitates tissue 
+repair.
+
+DOI: 10.1182/blood-2003-06-1974
+PMID: 14525760 [Indexed for MEDLINE]

--- a/publications/PMID_15516695.md
+++ b/publications/PMID_15516695.md
@@ -1,0 +1,68 @@
+---
+pmid: '15516695'
+title: Involvement of NADPH in the interaction between heme oxygenase-1 and cytochrome
+  P450 reductase.
+authors:
+- Higashimoto Y
+- Sakamoto H
+- Hayashi S
+- Sugishima M
+- Fukuyama K
+- Palmer G
+- Noguchi M
+journal: J Biol Chem
+year: '2005'
+full_text_available: false
+doi: 10.1074/jbc.M406203200
+pubmed_publication_types:
+- Journal Article
+- Research Support, N.I.H., Extramural
+- Research Support, Non-U.S. Gov't
+- Research Support, U.S. Gov't, P.H.S.
+publication_type: PRIMARY_RESEARCH
+---
+
+# Involvement of NADPH in the interaction between heme oxygenase-1 and cytochrome P450 reductase.
+**Authors:** Higashimoto Y, Sakamoto H, Hayashi S, Sugishima M, Fukuyama K, Palmer G, Noguchi M
+**Journal:** J Biol Chem (2005)
+**DOI:** [10.1074/jbc.M406203200](https://doi.org/10.1074/jbc.M406203200)
+
+## Abstract
+
+1. J Biol Chem. 2005 Jan 7;280(1):729-37. doi: 10.1074/jbc.M406203200. Epub 2004 
+Oct 31.
+
+Involvement of NADPH in the interaction between heme oxygenase-1 and cytochrome 
+P450 reductase.
+
+Higashimoto Y(1), Sakamoto H, Hayashi S, Sugishima M, Fukuyama K, Palmer G, 
+Noguchi M.
+
+Author information:
+(1)Department of Medical Biochemistry, Kurume University School of Medicine, 67 
+Asahi-machi, Kurume 830-0011, Japan.
+
+Heme oxygenase-1 (HO-1) catalyzes the physiological degradation of heme at the 
+expense of molecular oxygen using electrons donated by NADPH-cytochrome P450 
+reductase (CPR). In this study, we investigated the effect of NADP(H) on the 
+interaction of HO-1 with CPR by surface plasmon resonance. We found that HO-1 
+associated with CPR more tightly in the presence of NADP(+) (K(D) = 0.5 microm) 
+than in its absence (K(D) = 2.4 microm). The HO-1 mutants, K149A, K149A/K153A, 
+and R185A, showed almost no heme degradation activity with NADPH-CPR, whereas 
+they exhibited activity comparable to that of the wild type when sodium 
+ascorbate was used. R185A showed a 100-fold decreased affinity for CPR compared 
+with wild type, even in the presence of NADP(+) (K(D) = 36.3 microm). The 
+affinities of K149A and K149A/K153A for CPR were decreased 7- and 9-fold (K(D) = 
+16.8 and 21.8 microm), respectively. In contrast to R185A, the affinities of 
+K149A and K149A/K153A were improved by the addition of NADP(+) (K(D) = 5.2 and 
+9.6 microm, respectively), as was the case with wild type. Computer modeling of 
+the HO-1/CPR complex showed that the guanidino group of Arg(185) is located 
+within the hydrogen bonding distance of 2'-phosphate of NADPH, suggesting that 
+Arg(185) contributes to the binding to CPR through an electrostatic interaction 
+with the phosphate group. On the other hand, Lys(149) is close to a cluster of 
+acidic amino acids near the FMN binding site of CPR. Thus, Lys(149) and Lys(153) 
+appear to interact with CPR in such a way as to orient the redox partners for 
+optimal electron transfer from FMN of CPR to heme of HO-1.
+
+DOI: 10.1074/jbc.M406203200
+PMID: 15516695 [Indexed for MEDLINE]

--- a/publications/PMID_1575508.md
+++ b/publications/PMID_1575508.md
@@ -1,0 +1,64 @@
+---
+pmid: '1575508'
+title: 'Human heme oxygenase-2: characterization and expression of a full-length cDNA
+  and evidence suggesting that the two HO-2 transcripts may differ by choice of polyadenylation
+  signal.'
+authors:
+- McCoubrey WK Jr
+- Ewing JF
+- Maines MD
+journal: Arch Biochem Biophys
+year: '1992'
+full_text_available: false
+doi: 10.1016/0003-9861(92)90481-b
+pubmed_publication_types:
+- Comparative Study
+- Journal Article
+- Research Support, Non-U.S. Gov't
+- Research Support, U.S. Gov't, P.H.S.
+publication_type: PRIMARY_RESEARCH
+---
+
+# Human heme oxygenase-2: characterization and expression of a full-length cDNA and evidence suggesting that the two HO-2 transcripts may differ by choice of polyadenylation signal.
+**Authors:** McCoubrey WK Jr, Ewing JF, Maines MD
+**Journal:** Arch Biochem Biophys (1992)
+**DOI:** [10.1016/0003-9861(92)90481-b](https://doi.org/10.1016/0003-9861(92)90481-b)
+
+## Abstract
+
+1. Arch Biochem Biophys. 1992 May 15;295(1):13-20. doi: 
+10.1016/0003-9861(92)90481-b.
+
+Human heme oxygenase-2: characterization and expression of a full-length cDNA 
+and evidence suggesting that the two HO-2 transcripts may differ by choice of 
+polyadenylation signal.
+
+McCoubrey WK Jr(1), Ewing JF, Maines MD.
+
+Author information:
+(1)Department of Biophysics, University of Rochester School of Medicine, New 
+York 14642.
+
+We show by Northern blot analysis that human HO-2 is encoded by two transcripts 
+(1.3 and 1.7 kb) and is a single-copy gene as judged by Southern blot analysis. 
+We further provide evidence based on Northern blot and sequence analysis of a 
+cDNA representing the larger transcript that the transcripts differ in the 3' 
+untranslated region. A 274-base-pair DNA fragment from the rat heme oxygenase-2 
+gene (I. Cruse and M.D. Maines, 1988, J. Biol. Chem. 263, 3348-3353) was used to 
+isolate a human HO-2 cDNA from a fetal kidney library in lambda gt11. The clone, 
+designated hK-1, was sequenced and the cDNA insert was determined to be 1625 
+base pairs in length, encoding a protein of 313 amino acids. Two consensus 
+polyadenylation signals separated by 440 nucleotides were identified in the 3' 
+untranslated region. The size of the cDNA insert closely approximated the larger 
+of two mRNAs. The nucleotide sequence was 88% identical to the rat HO-2 gene 
+within the predicted coding region and the putative translation product was also 
+estimated to be 88% identical to the rat gene product (M. O. Rotenberg and D. 
+Maines, 1990, J. Biol. Chem. 265, 7501). The predicted size, 36 kDa, 
+corresponded well with HO-2 detected in human testis microsomes by Western blot 
+analysis. Further, the fusion protein expressed in Escherichia coli displayed 
+significant heme oxygenase activity, which was inhibited by Zn- and 
+Sn-protoporphyrins, known inhibitors of eukaryotic heme oxygenase, but not by 
+sulfhydryl reagents.
+
+DOI: 10.1016/0003-9861(92)90481-b
+PMID: 1575508 [Indexed for MEDLINE]

--- a/publications/PMID_17600318.md
+++ b/publications/PMID_17600318.md
@@ -1,0 +1,64 @@
+---
+pmid: '17600318'
+title: BMP4 induces HO-1 via a Smad-independent, p38MAPK-dependent pathway in pulmonary
+  artery myocytes.
+authors:
+- Yang X
+- Lee PJ
+- Long L
+- Trembath RC
+- Morrell NW
+journal: Am J Respir Cell Mol Biol
+year: '2007'
+full_text_available: false
+doi: 10.1165/rcmb.2006-0360OC
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# BMP4 induces HO-1 via a Smad-independent, p38MAPK-dependent pathway in pulmonary artery myocytes.
+**Authors:** Yang X, Lee PJ, Long L, Trembath RC, Morrell NW
+**Journal:** Am J Respir Cell Mol Biol (2007)
+**DOI:** [10.1165/rcmb.2006-0360OC](https://doi.org/10.1165/rcmb.2006-0360OC)
+
+## Abstract
+
+1. Am J Respir Cell Mol Biol. 2007 Nov;37(5):598-605. doi: 
+10.1165/rcmb.2006-0360OC. Epub 2007 Jun 28.
+
+BMP4 induces HO-1 via a Smad-independent, p38MAPK-dependent pathway in pulmonary 
+artery myocytes.
+
+Yang X(1), Lee PJ, Long L, Trembath RC, Morrell NW.
+
+Author information:
+(1)Department of Medicine, University of Cambridge, Addenbrooke's and Papworth 
+Hospitals, Cambridge, United Kingdom.
+
+Bone morphogenetic proteins (BMPs) are multifunctional cytokines, which play a 
+key role in vascular development and remodeling. Heme oxygenase-1 (HO-1), the 
+rate-limiting enzyme in heme catabolism, has been shown to be protective against 
+vascular and lung injury. In a microarray study, we identified HO-1 as a major 
+target of BMP4 signaling in human pulmonary artery smooth muscle cells (PASMCs), 
+and confirmed the induction of HO-1 mRNA and protein by RT-PCR and Western 
+blotting, respectively. Immunoblotting demonstrated that incubation of PASMCs 
+with BMP4 rapidly phosphorylated Smad1/5 and activated the mitogen-activated 
+protein kinases, p38(MAPK) and ERK1/2, in PASMCs, but not JNK. Using pathway 
+selective inhibitors, the induction of HO-1 mRNA and protein was shown to be 
+dependent on activation of p38(MAPK). Induction was independent of Smad1/5 
+signaling, since HO-1 mRNA and protein induction was intact in PASMCs harboring 
+mutations in the kinase domain of BMP type II receptor, with disrupted Smad 
+signaling. In addition, adenoviral transfection of kinase-deficient BMPR-II also 
+failed to inhibit BMP4-induced HO-1 expression. In functional studies, the HO-1 
+inhibitor, ZnPP-IX, partly reversed the growth-inhibitory effects of BMP4, and 
+overexpression of HO-1 in PASMCs inhibited serum-stimulated [3H]-thymidine 
+incorporation. Taken together, these findings show that HO-1 is an important 
+Smad-independent target of BMP signaling in vascular smooth muscle. Inhibition 
+of HO-1 function or expression will further increase the proproliferative 
+capacity of BMPR-II-deficient PASMCs and may thus represent a potential "second 
+hit" necessary for disease manifestation.
+
+DOI: 10.1165/rcmb.2006-0360OC
+PMID: 17600318 [Indexed for MEDLINE]

--- a/publications/PMID_17652371.md
+++ b/publications/PMID_17652371.md
@@ -1,0 +1,68 @@
+---
+pmid: '17652371'
+title: Heme oxygenase-1 modulates the expression of the anti-angiogenic chemokine
+  CXCL-10 in renal tubular epithelial cells.
+authors:
+- Datta D
+- Dormond O
+- Basu A
+- Briscoe DM
+- Pal S
+journal: Am J Physiol Renal Physiol
+year: '2007'
+full_text_available: false
+doi: 10.1152/ajprenal.00164.2007
+pubmed_publication_types:
+- Journal Article
+- Research Support, N.I.H., Extramural
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Heme oxygenase-1 modulates the expression of the anti-angiogenic chemokine CXCL-10 in renal tubular epithelial cells.
+**Authors:** Datta D, Dormond O, Basu A, Briscoe DM, Pal S
+**Journal:** Am J Physiol Renal Physiol (2007)
+**DOI:** [10.1152/ajprenal.00164.2007](https://doi.org/10.1152/ajprenal.00164.2007)
+
+## Abstract
+
+1. Am J Physiol Renal Physiol. 2007 Oct;293(4):F1222-30. doi: 
+10.1152/ajprenal.00164.2007. Epub 2007 Jul 25.
+
+Heme oxygenase-1 modulates the expression of the anti-angiogenic chemokine 
+CXCL-10 in renal tubular epithelial cells.
+
+Datta D(1), Dormond O, Basu A, Briscoe DM, Pal S.
+
+Author information:
+(1)Division of Nephrology and the Transplantation Research Center, Children's 
+Hospital Boston, MA 02115, USA.
+
+The turnover and repair of peritubular capillaries is essential for the 
+maintenance of normal renal tubular structure and function. Following injury, 
+ineffective capillary repair/angiogenesis may result in chronic disease, whereas 
+effective repair attenuates the injury process. Thus the process of healing in 
+the kidney is likely dependent on an intricate balance between angiogenic and 
+anti-angiogenic factors to maintain the renal microvasculature. We investigated 
+the role of cytoprotective heme oxygenase-1 (HO-1) in the regulation of 
+chemokines in human renal proximal tubular epithelial cells (RPTEC). 
+Transfection of RPTEC with a HO-1 overexpression plasmid promoted a marked 
+induction in the mRNA expression of the anti-angiogenic chemokine CXCL-10, along 
+with angiogenic chemokines CXCL-8 and CCL-2. Utilizing a CXCL-10 promoter 
+luciferase construct, we observed that HO-1-induced CXCL-10 expression is 
+regulated at the transcriptional level. However, with increases in 
+concentrations and time intervals of HO-1 induction, there was a marked decrease 
+in CXCL-10 expression. Using pharmacological inhibitors, we found that 
+HO-1-induced early robust CXCL-10 transcription is mediated through the PKC 
+signaling pathway. To evaluate the functional significance of HO-1-induced 
+CXCL-10 release, we cultured human vascular endothelial cells in the absence and 
+presence of culture supernatants of the HO-1 plasmid-transfected RPTEC. We found 
+that early (24 h) supernatants of the HO-1 plasmid-transfected cells (RPTEC) 
+inhibited endothelial cell proliferation, and this effect was blocked by 
+addition of a CXCL-10 neutralizing antibody. Thus HO-1 can regulate the 
+expression of the anti-angiogenic CXCL-10 and may alter a critical balance 
+between angiogenic vs. anti-angiogenic factors that are important to maintain 
+renal microvasculature during injury.
+
+DOI: 10.1152/ajprenal.00164.2007
+PMID: 17652371 [Indexed for MEDLINE]

--- a/publications/PMID_17915953.md
+++ b/publications/PMID_17915953.md
@@ -1,0 +1,71 @@
+---
+pmid: '17915953'
+title: 'Expression and characterization of full-length human heme oxygenase-1: the
+  presence of intact membrane-binding region leads to increased binding affinity for
+  NADPH cytochrome P450 reductase.'
+authors:
+- Huber WJ 3rd
+- Backes WL
+journal: Biochemistry
+year: '2007'
+full_text_available: false
+pmcid: PMC2788297
+doi: 10.1021/bi701496z
+pubmed_publication_types:
+- Journal Article
+- Research Support, N.I.H., Extramural
+publication_type: PRIMARY_RESEARCH
+---
+
+# Expression and characterization of full-length human heme oxygenase-1: the presence of intact membrane-binding region leads to increased binding affinity for NADPH cytochrome P450 reductase.
+**Authors:** Huber WJ 3rd, Backes WL
+**Journal:** Biochemistry (2007)
+**DOI:** [10.1021/bi701496z](https://doi.org/10.1021/bi701496z)
+**PMC:** [PMC2788297](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2788297/)
+
+## Abstract
+
+1. Biochemistry. 2007 Oct 30;46(43):12212-9. doi: 10.1021/bi701496z. Epub 2007
+Oct  4.
+
+Expression and characterization of full-length human heme oxygenase-1: the 
+presence of intact membrane-binding region leads to increased binding affinity 
+for NADPH cytochrome P450 reductase.
+
+Huber WJ 3rd(1), Backes WL.
+
+Author information:
+(1)Department of Pharmacology and Experimental Therapeutics and The Stanley S. 
+Scott Cancer Center, Louisiana State University Health Sciences Center, 533 
+Bolivar Street, New Orleans, Louisiana 70112, USA.
+
+Heme oxygenase-1 (HO-1) is the chief regulatory enzyme in the oxidative 
+degradation of heme to biliverdin. In the process of heme degradation, HO-1 
+receives the electrons necessary for catalysis from the flavoprotein NADPH 
+cytochrome P450 reductase (CPR), releasing free iron and carbon monoxide. Much 
+of the recent research involving heme oxygenase has been done using a 30 kDa 
+soluble form of the enzyme, which lacks the membrane binding region (C-terminal 
+23 amino acids). The goal of this study was to express and purify a full-length 
+human HO-1 (hHO-1) protein; however, due to the lability of the full-length 
+form, a rapid purification procedure was required. This was accomplished by use 
+of a glutathione-s-transferase (GST)-tagged hHO-1 construct. Although the 
+procedure permitted the generation of a full-length HO-1, this form was 
+contaminated with a 30 kDa degradation product that could not be eliminated. 
+Therefore, attempts were made to remove a putative secondary thrombin cleavage 
+site by a conservative mutation of amino acid 254, which replaces arginine with 
+lysine. This mutation allowed the expression and purification of a full-length 
+hHO-1 protein. Unlike wild type (WT) HO-1, the R254K mutant could be purified to 
+a single 32 kDa protein capable of degrading heme at the same rate as the WT 
+enzyme. The R254K full-length form had a specific activity of approximately 
+200-225 nmol of bilirubin h-1 nmol-1 HO-1 as compared to approximately 140-150 
+nmol of bilirubin h-1 nmol-1 for the WT form, which contains the 30 kDa 
+contaminant. This is a 2-3-fold increase from the previously reported soluble 30 
+kDa HO-1, suggesting that the C-terminal 23 amino acids are essential for 
+maximal catalytic activity. Because the membrane-spanning domain is present, the 
+full-length hHO-1 has the potential to incorporate into phospholipid membranes, 
+which can be reconstituted at known concentrations, in combination with other 
+endoplasmic reticulum resident enzymes.
+
+DOI: 10.1021/bi701496z
+PMCID: PMC2788297
+PMID: 17915953 [Indexed for MEDLINE]

--- a/publications/PMID_18205746.md
+++ b/publications/PMID_18205746.md
@@ -1,0 +1,76 @@
+---
+pmid: '18205746'
+title: Differential induction of heme oxygenase-1 against nicotine-induced cytotoxicity
+  via the PI3K, MAPK, and NF-kappa B pathways in immortalized and malignant human
+  oral keratinocytes.
+authors:
+- Lee HJ
+- Lee J
+- Min SK
+- Guo HY
+- Lee SK
+- Kim HR
+- Pae HO
+- Chung HT
+- Hong SH
+- Lee SK
+- Kim EC
+journal: J Oral Pathol Med
+year: '2008'
+full_text_available: false
+doi: 10.1111/j.1600-0714.2007.00616.x
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Differential induction of heme oxygenase-1 against nicotine-induced cytotoxicity via the PI3K, MAPK, and NF-kappa B pathways in immortalized and malignant human oral keratinocytes.
+**Authors:** Lee HJ, Lee J, Min SK, Guo HY, Lee SK, Kim HR, Pae HO, Chung HT, Hong SH, Lee SK, Kim EC
+**Journal:** J Oral Pathol Med (2008)
+**DOI:** [10.1111/j.1600-0714.2007.00616.x](https://doi.org/10.1111/j.1600-0714.2007.00616.x)
+
+## Abstract
+
+1. J Oral Pathol Med. 2008 May;37(5):278-86. doi:
+10.1111/j.1600-0714.2007.00616.x.  Epub 2008 Jan 15.
+
+Differential induction of heme oxygenase-1 against nicotine-induced cytotoxicity 
+via the PI3K, MAPK, and NF-kappa B pathways in immortalized and malignant human 
+oral keratinocytes.
+
+Lee HJ(1), Lee J, Min SK, Guo HY, Lee SK, Kim HR, Pae HO, Chung HT, Hong SH, Lee 
+SK, Kim EC.
+
+Author information:
+(1)Department of Oral & Maxillofacial Pathology, College of Dentistry, Wonkwang 
+University, Iksan, Korea.
+
+BACKGROUND: Heme oxygenase-1 (HO-1) exhibits cytoprotective effects in many 
+different cell types and is induced by nicotine exposure in human gingival 
+fibroblasts. However, the role of HO-1 in cancer cells exposed to nicotine has 
+not previously been described.
+METHODS: We investigated the effects of nicotine on HO-1 protein expression and 
+cell viability in immortalized (IHOK) and malignant (HN12) human oral 
+keratinocyte cells using the 3,4,5-dimethylthiazol-2-yl-2,5-diphenyl tetrazolium 
+bromide assay and Western blotting. We also examined the involvement of the 
+phosphoinositide-3-kinase (PI3K), mitogen-activated protein kinase (MAPK), and 
+nuclear factor-kappaB (NF-kappaB) signaling pathways in nicotine-induced 
+cytotoxicity and HO-1 levels in IHOK and HN12 cells.
+RESULTS: Nicotine-induced HO-1 production and had cytotoxic effects on cells in 
+both a concentration- and time-dependent manner. Nicotine-induced cytotoxicity 
+and accumulation of HO-1 were greater in IHOK cells than in HN12 cells. 
+Molecular inhibitors of the ERK, p38 MAP kinase, PI3 K, and NF-kappaB signaling 
+pathways blocked the cytotoxic effects and induction of HO-1 expression by 
+nicotine. Treatment with antioxidants (bilirubin, N-acetylcysteine) protected 
+cells against nicotine-induced cytotoxicity and blocked the upregulation of 
+HO-1, the effects of which were more pronounced in IHOK cells than in HN12 
+cells.
+CONCLUSIONS: Collectively, these results suggest that HO-1 plays a principal 
+role in the protective response to nicotine in oral cancer and immortalized 
+keratinocytes. Moreover, the addition of exogenous antioxidants may help to 
+protect oral epithelial cells as chemopreventive agents against nicotine-induced 
+oxidative stress.
+
+DOI: 10.1111/j.1600-0714.2007.00616.x
+PMID: 18205746 [Indexed for MEDLINE]

--- a/publications/PMID_18241201.md
+++ b/publications/PMID_18241201.md
@@ -1,0 +1,61 @@
+---
+pmid: '18241201'
+title: Computational and experimental studies on the catalytic mechanism of biliverdin-IXbeta
+  reductase.
+authors:
+- Smith LJ
+- Browne S
+- Mulholland AJ
+- Mantle TJ
+journal: Biochem J
+year: '2008'
+full_text_available: false
+doi: 10.1042/BJ20071495
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Computational and experimental studies on the catalytic mechanism of biliverdin-IXbeta reductase.
+**Authors:** Smith LJ, Browne S, Mulholland AJ, Mantle TJ
+**Journal:** Biochem J (2008)
+**DOI:** [10.1042/BJ20071495](https://doi.org/10.1042/BJ20071495)
+
+## Abstract
+
+1. Biochem J. 2008 May 1;411(3):475-84. doi: 10.1042/BJ20071495.
+
+Computational and experimental studies on the catalytic mechanism of 
+biliverdin-IXbeta reductase.
+
+Smith LJ(1), Browne S, Mulholland AJ, Mantle TJ.
+
+Author information:
+(1)School of Biochemistry and Immunology, Trinity College Dublin, Dublin 2, 
+Ireland.
+
+BVR-B (biliverdin-IXbeta reductase) also known as FR (flavin reductase) is a 
+promiscuous enzyme catalysing the pyridine-nucleotide-dependent reduction of a 
+variety of flavins, biliverdins, PQQ (pyrroloquinoline quinone) and ferric ion. 
+Mechanistically it is a good model for BVR-A (biliverdin-IXalpha reductase), a 
+potential pharmacological target for neonatal jaundice and also a potential 
+target for adjunct therapy to maintain protective levels of biliverdin-IXalpha 
+during organ transplantation. In a commentary on the structure of BVR-B it was 
+noted that one outstanding issue remained: whether the mechanism was a concerted 
+hydride transfer followed by protonation of a pyrrolic anion or protonation of 
+the pyrrole followed by hydride transfer. In the present study we have attempted 
+to address this question using QM/MM (quantum mechanics/molecular mechanics) 
+calculations. QM/MM potential energy surfaces show that the lowest energy 
+pathway proceeds with a positively charged pyrrole intermediate via two 
+transition states. These initial calculations were performed with His(153) as 
+the source of the proton. However site-directed mutagenesis studies with both 
+the H153A and the H153N mutant reveal that His(153) is not required for 
+catalytic activity. We have repeated the calculation with a solvent hydroxonium 
+donor and obtain a similar energy landscape indicating that protonation of the 
+pyrrole is the most likely first step followed by hydride transfer and that the 
+required proton may come from bulk solvent. The implications of the present 
+study for the design of inhibitors of BVR-A are discussed.
+
+DOI: 10.1042/BJ20071495
+PMID: 18241201 [Indexed for MEDLINE]

--- a/publications/PMID_18289072.md
+++ b/publications/PMID_18289072.md
@@ -1,0 +1,50 @@
+---
+pmid: '18289072'
+title: 'The role of heme oxygenase-1 in T cell-mediated immunity: the all encompassing
+  enzyme.'
+authors:
+- Xia ZW
+- Zhong WW
+- Meyrowitz JS
+- Zhang ZL
+journal: Curr Pharm Des
+year: '2008'
+full_text_available: false
+doi: 10.2174/138161208783597326
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+- Review
+publication_type: REVIEW
+---
+
+# The role of heme oxygenase-1 in T cell-mediated immunity: the all encompassing enzyme.
+**Authors:** Xia ZW, Zhong WW, Meyrowitz JS, Zhang ZL
+**Journal:** Curr Pharm Des (2008)
+**DOI:** [10.2174/138161208783597326](https://doi.org/10.2174/138161208783597326)
+
+## Abstract
+
+1. Curr Pharm Des. 2008;14(5):454-64. doi: 10.2174/138161208783597326.
+
+The role of heme oxygenase-1 in T cell-mediated immunity: the all encompassing 
+enzyme.
+
+Xia ZW(1), Zhong WW, Meyrowitz JS, Zhang ZL.
+
+Author information:
+(1)Department of Pediatrics, Ruijin Hospital, School of Medicine, Shanghai 
+Jiaotong University, 200025, Shanghai, China. xzw63@hotmail.com
+
+Heme oxygenase-1 (HO-1) is the rate-limiting enzyme of ferroheme metabolic 
+pathway, which has the functions of anti-oxidation, anti-inflammatory, 
+anti-apoptosis and anti-smooth muscle hyperplasia. Furthermore, HO-1 exerts a 
+protective action in the diseases mediated by effector T lymphocytes such as T 
+helper (Th) 1, Th2 and Th17. In addition, regulatory T cells (Treg) control the 
+activity of CD4+CD25- effector cells in a suppressive manner. Numerous studies 
+indicate that the protective action of HO-1 in diseases is through CD4+CD25+ 
+Treg. This paper will review the current research and understanding of HO-1's 
+role in T cells-mediated immunoregulation.
+
+DOI: 10.2174/138161208783597326
+PMID: 18289072 [Indexed for MEDLINE]

--- a/publications/PMID_18307065.md
+++ b/publications/PMID_18307065.md
@@ -1,0 +1,64 @@
+---
+pmid: '18307065'
+title: Decidual expression and maternal serum levels of heme oxygenase 1 are increased
+  in pre-eclampsia.
+authors:
+- Eide IP
+- Isaksen CV
+- Salvesen KA
+- Langaas M
+- Schønberg SA
+- Austgulen R
+journal: Acta Obstet Gynecol Scand
+year: '2008'
+full_text_available: false
+doi: 10.1080/00016340701763015
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Decidual expression and maternal serum levels of heme oxygenase 1 are increased in pre-eclampsia.
+**Authors:** Eide IP, Isaksen CV, Salvesen KA, Langaas M, Schønberg SA, Austgulen R
+**Journal:** Acta Obstet Gynecol Scand (2008)
+**DOI:** [10.1080/00016340701763015](https://doi.org/10.1080/00016340701763015)
+
+## Abstract
+
+1. Acta Obstet Gynecol Scand. 2008;87(3):272-9. doi: 10.1080/00016340701763015.
+
+Decidual expression and maternal serum levels of heme oxygenase 1 are increased 
+in pre-eclampsia.
+
+Eide IP(1), Isaksen CV, Salvesen KA, Langaas M, Schønberg SA, Austgulen R.
+
+Author information:
+(1)Department of Cancer Research and Molecular Medicine, Children's and Women's 
+Health, Trondheim, Norway. irina.p.eide@ntnu.no
+
+BACKGROUND: Pre-eclampsia (PE) is associated with increased oxidative stress and 
+excessive maternal inflammatory response. Heme oxygenase 1 (HMOX1) is an 
+important stress response enzyme and a mediator of cytoprotection against a wide 
+variety of tissue injuries.
+METHODS: In the present study, microarray technology was used to compare the 
+expression of HMOX1 and other genes involved in stress and inflammatory 
+responses in decidua basalis from 16 pregnancies complicated by PE and 17 
+healthy controls. In addition, the presence of HMOX1 protein in decidua basalis 
+was examined by means of immunohistochemistry, and ELISA was used to measure the 
+maternal serum concentration of HMOX1.
+RESULTS: Fifteen transcripts involved in stress response including HMOX1 were 
+up-regulated in cases, using a cut-off value at p=0.01. HMOX1 protein expression 
+in decidua basalis was significantly increased in cases compared to controls 
+reflected by more pronounced intensity of HMOX1 positive decidual cells 
+(1.8+/-0.3 versus 1.5+/-0.4, p=0.02) and an increased proportion of HMOX1 
+positive decidual leukocytes (31+/-29 versus 9+/-6%, p=0.001). Finally, serum 
+HMOX1 levels were significantly higher among cases compared to controls 
+(3.1+/-1.3 versus 1.9+/-0.5 ng/ml, p=0.008).
+CONCLUSIONS: Increased decidual and serum HMOX1 levels, together with altered 
+decidual expression of some stress-related genes in cases, support the role of 
+oxidative stress and excessive maternal inflammatory response in the 
+pathogenesis of PE.
+
+DOI: 10.1080/00016340701763015
+PMID: 18307065 [Indexed for MEDLINE]

--- a/publications/PMID_19556236.md
+++ b/publications/PMID_19556236.md
@@ -1,0 +1,70 @@
+---
+pmid: '19556236'
+title: Oligomerization is crucial for the stability and function of heme oxygenase-1
+  in the endoplasmic reticulum.
+authors:
+- Hwang HW
+- Lee JR
+- Chou KY
+- Suen CS
+- Hwang MJ
+- Chen C
+- Shieh RC
+- Chau LY
+journal: J Biol Chem
+year: '2009'
+full_text_available: false
+pmcid: PMC2755675
+doi: 10.1074/jbc.M109.028001
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Oligomerization is crucial for the stability and function of heme oxygenase-1 in the endoplasmic reticulum.
+**Authors:** Hwang HW, Lee JR, Chou KY, Suen CS, Hwang MJ, Chen C, Shieh RC, Chau LY
+**Journal:** J Biol Chem (2009)
+**DOI:** [10.1074/jbc.M109.028001](https://doi.org/10.1074/jbc.M109.028001)
+**PMC:** [PMC2755675](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2755675/)
+
+## Abstract
+
+1. J Biol Chem. 2009 Aug 21;284(34):22672-9. doi: 10.1074/jbc.M109.028001. Epub 
+2009 Jun 25.
+
+Oligomerization is crucial for the stability and function of heme oxygenase-1 in 
+the endoplasmic reticulum.
+
+Hwang HW(1), Lee JR, Chou KY, Suen CS, Hwang MJ, Chen C, Shieh RC, Chau LY.
+
+Author information:
+(1)Institute of Biomedical Sciences, Academia Sinica, Taipei 115, Taiwan.
+
+Heme oxygenase-1 (HO-1), a stress-inducible enzyme anchored in the endoplasmic 
+reticulum (ER) by a single transmembrane segment (TMS) located at the C 
+terminus, interacts with NADPH cytochrome P450 reductase and biliverdin 
+reductase to catalyze heme degradation to biliverdin and its metabolite, 
+bilirubin. Previous studies suggested that HO-1 functions as a monomer. Using 
+chemical cross-linking, co-immunoprecipitation, and fluorescence resonance 
+energy transfer (FRET) experiments, here we showed that HO-1 forms 
+dimers/oligomers in the ER. However, oligomerization was not observed with a 
+truncated HO-1 lacking the C-terminal TMS (amino acids 266-285), which exhibited 
+cytosolic and nuclear localization, indicating that the TMS is essential for the 
+self-assembly of HO-1 in the ER. To identify the interface involved in the 
+TMS-TMS interaction, residue Trp-270, predicted by molecular modeling as a 
+potential interfacial residue of TMS alpha-helices, was mutated, and the effects 
+on protein subcellular localization and activity assessed. The results showed 
+that the W270A mutant was present exclusively in the ER and formed oligomers 
+with similar activity to those of the wild type HO-1. Interestingly, the W270N 
+mutant was localized not only in the ER, but also in the cytosol and nucleus, 
+suggesting it is susceptible to proteolytic cleavage. Moreover, the microsomal 
+HO activity of the W270N mutant was significantly lower than that of the wild 
+type. The W270N mutation appears to interfere with the oligomeric state, as 
+revealed by a lower FRET efficiency. Collectively, these data suggest that 
+oligomerization, driven by TMS-TMS interactions, is crucial for the 
+stabilization and function of HO-1 in the ER.
+
+DOI: 10.1074/jbc.M109.028001
+PMCID: PMC2755675
+PMID: 19556236 [Indexed for MEDLINE]

--- a/publications/PMID_21788589.md
+++ b/publications/PMID_21788589.md
@@ -1,0 +1,82 @@
+---
+pmid: '21788589'
+title: MicroRNA-24 regulates vascularity after myocardial infarction.
+authors:
+- Fiedler J
+- Jazbutyte V
+- Kirchmaier BC
+- Gupta SK
+- Lorenzen J
+- Hartmann D
+- Galuppo P
+- Kneitz S
+- Pena JT
+- Sohn-Lee C
+- Loyer X
+- Soutschek J
+- Brand T
+- Tuschl T
+- Heineke J
+- Martin U
+- Schulte-Merker S
+- Ertl G
+- Engelhardt S
+- Bauersachs J
+- Thum T
+journal: Circulation
+year: '2011'
+full_text_available: false
+doi: 10.1161/CIRCULATIONAHA.111.039008
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# MicroRNA-24 regulates vascularity after myocardial infarction.
+**Authors:** Fiedler J, Jazbutyte V, Kirchmaier BC, Gupta SK, Lorenzen J, Hartmann D, Galuppo P, Kneitz S, Pena JT, Sohn-Lee C, Loyer X, Soutschek J, Brand T, Tuschl T, Heineke J, Martin U, Schulte-Merker S, Ertl G, Engelhardt S, Bauersachs J, Thum T
+**Journal:** Circulation (2011)
+**DOI:** [10.1161/CIRCULATIONAHA.111.039008](https://doi.org/10.1161/CIRCULATIONAHA.111.039008)
+
+## Abstract
+
+1. Circulation. 2011 Aug 9;124(6):720-30. doi: 10.1161/CIRCULATIONAHA.111.039008.
+ Epub 2011 Jul 25.
+
+MicroRNA-24 regulates vascularity after myocardial infarction.
+
+Fiedler J(1), Jazbutyte V, Kirchmaier BC, Gupta SK, Lorenzen J, Hartmann D, 
+Galuppo P, Kneitz S, Pena JT, Sohn-Lee C, Loyer X, Soutschek J, Brand T, Tuschl 
+T, Heineke J, Martin U, Schulte-Merker S, Ertl G, Engelhardt S, Bauersachs J, 
+Thum T.
+
+Author information:
+(1)Hannover Medical School, Institute for Molecular and Translational 
+Therapeutic Strategies, Hannover, Germany. Thum.Thomas@mh-hannover.de
+
+BACKGROUND: Myocardial infarction leads to cardiac remodeling and development of 
+heart failure. Insufficient myocardial capillary density after myocardial 
+infarction has been identified as a critical event in this process, although the 
+underlying mechanisms of cardiac angiogenesis are mechanistically not well 
+understood.
+METHODS AND RESULTS: Here, we show that the small noncoding RNA microRNA-24 
+(miR-24) is enriched in cardiac endothelial cells and considerably upregulated 
+after cardiac ischemia. MiR-24 induces endothelial cell apoptosis, abolishes 
+endothelial capillary network formation on Matrigel, and inhibits cell sprouting 
+from endothelial spheroids. These effects are mediated through targeting of the 
+endothelium-enriched transcription factor GATA2 and the p21-activated kinase 
+PAK4, which were identified by bioinformatic predictions and validated by 
+luciferase gene reporter assays. Respective downstream signaling cascades 
+involving phosphorylated BAD (Bcl-XL/Bcl-2-associated death promoter) and 
+Sirtuin1 were identified by transcriptome, protein arrays, and chromatin 
+immunoprecipitation analyses. Overexpression of miR-24 or silencing of its 
+targets significantly impaired angiogenesis in zebrafish embryos. Blocking of 
+endothelial miR-24 limited myocardial infarct size of mice via prevention of 
+endothelial apoptosis and enhancement of vascularity, which led to preserved 
+cardiac function and survival.
+CONCLUSIONS: Our findings indicate that miR-24 acts as a critical regulator of 
+endothelial cell apoptosis and angiogenesis and is suitable for therapeutic 
+intervention in the setting of ischemic heart disease.
+
+DOI: 10.1161/CIRCULATIONAHA.111.039008
+PMID: 21788589 [Indexed for MEDLINE]

--- a/publications/PMID_22419571.md
+++ b/publications/PMID_22419571.md
@@ -1,0 +1,56 @@
+---
+pmid: '22419571'
+title: Endoplasmic reticulum anchored heme-oxygenase 1 faces the cytosol.
+authors:
+- Gottlieb Y
+- Truman M
+- Cohen LA
+- Leichtmann-Bardoogo Y
+- Meyron-Holtz EG
+journal: Haematologica
+year: '2012'
+full_text_available: false
+pmcid: PMC3487549
+doi: 10.3324/haematol.2012.063651
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Endoplasmic reticulum anchored heme-oxygenase 1 faces the cytosol.
+**Authors:** Gottlieb Y, Truman M, Cohen LA, Leichtmann-Bardoogo Y, Meyron-Holtz EG
+**Journal:** Haematologica (2012)
+**DOI:** [10.3324/haematol.2012.063651](https://doi.org/10.3324/haematol.2012.063651)
+**PMC:** [PMC3487549](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3487549/)
+
+## Abstract
+
+1. Haematologica. 2012 Oct;97(10):1489-93. doi: 10.3324/haematol.2012.063651.
+Epub  2012 Mar 14.
+
+Endoplasmic reticulum anchored heme-oxygenase 1 faces the cytosol.
+
+Gottlieb Y(1), Truman M, Cohen LA, Leichtmann-Bardoogo Y, Meyron-Holtz EG.
+
+Author information:
+(1)Department of Biotechnology and Food Engineering, Technion-Israel Institute 
+of Technology, Haifa 32000, Israel.
+
+Heme-oxygenase 1 is an endoplasmic reticulum-anchored enzyme that breaks down 
+heme into iron, carbon monoxide and biliverdin. Heme is a hydrophobic co-factor 
+in many proteins, including hemoglobin. Free heme is highly cytotoxic and, 
+therefore, both heme synthesis and breakdown are tightly regulated. During 
+turnover of heme proteins, heme is released in the phago-lysosomal compartment 
+or the cytosol. The subcellular location of the heme-oxygenase 1 active site has 
+not been clarified. Using constructs of heme-oxygenase 1 with fluorescent 
+proteins, and the endogenous heme-oxygenase 1 in two variations of protease 
+protection assays, we determined that heme-oxygenase 1 is membrane-bound and 
+faces the cytosol in non-activated macrophages in vivo. These findings imply 
+that in quiescent macrophages, heme breakdown products are generated in the 
+cytosol. This facilitates iron recycling to ferroportin for iron export and to 
+ferritin for iron storage.
+
+DOI: 10.3324/haematol.2012.063651
+PMCID: PMC3487549
+PMID: 22419571 [Indexed for MEDLINE]

--- a/publications/PMID_22989377.md
+++ b/publications/PMID_22989377.md
@@ -1,0 +1,58 @@
+---
+pmid: '22989377'
+title: Haem oxygenase-1 overexpression alters intracellular iron distribution.
+authors:
+- Lanceta L
+- Li C
+- Choi AM
+- Eaton JW
+journal: Biochem J
+year: '2013'
+full_text_available: false
+doi: 10.1042/BJ20120936
+pubmed_publication_types:
+- Journal Article
+- Research Support, N.I.H., Extramural
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Haem oxygenase-1 overexpression alters intracellular iron distribution.
+**Authors:** Lanceta L, Li C, Choi AM, Eaton JW
+**Journal:** Biochem J (2013)
+**DOI:** [10.1042/BJ20120936](https://doi.org/10.1042/BJ20120936)
+
+## Abstract
+
+1. Biochem J. 2013 Jan 1;449(1):189-94. doi: 10.1042/BJ20120936.
+
+Haem oxygenase-1 overexpression alters intracellular iron distribution.
+
+Lanceta L(1), Li C, Choi AM, Eaton JW.
+
+Author information:
+(1)Molecular Targets Program, James Graham Brown Cancer Center, University of 
+Louisville, 505 South Hancock Street, Louisville, KY 40202, U.S.A.
+
+Induction or ectopic overexpression of HO-1 (haem oxygenase 1) protects against 
+a wide variety of disorders. These protective effects have been variably 
+ascribed to generation of carbon monoxide (released during cleavage of the 
+alpha-methene bridge of haem) and/or to production of the antioxidant bilirubin. 
+We investigated HO-1-overexpressing A549 cells and find that, as expected, 
+HO-1-overexpressing cells are resistant to killing by hydrogen peroxide. 
+Surprisingly, these cells have approximately twice the normal amount of 
+intracellular iron which usually tends to amplify oxidant killing. However, 
+HO-1-overexpressing cells contain only ~25% as much 'loose' (probably redox 
+active) iron. Indeed, inhibition of ferritin synthesis [via siRNA (small 
+interfering RNA) directed at the ferritin heavy chain] sensitizes the 
+HO-1-overexpressing cells to peroxide killing. It appears that HO-1 
+overexpression leads to enhanced destruction of haem, consequent 2-3-fold 
+induction of ferritin, and compensatory increases in transferrin receptor 
+expression and haem synthesis. However, there is no functional haem deficiency 
+because cellular oxygen consumption and catalase activity are similar in both 
+cell types. We conclude that, at least in many cases, the cytoprotective effects 
+of HO-1 induction or forced overexpression may derive from elevated expression 
+of ferritin and consequent reduction of redox active 'loose' iron.
+
+DOI: 10.1042/BJ20120936
+PMID: 22989377 [Indexed for MEDLINE]

--- a/publications/PMID_27207795.md
+++ b/publications/PMID_27207795.md
@@ -1,0 +1,107 @@
+---
+pmid: '27207795'
+title: BLVRB redox mutation defines heme degradation in a metabolic pathway of enhanced
+  thrombopoiesis in humans.
+authors:
+- Wu S
+- Li Z
+- Gnatenko DV
+- Zhang B
+- Zhao L
+- Malone LE
+- Markova N
+- Mantle TJ
+- Nesbitt NM
+- Bahou WF
+journal: Blood
+year: '2016'
+full_text_available: true
+full_text_extraction_method: html
+pmcid: PMC4974201
+doi: 10.1182/blood-2016-02-696997
+pubmed_publication_types:
+- Journal Article
+- Research Support, N.I.H., Extramural
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# BLVRB redox mutation defines heme degradation in a metabolic pathway of enhanced thrombopoiesis in humans.
+**Authors:** Wu S, Li Z, Gnatenko DV, Zhang B, Zhao L, Malone LE, Markova N, Mantle TJ, Nesbitt NM, Bahou WF
+**Journal:** Blood (2016)
+**DOI:** [10.1182/blood-2016-02-696997](https://doi.org/10.1182/blood-2016-02-696997)
+**PMC:** [PMC4974201](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4974201/)
+
+## Abstract
+
+1. Blood. 2016 Aug 4;128(5):699-709. doi: 10.1182/blood-2016-02-696997. Epub 2016
+ May 16.
+
+BLVRB redox mutation defines heme degradation in a metabolic pathway of enhanced 
+thrombopoiesis in humans.
+
+Wu S(1), Li Z(2), Gnatenko DV(2), Zhang B(3), Zhao L(1), Malone LE(2), Markova 
+N(2), Mantle TJ(4), Nesbitt NM(2), Bahou WF(2).
+
+Author information:
+(1)Department of Applied Mathematics and Statistics.
+(2)Department of Medicine, and.
+(3)Department of Biochemistry and Cell Biology, Stony Brook University, Stony 
+Brook, NY; and.
+(4)Department of Biochemistry, Trinity College, Dublin, Ireland.
+
+Comment in
+    Blood. 2016 Aug 4;128(5):613-4. doi: 10.1182/blood-2016-06-718544.
+
+Human blood cell counts are tightly maintained within narrow physiologic ranges, 
+largely controlled by cytokine-integrated signaling and transcriptional circuits 
+that regulate multilineage hematopoietic specification. Known genetic loci 
+influencing blood cell production account for <10% of platelet and red blood 
+cell variability, and thrombopoietin/cellular myeloproliferative leukemia virus 
+liganding is dispensable for definitive thrombopoiesis, establishing that 
+fundamentally important modifier loci remain unelucidated. In this study, 
+platelet transcriptome sequencing and extended thrombocytosis cohort analyses 
+identified a single loss-of-function mutation (BLVRB(S111L)) causally associated 
+with clonal and nonclonal disorders of enhanced platelet production. 
+BLVRB(S111L) encompassed within the substrate/cofactor [α/β dinucleotide 
+NAD(P)H] binding fold is a functionally defective redox coupler using flavin and 
+biliverdin (BV) IXβ tetrapyrrole(s) and results in exaggerated reactive oxygen 
+species accumulation as a putative metabolic signal leading to differential 
+hematopoietic lineage commitment and enhanced thrombopoiesis. These data define 
+the first physiologically relevant function of BLVRB and implicate its activity 
+and/or heme-regulated BV tetrapyrrole(s) in a unique redox-regulated 
+bioenergetic pathway governing terminal megakaryocytopoiesis; these observations 
+also define a mechanistically restricted drug target retaining potential for 
+enhancing human platelet counts.
+
+© 2016 by The American Society of Hematology.
+
+DOI: 10.1182/blood-2016-02-696997
+PMCID: PMC4974201
+PMID: 27207795 [Indexed for MEDLINE]
+
+## Full Text
+
+Abstract
+
+Human blood cell counts are tightly maintained within narrow physiologic ranges, largely controlled by cytokine-integrated signaling and transcriptional circuits that regulate multilineage hematopoietic specification. Known genetic loci influencing blood cell production account for <10% of platelet and red blood cell variability, and thrombopoietin/cellular myeloproliferative leukemia virus liganding is dispensable for definitive thrombopoiesis, establishing that fundamentally important modifier loci remain unelucidated. In this study, platelet transcriptome sequencing and extended thrombocytosis cohort analyses identified a single loss-of-function mutation ( BLVRB S111L ) causally associated with clonal and nonclonal disorders of enhanced platelet production. BLVRB S111L encompassed within the substrate/cofactor [α/β dinucleotide NAD(P)H] binding fold is a functionally defective redox coupler using flavin and biliverdin (BV) IXβ tetrapyrrole(s) and results in exaggerated reactive oxygen species accumulation as a putative metabolic signal leading to differential hematopoietic lineage commitment and enhanced thrombopoiesis. These data define the first physiologically relevant function of BLVRB and implicate its activity and/or heme-regulated BV tetrapyrrole(s) in a unique redox-regulated bioenergetic pathway governing terminal megakaryocytopoiesis; these observations also define a mechanistically restricted drug target retaining potential for enhancing human platelet counts.
+
+Introduction
+
+Megakaryocytopoiesis and proplatelet formation represent progressively linked stages of hematopoietic stem cell development that maintain the normal circulating pool of platelets, 1 cells critical to normal hemostasis, pathologic thrombosis, and host adaptive immunologic responses. 2 , 3 Platelet generation (∼1 × 10 11 cells daily) is largely controlled by the thrombopoietin (TPO)/cellular myeloproliferative leukemia virus (c-MPL) axis, derived by megakaryocyte (MK) commitment form common bipotent MK-erythrocyte progenitors (MEPs). 4 Although MKs are reduced in MPL -deficient mice, animals still produce MKs and platelets, implying that hematopoietic stem cells (HSCs) maintain the capacity for lineage fate in the absence of MPL. 5 Transcription factors including GATA-1 , GATA-2 , FOG1/ZFPM1 , RUNX1 , and NFE2 are important for MK development, 2 but none exclusively specify MK fate. 1 Whereas human blood counts have a heritable component, known genetic loci account for ∼5% of platelet variability, 6 , 7 highlighting the considerable knowledge gap of genetic pathways regulating physiologic and pathologic thrombopoiesis.
+
+In this study, we applied large-scale platelet transcriptomic sequencing to unmask heme degradation in a novel metabolic pathway controlling megakaryocytopoiesis and platelet production. Whereas nearly 80% of organismal heme is found in circulating erythrocytes, heme degradation is largely studied in the context of reticulendothelial cell-mediated detoxification, with no prior evidence that tetrapyrroles (or their processing enzymes) engage in regulatory functions governing hematopoiesis. Defective oxidation/reductase (redox) activity involving biliverdin IXβ reductase (BLVRB) provides novel insights into the accumulation of reactive oxygen species, with implications for metabolic and bioenergetic determinants of lineage fate. In principle, redox-selected inhibitors represent novel biochemical approaches retaining potential for modulating human platelet counts.
+
+Discussion
+
+Our data provide the first evidence linking redox activity within the heme degradation pathway to MK lineage fate and physiologically relevant platelet expansion in humans. Support for this conclusion stems from (1) genetic association studies in both clonal and nonclonal disorders of thrombocytosis, (2) biochemical analyses using complementary NADPH-dependent enzymatic determinations of both flavin and BV substrates, (3) documentation that defective redox activity is associated with ROS mishandling as a metabolic cellular consequence in both iPSCs and primary hematopoietic cells, and (4) evidence for disparate effects on MK lineage fate in suspension and collagen-based culture systems. Although BLVRB S111L is clearly associated with ROS mishandling as a putative explanation for accelerated differentiation (or “priming”) 33 during a developmentally regulated stage of megakaryocytopoiesis, a direct metabolic effect related to tetrapyrrole coupling (unrelated to the surrogate ROS accumulation) remains plausible and is currently under investigation; similarly, we cannot exclude an additive effect of enhanced ROS-associated proplatelet formation during late-stage MK development. 38
+
+Interestingly, there is minimal evidence implicating any of the heme degradation pathway components in hematopoietic development, which is an unexpected finding in our study. Despite evidence for cytoprotective effects of HMOX and BLVRB, 16 , 39 heme degradation is generally considered a catabolic pathway, predominantly active in cells of the reticulo-endothelial system to process pro-oxidant (free) heme generated during erythroid senescence or turnover of cytochrome p450 enzymes. Within the subset of heme degradation pathway genes, BLVRB expression (to the exclusion of the other 3 genes HMOX1, HMOX2, and BLVRA ) demonstrated a striking induction during terminal erythropoiesis and a restricted temporal pattern of expression during megakaryocytopoiesis. Thus, our data are consistent with a recent report highlighting the importance of HMOX1 in murine erythroid development 25 and extend this observation to a lineage-restricted effect on megakaryocytopoiesis. Importantly, the comparatively disparate expression patterns also suggest that BLVRB maintains functional effects distinct from those of other heme degradation components.
+
+To date, it remains unestablished if BLVRB megakaryocytic effects are restricted to its activity as a flavin reductase, in partnered electron exchange with an unidentified protein, or as a verdin-regulated redox coupler. The latter mechanism implies a developmentally coordinated hematopoietic function(s) regulated by heme degradation and isomer-restricted BV IXβ (or IXδ, IXγ) generation. Indeed, this conclusion seems paradoxical given our current understanding of BV/BR isomeric patterns in adults. All natural BVs are formed by ring cleavage of preassembled heme and not by de novo assembly from smaller units 40 ; although cleavage could occur at any of the 4 meso bridge carbons, there is striking regioselectivity of HMOX for the α-meso (IXα) carbon bridge with limited generation of BLVRB-specific IXβ, IXδ, and IXγ isomers. 28 Interestingly, BV isomer generation appears distinct in the fetus where BV IXβ may predominate, 41 although the mechanism for BV IXβ generation remains enigmatic. Nonetheless, BLVRB binds promiscuously (and nonproductively) to other tetrapyrroles such as protohemin 27 or BV IXα, 28 suggesting that its redox activity could be modulated by endogenous cellular heme byproducts with resultant effects on redox coupling and lineage commitment (ie, function as a metabolically regulated cellular rheostat 34 ).
+
+The loss-of-function redox mutation causes defective ROS handling in the background of endogenous BLVRB expression, establishing a dominant inhibitory mechanism of action. This is somewhat unexpected because the crystal structure provides no convincing evidence for dimerization sequences 28 (either homo- or heterodimers) as one putative explanation, although an alternative model of enzymatically locked substrate (and/or cofactor) binding remains plausible. Indeed, a compulsory ordered kinetic mechanism has been proposed in which NADPH binding followed by substrate results in sequential release of product and oxidized cofactor. 28 A definitive explanation will require crystallization and structure determination of BLVRB S111L ; indeed, this issue may be relevant for previous suggestions imputing the existence of a BV/BR redox cycle and progressively amplified BR antioxidant functions. 16 Finally, the dominant inhibitory mechanism predicts that low-level BLVRB 462 C→T allelic expression could have exaggerated cellular effects in the background of wild-type C alleles.
+
+Low intracellular ROS levels evident in quiescent HSCs are regulated by the FoxO family of transcription factors, 42 and the primary non-mitochondrial sources for ROS production are NADPH oxidases. In addition, the thiol balance also contributes to hematopoietic progenitor cell mobilization, as cellular redox status can be regulated by free or protein-incorporated thiols. Previous data have established that p22 hox -dependent NADPH oxidase activity is responsible for ROS production and required for MK differentiation. 32 Despite the importance of ROS signaling in cell quiescence and lineage fate, 33 there are no identified ROS-regulating mutations that modulate human platelet counts, and we would speculate that the temporally restricted nature of BLVRB-associated ROS priming provides the developmentally regulated signal for accelerated MK differentiation. Using a bilineage model of erythro/megakaryocytopoiesis, we saw no evidence for MK lineage partitioning, most consistent with a model of postcommitment megakaryocytopoiesis and not altered E/Meg lineage balance. 13 Nonetheless, it is intriguing that our limited cohort analysis demonstrated reciprocal effects on hemoglobin and platelet counts in BLVRB S111L subsets, observations that need to be confirmed in expanded MPN subtypes including polycythemia vera. Expectedly, we saw no evidence that BLVRB S111L caused methemoglobinemia in the setting of functionally intact cytochrome b5 reductase, 27 although statistically significant erythroid expansion was evident in BLVRB WT multipotential progenitor and bilineage cultures. The latter observation remains under investigation but suggests an erythroid function in redox-regulated bioenergetic metabolism, with possible effects on stage-specific erythropoiesis. 43 , 44
+
+BLVRB (and the BLVRA homolog) are unusual, possibly unique, in their ability to use either NADPH or NADH as cofactors with a different pH optimum for each cofactor. 45 Nonetheless, BLVRB accommodates NADPH more favorably, 28 and cofactor binding is required for apoprotein stability; furthermore, broad substrate discrimination occurs by steric constraints for chemical groups adjacent to the electrophilic C10 methene carbon. When integrated with our data, this model suggests that development of BLVRB-selective redox inhibitors with thermodynamically distinct chemical modifications represents logical approaches to selectively alter a regulatory pathway controlling MK lineage expansion and human platelet counts.

--- a/publications/PMID_3345742.md
+++ b/publications/PMID_3345742.md
@@ -1,0 +1,55 @@
+---
+pmid: '3345742'
+title: Human heme oxygenase cDNA and induction of its mRNA by hemin.
+authors:
+- Yoshida T
+- Biro P
+- Cohen T
+- Müller RM
+- Shibahara S
+journal: Eur J Biochem
+year: '1988'
+full_text_available: false
+doi: 10.1111/j.1432-1033.1988.tb13811.x
+pubmed_publication_types:
+- Journal Article
+publication_type: PRIMARY_RESEARCH
+---
+
+# Human heme oxygenase cDNA and induction of its mRNA by hemin.
+**Authors:** Yoshida T, Biro P, Cohen T, Müller RM, Shibahara S
+**Journal:** Eur J Biochem (1988)
+**DOI:** [10.1111/j.1432-1033.1988.tb13811.x](https://doi.org/10.1111/j.1432-1033.1988.tb13811.x)
+
+## Abstract
+
+1. Eur J Biochem. 1988 Feb 1;171(3):457-61. doi: 
+10.1111/j.1432-1033.1988.tb13811.x.
+
+Human heme oxygenase cDNA and induction of its mRNA by hemin.
+
+Yoshida T(1), Biro P, Cohen T, Müller RM, Shibahara S.
+
+Author information:
+(1)Friedrich-Miescher-Institut, Basel, Switzerland.
+
+Hemin treatment increased both activity and mRNA level of heme oxygenase in 
+human macrophages. Using poly(A)-rich RNA prepared from human macrophages 
+treated with hemin, we have constructed a cDNA library in the Okayama-Berg 
+vector. The human heme oxygenase cDNA was isolated by screening this library 
+with a rat cDNA and was subjected to nucleotide sequence analysis. The deduced 
+human heme oxygenase is composed of 288 amino acids with a molecular mass of 
+32,800 Da. The homology in amino acid sequences between rat and human heme 
+oxygenase is 80%. Like rat heme oxygenase, human enzyme has a putative membrane 
+segment at its carboxyl terminus, which is probably essential for the insertion 
+of heme oxygenase into endoplasmic reticulum. Both rat and human heme oxygenase 
+have no cysteine residues. Recently we have shown that rat heme oxygenase is a 
+heat-shock protein [J. Biol. Chem. 262, 12889-12892 (1987)], and therefore we 
+examined the effects of heat treatment on the induction of heme oxygenase in 
+human macrophages and glioma cells. In contrast to hemin treatment, heat 
+treatment had no apparent effects in either human cell line on the activity of 
+heme oxygenase and its mRNA levels. These results suggest that human heme 
+oxygenase may not be a heat-shock protein.
+
+DOI: 10.1111/j.1432-1033.1988.tb13811.x
+PMID: 3345742 [Indexed for MEDLINE]

--- a/publications/PMID_38056462.md
+++ b/publications/PMID_38056462.md
@@ -1,0 +1,3468 @@
+---
+pmid: '38056462'
+title: An enzyme that selectively S-nitrosylates proteins to regulate insulin signaling.
+authors:
+- Zhou HL
+- Grimmett ZW
+- Venetos NM
+- Stomberski CT
+- Qian Z
+- McLaughlin PJ
+- Bansal PK
+- Zhang R
+- Reynolds JD
+- Premont RT
+- Stamler JS
+journal: Cell
+year: '2023'
+full_text_available: true
+full_text_extraction_method: xml
+pmcid: PMC10794992
+doi: 10.1016/j.cell.2023.11.009
+pubmed_publication_types:
+- Journal Article
+- Research Support, N.I.H., Extramural
+publication_type: PRIMARY_RESEARCH
+---
+
+# An enzyme that selectively S-nitrosylates proteins to regulate insulin signaling.
+**Authors:** Zhou HL, Grimmett ZW, Venetos NM, Stomberski CT, Qian Z, McLaughlin PJ, Bansal PK, Zhang R, Reynolds JD, Premont RT, Stamler JS
+**Journal:** Cell (2023)
+**DOI:** [10.1016/j.cell.2023.11.009](https://doi.org/10.1016/j.cell.2023.11.009)
+**PMC:** [PMC10794992](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10794992/)
+
+## Abstract
+
+1. Cell. 2023 Dec 21;186(26):5812-5825.e21. doi: 10.1016/j.cell.2023.11.009. Epub
+ 2023 Dec 5.
+
+An enzyme that selectively S-nitrosylates proteins to regulate insulin 
+signaling.
+
+Zhou HL(1), Grimmett ZW(2), Venetos NM(3), Stomberski CT(3), Qian Z(1), 
+McLaughlin PJ(1), Bansal PK(4), Zhang R(1), Reynolds JD(5), Premont RT(6), 
+Stamler JS(7).
+
+Author information:
+(1)Department of Medicine, Case Western Reserve University School of Medicine, 
+Cleveland, OH, USA; Institute for Transformative Molecular Medicine, Case 
+Western Reserve University School of Medicine, Cleveland, OH, USA.
+(2)Institute for Transformative Molecular Medicine, Case Western Reserve 
+University School of Medicine, Cleveland, OH, USA; Department of Pathology, Case 
+Western Reserve University School of Medicine, Cleveland, OH, USA.
+(3)Institute for Transformative Molecular Medicine, Case Western Reserve 
+University School of Medicine, Cleveland, OH, USA; Department of Biochemistry, 
+Case Western Reserve University School of Medicine, Cleveland, OH, USA.
+(4)Department of Biochemistry, Case Western Reserve University School of 
+Medicine, Cleveland, OH, USA.
+(5)Institute for Transformative Molecular Medicine, Case Western Reserve 
+University School of Medicine, Cleveland, OH, USA; Anesthesiology and 
+Perioperative Medicine, Case Western Reserve University School of Medicine, 
+Cleveland, OH, USA; Harrington Discovery Institute, University Hospitals 
+Cleveland Medical Center, Cleveland, OH, USA.
+(6)Department of Medicine, Case Western Reserve University School of Medicine, 
+Cleveland, OH, USA; Institute for Transformative Molecular Medicine, Case 
+Western Reserve University School of Medicine, Cleveland, OH, USA; Harrington 
+Discovery Institute, University Hospitals Cleveland Medical Center, Cleveland, 
+OH, USA.
+(7)Department of Medicine, Case Western Reserve University School of Medicine, 
+Cleveland, OH, USA; Institute for Transformative Molecular Medicine, Case 
+Western Reserve University School of Medicine, Cleveland, OH, USA; Department of 
+Biochemistry, Case Western Reserve University School of Medicine, Cleveland, OH, 
+USA; Harrington Discovery Institute, University Hospitals Cleveland Medical 
+Center, Cleveland, OH, USA. Electronic address: jonathan.stamler@case.edu.
+
+Comment in
+    Mol Cell. 2024 Jan 18;84(2):191-193. doi: 10.1016/j.molcel.2023.12.018.
+
+Acyl-coenzyme A (acyl-CoA) species are cofactors for numerous enzymes that 
+acylate thousands of proteins. Here, we describe an enzyme that uses 
+S-nitroso-CoA (SNO-CoA) as its cofactor to S-nitrosylate multiple proteins 
+(SNO-CoA-assisted nitrosylase, SCAN). Separate domains in SCAN mediate SNO-CoA 
+and substrate binding, allowing SCAN to selectively catalyze SNO transfer from 
+SNO-CoA to SCAN to multiple protein targets, including the insulin receptor 
+(INSR) and insulin receptor substrate 1 (IRS1). Insulin-stimulated 
+S-nitrosylation of INSR/IRS1 by SCAN reduces insulin signaling physiologically, 
+whereas increased SCAN activity in obesity causes INSR/IRS1 hypernitrosylation 
+and insulin resistance. SCAN-deficient mice are thus protected from diabetes. In 
+human skeletal muscle and adipose tissue, SCAN expression increases with body 
+mass index and correlates with INSR S-nitrosylation. S-nitrosylation by 
+SCAN/SNO-CoA thus defines a new enzyme class, a unique mode of receptor tyrosine 
+kinase regulation, and a revised paradigm for NO function in physiology and 
+disease.
+
+Copyright © 2023 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.cell.2023.11.009
+PMCID: PMC10794992
+PMID: 38056462 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of interests J.S.S. is a founder and 
+board member of and has equity interest in SNO bio, a company developing 
+nitrosylation related therapeutics, and NNOXX, a company developing NO-based 
+device technology. Case Western Reserve University (CWRU) and University 
+Hospitals Cleveland Medical Center (UHCMC) are aware of these conflicts, and 
+appropriate management plans are in place. Discoveries herein (J.S.S. and 
+H.-L.Z.) have been disclosed to CWRU/UHCMC, and a patent application is 
+anticipated.
+
+## Full Text
+
+IntroductionCoenzyme A (CoA) is a cofactor for ~4% of cellular enzymes, where its
+reactive thiol is used to ferry biomolecule metabolites and building blocks, most
+prominently acetyl groups during metabolism of glucose and the synthesis of fatty
+acids 1,2. CoA also has a key role in cellular signaling where it is
+used by enzymes to carry molecules employed for post-translational modification
+(PTM) of target proteins. These include most notably histone acetyltransferases
+(HATs) that acetylate histones and other proteins, and palmitoyl-transferases (PATs)
+that add palmitate or other fatty acids to proteins to regulate protein association
+with cell membranes 3. Enzymes
+utilizing CoA and its congeners for metabolic and signaling functions are
+represented by diverse structural families but share a basic mechanism in charging
+CoA via a thioester linkage and in transfer of acyl groups to nucleophilic
+substrates 4.Coenzyme A has most recently been identified with a function in carrying
+endogenous nitric oxide (NO) in the form of an S-nitrosothiol (SNO;
+SNO-CoA)5. Here the thiol
+of CoA is uniquely activated via a thionitrite linkage (as opposed to a thioester),
+providing a basis for NO group transfer to target proteins in cellular signaling
+(aka S-nitrosylation). Thus conceived, SNO-CoA participates in a reversible chemical
+equilibrium with SNO-protein substrates to determine steady-state levels of cellular
+SNOs 5–8. This is well-exemplified in the functions of
+SNO-CoA reductases (SCoRs), enzymes that degrade SNO-CoA 5,6.
+Deletion of SCoRs leads to elevated SNO-CoA, thereby increasing SNO-protein levels
+5,6,9. Yet protein
+S-nitrosylation in this model remains exclusively non-enzymatic (i.e., SNO-CoA acts
+as a non-specific NO donor), and no enzymes are known to utilize SNO-CoA as a
+cofactor for any purpose.As principal mediators of signal transduction, protein S-nitrosylation and
+phosphorylation have been suggested to share features 10, including conservation across phylogeny,
+global control over cellular function and site-directed modification through
+sequence motif recognition 10–12. In
+addition, excessive or dysregulated S-nitrosylation plays causal roles in many of
+the same diseases as dysregulated phosphorylation, including Alzheimer’s,
+cancers, muscular dystrophy, heart failure and diabetes 13–17. But whereas phosphorylation of proteins is enzymatically
+driven, convention holds that dysregulated S-nitrosylation is mediated chemically by
+high amounts of NO and of LMW SNOs (like SNO-CoA) that modify proteins
+indiscriminately 18,19. More recently, the idea has been raised
+that NO synthase-derived NO may be transferred between proteins, constituting
+‘nitrosylase activity’, and heterotrimeric machinery for
+S-nitrosylation analogous to that used for ubiquitinylation has been identified in
+bacteria 10–12,20–25. However,
+a basic catalytic mechanism that would solidify an enzymatic basis for
+S-nitrosylation has been elusive, and no S-nitrosylases are known to mediate
+physiology or disease.Here we describe the prototype for a class of enzyme, SCAN (for
+SNO-CoA-Assisted Nitrosylase) that uses SNO-CoA as its cofactor to S-nitrosylate
+specific target proteins, and reveal core mechanistic parallels with
+acyltransferases, firmly establishing enzymatic function. Separate domains in SCAN
+are involved in SNO-CoA and target protein binding, allowing SCAN to selectively
+catalyze NO group transfer from SNO-CoA to SCAN to multiple target proteins,
+including the insulin receptor β-subunit (INSRβ) and insulin receptor
+substrate 1 (IRS1). SCAN activity acts physiologically to regulate insulin signaling
+on the one hand, while aberrant activity contributes to diabetes on the other hand.
+While SCAN activity is dependent on NO derived from NOS, the major role of NOS is to
+generate the LMW SNO cofactor. Thus, our characterization of SCAN unveils enzymatic
+principles shared with other enzymatic mediators of signal transduction and supports
+a new paradigm for NO biology.
+
+Introduction
+
+Coenzyme A (CoA) is a cofactor for ~4% of cellular enzymes, where its
+reactive thiol is used to ferry biomolecule metabolites and building blocks, most
+prominently acetyl groups during metabolism of glucose and the synthesis of fatty
+acids 1,2. CoA also has a key role in cellular signaling where it is
+used by enzymes to carry molecules employed for post-translational modification
+(PTM) of target proteins. These include most notably histone acetyltransferases
+(HATs) that acetylate histones and other proteins, and palmitoyl-transferases (PATs)
+that add palmitate or other fatty acids to proteins to regulate protein association
+with cell membranes 3. Enzymes
+utilizing CoA and its congeners for metabolic and signaling functions are
+represented by diverse structural families but share a basic mechanism in charging
+CoA via a thioester linkage and in transfer of acyl groups to nucleophilic
+substrates 4.
+
+Coenzyme A has most recently been identified with a function in carrying
+endogenous nitric oxide (NO) in the form of an S-nitrosothiol (SNO;
+SNO-CoA)5. Here the thiol
+of CoA is uniquely activated via a thionitrite linkage (as opposed to a thioester),
+providing a basis for NO group transfer to target proteins in cellular signaling
+(aka S-nitrosylation). Thus conceived, SNO-CoA participates in a reversible chemical
+equilibrium with SNO-protein substrates to determine steady-state levels of cellular
+SNOs 5–8. This is well-exemplified in the functions of
+SNO-CoA reductases (SCoRs), enzymes that degrade SNO-CoA 5,6.
+Deletion of SCoRs leads to elevated SNO-CoA, thereby increasing SNO-protein levels
+5,6,9. Yet protein
+S-nitrosylation in this model remains exclusively non-enzymatic (i.e., SNO-CoA acts
+as a non-specific NO donor), and no enzymes are known to utilize SNO-CoA as a
+cofactor for any purpose.
+
+As principal mediators of signal transduction, protein S-nitrosylation and
+phosphorylation have been suggested to share features 10, including conservation across phylogeny,
+global control over cellular function and site-directed modification through
+sequence motif recognition 10–12. In
+addition, excessive or dysregulated S-nitrosylation plays causal roles in many of
+the same diseases as dysregulated phosphorylation, including Alzheimer’s,
+cancers, muscular dystrophy, heart failure and diabetes 13–17. But whereas phosphorylation of proteins is enzymatically
+driven, convention holds that dysregulated S-nitrosylation is mediated chemically by
+high amounts of NO and of LMW SNOs (like SNO-CoA) that modify proteins
+indiscriminately 18,19. More recently, the idea has been raised
+that NO synthase-derived NO may be transferred between proteins, constituting
+‘nitrosylase activity’, and heterotrimeric machinery for
+S-nitrosylation analogous to that used for ubiquitinylation has been identified in
+bacteria 10–12,20–25. However,
+a basic catalytic mechanism that would solidify an enzymatic basis for
+S-nitrosylation has been elusive, and no S-nitrosylases are known to mediate
+physiology or disease.
+
+Here we describe the prototype for a class of enzyme, SCAN (for
+SNO-CoA-Assisted Nitrosylase) that uses SNO-CoA as its cofactor to S-nitrosylate
+specific target proteins, and reveal core mechanistic parallels with
+acyltransferases, firmly establishing enzymatic function. Separate domains in SCAN
+are involved in SNO-CoA and target protein binding, allowing SCAN to selectively
+catalyze NO group transfer from SNO-CoA to SCAN to multiple target proteins,
+including the insulin receptor β-subunit (INSRβ) and insulin receptor
+substrate 1 (IRS1). SCAN activity acts physiologically to regulate insulin signaling
+on the one hand, while aberrant activity contributes to diabetes on the other hand.
+While SCAN activity is dependent on NO derived from NOS, the major role of NOS is to
+generate the LMW SNO cofactor. Thus, our characterization of SCAN unveils enzymatic
+principles shared with other enzymatic mediators of signal transduction and supports
+a new paradigm for NO biology.
+
+ResultsBy analogy to acyltransferases that use acetyl-CoA to acetylate proteins
+26, we considered that
+SNO-CoA might serve as cofactor for unknown nitrosylase enzymes that target
+S-nitrosylation of specific substrate proteins. We therefore purified SNO-CoA
+binding proteins from bovine liver to identify candidate SNO-CoA-dependent
+nitrosylases. Eight proteins that bound SNO-CoA, but not CoA, were identified (Figure 1A). Biliverdin reductase B (BLVRB) and
+CBR1 were the two most enriched SNO-CoA binding proteins. CBR1 is known to be a LMW
+SNO reductase 27; however, the
+function of BLVRB is unclear. BLVRB converts fetal β-biliverdin to bilirubin
+during development, but retains expression in adults where its substrate is not
+present 28,29.Using HEK293 cell lysates and recombinant BLVRB protein, we first confirmed
+that BLVRB bound SNO-CoA with relatively high affinity versus a panel of both LMW
+SNO- and CoA- conjugates (Figure 1B, S1A and S1B). Despite being known as an
+NADPH-dependent reductase enzyme 30,31, BLVRB was unable
+to reduce SNO-CoA (Figures
+S1C and S1D). To
+assess whether BLVRB contributed in some other manner to SNO-protein metabolism, we
+used SNO-protein quantitative mass spectrometry in lysates from
+HEK-BLVRB−/− cells compared with parental wild-type HEK
+cells (HEK-WT). We found 50 proteins whose S-nitrosylation was significantly
+diminished in the absence of BLVRB expression, representing potential targets of
+BLVRB acting as a nitrosylase (Table S1). Since protein S-nitrosylation typically operates within
+multiprotein complexes, we isolated the BLVRB interactome by immunoprecipitation
+from HEK293 cell lysates and identified 47 proteins (Table S2). Notably, six of these
+BLVRB-associated cytoplasmic proteins (BLVRB is mainly localized in the cytoplasm
+(Figures S1E and S1F)) overlapped with the
+BLVRB nitrosoproteome (Figure 1C), including
+heme oxygenase 2 (HO2), which is known to function together with BLVRB in heme
+metabolism 32.In HEK293 cells or RAW 264.7 cells, HO2 was endogenously S-nitrosylated in
+an eNOS- or iNOS-dependent manner (Figures S2A and S2B) at two Cys sites (Cys265 and Cys282), as mutation of both Cys265
+and Cys282 to arginine (HO2-C265/282R) blocked S-nitrosylation of HO2 (Figure S2C). We confirmed
+that BLVRB directly interacted with HO2 and this was enhanced by an NO donor (Figure S2D), and verified
+that S-nitrosylation of HO2 (SNO-HO2) was markedly reduced in
+HEK-BLVRB−/− cells compared with HEK-WT cells (Figures 1D and 1F). Recombinant BLVRB catalyzed S-nitrosylation of purified HO2 by
+SNO-CoA (Km of 13 μM), while SNO-CoA itself (in the presence of GST protein
+control) S-nitrosylated HO2 only at very high concentrations (Figures 1E, 1G and
+1H). We conclude that BLVRB functions as a
+SNO-CoA-Assisted Nitrosylase (SCAN).SNO-CoA and NADPH are structurally related (Figure S2E), and BLVDB/SCAN is a known
+NADPH-binding protein 33. We
+investigated whether the NADPH-binding motif in SCAN might be required for SNO-CoA
+binding. Addition of NADPH, but not SNO-cysteamine (SNO-CoA analog), inhibited SCAN
+binding to SNO-CoA resin (Figure 1I) in a
+dose-dependent manner (Figure 1J), suggesting
+that NADPH and SNO-CoA share the same binding site. Although NADPH competes with
+SCAN binding to SNO-CoA in vitro, SCAN can utilize SNO-CoA (1μM) to
+S-nitrosylate HO2 in the presence of high excess concentrations of NADPH (250
+μM) or NADH (1mM) (Figures
+S2F–S2H),
+concentrations that far exceed endogenous cytosolic NADPH (3μM) or NADH
+(50–110μM)34,35. Mutation of three critical amino
+acids, Q14N,T15A,G16A (SCAN-QTG/NAA) within the NADPH-binding motif 33 prevented SCAN binding to SNO-CoA
+resin, confirming that the NADPH-binding site in SCAN is required for SNO-CoA
+binding (Figure 1K). Overexpression of
+SCAN-QTG/NAA in HEK-SCAN−/− cells was unable to rescue
+S-nitrosylation of HO2 (Figures 1L, 1M, S2I and S2J), and recombinant SCAN-QTG/NAA
+could not efficiently S-nitrosylate HO2 in the presence of SNO-CoA in an in
+vitro assay (Figures 1N and 1O). Thus, SNO-CoA binding to SCAN is required
+for SCAN-mediated S-nitrosylation of its protein substrate HO2.To explore the mechanism of SCAN-mediated S-nitrosylation, we investigated
+whether SNO-Cys within SCAN is required for transnitrosylation (i.e., whether
+SNO-SCAN exists as an intermediate in transfer of NO groups to substrate). In HEK293
+cells or RAW 264.7 cells, SCAN was endogenously S-nitrosylated in an eNOS- or
+iNOS-dependent manner (Figures
+S2K and S2L).
+There are two cysteine residues (C109 and C188) within SCAN. Mutation of both C188
+and C109 to arginine eliminated SNO modification of SCAN (Figure 1P). SCAN-C109/188R expressed in
+HEK-BLVRB−/− cells could not rescue HO2 S-nitrosylation
+(Figure 1Q), and recombinant SCAN-C109/188R
+cannot S-nitrosylate the substrate HO2 in vitro (Figure 1R and 1S), indicating that
+SNO-SCAN is required for S-nitrosylation of HO2. To investigate if interaction
+between BLVRB and substrate HO2 is required for BLVRB-mediated S-nitrosylation, we
+generated a truncated HO2 protein (HO2-195-316), which retains the two SNO sites
+(Cys265/282), but is unable to interact with BLVRB (Figures S2M and S2N). In vitro assays indicated that
+BLVRB/SCAN cannot efficiently nitrosylate HO2-195-316 (Figure S2O). These results suggest that
+SCAN utilizes a ‘ping-pong’ mechanism to catalyze S-nitrosylation.
+SCAN associates with both SNO-CoA and HO2 substrate; NO groups are then transferred
+from SNO-CoA to SCAN-C109/188 (forming SNO-SCAN), and from SNO-SCAN to the substrate
+(Figure 1T), yielding product
+(SNO-HO2).To investigate the physiological role of SCAN in mammals, we utilized global
+SCAN-knockout mice (SCAN−/−) (Figures 2A and S3A). The level of bilirubin in serum and whole blood cell counts are
+indistinguishable in SCAN−/− and wild-type mice
+(SCAN+/+), confirming that BLVRB/SCAN is not involved in biliverdin
+degradation or hematopoiesis in adult mice under normal conditions (Figures S3B–S3F)36. Because insulin receptor substrate 4
+(IRS4), the IRS family member predominantly expressed in HEK293 cells, was
+identified in the SCAN-dependent nitrosoproteome (Figure 1C), and because SCAN contains an insulin receptor
+(INSR)-interacting motif with unknown function 37, we explored a role for SCAN/SNO-CoA in insulin
+signaling.We first confirmed that SCAN interacts with both INSR and IRS1 and found
+that interactions are greatly increased by NO donor treatment or insulin stimulation
+(Figures
+S4A–S4C).
+Mutation of the SCAN SNO-CoA binding site (QTG/NAA) or its SNO sites (C109/188R)
+reduced the association of SCAN with the INSR (Figure S4D), consistent with a
+ping-pong mechanism (Figure 1T). Expression of
+SCAN was dramatically increased in skeletal muscle from 12-week-old genetically
+obese mice (ob/ob) and from wildtype mice fed a high fat diet (HFD) for 12 weeks and
+was paralleled by increases in iNOS expression (Figure
+2B). SCAN−/− mice gained weight more slowly than
+SCAN+/+ mice on HFD (Figure S4E).
+SCAN−/− mice fed a HFD for 16-weeks displayed reduced
+blood glucose after 5-hours of fasting, compared to SCAN+/+ mice (Figure 2C), but blood insulin levels were normal
+(Figure 2D), indicating that insulin
+signaling, not pancreatic insulin production/secretion, is responsible for
+protection from hyperglycemia. Insulin tolerance tests showed higher sensitivity to
+insulin in HFD-fed SCAN−/− mice than in SCAN+/+
+mice (Figure 2E). Although basal glucose levels
+are much lower in HFD-fed SCAN−/− mice than WT, glucose
+tolerance tests demonstrated a similar pattern in glucose uptake between HFD-fed
+SCAN+/+ and SCAN−/− mice (Figure 2F), which may reflect elevated insulin levels in
+HFD-fed WT mice (Figure 2D). That is, higher
+insulin levels may alleviate glucose intolerance in WT mice resulting from
+hyper-S-nitrosylation of IRS1/INSR. Using the 14C-labeled
+non-metabolizable glucose analog 2-deoxyglucose as a tracer, we found that knockout
+of SCAN in HFD-fed mice improved insulin-stimulated glucose transport in ex
+vivo soleus muscle (Figure 2G).
+Therefore, SCAN contributes to insulin resistance in HFD-obese mice, whereas SCAN
+deletion improves insulin sensitivity.Excessive S-nitrosylation of INSRβ/IRS1 by iNOS-derived NO is
+implicated in insulin resistance and provides a model for pathological
+S-nitrosylation in disease 38,39. In this model, S-nitrosylation
+was proposed to be mediated chemically by high amounts of reactive NO. Thus, we
+sought to determine if S-nitrosylation of INSRβ/IRS1 is in fact mediated
+enzymatically by SCAN/SNO-CoA. Amounts of SNO-INSRβ and SNO-IRS1 were much
+higher in skeletal muscle of HFD- or chow-fed WT mice than in
+SCAN−/− mice (Figures
+2H and 2I). Further, amounts of
+SNO-INSRβ and SNO-IRS1 were higher in HFD- than chow-fed WT mice, but diet
+had no effect on SNO-levels in SCAN−/− mice. Thus, SCAN is
+required for S-nitrosylation of INSRβ and IRS1 in situ. Further, in in vitro
+assays, purified SCAN efficiently S-nitrosylated purified INSR and IRS1 (Km of 0.96
+μM and 4.57 μM, respectively) (Figures
+2J, 2K and S4F–S4H). To investigate the role of
+SNO-CoA per se in S-nitrosylation of INSR/IRS1, we utilized SNO-CoA reductase (SCoR)
+knockout mice and cells, which cannot effectively metabolize SNO-CoA. Both SCoR and
+SCAN are localized mainly in the cytoplasm (Figure S5A). Deletion of SCoR in HEK
+cells increased association of SCAN with INSRβ (Figure S5B). High-fat diet fed
+SCoR-knockout mice (SCoR−/−) demonstrated increased
+S-nitrosylation of INSRβ/IRS1 and reduced phosphorylation of the insulin
+effectors AKT and AS160 (Figures
+S5C–S5F).
+Taken together, our data support the notion that S-nitrosylation of INSRβ and
+IRS1 is enzymatically mediated, and that hypernitrosylation of proteins after iNOS
+induction may require SCAN and SNO-CoA.To determine if SCAN-mediated S-nitrosylation of INSRβ/IRS1 regulates
+insulin signaling, we measured the phosphorylation of INSRβ, IRS1, AKT and
+AS160 in skeletal muscle of HFD-fed mice after intraperitoneal injection of insulin.
+The insulin-stimulated phosphorylation levels of INSRβ(Tyr1162),
+IRS1(Tyr608), AKT(Ser473) and AS160(Thr642) were all higher in
+SCAN−/− mice than SCAN+/+ mice, indicating
+that S-nitrosylation by SCAN inhibits INSRβ/IRS1-dependent insulin signaling,
+at least in significant part through inhibition of tyrosine kinase activity of
+INSRβ (Figures 2L and S5G).To further explore the physiological role of SCAN-mediated inhibition of
+insulin signaling, we generated SCAN-deficient rat myoblast L6 cell lines
+(L6-SCAN−/−) (Figure S5H). While
+L6-SCAN−/− cells and wild-type parental L6 cells
+(L6-WT) have similarly low basal levels of SNO-INSRβ and SNO-IRS1, insulin
+increased S-nitrosylation of INSRβ/IRS1 in L6-WT cells, but not in
+L6-SCAN−/− cells. Insulin-stimulated S-nitrosylation of
+INSRβ/IRS1 was dynamic in L6-WT cells, reaching a peak 60–120 min
+after removal of insulin (after a 10-minute treatment), and gradually subsiding
+(Figures 3A–3C). Similarly, intraperitoneal insulin injection in
+chow-fed SCAN+/+ mice induced significant S-nitrosylation of
+INSRβ/IRS1, but not in SCAN−/− mice (Figures 3D and 3E).
+We investigated the function of insulin-induced S-nitrosylation of INSRβ/IRS1
+in L6 cells and in healthy mice. We found that deletion of SCAN in L6 cells prolongs
+insulin-stimulated phosphorylation of IRS1, AKT and AS160 (Figures 3F and S5I–S5L). This suggests that
+agonist-stimulated S-nitrosylation of INSRβ/IRS1 is part of a negative
+feedback loop that turns off insulin signaling. To validate this idea in mammals, we
+performed an insulin tolerance test in chow-fed SCAN+/+ and
+SCAN−/− mice. Recovery of glucose levels after insulin
+injection (1 U/kg or 2.5 U/kg) was delayed in SCAN−/− mice
+compared to SCAN+/+ mice (Figures 3G
+and 3H), consistent with higher S-nitrosylation
+of INSRβ in SCAN+/+ than in SCAN−/−
+skeletal muscle (Figure 3I and 3J). These results confirm that insulin-induced
+S-nitrosylation mediated by SCAN acts to turn off insulin signaling in skeletal
+muscle, thereby slowing glucose uptake to prevent hypoglycemia.Insulin treatment in both WT mice and L6-WT cells markedly increased
+phosphorylation of eNOS at Ser1177 and nNOS at Ser1412, respective measures of eNOS
+and nNOS activity (Figures 4A–4F and S5M) 40. Taken together, our results indicate that
+SCAN mediates insulin-stimulated S-nitrosylation of INSRβ/IRS1 in both L6
+cells and skeletal muscle of healthy mice, likely using NO generated by eNOS or nNOS
+(Figures S5N and S5O). This was confirmed by
+showing that in L6 cells, the NOS inhibitor L-NMMA blocked insulin stimulated
+S-nitrosylation not only of INSRβ and IRS1 but also of SCAN itself (Figures 4G–4J). Accordingly, phosphorylation of AKT and AS160 was increased in the
+presence of L-NMMA (Figures 4K, S5P and S5Q). Thus, eNOS and nNOS may provide
+the source of SNO for SCAN activity under physiological conditions.As a confirmatory measure, we re-expressed SCAN-WT (L6-SCAN-WT), the
+SCAN-QTG/NAA mutant unable to bind SNO-CoA (L6-SCAN-QTG/NAA) or the SCAN-C109/188R
+mutant unable to form SNO (L6-SCAN-C109/188R) in SCAN-deficient rat myoblast L6 cell
+lines (L6-SCAN−/−) (Figure S6A). Re-expression of SCAN-WT,
+but not SCAN-QTG/NAA or L6-SCAN-C109/188R, rescued the S-nitrosylation of
+INSRβ and IRS1, and inhibited insulin-stimulated phosphorylation of IRS1 and
+AKT (Figures 5A–5D). Thus, the S-nitrosylation of INSRβ/IRS1 and
+subsequent inhibition of insulin signaling requires SCAN and SNO-CoA. To dissect the
+role SNO-INSRβ in insulin signaling, we first mapped the SNO sites in INSR.
+Four peptides containing four candidate Cys SNO sites were identified (Figure 5E); Cys825, Cys834 and Cys1083 are
+present in INSRβ, while Cys462 is in INSRα. Using mutagenesis, we
+determined that Cys1083 is the primary SNO site in INSRβ; in HEK293 cells,
+mutation of Cys1083 to Ala (INSR-C1083A) reduced the S-nitrosylation of INSRβ
+by ~70% (Figures 5F and 5G). The INSRβ SNO-site (Cys1083) is localized in
+the tyrosine kinase catalytic domain (IRK). Insulin-stimulated IRK
+cross-phosphorylates the activation loop of the other INSR in the dimer, triggering
+its intrinsic tyrosine kinase activity 41. Using Pymol, we determined that the SNO-site Cys1083
+resides at the interface between two IRKs of dimeric INSR, suggesting that
+S-nitrosylation may affect cross-phosphorylation (Figure S6B). To investigate the role of
+INSR-C1083A in insulin signaling, endogenous INSR in L6 cells was deleted and then
+replaced by INSR-WT or INSR-C1083A (Figures S6C and S6D). Following stimulation with
+insulin, cells expressing mutant receptor refractory to S-nitrosylation
+(INSR-C1083A) showed increased and sustained phosphorylation of AKT and AS160 (vs.
+WT INSR) (Figures 5H–5J). Thus, SCAN turns off insulin signaling by
+S-nitrosylation of INSRβ. SNO-INSRβ may be considered a marker of
+insulin receptor desensitization.To determine if S-nitrosylation of INSRβ by SCAN is involved in
+obesity-related insulin resistance in humans, we quantified the expression of SCAN
+and amount of SNO-INSRβ in 14 human skeletal muscle samples and in 26 human
+adipose depot samples from patients with a range of Body Mass Index (BMI) (Table S3). Notably, we found
+that expression of SCAN is upregulated in both skeletal muscle and in visceral and
+subcutaneous adipose samples from patients with higher BMI (Figures 6A–6C,
+S6E and S6F). A significant linear relationship
+between the amount of SNO-INSRβ and BMI in human tissues suggests that
+S-nitrosylation of INSRβ is an important factor in insulin resistance in
+humans (Figures 6D–6F, S6G and S6H).
+Further, a significant linear correlation between amounts of SNO-INSRβ and
+the expression of SCAN protein in both human skeletal muscle and human adipose
+tissues (Figures 6G and 6H) implies that S-nitrosylation of INSRβ is likely
+mediated by SCAN in human tissues. Collectively, the multiple linear correlations
+among SCAN expression, BMI, and SNO-INSRβ (taken together with animal data),
+suggests that overexpression of SCAN in obese patients contributes to insulin
+resistance through hypernitrosylation of INSRβ.INSRβ is one of multiple receptor tyrosine kinases (RTKs) that have
+been reported to be S-nitrosylated, including insulin-like growth factor 1 receptor
+(IGF-1) and epidermal growth factor receptor (EGFR), and our survey of papers
+reporting SNO-protein identification from untargeted mass spectroscopy identified 20
+of the 58 RTK family members as S-nitrosylated (Table S4) 42–45. We find that four additional RTKs (FGFR1, PDGFRβ,
+VEGFR2 and HER3) are S-nitrosylated in human HEK293 cells (Figures S6I–S6K). S-nitrosylation of other RTKs by
+additional SCAN-like enzymes therefore seems likely.
+
+By analogy to acyltransferases that use acetyl-CoA to acetylate proteins
+26, we considered that
+SNO-CoA might serve as cofactor for unknown nitrosylase enzymes that target
+S-nitrosylation of specific substrate proteins. We therefore purified SNO-CoA
+binding proteins from bovine liver to identify candidate SNO-CoA-dependent
+nitrosylases. Eight proteins that bound SNO-CoA, but not CoA, were identified (Figure 1A). Biliverdin reductase B (BLVRB) and
+CBR1 were the two most enriched SNO-CoA binding proteins. CBR1 is known to be a LMW
+SNO reductase 27; however, the
+function of BLVRB is unclear. BLVRB converts fetal β-biliverdin to bilirubin
+during development, but retains expression in adults where its substrate is not
+present 28,29.
+
+Using HEK293 cell lysates and recombinant BLVRB protein, we first confirmed
+that BLVRB bound SNO-CoA with relatively high affinity versus a panel of both LMW
+SNO- and CoA- conjugates (Figure 1B, S1A and S1B). Despite being known as an
+NADPH-dependent reductase enzyme 30,31, BLVRB was unable
+to reduce SNO-CoA (Figures
+S1C and S1D). To
+assess whether BLVRB contributed in some other manner to SNO-protein metabolism, we
+used SNO-protein quantitative mass spectrometry in lysates from
+HEK-BLVRB−/− cells compared with parental wild-type HEK
+cells (HEK-WT). We found 50 proteins whose S-nitrosylation was significantly
+diminished in the absence of BLVRB expression, representing potential targets of
+BLVRB acting as a nitrosylase (Table S1). Since protein S-nitrosylation typically operates within
+multiprotein complexes, we isolated the BLVRB interactome by immunoprecipitation
+from HEK293 cell lysates and identified 47 proteins (Table S2). Notably, six of these
+BLVRB-associated cytoplasmic proteins (BLVRB is mainly localized in the cytoplasm
+(Figures S1E and S1F)) overlapped with the
+BLVRB nitrosoproteome (Figure 1C), including
+heme oxygenase 2 (HO2), which is known to function together with BLVRB in heme
+metabolism 32.
+
+In HEK293 cells or RAW 264.7 cells, HO2 was endogenously S-nitrosylated in
+an eNOS- or iNOS-dependent manner (Figures S2A and S2B) at two Cys sites (Cys265 and Cys282), as mutation of both Cys265
+and Cys282 to arginine (HO2-C265/282R) blocked S-nitrosylation of HO2 (Figure S2C). We confirmed
+that BLVRB directly interacted with HO2 and this was enhanced by an NO donor (Figure S2D), and verified
+that S-nitrosylation of HO2 (SNO-HO2) was markedly reduced in
+HEK-BLVRB−/− cells compared with HEK-WT cells (Figures 1D and 1F). Recombinant BLVRB catalyzed S-nitrosylation of purified HO2 by
+SNO-CoA (Km of 13 μM), while SNO-CoA itself (in the presence of GST protein
+control) S-nitrosylated HO2 only at very high concentrations (Figures 1E, 1G and
+1H). We conclude that BLVRB functions as a
+SNO-CoA-Assisted Nitrosylase (SCAN).
+
+SNO-CoA and NADPH are structurally related (Figure S2E), and BLVDB/SCAN is a known
+NADPH-binding protein 33. We
+investigated whether the NADPH-binding motif in SCAN might be required for SNO-CoA
+binding. Addition of NADPH, but not SNO-cysteamine (SNO-CoA analog), inhibited SCAN
+binding to SNO-CoA resin (Figure 1I) in a
+dose-dependent manner (Figure 1J), suggesting
+that NADPH and SNO-CoA share the same binding site. Although NADPH competes with
+SCAN binding to SNO-CoA in vitro, SCAN can utilize SNO-CoA (1μM) to
+S-nitrosylate HO2 in the presence of high excess concentrations of NADPH (250
+μM) or NADH (1mM) (Figures
+S2F–S2H),
+concentrations that far exceed endogenous cytosolic NADPH (3μM) or NADH
+(50–110μM)34,35. Mutation of three critical amino
+acids, Q14N,T15A,G16A (SCAN-QTG/NAA) within the NADPH-binding motif 33 prevented SCAN binding to SNO-CoA
+resin, confirming that the NADPH-binding site in SCAN is required for SNO-CoA
+binding (Figure 1K). Overexpression of
+SCAN-QTG/NAA in HEK-SCAN−/− cells was unable to rescue
+S-nitrosylation of HO2 (Figures 1L, 1M, S2I and S2J), and recombinant SCAN-QTG/NAA
+could not efficiently S-nitrosylate HO2 in the presence of SNO-CoA in an in
+vitro assay (Figures 1N and 1O). Thus, SNO-CoA binding to SCAN is required
+for SCAN-mediated S-nitrosylation of its protein substrate HO2.
+
+To explore the mechanism of SCAN-mediated S-nitrosylation, we investigated
+whether SNO-Cys within SCAN is required for transnitrosylation (i.e., whether
+SNO-SCAN exists as an intermediate in transfer of NO groups to substrate). In HEK293
+cells or RAW 264.7 cells, SCAN was endogenously S-nitrosylated in an eNOS- or
+iNOS-dependent manner (Figures
+S2K and S2L).
+There are two cysteine residues (C109 and C188) within SCAN. Mutation of both C188
+and C109 to arginine eliminated SNO modification of SCAN (Figure 1P). SCAN-C109/188R expressed in
+HEK-BLVRB−/− cells could not rescue HO2 S-nitrosylation
+(Figure 1Q), and recombinant SCAN-C109/188R
+cannot S-nitrosylate the substrate HO2 in vitro (Figure 1R and 1S), indicating that
+SNO-SCAN is required for S-nitrosylation of HO2. To investigate if interaction
+between BLVRB and substrate HO2 is required for BLVRB-mediated S-nitrosylation, we
+generated a truncated HO2 protein (HO2-195-316), which retains the two SNO sites
+(Cys265/282), but is unable to interact with BLVRB (Figures S2M and S2N). In vitro assays indicated that
+BLVRB/SCAN cannot efficiently nitrosylate HO2-195-316 (Figure S2O). These results suggest that
+SCAN utilizes a ‘ping-pong’ mechanism to catalyze S-nitrosylation.
+SCAN associates with both SNO-CoA and HO2 substrate; NO groups are then transferred
+from SNO-CoA to SCAN-C109/188 (forming SNO-SCAN), and from SNO-SCAN to the substrate
+(Figure 1T), yielding product
+(SNO-HO2).
+
+To investigate the physiological role of SCAN in mammals, we utilized global
+SCAN-knockout mice (SCAN−/−) (Figures 2A and S3A). The level of bilirubin in serum and whole blood cell counts are
+indistinguishable in SCAN−/− and wild-type mice
+(SCAN+/+), confirming that BLVRB/SCAN is not involved in biliverdin
+degradation or hematopoiesis in adult mice under normal conditions (Figures S3B–S3F)36. Because insulin receptor substrate 4
+(IRS4), the IRS family member predominantly expressed in HEK293 cells, was
+identified in the SCAN-dependent nitrosoproteome (Figure 1C), and because SCAN contains an insulin receptor
+(INSR)-interacting motif with unknown function 37, we explored a role for SCAN/SNO-CoA in insulin
+signaling.
+
+We first confirmed that SCAN interacts with both INSR and IRS1 and found
+that interactions are greatly increased by NO donor treatment or insulin stimulation
+(Figures
+S4A–S4C).
+Mutation of the SCAN SNO-CoA binding site (QTG/NAA) or its SNO sites (C109/188R)
+reduced the association of SCAN with the INSR (Figure S4D), consistent with a
+ping-pong mechanism (Figure 1T). Expression of
+SCAN was dramatically increased in skeletal muscle from 12-week-old genetically
+obese mice (ob/ob) and from wildtype mice fed a high fat diet (HFD) for 12 weeks and
+was paralleled by increases in iNOS expression (Figure
+2B). SCAN−/− mice gained weight more slowly than
+SCAN+/+ mice on HFD (Figure S4E).
+SCAN−/− mice fed a HFD for 16-weeks displayed reduced
+blood glucose after 5-hours of fasting, compared to SCAN+/+ mice (Figure 2C), but blood insulin levels were normal
+(Figure 2D), indicating that insulin
+signaling, not pancreatic insulin production/secretion, is responsible for
+protection from hyperglycemia. Insulin tolerance tests showed higher sensitivity to
+insulin in HFD-fed SCAN−/− mice than in SCAN+/+
+mice (Figure 2E). Although basal glucose levels
+are much lower in HFD-fed SCAN−/− mice than WT, glucose
+tolerance tests demonstrated a similar pattern in glucose uptake between HFD-fed
+SCAN+/+ and SCAN−/− mice (Figure 2F), which may reflect elevated insulin levels in
+HFD-fed WT mice (Figure 2D). That is, higher
+insulin levels may alleviate glucose intolerance in WT mice resulting from
+hyper-S-nitrosylation of IRS1/INSR. Using the 14C-labeled
+non-metabolizable glucose analog 2-deoxyglucose as a tracer, we found that knockout
+of SCAN in HFD-fed mice improved insulin-stimulated glucose transport in ex
+vivo soleus muscle (Figure 2G).
+Therefore, SCAN contributes to insulin resistance in HFD-obese mice, whereas SCAN
+deletion improves insulin sensitivity.
+
+Excessive S-nitrosylation of INSRβ/IRS1 by iNOS-derived NO is
+implicated in insulin resistance and provides a model for pathological
+S-nitrosylation in disease 38,39. In this model, S-nitrosylation
+was proposed to be mediated chemically by high amounts of reactive NO. Thus, we
+sought to determine if S-nitrosylation of INSRβ/IRS1 is in fact mediated
+enzymatically by SCAN/SNO-CoA. Amounts of SNO-INSRβ and SNO-IRS1 were much
+higher in skeletal muscle of HFD- or chow-fed WT mice than in
+SCAN−/− mice (Figures
+2H and 2I). Further, amounts of
+SNO-INSRβ and SNO-IRS1 were higher in HFD- than chow-fed WT mice, but diet
+had no effect on SNO-levels in SCAN−/− mice. Thus, SCAN is
+required for S-nitrosylation of INSRβ and IRS1 in situ. Further, in in vitro
+assays, purified SCAN efficiently S-nitrosylated purified INSR and IRS1 (Km of 0.96
+μM and 4.57 μM, respectively) (Figures
+2J, 2K and S4F–S4H). To investigate the role of
+SNO-CoA per se in S-nitrosylation of INSR/IRS1, we utilized SNO-CoA reductase (SCoR)
+knockout mice and cells, which cannot effectively metabolize SNO-CoA. Both SCoR and
+SCAN are localized mainly in the cytoplasm (Figure S5A). Deletion of SCoR in HEK
+cells increased association of SCAN with INSRβ (Figure S5B). High-fat diet fed
+SCoR-knockout mice (SCoR−/−) demonstrated increased
+S-nitrosylation of INSRβ/IRS1 and reduced phosphorylation of the insulin
+effectors AKT and AS160 (Figures
+S5C–S5F).
+Taken together, our data support the notion that S-nitrosylation of INSRβ and
+IRS1 is enzymatically mediated, and that hypernitrosylation of proteins after iNOS
+induction may require SCAN and SNO-CoA.
+
+To determine if SCAN-mediated S-nitrosylation of INSRβ/IRS1 regulates
+insulin signaling, we measured the phosphorylation of INSRβ, IRS1, AKT and
+AS160 in skeletal muscle of HFD-fed mice after intraperitoneal injection of insulin.
+The insulin-stimulated phosphorylation levels of INSRβ(Tyr1162),
+IRS1(Tyr608), AKT(Ser473) and AS160(Thr642) were all higher in
+SCAN−/− mice than SCAN+/+ mice, indicating
+that S-nitrosylation by SCAN inhibits INSRβ/IRS1-dependent insulin signaling,
+at least in significant part through inhibition of tyrosine kinase activity of
+INSRβ (Figures 2L and S5G).
+
+To further explore the physiological role of SCAN-mediated inhibition of
+insulin signaling, we generated SCAN-deficient rat myoblast L6 cell lines
+(L6-SCAN−/−) (Figure S5H). While
+L6-SCAN−/− cells and wild-type parental L6 cells
+(L6-WT) have similarly low basal levels of SNO-INSRβ and SNO-IRS1, insulin
+increased S-nitrosylation of INSRβ/IRS1 in L6-WT cells, but not in
+L6-SCAN−/− cells. Insulin-stimulated S-nitrosylation of
+INSRβ/IRS1 was dynamic in L6-WT cells, reaching a peak 60–120 min
+after removal of insulin (after a 10-minute treatment), and gradually subsiding
+(Figures 3A–3C). Similarly, intraperitoneal insulin injection in
+chow-fed SCAN+/+ mice induced significant S-nitrosylation of
+INSRβ/IRS1, but not in SCAN−/− mice (Figures 3D and 3E).
+We investigated the function of insulin-induced S-nitrosylation of INSRβ/IRS1
+in L6 cells and in healthy mice. We found that deletion of SCAN in L6 cells prolongs
+insulin-stimulated phosphorylation of IRS1, AKT and AS160 (Figures 3F and S5I–S5L). This suggests that
+agonist-stimulated S-nitrosylation of INSRβ/IRS1 is part of a negative
+feedback loop that turns off insulin signaling. To validate this idea in mammals, we
+performed an insulin tolerance test in chow-fed SCAN+/+ and
+SCAN−/− mice. Recovery of glucose levels after insulin
+injection (1 U/kg or 2.5 U/kg) was delayed in SCAN−/− mice
+compared to SCAN+/+ mice (Figures 3G
+and 3H), consistent with higher S-nitrosylation
+of INSRβ in SCAN+/+ than in SCAN−/−
+skeletal muscle (Figure 3I and 3J). These results confirm that insulin-induced
+S-nitrosylation mediated by SCAN acts to turn off insulin signaling in skeletal
+muscle, thereby slowing glucose uptake to prevent hypoglycemia.
+
+Insulin treatment in both WT mice and L6-WT cells markedly increased
+phosphorylation of eNOS at Ser1177 and nNOS at Ser1412, respective measures of eNOS
+and nNOS activity (Figures 4A–4F and S5M) 40. Taken together, our results indicate that
+SCAN mediates insulin-stimulated S-nitrosylation of INSRβ/IRS1 in both L6
+cells and skeletal muscle of healthy mice, likely using NO generated by eNOS or nNOS
+(Figures S5N and S5O). This was confirmed by
+showing that in L6 cells, the NOS inhibitor L-NMMA blocked insulin stimulated
+S-nitrosylation not only of INSRβ and IRS1 but also of SCAN itself (Figures 4G–4J). Accordingly, phosphorylation of AKT and AS160 was increased in the
+presence of L-NMMA (Figures 4K, S5P and S5Q). Thus, eNOS and nNOS may provide
+the source of SNO for SCAN activity under physiological conditions.
+
+As a confirmatory measure, we re-expressed SCAN-WT (L6-SCAN-WT), the
+SCAN-QTG/NAA mutant unable to bind SNO-CoA (L6-SCAN-QTG/NAA) or the SCAN-C109/188R
+mutant unable to form SNO (L6-SCAN-C109/188R) in SCAN-deficient rat myoblast L6 cell
+lines (L6-SCAN−/−) (Figure S6A). Re-expression of SCAN-WT,
+but not SCAN-QTG/NAA or L6-SCAN-C109/188R, rescued the S-nitrosylation of
+INSRβ and IRS1, and inhibited insulin-stimulated phosphorylation of IRS1 and
+AKT (Figures 5A–5D). Thus, the S-nitrosylation of INSRβ/IRS1 and
+subsequent inhibition of insulin signaling requires SCAN and SNO-CoA. To dissect the
+role SNO-INSRβ in insulin signaling, we first mapped the SNO sites in INSR.
+Four peptides containing four candidate Cys SNO sites were identified (Figure 5E); Cys825, Cys834 and Cys1083 are
+present in INSRβ, while Cys462 is in INSRα. Using mutagenesis, we
+determined that Cys1083 is the primary SNO site in INSRβ; in HEK293 cells,
+mutation of Cys1083 to Ala (INSR-C1083A) reduced the S-nitrosylation of INSRβ
+by ~70% (Figures 5F and 5G). The INSRβ SNO-site (Cys1083) is localized in
+the tyrosine kinase catalytic domain (IRK). Insulin-stimulated IRK
+cross-phosphorylates the activation loop of the other INSR in the dimer, triggering
+its intrinsic tyrosine kinase activity 41. Using Pymol, we determined that the SNO-site Cys1083
+resides at the interface between two IRKs of dimeric INSR, suggesting that
+S-nitrosylation may affect cross-phosphorylation (Figure S6B). To investigate the role of
+INSR-C1083A in insulin signaling, endogenous INSR in L6 cells was deleted and then
+replaced by INSR-WT or INSR-C1083A (Figures S6C and S6D). Following stimulation with
+insulin, cells expressing mutant receptor refractory to S-nitrosylation
+(INSR-C1083A) showed increased and sustained phosphorylation of AKT and AS160 (vs.
+WT INSR) (Figures 5H–5J). Thus, SCAN turns off insulin signaling by
+S-nitrosylation of INSRβ. SNO-INSRβ may be considered a marker of
+insulin receptor desensitization.
+
+To determine if S-nitrosylation of INSRβ by SCAN is involved in
+obesity-related insulin resistance in humans, we quantified the expression of SCAN
+and amount of SNO-INSRβ in 14 human skeletal muscle samples and in 26 human
+adipose depot samples from patients with a range of Body Mass Index (BMI) (Table S3). Notably, we found
+that expression of SCAN is upregulated in both skeletal muscle and in visceral and
+subcutaneous adipose samples from patients with higher BMI (Figures 6A–6C,
+S6E and S6F). A significant linear relationship
+between the amount of SNO-INSRβ and BMI in human tissues suggests that
+S-nitrosylation of INSRβ is an important factor in insulin resistance in
+humans (Figures 6D–6F, S6G and S6H).
+Further, a significant linear correlation between amounts of SNO-INSRβ and
+the expression of SCAN protein in both human skeletal muscle and human adipose
+tissues (Figures 6G and 6H) implies that S-nitrosylation of INSRβ is likely
+mediated by SCAN in human tissues. Collectively, the multiple linear correlations
+among SCAN expression, BMI, and SNO-INSRβ (taken together with animal data),
+suggests that overexpression of SCAN in obese patients contributes to insulin
+resistance through hypernitrosylation of INSRβ.
+
+INSRβ is one of multiple receptor tyrosine kinases (RTKs) that have
+been reported to be S-nitrosylated, including insulin-like growth factor 1 receptor
+(IGF-1) and epidermal growth factor receptor (EGFR), and our survey of papers
+reporting SNO-protein identification from untargeted mass spectroscopy identified 20
+of the 58 RTK family members as S-nitrosylated (Table S4) 42–45. We find that four additional RTKs (FGFR1, PDGFRβ,
+VEGFR2 and HER3) are S-nitrosylated in human HEK293 cells (Figures S6I–S6K). S-nitrosylation of other RTKs by
+additional SCAN-like enzymes therefore seems likely.
+
+DiscussionIt is predicted that 70% of the entire proteome is subject to
+S-nitrosylation and over 10,000 SNO-proteins have been identified 46,47. Accumulating evidence suggests that S-nitrosylation is
+site-specific and enzymatically regulated, entailing enzymes that produce NO,
+generate SNO from NO, and transfer SNO to target proteins 11,12,21,22. In addition, multiple enzymes can eliminate SNO 5,6,48,49. Nonetheless, our understanding of basic
+catalytic mechanisms of S-nitrosylation remains rudimentary, and unifying features
+that would define enzyme families by analogy to kinases, acetyltransferases and
+ubiquitin ligases have remained elusive. Thus, it is still widely believed that
+S-nitrosylation is primarily non-enzymatic 18,50 i.e., mediated
+chemically by NO and related congeners. SCAN changes this paradigm by defining an
+enzymatic mechanism utilizing SNO-CoA that draws clear parallels to acyltransferases
+with their acyl-CoA cofactor 3.
+SCAN function is also instructive because physiological activity is stimulus-coupled
+via the insulin receptor tyrosine kinase, while aberrant activity causes disease,
+paralleling phosphorylation. These data argue strongly for enzymatic S-nitrosylation
+as a principal mechanism of signal transduction and define a nitrosylase class based
+on catalytic mechanism.Protein dependent S-nitrosylation has been convincingly demonstrated for
+multiple SNO-proteins including hemoglobin, GAPDH, thioredoxin and S100A8/A9
+12,22,23,25,51 However, strict enzymatic criteria (that would justify a
+‘nitrosylase’ designation) have not been met previously, as these
+SNO-proteins are consumed in a single reaction cycle that generates product (whereas
+a catalyst is not consumed in a chemical reaction). Thus, the concepts of catalyst
+and substrate are blended. By contrast, SCAN fully meets enzymatic criteria,
+including demonstrated specificity, catalytic activity, and conversion of substrate
+to product. SCAN thus turns over in vitro with classic enzyme kinetics. Moreover,
+SCAN reveals a unifying catalytic mechanism for transnitrosylases entailing NO group
+transfer chemistry from SNO-substrate (e.g. SNO-CoA) to SNO-product (e.g., SNO-INSR,
+SNO-IRS, SNO-HO2), and suggests at least 2 classes of transnitrosylases based on
+source of SNO: LMW-SNO (as in SCAN) and Protein-SNO (as in GAPDH), where a dedicated
+SNO synthase provides the SNO-substrate, as shown in E. coli 21.Given that multiple proteins bind to SNO-CoA resin (Figure 1A) and many of these (e.g., ACADVL, ALDH, ACADS,
+GLYAT) contain a binding domain for cosubstrates or cofactors (NADPH, FAD, or
+acetyl-CoA) that share structure with SNO-CoA, it seems likely that additional
+SCAN-like enzymes exist, by analogy to the multiple acetyl-CoA dependent
+acetyltransferase family members. Thus, multiple nitrosylases may utilize SNO-CoA
+cofactor, while other endogenous LMW SNOs, including GSNO and CysNO, may act as
+cofactors for additional classes of nitrosylases. Our findings thus fundamentally
+revise the conception of LMW SNO action, from being only nonspecific NO donors to
+acting as specific enzyme cofactors. More broadly, SCAN activity can be understood
+in terms of a catalytic mechanism shared by HATs, PATs and ubiquitin ligases: group
+transfer chemistry from activated thiyl-donors (thionitrites and thioesters) to
+target nucleophiles, including cysteine and lysine. Particularly, SCAN utilizes a
+‘ping-pong’ mechanism to catalyze S-nitrosylation. The NO group is
+first transferred from SNO-CoA to SCAN, and then from S-nitrosylated SCAN to its
+substrate; therefore, SCAN may only require transient binding to SNO-CoA to induce
+SCAN auto-S-nitrosylation. This may help explain why SNO-CoA can compete with
+endogenous NADPH to efficiently nitrosylate substrates (despite sharing a binding
+site in SCAN). By the same token, our results refine the mechanism of disease caused
+by S-nitrosylation from that of excessive NO (e.g., derived from iNOS) modifying
+proteins indiscriminately to that of dedicated enzymes directing elevated NO to
+specific targets just as they do at normal levels of NO (e.g., from eNOS). It should
+be noted in this regard that the hyper-S-nitrosylation of proteins that is known to
+be causal in insulin resistance, is also an established feature of other diseases
+including heart failure, Alzheimer’s disease, muscular dystrophy, malignant
+hyperthermia and liver cancer 15,17,52,53. SCAN-like
+enzymes may therefore represent attractive therapeutic targets in many diseases.We have identified SCAN activity as residing in the fetal biliverdin
+reductase protein (BLVRB). There are two non-redundant biliverdin reductases in
+mammals (BLVRA and BLVRB), which can respectively convert two types of isomeric
+biliverdins (adult α-biliverdin and fetal β-biliverdin) to bilirubin.
+The fetal β-biliverdin substrate is lacking in adults, yet BLVRB remains
+expressed in adult tissues 33,54 where it has been implicated in
+hematopoiesis 36,55, intermediary metabolism (glutaminolysis,
+glycolysis, TCA cycle and pentose phosphate pathway), and cholangiocarcinoma cell
+motility by inhibiting the Notch/Snail signaling pathway 56,57.
+BLVRB has been identified as a non-specific flavin reductase 58, but this activity is not linked to
+physiological functions or targets and the mechanism of BLVRB action has remained a
+mystery 28,36. Our work thus raises the possibility of
+enzymatic roles for S-nitrosylation in metabolic regulation, erythropoiesis and
+cancer.In addition to biliverdin reductase activity required for heme degradation,
+adult BLVRA is a serine/threonine kinase involved in the negative feedback
+regulation of insulin signaling. BLVRA is activated by the tyrosine kinase activity
+of the insulin receptor, and then phosphorylates IRS1 to inhibit insulin action
+59. Liver-specific
+knockout of BLVRA in obese mice has been associated with glucose/insulin alterations
+and fatty liver disease 60.
+Interestingly, BLVRB also has the insulin receptor interaction motif, but does not
+have protein kinase activity 28.
+Here we show that BLVRB is a protein S-nitrosylase that regulates the insulin
+pathway via S-nitrosylation of INSRβ and IRS1. Thus remarkably, both members
+of the BLVR family have enzymatic function to regulate the insulin pathway, but via
+distinct post-translational modifications: phosphorylation mediated by BLVRA and
+S-nitrosylation mediated by BLVRB/SCAN.eNOS in skeletal muscle is required for normal insulin responsiveness
+61,62. By contrast, iNOS-derived NO is deleterious
+to insulin signaling and contributes to the pathophysiology of T2DM 63,64. Thus, NO can mediate both beneficial and deleterious
+effects on insulin signaling. Our studies provide context and mechanism for these
+opposing effects. In healthy conditions, insulin stimulation of its receptor is
+coupled to eNOS/nNOS mediated S-nitrosylation of INSRβ/IRS1, which terminates
+physiological insulin signaling to avoid hypoglycemia. However, in obesity, iNOS is
+induced by pro-inflammatory cytokines in skeletal muscle, uncoupling NO generation
+from insulin signaling. This results in hyper-S-nitrosylation of INSRβ/IRS1
+and leads to insulin resistance (Figure 6I).
+Importantly, NOS activity is necessary but not sufficient for S-nitrosylation, as NO
+itself cannot chemically S-nitrosylate proteins 65. Rather, S-nitrosylation is routed through SNO-CoA by the
+enzymes SCAN and SCoR, which together determine steady state levels of
+SNO-INSRβ/IRS1, by analogy to a kinase/phosphatase pair.The insulin receptor is a member of the receptor tyrosine kinase (RTK)
+family of 58 cell surface receptors for growth factors, cytokines, and hormones
+66. We reveal many RTKs to
+be S-nitrosylated, implying a class effect with shared regulatory mechanisms (Figure S6 and Table S4). Thus, our finding of insulin
+induced S-nitrosylation of INSRβ/IRS1 in healthy tissues, and
+hypernitrosylation of INSRβ/IRS1 in diabetes, may provide a working model for
+enzymatic S-nitrosylation in health and disease (Figure 6I): In physiological situations, nitrosylase-catalyzed
+S-nitrosylation is induced by agonists to regulate cellular signaling. In disease,
+S-nitrosylation is dysregulated or disrupted by aberrant nitrosylase activity,
+possibly uncoupled from receptor stimulation. These findings suggest therapeutic
+opportunities that extend to the human condition. Collectively, our studies provide
+insights into obesity-linked diabetes mellitus, raise the tantalizing idea that RTKs
+may be feedback-regulated by SCAN or similar enzymes, and suggest a revised paradigm
+for NO biology in health and disease.Limitations of the StudyWhile the SNO-RAC-coupled western blot method for S-nitrosylation is
+amenable to calculating Km of SCAN, it is not suitable for calculating Kcat
+because of its low efficiency. Formally, SNO-CoA is a cosubstrate in the
+enzymatic reaction catalyzed by SCAN. For ease of understanding, we describe
+SNO-CoA as a cofactor (broader term). We used mice with constitutively deleted
+SCAN, so we cannot distinguish the role of S-nitrosylation of INSR and IRS1
+mediated by SNO-CoA/SCAN within specific organs or tissues, such as liver,
+adipose and skeletal muscle. The human data overall are supportive of
+associations among SCAN level and BMI/SNO-INSR, but these correlations will
+benefit from further validation in a larger number of samples (particularly at
+higher BMI).
+
+It is predicted that 70% of the entire proteome is subject to
+S-nitrosylation and over 10,000 SNO-proteins have been identified 46,47. Accumulating evidence suggests that S-nitrosylation is
+site-specific and enzymatically regulated, entailing enzymes that produce NO,
+generate SNO from NO, and transfer SNO to target proteins 11,12,21,22. In addition, multiple enzymes can eliminate SNO 5,6,48,49. Nonetheless, our understanding of basic
+catalytic mechanisms of S-nitrosylation remains rudimentary, and unifying features
+that would define enzyme families by analogy to kinases, acetyltransferases and
+ubiquitin ligases have remained elusive. Thus, it is still widely believed that
+S-nitrosylation is primarily non-enzymatic 18,50 i.e., mediated
+chemically by NO and related congeners. SCAN changes this paradigm by defining an
+enzymatic mechanism utilizing SNO-CoA that draws clear parallels to acyltransferases
+with their acyl-CoA cofactor 3.
+SCAN function is also instructive because physiological activity is stimulus-coupled
+via the insulin receptor tyrosine kinase, while aberrant activity causes disease,
+paralleling phosphorylation. These data argue strongly for enzymatic S-nitrosylation
+as a principal mechanism of signal transduction and define a nitrosylase class based
+on catalytic mechanism.
+
+Protein dependent S-nitrosylation has been convincingly demonstrated for
+multiple SNO-proteins including hemoglobin, GAPDH, thioredoxin and S100A8/A9
+12,22,23,25,51 However, strict enzymatic criteria (that would justify a
+‘nitrosylase’ designation) have not been met previously, as these
+SNO-proteins are consumed in a single reaction cycle that generates product (whereas
+a catalyst is not consumed in a chemical reaction). Thus, the concepts of catalyst
+and substrate are blended. By contrast, SCAN fully meets enzymatic criteria,
+including demonstrated specificity, catalytic activity, and conversion of substrate
+to product. SCAN thus turns over in vitro with classic enzyme kinetics. Moreover,
+SCAN reveals a unifying catalytic mechanism for transnitrosylases entailing NO group
+transfer chemistry from SNO-substrate (e.g. SNO-CoA) to SNO-product (e.g., SNO-INSR,
+SNO-IRS, SNO-HO2), and suggests at least 2 classes of transnitrosylases based on
+source of SNO: LMW-SNO (as in SCAN) and Protein-SNO (as in GAPDH), where a dedicated
+SNO synthase provides the SNO-substrate, as shown in E. coli 21.
+
+Given that multiple proteins bind to SNO-CoA resin (Figure 1A) and many of these (e.g., ACADVL, ALDH, ACADS,
+GLYAT) contain a binding domain for cosubstrates or cofactors (NADPH, FAD, or
+acetyl-CoA) that share structure with SNO-CoA, it seems likely that additional
+SCAN-like enzymes exist, by analogy to the multiple acetyl-CoA dependent
+acetyltransferase family members. Thus, multiple nitrosylases may utilize SNO-CoA
+cofactor, while other endogenous LMW SNOs, including GSNO and CysNO, may act as
+cofactors for additional classes of nitrosylases. Our findings thus fundamentally
+revise the conception of LMW SNO action, from being only nonspecific NO donors to
+acting as specific enzyme cofactors. More broadly, SCAN activity can be understood
+in terms of a catalytic mechanism shared by HATs, PATs and ubiquitin ligases: group
+transfer chemistry from activated thiyl-donors (thionitrites and thioesters) to
+target nucleophiles, including cysteine and lysine. Particularly, SCAN utilizes a
+‘ping-pong’ mechanism to catalyze S-nitrosylation. The NO group is
+first transferred from SNO-CoA to SCAN, and then from S-nitrosylated SCAN to its
+substrate; therefore, SCAN may only require transient binding to SNO-CoA to induce
+SCAN auto-S-nitrosylation. This may help explain why SNO-CoA can compete with
+endogenous NADPH to efficiently nitrosylate substrates (despite sharing a binding
+site in SCAN). By the same token, our results refine the mechanism of disease caused
+by S-nitrosylation from that of excessive NO (e.g., derived from iNOS) modifying
+proteins indiscriminately to that of dedicated enzymes directing elevated NO to
+specific targets just as they do at normal levels of NO (e.g., from eNOS). It should
+be noted in this regard that the hyper-S-nitrosylation of proteins that is known to
+be causal in insulin resistance, is also an established feature of other diseases
+including heart failure, Alzheimer’s disease, muscular dystrophy, malignant
+hyperthermia and liver cancer 15,17,52,53. SCAN-like
+enzymes may therefore represent attractive therapeutic targets in many diseases.
+
+We have identified SCAN activity as residing in the fetal biliverdin
+reductase protein (BLVRB). There are two non-redundant biliverdin reductases in
+mammals (BLVRA and BLVRB), which can respectively convert two types of isomeric
+biliverdins (adult α-biliverdin and fetal β-biliverdin) to bilirubin.
+The fetal β-biliverdin substrate is lacking in adults, yet BLVRB remains
+expressed in adult tissues 33,54 where it has been implicated in
+hematopoiesis 36,55, intermediary metabolism (glutaminolysis,
+glycolysis, TCA cycle and pentose phosphate pathway), and cholangiocarcinoma cell
+motility by inhibiting the Notch/Snail signaling pathway 56,57.
+BLVRB has been identified as a non-specific flavin reductase 58, but this activity is not linked to
+physiological functions or targets and the mechanism of BLVRB action has remained a
+mystery 28,36. Our work thus raises the possibility of
+enzymatic roles for S-nitrosylation in metabolic regulation, erythropoiesis and
+cancer.
+
+In addition to biliverdin reductase activity required for heme degradation,
+adult BLVRA is a serine/threonine kinase involved in the negative feedback
+regulation of insulin signaling. BLVRA is activated by the tyrosine kinase activity
+of the insulin receptor, and then phosphorylates IRS1 to inhibit insulin action
+59. Liver-specific
+knockout of BLVRA in obese mice has been associated with glucose/insulin alterations
+and fatty liver disease 60.
+Interestingly, BLVRB also has the insulin receptor interaction motif, but does not
+have protein kinase activity 28.
+Here we show that BLVRB is a protein S-nitrosylase that regulates the insulin
+pathway via S-nitrosylation of INSRβ and IRS1. Thus remarkably, both members
+of the BLVR family have enzymatic function to regulate the insulin pathway, but via
+distinct post-translational modifications: phosphorylation mediated by BLVRA and
+S-nitrosylation mediated by BLVRB/SCAN.
+
+eNOS in skeletal muscle is required for normal insulin responsiveness
+61,62. By contrast, iNOS-derived NO is deleterious
+to insulin signaling and contributes to the pathophysiology of T2DM 63,64. Thus, NO can mediate both beneficial and deleterious
+effects on insulin signaling. Our studies provide context and mechanism for these
+opposing effects. In healthy conditions, insulin stimulation of its receptor is
+coupled to eNOS/nNOS mediated S-nitrosylation of INSRβ/IRS1, which terminates
+physiological insulin signaling to avoid hypoglycemia. However, in obesity, iNOS is
+induced by pro-inflammatory cytokines in skeletal muscle, uncoupling NO generation
+from insulin signaling. This results in hyper-S-nitrosylation of INSRβ/IRS1
+and leads to insulin resistance (Figure 6I).
+Importantly, NOS activity is necessary but not sufficient for S-nitrosylation, as NO
+itself cannot chemically S-nitrosylate proteins 65. Rather, S-nitrosylation is routed through SNO-CoA by the
+enzymes SCAN and SCoR, which together determine steady state levels of
+SNO-INSRβ/IRS1, by analogy to a kinase/phosphatase pair.
+
+The insulin receptor is a member of the receptor tyrosine kinase (RTK)
+family of 58 cell surface receptors for growth factors, cytokines, and hormones
+66. We reveal many RTKs to
+be S-nitrosylated, implying a class effect with shared regulatory mechanisms (Figure S6 and Table S4). Thus, our finding of insulin
+induced S-nitrosylation of INSRβ/IRS1 in healthy tissues, and
+hypernitrosylation of INSRβ/IRS1 in diabetes, may provide a working model for
+enzymatic S-nitrosylation in health and disease (Figure 6I): In physiological situations, nitrosylase-catalyzed
+S-nitrosylation is induced by agonists to regulate cellular signaling. In disease,
+S-nitrosylation is dysregulated or disrupted by aberrant nitrosylase activity,
+possibly uncoupled from receptor stimulation. These findings suggest therapeutic
+opportunities that extend to the human condition. Collectively, our studies provide
+insights into obesity-linked diabetes mellitus, raise the tantalizing idea that RTKs
+may be feedback-regulated by SCAN or similar enzymes, and suggest a revised paradigm
+for NO biology in health and disease.
+
+Limitations of the StudyWhile the SNO-RAC-coupled western blot method for S-nitrosylation is
+amenable to calculating Km of SCAN, it is not suitable for calculating Kcat
+because of its low efficiency. Formally, SNO-CoA is a cosubstrate in the
+enzymatic reaction catalyzed by SCAN. For ease of understanding, we describe
+SNO-CoA as a cofactor (broader term). We used mice with constitutively deleted
+SCAN, so we cannot distinguish the role of S-nitrosylation of INSR and IRS1
+mediated by SNO-CoA/SCAN within specific organs or tissues, such as liver,
+adipose and skeletal muscle. The human data overall are supportive of
+associations among SCAN level and BMI/SNO-INSR, but these correlations will
+benefit from further validation in a larger number of samples (particularly at
+higher BMI).
+
+Limitations of the Study
+
+While the SNO-RAC-coupled western blot method for S-nitrosylation is
+amenable to calculating Km of SCAN, it is not suitable for calculating Kcat
+because of its low efficiency. Formally, SNO-CoA is a cosubstrate in the
+enzymatic reaction catalyzed by SCAN. For ease of understanding, we describe
+SNO-CoA as a cofactor (broader term). We used mice with constitutively deleted
+SCAN, so we cannot distinguish the role of S-nitrosylation of INSR and IRS1
+mediated by SNO-CoA/SCAN within specific organs or tissues, such as liver,
+adipose and skeletal muscle. The human data overall are supportive of
+associations among SCAN level and BMI/SNO-INSR, but these correlations will
+benefit from further validation in a larger number of samples (particularly at
+higher BMI).
+
+STAR MethodsRESOURCE AVAILABILITYLead contactFurther information and requests for resources and reagents
+should be directed to and will be fulfilled by the lead contact,
+Jonathan Stamler (jss156@case.edu).Materials availabilityPlasmids and other reagents generated in this study are
+available from the lead contact upon reasonable request.Data and code availabilityOriginal western blot images have been deposited at Mendeley
+Data and are publicly available as of the date of publication. The
+DOIs are listed in the key resources
+table.No original code was generated in this project.Any additional information required to reanalyze the data
+reported in this paper is available from the lead contact upon
+request.Experimental Model and Study Participant DetailsMiceMouse studies were approved by the Case Western Reserve University
+Institutional Animal Care and Use Committee (IACUC). Housing and procedures
+complied with the Guide for the Care and Use of Laboratory Animals and with
+the American Veterinary Medical Association Guidelines on Euthanasia. All
+mice were housed in a specific pathogen-free barrier facility on a 12:12
+light:dark cycle with ad libitum access to food and water. The standard chow
+diet was Teklad P3000 (Envigo).SCAN+/− mice were generated by Model Animal
+Research Center, Nanjing University. Briefly, the inactivated
+Blvrb allele in ES cells was first created by insertion
+of a LacZ-Neo cassette in place of exons 2, 3 and 4 of the
+Blvrb gene, disrupting in-frame translation of BLVRB
+(Figure S3A)
+67. Targeted ES
+cells were injected into blastocysts to generate chimeric mice, and male
+chimeras were bred to C57BL/6J females to produce BLVRB+/−
+F1 mice. BLVRB+/− F1 males and females were used as
+breeders to generate control mice (BLVRB+/+) and homozygous
+mutant mice (BLVRB−/−), which were maintained by
+intercrossing BLVRB+/+ males and BLVRB+/+ females or
+BLVRB−/− males and
+BLVRB−/− females, respectively. Genotyping of
+Blvrb used the following PCR primers: Blvrb-FRT-tF1
+5’AGAGTTTGGGTCCTCCCTTTCCT3’ and common-En2-R:
+5’CCAACTGACCTTGGGCAAGAACAT3’.To induce dietary obesity, 6–7-week-old male mice (body
+weight: 20–23g) were fed high-fat diet (60 kcal% fat diet D12492,
+Research Diets, Inc.) for 16 weeks before use in experiments.Male ob/ob mice (Jax #000632), homozygous for the
+obese spontaneous mutation, were purchased from Jackson Labs and fed
+standard chow diet for 16 weeks before use in experiments.Cell culture and generation of CRISPR-knockout and replacement cell
+lines.HEK293 and L6 cells were obtained from ATCC and cultured according
+to the ATCC protocols at 37°C under 5% CO2 in complete
+DMEM (10% FBS, 1% Pen-Strep). To induce the production of nitric oxide in
+HEK293 cells, pcDNA-eNOS was co-transfected into HEK293 cells using PolyJet
+transfection reagent. HEK-BLVRB knockout cell lines
+(HEK-BLVRB−/−), L6-SCAN knockout cell lines
+(L6-SCAN−/−), and L6-INSR knockout cell lines
+(L6-INSR−/−) were created using CRISPR-Cas9
+with specific guide RNAs. The human BLVRB CRISPR/Cas9 KO plasmid and BLVRB
+HDR plasmid were from Santa Cruz Biotechnology; the rat eSpCas9-rBLVRB and
+eSpCas9-rINSR plasmids were from GenScript. The eSpCas9-rSCAN contained
+gRNAs 5’-CCCCTCTGACGGTAACCTGC-3’ and
+5’-TCGGTGCCACCGGAAGGACC-3’ targeting rat BLVRB gene. The
+eSpCas9-rINSR plasmids contained gRNAs
+5’-TATCGACTGGTCCCGCATCCTGG-3’ and
+5’-GCCTGATTATCAACATCCGAGGG-3’ targeting rat INSR gene. HEK-293
+or L6 cells were transfected with BLVRB CRISPR/Cas9 KO /BLVRB HDR plasmid,
+eSpCas9-rBLVRB or eSpCas9-rINSR using PolyJet transfection reagent per
+manufacturer’s instructions. Twenty-four hours after transfection,
+the media was replaced, and cells were grown for another 24 hours. Cells
+were then split into growth media. After 48 hours, media containing 3
+μg/mL puromycin was added to select for candidate knockout cell
+colonies. Single colonies were picked and cultured in 96-well plates with
+growth media containing 3 μg/mL puromycin. Knockout cell lines were
+confirmed by western blot. Puromycin-resistant colonies containing normal
+endogenous expression of BLVRB (or INSR) were used for negative controls. To
+build stable HEK-BLVRB-WT, BLVRB-QTG/NAA, L6-SCAN-WT and L6-SCAN-QTG/NAA
+cell lines, HEK-BLVRB−/− or
+L6-SCAN−/− knockout cells were transfected with
+pcDNA-hBLVRB-WT or pcDNA-hBLVRB-QTG/NAA using PolyJet transfection reagent
+per manufacturer’s instructions. To build stable L6-INSR-WT and
+L6-INSR-C1083 cell lines, L6-INSR−/− were
+transfected with pcDNA-hINSR-WT or pcDNA-hINSR-C1083. Twenty-four hours
+after transfection, media was changed and cells grown for another 24 hours
+before being split into growth media. After 48 hours, G418 was added into
+the media at 400 μg/mL to select for cell lines expressing the
+proteins of interest. Expression in the stable cell lines was confirmed by
+western blot.Human SamplesAcquisition of deidentified human skeletal muscle samples, human
+visceral adipose and human subcutaneous adipose tissue samples was approved
+by the Institutional Review Board (IRB) for the protection of human subjects
+at Case Western Reserve University under a protocol waiver.Deidentified frozen human samples with pathological characterization
+were provided by the Tissue Resource Core at University Hospitals Cleveland.
+Human tissue was snap-frozen in liquid nitrogen immediately after collection
+from surgical procedures. Information of patient’s age, sex, race,
+BMI and type of tissue was obtained from pathology reports, and are provided
+in Table S3.
+Average age of patients for adipose tissues is 55.3 ± 13.4 years
+(ranging from 34 to 87 years). Average age of patients for skeletal muscle
+is 61.2 ± 12.6 years (ranging from 37 to 85 years). The SCAN
+expression and SNO levels of INSR in human samples were quantified by
+semi-quantitative analysis from western blots. SCAN expression was
+normalized relative to GAPDH detected on the same gel to control for any
+variation of protein loading among samples. These values were then
+normalized to the mean value (mean for all samples in same gel) for each gel
+to create a normalized measure to allow samples from two replicate gels to
+be directly compared.METHOD DETAILSPlasmids, Cloning and MutagenesisHuman cDNA of HO2 and cDNA of SCAN were cloned through reverse
+transcriptase–polymerase chain reaction (RT-PCR). The mammalian cell
+expression plasmids pCS2-flag-hHO2 and pcDNA-myc-hSCAN were generated
+through inserting cDNA of HO2 and SCAN into vector pCS2-flag and
+pcDNA3.1-myc, respectively. The pcDNA-flag-hIRS1 and pcDNA-flag-hINSR were
+obtained from GenScript. pCS2-flag-hHO2-C127R, pCS2-flag-hHO2-C265R,
+pCS2-flag-hHO2-C282R, pcDNA-myc-hSCAN-QTG/NAA, pcDNA-myc-hSCAN-C109R,
+pcDNA-myc-hSCAN-C188R and pcDNA-myc-hSCAN-C109/188R, pcDNA-flag-hINSR-C825A,
+pcDNA-flag-hINSR-C834A and pcDNA-flag-hINSR-C1083 mutants were generated by
+QuikChange II Site-Directed Mutagenesis Kit (Agilent). The mammalian cell
+expression plasmids containing truncated hHO2(1–296),
+hHO2(65–316), hHO2(130–316) or hHO2(195–316) were
+generated subcloning PCR bands of HO2 truncations into pCS2-flag. Primers
+are listed in Table
+S5. For purification of recombinant hHO2, hHO2(195–316),
+hSCAN-WT or hSCAN-QTG/NAA and hSCAN-C109/188R, cDNA encoding human HO2,
+hHO2(195–316), SCAN-WT, SCAN-QTG/NAA and hSCAN-C109/188R gene were
+subcloned into the pET21b vector to introduce a C-terminal 6xHis tag on the
+expressed protein. FGFR1 in pDONR221 vector was purchased from DNASU. All
+others (VEGFR2/KDR #23925, PDGFRa #23892, PDGFRb #23893, HER3 #23874) in
+pDONR223 vector were purchased from Addgene. These entry vectors were cloned
+into pcDNA-DEST40 Gateway destination vectors (Invitrogen) using Gateway LR
+clonase II reaction, generating mammalian expression plasmids with terminal
+V5 tag. All plasmids and mutations were confirmed by DNA sequencing.SNO-CoA agarose bead pull downCoenzyme A–agarose (50% slurry) was prepared by suspending
+Coenzyme A–agarose powder (Sigma) in water overnight at 4°C.
+To generate SNO-CoA beads, CoA beads were washed twice with 30 volumes of 10
+mM HCl and supernatant was aspirated. Pelleted CoA beads were resuspended in
+0.5 ml of 10 mM HCl, and 0.5 ml of 10 mM NaNO2 was added to the
+suspension to generate SNO-CoA. Immediately following NaNO2
+addition, 10 ml of washing buffer (150 mM NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM
+neocuproine (Sigma) and 50 mM borate buffer, pH 8.0) was added to dilute the
+SNO-CoA beads. The SNO-CoA beads were washed three times with washing
+buffer. For pulldown experiments, bovine liver tissue (5g) was suspended in
+25 mL of lysis buffer (150 mM NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM
+neocuproine, 50 mM borate buffer, pH 8.0, 1 mM PMSF and protease inhibitor
+mixture) and lysed in a blender, followed by homogenization with a Dounce
+homogenizer (Wheaton). Following centrifugation twice at 60,000 × g
+for 45 min, the supernatant was collected. The low-molecular weight cofactor
+NADPH was removed from the lysate using Amicon Ultra 3K Centrifugal Filter
+Devices. To pre-clear the CoA-binding proteins in the lysate, 10 ml of
+lysate (30 mg/ml) was incubated with 0.3 ml CoA–agarose beads for 2
+hours in the cold room in the dark. The pre-cleared lysate was incubated
+with 0.1 ml SNO-CoA beads for 2 hours at 4°C in the dark. After
+incubation, the beads were washed six times with washing buffer (150 mM
+NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM neocuproine, and 50 mM borate buffer, pH
+8.0), and SNO-CoA-binding proteins were eluted with excess SNO-CoA (20 mM,
+prepared as for SNO-CoA beads).For in vitro binding experiments, 1 μg of recombinant BLVRB
+protein diluted in 1 ml of binding buffer (150 mM NaCl, 1 mM EDTA, 1 mM
+DPTA, 0.1 mM neocuproine, and 50 mM borate buffer, pH 8.0) was incubated
+with 30 μl of 50% amylose resin (BioLabs), activated thiol Sepharose
+4B (Cytiva GE Healthcare), thiopropyl Sepharose 6B (GE healthcare),
+glutathione–agarose (Invitrogen), SNO-modified activated thiol
+(GSNO)–Sepharose 4B, SNO-CoA–agarose or CoA–agarose for
+2 hours at 4°C in the dark. For in vivo binding experiments, 1 ml of
+HEK cell lysate (1 mg/ml) was incubated with 30 μl of 50%
+GSH–agarose, GSNO–Sepharose 4B, CoA–agarose,
+Acetyl-CoA–agarose, SNO-CoA–agarose or Palmitoyl-Coenzyme
+A–agarose (Sigma) for 2 hours at 4°C in the dark. Beads were
+washed six times with binding buffer, and bound proteins were eluted with 50
+μl of 1X SDS loading dye (Invitrogen) containing 5% 2-mercaptoethanol
+(Sigma).SNO-RACSNO-RAC was carried out as described previously 52. Mouse skeletal muscle and human
+skeletal muscle were manually homogenized in liquid nitrogen with mortar and
+pestle. Ground skeletal muscle or human adipose tissue were homogenized in
+lysis buffer (1 mg/5 μl lysis buffer) containing 100 mM Hepes, 1 mM
+EDTA, 100 μM neocuproine (HEN), 50 mM NaCl, 0.1% (vol/vol) Nonidet
+P-40, 0.2% S-methylmethanethiosulfonate (MMTS) as a free thiol-blocking
+agent, 1 mM PMSF and protease inhibitors using Beadbeater (BioSpec). After
+centrifugation (20,000 × g, 4 °C, 20 min, ×2), SDS and
+MMTS were added to the supernatants to 2.5% and 0.2% respectively, and
+incubated at 50°C for 20 min. Proteins were precipitated with
+−20°C acetone, and re-dissolved in 1 mL of HEN, 1% SDS.
+Precipitation of proteins were repeated with −20°C acetone and
+the final pellets were resuspended in HEN, 1% SDS buffer, and protein
+concentrations were determined using the Bicinchoninic Acid (BCA) method.
+Total lysates (2 mg) were incubated with freshly prepared 50 mM ascorbate
+and 50 μl thiopropyl-Sepharose (50% slurry) and rotated end-over-end
+in the dark for 4 h. The bound SNO-proteins were sequentially washed with
+HEN, 1% SDS and then 10% HEN, 0.1% SDS buffers; SNO-proteins were eluted
+with 10% HEN, 1% SDS, 10% β-meracaptoethanol and analyzed by SDS/PAGE
+and immunoblotting.In vitro S-nitrosylation assayFor in vitro assay of S-nitrosylation of HO2, two master tubes were
+prepared. The control reaction tube contained 5 μg of
+HO2–6xHis, 5 μg GST and 2000 μL assay buffer (phosphate
+buffer pH 7.0 supplemented with 100 μM EDTA, 100 μM DTPA and
+0.1% NP-40). The enzyme reaction tube contained 5 μg of
+HO2–6xHis, 5 μg SCAN and 2000 μL assay buffer. The
+master mixture was separated into 5 tubes (400 μl/tube). 20 μl
+of SNO-CoA dilutions (0, 2 μM, 20 μM, 200 μM or 2 mM)
+were added into pairs of control and enzyme tubes.For in vitro assay of S-nitrosylation of HO2 mediated by mutant
+SCAN, two master tubes were prepared. The control reaction tube contained 4
+μg of HO2–6xHis, 4 μg GST and 1600 μL assay
+buffer. The enzyme reaction tube contained 4 μg of HO2–6xHis,
+4 μg SCAN-QTG/NAA, SCAN-C109/188R and 1600 μL assay buffer.
+Master mixture was split into 4 assay tubes (400μl/each tube), and
+20μl SNO-CoA dilutions were added into individual tubes to final
+concentrations of 0, 20 μM, 200 μM or 2 mM. For in vitro
+S-nitrosylation of IRS1 and INSR, two master tubes were prepared. Control
+reaction tube contained 1 μg of IRS1-FLAG or 1 μg of
+INSR-FLAG, 5 μg GST and 2000 μL assay buffer. Enzyme reaction
+tube contained 1 μg IRS1-FLAG or 1 μg INSR-FLAG, 5 μg
+SCAN and 2000 μL assay buffer. The master mixture was equally
+separated into 5 tubes (400 μl/each tube). 20 μl SNO-CoA (0,
+20 μM, 200 μM, 2 mM or 4 mM) was respectively added into the
+tubes. Reaction tubes were incubated at 37°C for 30 minutes in the
+dark. Reactions were quenched by the addition of 3 volumes ice cold 100%
+acetone. Following quenching, 50 μL 2 μg/μL BSA was
+added to samples. Proteins were precipitated at −20°C for 30
+minutes, pelleted at 4500 g for 8 minutes, and washed 4X with 70% acetone.
+Protein pellets were resuspended in 300 μL HEN buffer containing 2.5%
+SDS and 0.3% MMTS. Resuspended proteins were processed by SNO-RAC as
+described above.Glucose uptake measurementIn vitro glucose uptake measurement was performed as previously
+described 68. Naïve
+SCAN+/+ and SCAN−/− mice (5 male and
+5 female) per group were euthanized by isoflurane anesthesia. Soleus muscles
+were dissected tendon-to-tendon and rapidly rinsed in ice-cold 1X
+Krebs–Henseleit buffer. Muscles were recovered in vials including the
+recovery buffer (1X Krebs–Henseleit buffer, 0.1% BSA, 2 mM sodium
+pyruvate, 32 mM mannitol, 8 mM glucose supplemented with human-effective
+insulin dose (12 nM) or without insulin (basal)), shaken at 45 revolutions
+per minute while continuously gassed (95% O2–5%
+CO2) in a heated water bath (35°C) for 60 minutes.
+Muscles were subsequently washed twice for 10 minutes with at 35°C
+for 10 minutes in washing buffer (1X Krebs–Henseleit buffer, 0.1%
+BSA, 2mM sodium pyruvate and 32 mM Mannitol). Muscles were transferred to a
+vial containing 5 ml incubation buffer (1X Krebs–Henseleit buffer,
+0.1% BSA, 2 mM sodium pyruvate, 32 mM mannitol, 4 mM 2-deoxyglucose, 2
+μCi/ml 3H-2-deoxyglucose, and 0.3 μCi/ml
+14C-mannitol). Separate incubations were performed with
+insulin (12 nM) or without insulin (basal). Vials were shaken at 45
+revolutions per minute while continuously gassed (95%
+O2–5% CO2) in a heated water bath (35°C)
+for 20 minutes. Following this step, muscles were rinsed quickly in 1X
+Krebs–Henseleit buffer once and dried on filter paper and weighed.
+Muscle was digested with 1:10 (1 mg/10 μl) 1 M NaOH at 60°C
+for 1 hour. The samples were centrifuged 15,000 × g for 15 minutes at
+4°C. Supernatants (150 μl) were transferred to new tubes and
+neutralized with 150 μl of 1M HCl. Fifty μl of each
+neutralized sample was placed in a scintillation vial and the 3H
+and 14C counts determined in a scintillation counter
+(PerkinElmer). Extracellular volume was calculated using disintegrations per
+minute (DPM) of the 14C-mannitol, which is not membrane permeant.
+Intracellular 2-DG levels were then determined after accounting for
+3H DPM in the extracellular space, and 2-DG uptake rates were
+expressed as nmol 2-DG/100 mg muscle/20 minutes.Intraperitoneal glucose tolerance test (IPGTT), intraperitoneal insulin
+tolerance test (IPITT) and acute hypoglycemiaIPGTT and IPITT were performed according to the standard protocol of
+the International Mouse Phenotyping Consortium (https://www.mousephenotype.org). Mice
+were fasted for 16 hours for IPGTT or 5 hours for IPITT in clean cages with
+no food or feces in the bedding, in the standard light–dark cycle and
+with free access to water. Blood was collected from the tail tip directly
+onto a glucose test strip and read immediately using a calibrated
+glucometer. For IPGTT, glucose was injected i.p. at 2 g of glucose/kg of
+body weight. Blood drawn from sequential tail tip cuts was used to measure
+glucose at 15, 30, 60, 90 and 120 min after glucose injection. For IPITT,
+insulin was injected i.p at 1 unit insulin/kg of body weight. Glucose levels
+in tail tip blood were measured at 15, 30, 60, 90 and 120 min after insulin
+injection. Insulin-induced acute hypoglycemia (“severe” ITT)
+in mice was produced according to a published protocol 69. Insulin (2.5 units/kg body weight)
+was injected i.p. into 3 h-fasted mice, producing blood glucose <40
+mg/dl when measured at 90 min after injection and without leading to
+unconsciousness, seizures, or death. Blood glucose was measured before
+insulin injection and after 30, 90, 120,180 and 240 min via tail tip
+bleed.Insulin, bilirubin, free hemin, and blood testsBlood (50 μl) was collected from the mouse facial vein. To
+measure insulin, bilirubin and free hemin in serum, blood was placed in BD
+Microtainer tubes with Serum Separator, and centrifuged at 4°C at
+2000 × g for 10 min to obtain serum. Insulin
+concentration was measured following the protocol of Ultra Sensitive Mouse
+Insulin ELISA Kit (Crystal Chem). Mice were fasted for 5 hours prior to
+basal insulin measurement. Hematology analyses were performed using HESKA
+HemaTrue System. Blood was placed in heparin-treated 1.5ml microtube. Twenty
+μl blood was used for measurement of 17 parameters including total
+red blood cell count, total white blood cell count, total platelet count,
+hemoglobin concentration, lymphocyte percentage, mid-sized cells (e.g.,
+monocytes) percentage, and granulocyte percentage.Insulin treatmentFor L6 cell treatment, L6 cells at 50–70% confluence on 10 cm
+plates were starved in DMEM medium (+5% BSA) for 16 hours. Human insulin was
+added into medium to 100 nM final. Following 10-minute insulin treatment,
+cells were washed three times using warm 1X PBS, and complete DMEM medium
+(+10% FBS and 1% Pen-Strep) was added. L6 cells were collected at 1, 30, 60,
+120 and 240 minutes after media change and stored −80°C. For
+mouse treatment, human insulin (1 U/kg body weight) was intraperitoneally
+injected into mice that had been fasted for five hours. After 30 or 60
+minutes, mice were euthanized by isoflurane anesthesia. Skeletal muscle
+(lateral gastrocnemius) was collected and quickly frozen in liquid
+nitrogen.iTRAQ-Coupled SNO-RACiTRAQ-Coupled SNO-RAC was carried out as described previously
+5.
+HEK-BLVRB−/− and HEK-BLVRB+/+
+(control) lysates were prepared, and SNO-RAC (4 mg of protein per sample)
+was carried out as described above. SDS/PAGE gels were Coomassie-blue
+stained, and lanes were separated into eight segments top-to-bottom and
+collected in two 1.5 ml tubes. Five hundred μl of 50% acetonitrile
+(ACN)/50% 100 mM ammonium bicarbonate was used to wash gel bands for more
+than 5 hours while vortexing. After removal of washing buffer, 400 μl
+of 100% acetonitrile was added to gel pieces and vortexed for 10 min. After
+removal of ACN, gel pieces were dried in a speed vacuum dryer for 10 min.
+Two hundred μl of 10 mM dithiothreitol (DTT) was added to dry gel
+pieces and vortexed for 45 min. After removal of DTT buffer, 200 μl
+of 55 mM iodoacetamide (IAA) was added to the gel pieces and incubated for
+45 min in the dark. After removal of IAA buffer, 400 μl of 1x iTRAQ
+dissolution solution and 400 μl ACN were used to wash the gel pieces
+twice. Gel pieces were dried for 10 min in a speed vacuum dryer. 500 ng
+trypsin in 150 μl 1x iTRAQ buffer was added to dried gel pieces on
+ice for 30 mins to rehydrate, and then incubated overnight at 37°C.
+Supernatant from the digested protein solution was transferred to a 1.5 ml
+tube using gel-loading tips. 200 μl extraction buffer (60% ACN/5%
+formic acid) were added to gel pieces, vortexed for 30 min, and sonicated
+for 15 min. The supernatant containing peptide extracts was transferred to
+the same 1.5 ml tube, and extractions were repeated two more times. The
+final digested solution pool was dried completely in a speed vacuum
+dryer.iTRAQ labeling was performed according to the instructions of iTRAQ
+Reagents - 4plex Applications Kit. Briefly, 30 μl of iTRAQ
+dissolution buffer (10x) was added to each sample tube (pH > 7), and
+then one iTraq labeling reagent (mass 114, 115, 116 or 117) was added to
+individual sample tubes. Reactions were incubated for more than 5 hours at
+room temperature with vortexing to ensure complete labeling. The four
+labeled samples were mixed together and dried. One hundred sixty μl
+of 5% ACN containing 0.5% TFA was added to the labeled sample mix, and the
+solution cleaned using C18 ziptips. Briefly, C18 tips were wetted 5 times
+with 20 μl of 50% ACN, and equilibrated with 100 μl of 5% ACN
+containing 0.5% TFA. Samples were then loaded to the tip by drawing and
+expelling 50 cycles to ensure complete binding. The tips were then washed
+with 20 μl of 5% ACN containing 0.5% TFA 10 times. Peptides were
+eluted from tips in 3× 20 μl of 60% ACN containing 0.1% formic
+acid, and eluates combined and dried for LC-MS/MS Analysis.LC-MS/MS AnalysisDigested peptides were separated by UPLC (Waters, Milford, MA) with
+a Nano-ACQUITY UPLC BEH300 C18 column. Separated peptides were continuously
+injected into an Orbitrap Elite hybrid mass spectrometer (Thermo Finnigan,
+San Jose, CA) by a nanospray emitter (10 μm, New Objective). Peptides
+were eluted using a linear gradient using mobile phase A (0.1% formic acid
+in water) and B (100% acetonitrile) was used at a flow rate of 0.3
+μl/min, starting with 1% mobile phase B and increasing to 40% B at 65
+min for protein interaction identification, or increasing to 40% B at 130
+min for iTRAQ experiments. All mass spectrometry data were acquired in
+positive ion mode. For protein interaction identification, a full MS scan
+(m/z 350–1800) at resolution of 120,000 was conducted, twenty MS2
+scans (m/z 350–1800) were selected using the twenty most intense
+peptide peaks of full MS scans. CID cleavage mode was performed at
+normalized collision energy of 35%. For iTRAQ experiments, a full MS scan
+(m/z 300–1800) at resolution of 120,000 was conducted, and ten MS2
+scans (m/z 100–1600) were activated from the five most intense
+peptide peaks of full MS scans. CID and HCD cleavage modes were performed
+alternatively of the same peptides selected from full MS scans. MS2
+resolution of HCD is 15,000. Bioinformatic software MassMatrix was used to
+search MS data against a database composed of sequences of mouse proteins
+from Uniprot and their reversed sequences as a decoy database. Modifications
+including oxidation of methionine and labeling of cysteine (IA
+modifications) were selected as variable modifications in searching. For
+iTRAQ labeling searching, MS tag of N terminus, Lys and/or Tyr were selected
+as variable modification to test labeling efficiency and fixed modification
+for iTRAQ quantitation analysis. Trypsin was selected as the in-silico
+enzyme to cleave proteins after Lys and Arg. Precursor ion searching was
+within 10 ppm mass accuracy and product ions within 0.8 Da for CID cleavage
+mode and 0.02 Da for HCD cleavage mode. 95% confidence interval was required
+for protein identification.ImmunoprecipitationTo investigate the interaction of SCAN and IRS1, Myc-SCAN and
+IRS1-Flag were co-expressed in HEK293 cells. To investigate the effect of
+insulin stimulation, disruption of SNO-CoA binding, mutation of SNO site
+C109/188 and of SCoR, Myc-SCAN, Myc-SCAN-QTG/NAA or Myc-SCAN-C109/188R were
+co-expressed with INSR-Flag in parental or SCoR-knockout HEK cells or L6
+cells. HEK cells or L6 cells were treated with NO donor DPTA (200μM)
+for 20 hours as required. Anti-rabbit C-Myc Agarose Affinity Gel (Sigma) was
+used for immunoprecipitation. To investigate the interaction of endogenous
+SCAN with HO2 or INSR, 10 μg of BLVRB Rabbit monoclonal antibody
+(Sino Biological) was incubated with 50 μl of Protein G Sepharose
+(GE) (1:1 slurry) at 4°C overnight, then washed with NETN buffer (150
+mM NaCl, 20 mM Tris-Cl (pH 8.0), 0.5 mM EDTA, 0.5% (v/v) Nonidet P-40) three
+times to prepare for immunoprecipitation. HEK cells or L6 cells were
+homogenized in EBC lysis buffer (120 mM NaCl, 20 mM Tris-Cl (pH 8.0), 0.5 mM
+EDTA, 0.5% (v/v) NP-40, 1 mM PMSF and protease inhibitor cocktail). After
+centrifugation (20,000 × g, 4°C, 20 min, ×2), 2 ml (2
+mg/ml) supernatant was pre-cleared by incubation with 50 μl Protein G
+Sepharose (1:1 slurry) for 1 hour at 4 °C. After spinning at 1000
+× g for 1 min, the supernatant was transferred into new tubes and
+incubated with 50 μl anti BLVRB antibody-Protein G Sepharose or with
+anti c-Myc-Agarose (1:1 slurry) for 5 hours at 4°C. Beads were washed
+by NETN buffer and proteins were eluted with 50 μl 1X SDS loading dye
+containing 5% 2-mercaptoethanol. Eluted proteins were electrophoresed in
+4–20% Criterion Precast Midi Protein Gels (Bio Rad), transferred to
+PVDF membranes, and membranes were blotted with mouse Flag antibody, HO2
+antibody or INSR antibody.Western blot analysisProteins were extracted from cells using sonication in RIPA buffer
+(Sigma) supplemented with 1 mM PMSF, protease inhibitor cocktail and
+phosphatase inhibitor cocktail. Muscle samples were ground with a mortar and
+pestle under liquid nitrogen, then the powder added to RIPA buffer as above,
+and mechanically homogenized using a bead beater. Extracts were clarified by
+centrifugation (20,000 × g, 4°C, 20 min, ×2), and
+protein concentration was determined by bicinchoninic acid assay. The
+extracts were electrophoresed in 4–20% Criterion Precast Midi Protein
+Gels and transferred to PVDF membranes. Membranes were incubated overnight
+at 4°C with primary antibodies, washed with PBS containing 0.1%
+Tween-20, incubated with HRP-conjugated secondary antibody for 1 hour,
+washed, and detected by chemiluminescent detection (ECL) using X-ray film
+developer system (JPI, Filmprocessor) or a digital imager system
+(Kwikquant). Antibodies employed in western blotting included: rabbit
+polyclonal rabbit Anti-BLVRB (13151-R009, Sino Biological Inc), mouse
+monoclonal Anti-HO2 (H00003163, Abnova), rabbit polyclonal Anti-IRS1
+(06–248, EMD Millipore), rabbit polyclonal Anti-INSRβ (sc-711,
+Santa Cruz), rabbit monoclonal Anti-INSRβ (phospho-Y1163,1164)
+(MA5–15148, Invitrogen), rabbit Anti-IRS1 phospho-Tyr608 (09432, EMD
+Millipore), rabbit monoclonal Anti-NOS2 (D9A5L, Cell Signaling), rabbit
+Anti-eNOS (phospho-S1177) (PA597371, Invitrogen), rabbit monoclonal Anti-AKT
+(C67E7, Cell Signaling), rabbit Anti-AKT (phospho-S473) (9271, Cell
+Signaling), mouse monoclonal p97 (10R-P104A, Fitzgerald), rabbit monoclonal
+GAPDH (Ab181602, abcam), rabbit monoclonal Anti-AS160 (MA5–14840,
+Invitrogen), rabbit Anti-AS160 (phospho-T642) (44–1071G, Invitrogen)
+and mouse monoclonal FLAG-M2 (F3165, Sigma) (see Key Resources). Protein levels were quantified
+by semi-quantitative analysis from western blots using ImageJ (NIH).Identification of SNO site of INSR by mass spectrometryThe pcDNA-INSR-FLAG plasmid (GenScript) was transfected into HEK293
+cells using PolyJet. Cells were harvested and lysed in EBC lysis buffer.
+INSR-FLAG was purified from lysate with anti-FLAG M2 affinity gel (Sigma)
+and eluted with 100 mM phosphate buffer, pH 7.4 containing 100 μg/mL
+FLAG peptide (Sigma), 100 μM EDTA and 100 μM DTPA. Purified
+INSR was subsequently treated with 100 μM freshly prepared SNO-CoA
+for 20 minutes at room temperature in the dark. Following treatment with
+SNO-CoA, protein was supplemented with 100 μg bovine serum albumin
+carrier, mixed with 3 volumes ice cold 100% acetone, and kept at
+−20°C for 30 minutes. Following cold incubation, the sample
+was spun at 14000 × g for 15 minutes to precipitate protein. Pelleted
+protein was washed 3 times with ice cold 70% acetone, air dried, and
+resuspended in 400 μL of HENS buffer. Unreacted SNO-CoA was removed
+using Zeba desalting spin columns (Thermo Fisher) preequilibrated with HENS
+buffer. Following filtration, 1 M MMTS and 25% SDS were added into the
+protein solution (final 20mM MMTS and 2.5% SDS) and the solution was
+vortexed. The solution was incubated for 20 minutes at 50°C to block
+free thiols. Protein was again precipitated with 3 volumes ice cold 100%
+acetone with incubation for 1 hour at −20°C. Following
+incubation, precipitated proteins were collected by centrifugation at 10000
+× g for 10 minutes at 4°C. Supernatant was removed from
+precipitated protein pellets, and pellets allowed to dry at room temperature
+for 10 minutes. Proteins were resuspended in HENS buffer and labeled with
+iodoTMT (Thermo Fisher) in the presence of 20 mM sodium ascorbate for 1 hour
+at room temperature in the dark. Reactions were quenched with 20 mM DTT for
+15 minutes at room temperature in the dark. Protein was precipitated with 3
+volumes ice cold 100% acetone at −20°C for 1 hour, then
+centrifuged at 10000 × g for 10 minutes at 4°C. Supernatant
+was removed, and the protein pellet dried for 10 minutes. Protein was
+resuspended in HENS buffer and treated with 16.67 mM iodoacetamide for 1
+hour at room temperature in the dark. Protein was again precipitated as
+above, supernatant removed, and protein pellet dried. Precipitated protein
+was then resuspended in 50 mM ammonium bicarbonate buffer, pH 8.0. Proteins
+were then serially digested with 25 μg/mg protein using Lys-c (4
+hours at 37°C) then 20 μg/mg protein using trypsin overnight
+at 37°C. Following digestion, samples were acidified with 25
+μL of 10% TFA. Peptides were processed through a C18 SPE column and
+then frozen and lyophilized. Lyophilized peptides were resuspended in TBS
+and enriched using anti-TMT resin (Thermo Fisher) following the
+manufacturer’s instructions, and subsequently frozen and lyophilized.
+Samples were resuspended in 5% acetonitrile, 0.1% formic acid and run
+through a 0.22 μm filter to remove any excess anti-TMT resin.
+Peptides were then injected into LC-MS/MS system for analysis.Purification of proteinsThe recombinant HO2, SCAN-WT or SCAN-QTG-NAA proteins were purified
+from BL21-CodonPlus Competent E. coli cells (Agilent).
+Overnight E. coli cultures were sub-cultured into 1 L of LB
+medium at 5%. At OD600 of 0.5, cultures were induced with 100 mM IPTG and
+grown 4 hours at 28°C. Cultures were centrifuged at 4000 × g
+for 10 min to harvest the cells. Cell pellets from 1 L cultures were lysed
+by sonication in 10 mL of PBS buffer containing 1 mM PMSF and
+protease-inhibitor cocktail. After centrifugation at 14500 × g for 20
+min, the supernatant was collected and diluted (up to 30 ml) with PBS buffer
+containing 1 mM PMSF and protease-inhibitor cocktail. This lysate was
+incubated with 1 mL of Ni-NTA agarose at 4°C for 1 hour with
+rotation. The slurry was then poured into an empty PD-10 column (GE
+Healthcare), and the beads washed with 100 mL of 50 mM
+NaH2PO4, 300 mM NaCl buffer containing 20 mM
+imidazole. Elution was done with 2 mL of 50 mM
+NaH2PO4, 300 mM NaCl, 250 mM imidazole. Eluate buffer
+was exchanged with modified Roeder D [(20mM HEPES (pH 7.9), 20% (v/v)
+glycerol, 0.1M KCL, 0.2mM EDTA)] using a Microcon centrifugal filter device
+(Millipore).IRS1-FLAG and INSR-FLAG were purified from HEK cells. Briefly, HEK
+cells were transfected with pcDNA-Flag-hIRS1 or pcDNA-Flag-hINSR plasmid
+using PolyJet transfection reagent (SignaGen) per manufacturer’s
+instructions and grown for 48 hours. After 48 hours, cells were harvested in
+IP wash buffer (as above) supplemented with 0.5% Triton X-100 and protease
+inhibitor cocktail. Cells were lysed by sonication and lysate clarified by
+centrifugation at 15000 × g for 15 minutes. Anti-FLAG agarose
+affinity gel was equilibrated into IP wash buffer, and clarified lysate was
+applied to anti-FLAG agarose affinity gel. After 4 hours incubation in
+4°C, beads were washed 5 times with IP wash buffer. Proteins were
+eluted in 300μL 1xPBS containing 100 μg/mL 3X FLAG peptide.
+Protein concentration was determined using BCA.Tyrosine kinase activityTyrosine kinase activity of INSR was measured using InsR Kinase
+Enzyme System-coupled with ADP-Glo™ Assay (Promega). To
+purify the INSR-FLAG from HEK cells, the same procedure was used in above
+“Purification of proteins” except INSR-FLAG complex was eluted
+in 200μL reaction buffer A (provided in InsR Kinase Enzyme System)
+containing 100 μg/mL 3X FLAG peptide and 2mM MnCl2. Ten
+μl (100ng/μl) purified INSR-FLAG complex was treated with
+control Tris buffer or 500 μM SNO-CoA (5 μl) for 30 min at
+37°C. Ten μl AxLtide (substrate, 1mg/ml)+ATP (125 μM)
+mixture was added into the reaction. After 60 min incubation at 25°C,
+25 μl ADP-Glo™ Reagent was added into the reaction.
+Fifty μl kinase detection reagent was added after 40 min incubation
+at 25°C, and the luminescence read after 30 min incubation at
+25°C in a Promega GloMax Luminometer.ImmunostainingHEK293 cells were grown in 2 mL culture medium to approximately 50%
+confluency on cover slips in 6-well plates. For studying insulin
+stimulation, cells were starved in DMEM medium (+5% BSA) for 16 hours. Human
+insulin was added into medium to 100 nM final concentration for 10min. Media
+was aspirated, and 1mL cold 4% PFA in PBS was used to fix cells for 15 min
+at room temperature. After each incubation step, cells were washed 3x with
+PBS. Cells were permeabilized with PBS +.05% Triton X100 for 5 min, washed,
+blocked with 8% BSA in PBS for 20min, washed and incubated with primary
+antibodies diluted in blocking buffer for 2 hours. Primary antibodies rabbit
+anti-SCAN (Sino Biological Inc), mouse anti-Cytochrome C (Cell Signaling)
+and mouse anti-AKR1A1 (Origene TA500740 clone 9F1) were used in
+immunostaining. After washing, secondary antibodies were added for 2 hours
+at room temperature. Secondary antibodies used were A11001 (Invitrogen,
+AF488 anti-mouse IgG at 1:1000) and A11036 (AF568 anti-rabbit IgG at
+1:1000). DAPI (Biotium, 5mg/ml) was used to stain nuclei. Samples were
+washed once again, mounted with Fluoromount G onto slides and imaged with a
+Nikon Eclipse Ti2 microscope using a 60x objective. TIFF images were
+processed in FIJI/ImageJ with the JaCoP plugin used to calculate
+Pearson’s and M1/M2 coefficients.QUANTIFICATION AND STATISTICAL ANALYSISStatistics were analyzed using GraphPad Prism 8. Comparisons between
+continuous characteristics of two subject groups were analyzed with two-tailed
+Student’s t-test. For comparisons among more than two groups, one-way
+ANOVA with Tukey post hoc or two-way ANOVA with Sidak’s multiple
+comparisons test were used. Simple linear regression was performed in comparing
+human samples. Bar graphs with the corresponding dot plots were created using
+GraphPad Prism. Results are presented as mean ± SD, and sample sizes or
+number of replicates are indicated in individual figure legends.
+
+STAR Methods
+
+RESOURCE AVAILABILITYLead contactFurther information and requests for resources and reagents
+should be directed to and will be fulfilled by the lead contact,
+Jonathan Stamler (jss156@case.edu).Materials availabilityPlasmids and other reagents generated in this study are
+available from the lead contact upon reasonable request.Data and code availabilityOriginal western blot images have been deposited at Mendeley
+Data and are publicly available as of the date of publication. The
+DOIs are listed in the key resources
+table.No original code was generated in this project.Any additional information required to reanalyze the data
+reported in this paper is available from the lead contact upon
+request.
+
+RESOURCE AVAILABILITY
+
+Lead contactFurther information and requests for resources and reagents
+should be directed to and will be fulfilled by the lead contact,
+Jonathan Stamler (jss156@case.edu).
+
+Lead contact
+
+Further information and requests for resources and reagents
+should be directed to and will be fulfilled by the lead contact,
+Jonathan Stamler (jss156@case.edu).
+
+Materials availabilityPlasmids and other reagents generated in this study are
+available from the lead contact upon reasonable request.
+
+Materials availability
+
+Plasmids and other reagents generated in this study are
+available from the lead contact upon reasonable request.
+
+Data and code availabilityOriginal western blot images have been deposited at Mendeley
+Data and are publicly available as of the date of publication. The
+DOIs are listed in the key resources
+table.No original code was generated in this project.Any additional information required to reanalyze the data
+reported in this paper is available from the lead contact upon
+request.
+
+Data and code availability
+
+Original western blot images have been deposited at Mendeley
+Data and are publicly available as of the date of publication. The
+DOIs are listed in the key resources
+table.
+
+No original code was generated in this project.
+
+Any additional information required to reanalyze the data
+reported in this paper is available from the lead contact upon
+request.
+
+Experimental Model and Study Participant DetailsMiceMouse studies were approved by the Case Western Reserve University
+Institutional Animal Care and Use Committee (IACUC). Housing and procedures
+complied with the Guide for the Care and Use of Laboratory Animals and with
+the American Veterinary Medical Association Guidelines on Euthanasia. All
+mice were housed in a specific pathogen-free barrier facility on a 12:12
+light:dark cycle with ad libitum access to food and water. The standard chow
+diet was Teklad P3000 (Envigo).SCAN+/− mice were generated by Model Animal
+Research Center, Nanjing University. Briefly, the inactivated
+Blvrb allele in ES cells was first created by insertion
+of a LacZ-Neo cassette in place of exons 2, 3 and 4 of the
+Blvrb gene, disrupting in-frame translation of BLVRB
+(Figure S3A)
+67. Targeted ES
+cells were injected into blastocysts to generate chimeric mice, and male
+chimeras were bred to C57BL/6J females to produce BLVRB+/−
+F1 mice. BLVRB+/− F1 males and females were used as
+breeders to generate control mice (BLVRB+/+) and homozygous
+mutant mice (BLVRB−/−), which were maintained by
+intercrossing BLVRB+/+ males and BLVRB+/+ females or
+BLVRB−/− males and
+BLVRB−/− females, respectively. Genotyping of
+Blvrb used the following PCR primers: Blvrb-FRT-tF1
+5’AGAGTTTGGGTCCTCCCTTTCCT3’ and common-En2-R:
+5’CCAACTGACCTTGGGCAAGAACAT3’.To induce dietary obesity, 6–7-week-old male mice (body
+weight: 20–23g) were fed high-fat diet (60 kcal% fat diet D12492,
+Research Diets, Inc.) for 16 weeks before use in experiments.Male ob/ob mice (Jax #000632), homozygous for the
+obese spontaneous mutation, were purchased from Jackson Labs and fed
+standard chow diet for 16 weeks before use in experiments.Cell culture and generation of CRISPR-knockout and replacement cell
+lines.HEK293 and L6 cells were obtained from ATCC and cultured according
+to the ATCC protocols at 37°C under 5% CO2 in complete
+DMEM (10% FBS, 1% Pen-Strep). To induce the production of nitric oxide in
+HEK293 cells, pcDNA-eNOS was co-transfected into HEK293 cells using PolyJet
+transfection reagent. HEK-BLVRB knockout cell lines
+(HEK-BLVRB−/−), L6-SCAN knockout cell lines
+(L6-SCAN−/−), and L6-INSR knockout cell lines
+(L6-INSR−/−) were created using CRISPR-Cas9
+with specific guide RNAs. The human BLVRB CRISPR/Cas9 KO plasmid and BLVRB
+HDR plasmid were from Santa Cruz Biotechnology; the rat eSpCas9-rBLVRB and
+eSpCas9-rINSR plasmids were from GenScript. The eSpCas9-rSCAN contained
+gRNAs 5’-CCCCTCTGACGGTAACCTGC-3’ and
+5’-TCGGTGCCACCGGAAGGACC-3’ targeting rat BLVRB gene. The
+eSpCas9-rINSR plasmids contained gRNAs
+5’-TATCGACTGGTCCCGCATCCTGG-3’ and
+5’-GCCTGATTATCAACATCCGAGGG-3’ targeting rat INSR gene. HEK-293
+or L6 cells were transfected with BLVRB CRISPR/Cas9 KO /BLVRB HDR plasmid,
+eSpCas9-rBLVRB or eSpCas9-rINSR using PolyJet transfection reagent per
+manufacturer’s instructions. Twenty-four hours after transfection,
+the media was replaced, and cells were grown for another 24 hours. Cells
+were then split into growth media. After 48 hours, media containing 3
+μg/mL puromycin was added to select for candidate knockout cell
+colonies. Single colonies were picked and cultured in 96-well plates with
+growth media containing 3 μg/mL puromycin. Knockout cell lines were
+confirmed by western blot. Puromycin-resistant colonies containing normal
+endogenous expression of BLVRB (or INSR) were used for negative controls. To
+build stable HEK-BLVRB-WT, BLVRB-QTG/NAA, L6-SCAN-WT and L6-SCAN-QTG/NAA
+cell lines, HEK-BLVRB−/− or
+L6-SCAN−/− knockout cells were transfected with
+pcDNA-hBLVRB-WT or pcDNA-hBLVRB-QTG/NAA using PolyJet transfection reagent
+per manufacturer’s instructions. To build stable L6-INSR-WT and
+L6-INSR-C1083 cell lines, L6-INSR−/− were
+transfected with pcDNA-hINSR-WT or pcDNA-hINSR-C1083. Twenty-four hours
+after transfection, media was changed and cells grown for another 24 hours
+before being split into growth media. After 48 hours, G418 was added into
+the media at 400 μg/mL to select for cell lines expressing the
+proteins of interest. Expression in the stable cell lines was confirmed by
+western blot.Human SamplesAcquisition of deidentified human skeletal muscle samples, human
+visceral adipose and human subcutaneous adipose tissue samples was approved
+by the Institutional Review Board (IRB) for the protection of human subjects
+at Case Western Reserve University under a protocol waiver.Deidentified frozen human samples with pathological characterization
+were provided by the Tissue Resource Core at University Hospitals Cleveland.
+Human tissue was snap-frozen in liquid nitrogen immediately after collection
+from surgical procedures. Information of patient’s age, sex, race,
+BMI and type of tissue was obtained from pathology reports, and are provided
+in Table S3.
+Average age of patients for adipose tissues is 55.3 ± 13.4 years
+(ranging from 34 to 87 years). Average age of patients for skeletal muscle
+is 61.2 ± 12.6 years (ranging from 37 to 85 years). The SCAN
+expression and SNO levels of INSR in human samples were quantified by
+semi-quantitative analysis from western blots. SCAN expression was
+normalized relative to GAPDH detected on the same gel to control for any
+variation of protein loading among samples. These values were then
+normalized to the mean value (mean for all samples in same gel) for each gel
+to create a normalized measure to allow samples from two replicate gels to
+be directly compared.
+
+Experimental Model and Study Participant Details
+
+MiceMouse studies were approved by the Case Western Reserve University
+Institutional Animal Care and Use Committee (IACUC). Housing and procedures
+complied with the Guide for the Care and Use of Laboratory Animals and with
+the American Veterinary Medical Association Guidelines on Euthanasia. All
+mice were housed in a specific pathogen-free barrier facility on a 12:12
+light:dark cycle with ad libitum access to food and water. The standard chow
+diet was Teklad P3000 (Envigo).SCAN+/− mice were generated by Model Animal
+Research Center, Nanjing University. Briefly, the inactivated
+Blvrb allele in ES cells was first created by insertion
+of a LacZ-Neo cassette in place of exons 2, 3 and 4 of the
+Blvrb gene, disrupting in-frame translation of BLVRB
+(Figure S3A)
+67. Targeted ES
+cells were injected into blastocysts to generate chimeric mice, and male
+chimeras were bred to C57BL/6J females to produce BLVRB+/−
+F1 mice. BLVRB+/− F1 males and females were used as
+breeders to generate control mice (BLVRB+/+) and homozygous
+mutant mice (BLVRB−/−), which were maintained by
+intercrossing BLVRB+/+ males and BLVRB+/+ females or
+BLVRB−/− males and
+BLVRB−/− females, respectively. Genotyping of
+Blvrb used the following PCR primers: Blvrb-FRT-tF1
+5’AGAGTTTGGGTCCTCCCTTTCCT3’ and common-En2-R:
+5’CCAACTGACCTTGGGCAAGAACAT3’.To induce dietary obesity, 6–7-week-old male mice (body
+weight: 20–23g) were fed high-fat diet (60 kcal% fat diet D12492,
+Research Diets, Inc.) for 16 weeks before use in experiments.Male ob/ob mice (Jax #000632), homozygous for the
+obese spontaneous mutation, were purchased from Jackson Labs and fed
+standard chow diet for 16 weeks before use in experiments.
+
+Mouse studies were approved by the Case Western Reserve University
+Institutional Animal Care and Use Committee (IACUC). Housing and procedures
+complied with the Guide for the Care and Use of Laboratory Animals and with
+the American Veterinary Medical Association Guidelines on Euthanasia. All
+mice were housed in a specific pathogen-free barrier facility on a 12:12
+light:dark cycle with ad libitum access to food and water. The standard chow
+diet was Teklad P3000 (Envigo).
+
+SCAN+/− mice were generated by Model Animal
+Research Center, Nanjing University. Briefly, the inactivated
+Blvrb allele in ES cells was first created by insertion
+of a LacZ-Neo cassette in place of exons 2, 3 and 4 of the
+Blvrb gene, disrupting in-frame translation of BLVRB
+(Figure S3A)
+67. Targeted ES
+cells were injected into blastocysts to generate chimeric mice, and male
+chimeras were bred to C57BL/6J females to produce BLVRB+/−
+F1 mice. BLVRB+/− F1 males and females were used as
+breeders to generate control mice (BLVRB+/+) and homozygous
+mutant mice (BLVRB−/−), which were maintained by
+intercrossing BLVRB+/+ males and BLVRB+/+ females or
+BLVRB−/− males and
+BLVRB−/− females, respectively. Genotyping of
+Blvrb used the following PCR primers: Blvrb-FRT-tF1
+5’AGAGTTTGGGTCCTCCCTTTCCT3’ and common-En2-R:
+5’CCAACTGACCTTGGGCAAGAACAT3’.
+
+To induce dietary obesity, 6–7-week-old male mice (body
+weight: 20–23g) were fed high-fat diet (60 kcal% fat diet D12492,
+Research Diets, Inc.) for 16 weeks before use in experiments.
+
+Male ob/ob mice (Jax #000632), homozygous for the
+obese spontaneous mutation, were purchased from Jackson Labs and fed
+standard chow diet for 16 weeks before use in experiments.
+
+Cell culture and generation of CRISPR-knockout and replacement cell
+lines.HEK293 and L6 cells were obtained from ATCC and cultured according
+to the ATCC protocols at 37°C under 5% CO2 in complete
+DMEM (10% FBS, 1% Pen-Strep). To induce the production of nitric oxide in
+HEK293 cells, pcDNA-eNOS was co-transfected into HEK293 cells using PolyJet
+transfection reagent. HEK-BLVRB knockout cell lines
+(HEK-BLVRB−/−), L6-SCAN knockout cell lines
+(L6-SCAN−/−), and L6-INSR knockout cell lines
+(L6-INSR−/−) were created using CRISPR-Cas9
+with specific guide RNAs. The human BLVRB CRISPR/Cas9 KO plasmid and BLVRB
+HDR plasmid were from Santa Cruz Biotechnology; the rat eSpCas9-rBLVRB and
+eSpCas9-rINSR plasmids were from GenScript. The eSpCas9-rSCAN contained
+gRNAs 5’-CCCCTCTGACGGTAACCTGC-3’ and
+5’-TCGGTGCCACCGGAAGGACC-3’ targeting rat BLVRB gene. The
+eSpCas9-rINSR plasmids contained gRNAs
+5’-TATCGACTGGTCCCGCATCCTGG-3’ and
+5’-GCCTGATTATCAACATCCGAGGG-3’ targeting rat INSR gene. HEK-293
+or L6 cells were transfected with BLVRB CRISPR/Cas9 KO /BLVRB HDR plasmid,
+eSpCas9-rBLVRB or eSpCas9-rINSR using PolyJet transfection reagent per
+manufacturer’s instructions. Twenty-four hours after transfection,
+the media was replaced, and cells were grown for another 24 hours. Cells
+were then split into growth media. After 48 hours, media containing 3
+μg/mL puromycin was added to select for candidate knockout cell
+colonies. Single colonies were picked and cultured in 96-well plates with
+growth media containing 3 μg/mL puromycin. Knockout cell lines were
+confirmed by western blot. Puromycin-resistant colonies containing normal
+endogenous expression of BLVRB (or INSR) were used for negative controls. To
+build stable HEK-BLVRB-WT, BLVRB-QTG/NAA, L6-SCAN-WT and L6-SCAN-QTG/NAA
+cell lines, HEK-BLVRB−/− or
+L6-SCAN−/− knockout cells were transfected with
+pcDNA-hBLVRB-WT or pcDNA-hBLVRB-QTG/NAA using PolyJet transfection reagent
+per manufacturer’s instructions. To build stable L6-INSR-WT and
+L6-INSR-C1083 cell lines, L6-INSR−/− were
+transfected with pcDNA-hINSR-WT or pcDNA-hINSR-C1083. Twenty-four hours
+after transfection, media was changed and cells grown for another 24 hours
+before being split into growth media. After 48 hours, G418 was added into
+the media at 400 μg/mL to select for cell lines expressing the
+proteins of interest. Expression in the stable cell lines was confirmed by
+western blot.
+
+Cell culture and generation of CRISPR-knockout and replacement cell
+lines.
+
+HEK293 and L6 cells were obtained from ATCC and cultured according
+to the ATCC protocols at 37°C under 5% CO2 in complete
+DMEM (10% FBS, 1% Pen-Strep). To induce the production of nitric oxide in
+HEK293 cells, pcDNA-eNOS was co-transfected into HEK293 cells using PolyJet
+transfection reagent. HEK-BLVRB knockout cell lines
+(HEK-BLVRB−/−), L6-SCAN knockout cell lines
+(L6-SCAN−/−), and L6-INSR knockout cell lines
+(L6-INSR−/−) were created using CRISPR-Cas9
+with specific guide RNAs. The human BLVRB CRISPR/Cas9 KO plasmid and BLVRB
+HDR plasmid were from Santa Cruz Biotechnology; the rat eSpCas9-rBLVRB and
+eSpCas9-rINSR plasmids were from GenScript. The eSpCas9-rSCAN contained
+gRNAs 5’-CCCCTCTGACGGTAACCTGC-3’ and
+5’-TCGGTGCCACCGGAAGGACC-3’ targeting rat BLVRB gene. The
+eSpCas9-rINSR plasmids contained gRNAs
+5’-TATCGACTGGTCCCGCATCCTGG-3’ and
+5’-GCCTGATTATCAACATCCGAGGG-3’ targeting rat INSR gene. HEK-293
+or L6 cells were transfected with BLVRB CRISPR/Cas9 KO /BLVRB HDR plasmid,
+eSpCas9-rBLVRB or eSpCas9-rINSR using PolyJet transfection reagent per
+manufacturer’s instructions. Twenty-four hours after transfection,
+the media was replaced, and cells were grown for another 24 hours. Cells
+were then split into growth media. After 48 hours, media containing 3
+μg/mL puromycin was added to select for candidate knockout cell
+colonies. Single colonies were picked and cultured in 96-well plates with
+growth media containing 3 μg/mL puromycin. Knockout cell lines were
+confirmed by western blot. Puromycin-resistant colonies containing normal
+endogenous expression of BLVRB (or INSR) were used for negative controls. To
+build stable HEK-BLVRB-WT, BLVRB-QTG/NAA, L6-SCAN-WT and L6-SCAN-QTG/NAA
+cell lines, HEK-BLVRB−/− or
+L6-SCAN−/− knockout cells were transfected with
+pcDNA-hBLVRB-WT or pcDNA-hBLVRB-QTG/NAA using PolyJet transfection reagent
+per manufacturer’s instructions. To build stable L6-INSR-WT and
+L6-INSR-C1083 cell lines, L6-INSR−/− were
+transfected with pcDNA-hINSR-WT or pcDNA-hINSR-C1083. Twenty-four hours
+after transfection, media was changed and cells grown for another 24 hours
+before being split into growth media. After 48 hours, G418 was added into
+the media at 400 μg/mL to select for cell lines expressing the
+proteins of interest. Expression in the stable cell lines was confirmed by
+western blot.
+
+Human SamplesAcquisition of deidentified human skeletal muscle samples, human
+visceral adipose and human subcutaneous adipose tissue samples was approved
+by the Institutional Review Board (IRB) for the protection of human subjects
+at Case Western Reserve University under a protocol waiver.Deidentified frozen human samples with pathological characterization
+were provided by the Tissue Resource Core at University Hospitals Cleveland.
+Human tissue was snap-frozen in liquid nitrogen immediately after collection
+from surgical procedures. Information of patient’s age, sex, race,
+BMI and type of tissue was obtained from pathology reports, and are provided
+in Table S3.
+Average age of patients for adipose tissues is 55.3 ± 13.4 years
+(ranging from 34 to 87 years). Average age of patients for skeletal muscle
+is 61.2 ± 12.6 years (ranging from 37 to 85 years). The SCAN
+expression and SNO levels of INSR in human samples were quantified by
+semi-quantitative analysis from western blots. SCAN expression was
+normalized relative to GAPDH detected on the same gel to control for any
+variation of protein loading among samples. These values were then
+normalized to the mean value (mean for all samples in same gel) for each gel
+to create a normalized measure to allow samples from two replicate gels to
+be directly compared.
+
+Human Samples
+
+Acquisition of deidentified human skeletal muscle samples, human
+visceral adipose and human subcutaneous adipose tissue samples was approved
+by the Institutional Review Board (IRB) for the protection of human subjects
+at Case Western Reserve University under a protocol waiver.
+
+Deidentified frozen human samples with pathological characterization
+were provided by the Tissue Resource Core at University Hospitals Cleveland.
+Human tissue was snap-frozen in liquid nitrogen immediately after collection
+from surgical procedures. Information of patient’s age, sex, race,
+BMI and type of tissue was obtained from pathology reports, and are provided
+in Table S3.
+Average age of patients for adipose tissues is 55.3 ± 13.4 years
+(ranging from 34 to 87 years). Average age of patients for skeletal muscle
+is 61.2 ± 12.6 years (ranging from 37 to 85 years). The SCAN
+expression and SNO levels of INSR in human samples were quantified by
+semi-quantitative analysis from western blots. SCAN expression was
+normalized relative to GAPDH detected on the same gel to control for any
+variation of protein loading among samples. These values were then
+normalized to the mean value (mean for all samples in same gel) for each gel
+to create a normalized measure to allow samples from two replicate gels to
+be directly compared.
+
+METHOD DETAILSPlasmids, Cloning and MutagenesisHuman cDNA of HO2 and cDNA of SCAN were cloned through reverse
+transcriptase–polymerase chain reaction (RT-PCR). The mammalian cell
+expression plasmids pCS2-flag-hHO2 and pcDNA-myc-hSCAN were generated
+through inserting cDNA of HO2 and SCAN into vector pCS2-flag and
+pcDNA3.1-myc, respectively. The pcDNA-flag-hIRS1 and pcDNA-flag-hINSR were
+obtained from GenScript. pCS2-flag-hHO2-C127R, pCS2-flag-hHO2-C265R,
+pCS2-flag-hHO2-C282R, pcDNA-myc-hSCAN-QTG/NAA, pcDNA-myc-hSCAN-C109R,
+pcDNA-myc-hSCAN-C188R and pcDNA-myc-hSCAN-C109/188R, pcDNA-flag-hINSR-C825A,
+pcDNA-flag-hINSR-C834A and pcDNA-flag-hINSR-C1083 mutants were generated by
+QuikChange II Site-Directed Mutagenesis Kit (Agilent). The mammalian cell
+expression plasmids containing truncated hHO2(1–296),
+hHO2(65–316), hHO2(130–316) or hHO2(195–316) were
+generated subcloning PCR bands of HO2 truncations into pCS2-flag. Primers
+are listed in Table
+S5. For purification of recombinant hHO2, hHO2(195–316),
+hSCAN-WT or hSCAN-QTG/NAA and hSCAN-C109/188R, cDNA encoding human HO2,
+hHO2(195–316), SCAN-WT, SCAN-QTG/NAA and hSCAN-C109/188R gene were
+subcloned into the pET21b vector to introduce a C-terminal 6xHis tag on the
+expressed protein. FGFR1 in pDONR221 vector was purchased from DNASU. All
+others (VEGFR2/KDR #23925, PDGFRa #23892, PDGFRb #23893, HER3 #23874) in
+pDONR223 vector were purchased from Addgene. These entry vectors were cloned
+into pcDNA-DEST40 Gateway destination vectors (Invitrogen) using Gateway LR
+clonase II reaction, generating mammalian expression plasmids with terminal
+V5 tag. All plasmids and mutations were confirmed by DNA sequencing.SNO-CoA agarose bead pull downCoenzyme A–agarose (50% slurry) was prepared by suspending
+Coenzyme A–agarose powder (Sigma) in water overnight at 4°C.
+To generate SNO-CoA beads, CoA beads were washed twice with 30 volumes of 10
+mM HCl and supernatant was aspirated. Pelleted CoA beads were resuspended in
+0.5 ml of 10 mM HCl, and 0.5 ml of 10 mM NaNO2 was added to the
+suspension to generate SNO-CoA. Immediately following NaNO2
+addition, 10 ml of washing buffer (150 mM NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM
+neocuproine (Sigma) and 50 mM borate buffer, pH 8.0) was added to dilute the
+SNO-CoA beads. The SNO-CoA beads were washed three times with washing
+buffer. For pulldown experiments, bovine liver tissue (5g) was suspended in
+25 mL of lysis buffer (150 mM NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM
+neocuproine, 50 mM borate buffer, pH 8.0, 1 mM PMSF and protease inhibitor
+mixture) and lysed in a blender, followed by homogenization with a Dounce
+homogenizer (Wheaton). Following centrifugation twice at 60,000 × g
+for 45 min, the supernatant was collected. The low-molecular weight cofactor
+NADPH was removed from the lysate using Amicon Ultra 3K Centrifugal Filter
+Devices. To pre-clear the CoA-binding proteins in the lysate, 10 ml of
+lysate (30 mg/ml) was incubated with 0.3 ml CoA–agarose beads for 2
+hours in the cold room in the dark. The pre-cleared lysate was incubated
+with 0.1 ml SNO-CoA beads for 2 hours at 4°C in the dark. After
+incubation, the beads were washed six times with washing buffer (150 mM
+NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM neocuproine, and 50 mM borate buffer, pH
+8.0), and SNO-CoA-binding proteins were eluted with excess SNO-CoA (20 mM,
+prepared as for SNO-CoA beads).For in vitro binding experiments, 1 μg of recombinant BLVRB
+protein diluted in 1 ml of binding buffer (150 mM NaCl, 1 mM EDTA, 1 mM
+DPTA, 0.1 mM neocuproine, and 50 mM borate buffer, pH 8.0) was incubated
+with 30 μl of 50% amylose resin (BioLabs), activated thiol Sepharose
+4B (Cytiva GE Healthcare), thiopropyl Sepharose 6B (GE healthcare),
+glutathione–agarose (Invitrogen), SNO-modified activated thiol
+(GSNO)–Sepharose 4B, SNO-CoA–agarose or CoA–agarose for
+2 hours at 4°C in the dark. For in vivo binding experiments, 1 ml of
+HEK cell lysate (1 mg/ml) was incubated with 30 μl of 50%
+GSH–agarose, GSNO–Sepharose 4B, CoA–agarose,
+Acetyl-CoA–agarose, SNO-CoA–agarose or Palmitoyl-Coenzyme
+A–agarose (Sigma) for 2 hours at 4°C in the dark. Beads were
+washed six times with binding buffer, and bound proteins were eluted with 50
+μl of 1X SDS loading dye (Invitrogen) containing 5% 2-mercaptoethanol
+(Sigma).SNO-RACSNO-RAC was carried out as described previously 52. Mouse skeletal muscle and human
+skeletal muscle were manually homogenized in liquid nitrogen with mortar and
+pestle. Ground skeletal muscle or human adipose tissue were homogenized in
+lysis buffer (1 mg/5 μl lysis buffer) containing 100 mM Hepes, 1 mM
+EDTA, 100 μM neocuproine (HEN), 50 mM NaCl, 0.1% (vol/vol) Nonidet
+P-40, 0.2% S-methylmethanethiosulfonate (MMTS) as a free thiol-blocking
+agent, 1 mM PMSF and protease inhibitors using Beadbeater (BioSpec). After
+centrifugation (20,000 × g, 4 °C, 20 min, ×2), SDS and
+MMTS were added to the supernatants to 2.5% and 0.2% respectively, and
+incubated at 50°C for 20 min. Proteins were precipitated with
+−20°C acetone, and re-dissolved in 1 mL of HEN, 1% SDS.
+Precipitation of proteins were repeated with −20°C acetone and
+the final pellets were resuspended in HEN, 1% SDS buffer, and protein
+concentrations were determined using the Bicinchoninic Acid (BCA) method.
+Total lysates (2 mg) were incubated with freshly prepared 50 mM ascorbate
+and 50 μl thiopropyl-Sepharose (50% slurry) and rotated end-over-end
+in the dark for 4 h. The bound SNO-proteins were sequentially washed with
+HEN, 1% SDS and then 10% HEN, 0.1% SDS buffers; SNO-proteins were eluted
+with 10% HEN, 1% SDS, 10% β-meracaptoethanol and analyzed by SDS/PAGE
+and immunoblotting.In vitro S-nitrosylation assayFor in vitro assay of S-nitrosylation of HO2, two master tubes were
+prepared. The control reaction tube contained 5 μg of
+HO2–6xHis, 5 μg GST and 2000 μL assay buffer (phosphate
+buffer pH 7.0 supplemented with 100 μM EDTA, 100 μM DTPA and
+0.1% NP-40). The enzyme reaction tube contained 5 μg of
+HO2–6xHis, 5 μg SCAN and 2000 μL assay buffer. The
+master mixture was separated into 5 tubes (400 μl/tube). 20 μl
+of SNO-CoA dilutions (0, 2 μM, 20 μM, 200 μM or 2 mM)
+were added into pairs of control and enzyme tubes.For in vitro assay of S-nitrosylation of HO2 mediated by mutant
+SCAN, two master tubes were prepared. The control reaction tube contained 4
+μg of HO2–6xHis, 4 μg GST and 1600 μL assay
+buffer. The enzyme reaction tube contained 4 μg of HO2–6xHis,
+4 μg SCAN-QTG/NAA, SCAN-C109/188R and 1600 μL assay buffer.
+Master mixture was split into 4 assay tubes (400μl/each tube), and
+20μl SNO-CoA dilutions were added into individual tubes to final
+concentrations of 0, 20 μM, 200 μM or 2 mM. For in vitro
+S-nitrosylation of IRS1 and INSR, two master tubes were prepared. Control
+reaction tube contained 1 μg of IRS1-FLAG or 1 μg of
+INSR-FLAG, 5 μg GST and 2000 μL assay buffer. Enzyme reaction
+tube contained 1 μg IRS1-FLAG or 1 μg INSR-FLAG, 5 μg
+SCAN and 2000 μL assay buffer. The master mixture was equally
+separated into 5 tubes (400 μl/each tube). 20 μl SNO-CoA (0,
+20 μM, 200 μM, 2 mM or 4 mM) was respectively added into the
+tubes. Reaction tubes were incubated at 37°C for 30 minutes in the
+dark. Reactions were quenched by the addition of 3 volumes ice cold 100%
+acetone. Following quenching, 50 μL 2 μg/μL BSA was
+added to samples. Proteins were precipitated at −20°C for 30
+minutes, pelleted at 4500 g for 8 minutes, and washed 4X with 70% acetone.
+Protein pellets were resuspended in 300 μL HEN buffer containing 2.5%
+SDS and 0.3% MMTS. Resuspended proteins were processed by SNO-RAC as
+described above.Glucose uptake measurementIn vitro glucose uptake measurement was performed as previously
+described 68. Naïve
+SCAN+/+ and SCAN−/− mice (5 male and
+5 female) per group were euthanized by isoflurane anesthesia. Soleus muscles
+were dissected tendon-to-tendon and rapidly rinsed in ice-cold 1X
+Krebs–Henseleit buffer. Muscles were recovered in vials including the
+recovery buffer (1X Krebs–Henseleit buffer, 0.1% BSA, 2 mM sodium
+pyruvate, 32 mM mannitol, 8 mM glucose supplemented with human-effective
+insulin dose (12 nM) or without insulin (basal)), shaken at 45 revolutions
+per minute while continuously gassed (95% O2–5%
+CO2) in a heated water bath (35°C) for 60 minutes.
+Muscles were subsequently washed twice for 10 minutes with at 35°C
+for 10 minutes in washing buffer (1X Krebs–Henseleit buffer, 0.1%
+BSA, 2mM sodium pyruvate and 32 mM Mannitol). Muscles were transferred to a
+vial containing 5 ml incubation buffer (1X Krebs–Henseleit buffer,
+0.1% BSA, 2 mM sodium pyruvate, 32 mM mannitol, 4 mM 2-deoxyglucose, 2
+μCi/ml 3H-2-deoxyglucose, and 0.3 μCi/ml
+14C-mannitol). Separate incubations were performed with
+insulin (12 nM) or without insulin (basal). Vials were shaken at 45
+revolutions per minute while continuously gassed (95%
+O2–5% CO2) in a heated water bath (35°C)
+for 20 minutes. Following this step, muscles were rinsed quickly in 1X
+Krebs–Henseleit buffer once and dried on filter paper and weighed.
+Muscle was digested with 1:10 (1 mg/10 μl) 1 M NaOH at 60°C
+for 1 hour. The samples were centrifuged 15,000 × g for 15 minutes at
+4°C. Supernatants (150 μl) were transferred to new tubes and
+neutralized with 150 μl of 1M HCl. Fifty μl of each
+neutralized sample was placed in a scintillation vial and the 3H
+and 14C counts determined in a scintillation counter
+(PerkinElmer). Extracellular volume was calculated using disintegrations per
+minute (DPM) of the 14C-mannitol, which is not membrane permeant.
+Intracellular 2-DG levels were then determined after accounting for
+3H DPM in the extracellular space, and 2-DG uptake rates were
+expressed as nmol 2-DG/100 mg muscle/20 minutes.Intraperitoneal glucose tolerance test (IPGTT), intraperitoneal insulin
+tolerance test (IPITT) and acute hypoglycemiaIPGTT and IPITT were performed according to the standard protocol of
+the International Mouse Phenotyping Consortium (https://www.mousephenotype.org). Mice
+were fasted for 16 hours for IPGTT or 5 hours for IPITT in clean cages with
+no food or feces in the bedding, in the standard light–dark cycle and
+with free access to water. Blood was collected from the tail tip directly
+onto a glucose test strip and read immediately using a calibrated
+glucometer. For IPGTT, glucose was injected i.p. at 2 g of glucose/kg of
+body weight. Blood drawn from sequential tail tip cuts was used to measure
+glucose at 15, 30, 60, 90 and 120 min after glucose injection. For IPITT,
+insulin was injected i.p at 1 unit insulin/kg of body weight. Glucose levels
+in tail tip blood were measured at 15, 30, 60, 90 and 120 min after insulin
+injection. Insulin-induced acute hypoglycemia (“severe” ITT)
+in mice was produced according to a published protocol 69. Insulin (2.5 units/kg body weight)
+was injected i.p. into 3 h-fasted mice, producing blood glucose <40
+mg/dl when measured at 90 min after injection and without leading to
+unconsciousness, seizures, or death. Blood glucose was measured before
+insulin injection and after 30, 90, 120,180 and 240 min via tail tip
+bleed.Insulin, bilirubin, free hemin, and blood testsBlood (50 μl) was collected from the mouse facial vein. To
+measure insulin, bilirubin and free hemin in serum, blood was placed in BD
+Microtainer tubes with Serum Separator, and centrifuged at 4°C at
+2000 × g for 10 min to obtain serum. Insulin
+concentration was measured following the protocol of Ultra Sensitive Mouse
+Insulin ELISA Kit (Crystal Chem). Mice were fasted for 5 hours prior to
+basal insulin measurement. Hematology analyses were performed using HESKA
+HemaTrue System. Blood was placed in heparin-treated 1.5ml microtube. Twenty
+μl blood was used for measurement of 17 parameters including total
+red blood cell count, total white blood cell count, total platelet count,
+hemoglobin concentration, lymphocyte percentage, mid-sized cells (e.g.,
+monocytes) percentage, and granulocyte percentage.Insulin treatmentFor L6 cell treatment, L6 cells at 50–70% confluence on 10 cm
+plates were starved in DMEM medium (+5% BSA) for 16 hours. Human insulin was
+added into medium to 100 nM final. Following 10-minute insulin treatment,
+cells were washed three times using warm 1X PBS, and complete DMEM medium
+(+10% FBS and 1% Pen-Strep) was added. L6 cells were collected at 1, 30, 60,
+120 and 240 minutes after media change and stored −80°C. For
+mouse treatment, human insulin (1 U/kg body weight) was intraperitoneally
+injected into mice that had been fasted for five hours. After 30 or 60
+minutes, mice were euthanized by isoflurane anesthesia. Skeletal muscle
+(lateral gastrocnemius) was collected and quickly frozen in liquid
+nitrogen.iTRAQ-Coupled SNO-RACiTRAQ-Coupled SNO-RAC was carried out as described previously
+5.
+HEK-BLVRB−/− and HEK-BLVRB+/+
+(control) lysates were prepared, and SNO-RAC (4 mg of protein per sample)
+was carried out as described above. SDS/PAGE gels were Coomassie-blue
+stained, and lanes were separated into eight segments top-to-bottom and
+collected in two 1.5 ml tubes. Five hundred μl of 50% acetonitrile
+(ACN)/50% 100 mM ammonium bicarbonate was used to wash gel bands for more
+than 5 hours while vortexing. After removal of washing buffer, 400 μl
+of 100% acetonitrile was added to gel pieces and vortexed for 10 min. After
+removal of ACN, gel pieces were dried in a speed vacuum dryer for 10 min.
+Two hundred μl of 10 mM dithiothreitol (DTT) was added to dry gel
+pieces and vortexed for 45 min. After removal of DTT buffer, 200 μl
+of 55 mM iodoacetamide (IAA) was added to the gel pieces and incubated for
+45 min in the dark. After removal of IAA buffer, 400 μl of 1x iTRAQ
+dissolution solution and 400 μl ACN were used to wash the gel pieces
+twice. Gel pieces were dried for 10 min in a speed vacuum dryer. 500 ng
+trypsin in 150 μl 1x iTRAQ buffer was added to dried gel pieces on
+ice for 30 mins to rehydrate, and then incubated overnight at 37°C.
+Supernatant from the digested protein solution was transferred to a 1.5 ml
+tube using gel-loading tips. 200 μl extraction buffer (60% ACN/5%
+formic acid) were added to gel pieces, vortexed for 30 min, and sonicated
+for 15 min. The supernatant containing peptide extracts was transferred to
+the same 1.5 ml tube, and extractions were repeated two more times. The
+final digested solution pool was dried completely in a speed vacuum
+dryer.iTRAQ labeling was performed according to the instructions of iTRAQ
+Reagents - 4plex Applications Kit. Briefly, 30 μl of iTRAQ
+dissolution buffer (10x) was added to each sample tube (pH > 7), and
+then one iTraq labeling reagent (mass 114, 115, 116 or 117) was added to
+individual sample tubes. Reactions were incubated for more than 5 hours at
+room temperature with vortexing to ensure complete labeling. The four
+labeled samples were mixed together and dried. One hundred sixty μl
+of 5% ACN containing 0.5% TFA was added to the labeled sample mix, and the
+solution cleaned using C18 ziptips. Briefly, C18 tips were wetted 5 times
+with 20 μl of 50% ACN, and equilibrated with 100 μl of 5% ACN
+containing 0.5% TFA. Samples were then loaded to the tip by drawing and
+expelling 50 cycles to ensure complete binding. The tips were then washed
+with 20 μl of 5% ACN containing 0.5% TFA 10 times. Peptides were
+eluted from tips in 3× 20 μl of 60% ACN containing 0.1% formic
+acid, and eluates combined and dried for LC-MS/MS Analysis.LC-MS/MS AnalysisDigested peptides were separated by UPLC (Waters, Milford, MA) with
+a Nano-ACQUITY UPLC BEH300 C18 column. Separated peptides were continuously
+injected into an Orbitrap Elite hybrid mass spectrometer (Thermo Finnigan,
+San Jose, CA) by a nanospray emitter (10 μm, New Objective). Peptides
+were eluted using a linear gradient using mobile phase A (0.1% formic acid
+in water) and B (100% acetonitrile) was used at a flow rate of 0.3
+μl/min, starting with 1% mobile phase B and increasing to 40% B at 65
+min for protein interaction identification, or increasing to 40% B at 130
+min for iTRAQ experiments. All mass spectrometry data were acquired in
+positive ion mode. For protein interaction identification, a full MS scan
+(m/z 350–1800) at resolution of 120,000 was conducted, twenty MS2
+scans (m/z 350–1800) were selected using the twenty most intense
+peptide peaks of full MS scans. CID cleavage mode was performed at
+normalized collision energy of 35%. For iTRAQ experiments, a full MS scan
+(m/z 300–1800) at resolution of 120,000 was conducted, and ten MS2
+scans (m/z 100–1600) were activated from the five most intense
+peptide peaks of full MS scans. CID and HCD cleavage modes were performed
+alternatively of the same peptides selected from full MS scans. MS2
+resolution of HCD is 15,000. Bioinformatic software MassMatrix was used to
+search MS data against a database composed of sequences of mouse proteins
+from Uniprot and their reversed sequences as a decoy database. Modifications
+including oxidation of methionine and labeling of cysteine (IA
+modifications) were selected as variable modifications in searching. For
+iTRAQ labeling searching, MS tag of N terminus, Lys and/or Tyr were selected
+as variable modification to test labeling efficiency and fixed modification
+for iTRAQ quantitation analysis. Trypsin was selected as the in-silico
+enzyme to cleave proteins after Lys and Arg. Precursor ion searching was
+within 10 ppm mass accuracy and product ions within 0.8 Da for CID cleavage
+mode and 0.02 Da for HCD cleavage mode. 95% confidence interval was required
+for protein identification.ImmunoprecipitationTo investigate the interaction of SCAN and IRS1, Myc-SCAN and
+IRS1-Flag were co-expressed in HEK293 cells. To investigate the effect of
+insulin stimulation, disruption of SNO-CoA binding, mutation of SNO site
+C109/188 and of SCoR, Myc-SCAN, Myc-SCAN-QTG/NAA or Myc-SCAN-C109/188R were
+co-expressed with INSR-Flag in parental or SCoR-knockout HEK cells or L6
+cells. HEK cells or L6 cells were treated with NO donor DPTA (200μM)
+for 20 hours as required. Anti-rabbit C-Myc Agarose Affinity Gel (Sigma) was
+used for immunoprecipitation. To investigate the interaction of endogenous
+SCAN with HO2 or INSR, 10 μg of BLVRB Rabbit monoclonal antibody
+(Sino Biological) was incubated with 50 μl of Protein G Sepharose
+(GE) (1:1 slurry) at 4°C overnight, then washed with NETN buffer (150
+mM NaCl, 20 mM Tris-Cl (pH 8.0), 0.5 mM EDTA, 0.5% (v/v) Nonidet P-40) three
+times to prepare for immunoprecipitation. HEK cells or L6 cells were
+homogenized in EBC lysis buffer (120 mM NaCl, 20 mM Tris-Cl (pH 8.0), 0.5 mM
+EDTA, 0.5% (v/v) NP-40, 1 mM PMSF and protease inhibitor cocktail). After
+centrifugation (20,000 × g, 4°C, 20 min, ×2), 2 ml (2
+mg/ml) supernatant was pre-cleared by incubation with 50 μl Protein G
+Sepharose (1:1 slurry) for 1 hour at 4 °C. After spinning at 1000
+× g for 1 min, the supernatant was transferred into new tubes and
+incubated with 50 μl anti BLVRB antibody-Protein G Sepharose or with
+anti c-Myc-Agarose (1:1 slurry) for 5 hours at 4°C. Beads were washed
+by NETN buffer and proteins were eluted with 50 μl 1X SDS loading dye
+containing 5% 2-mercaptoethanol. Eluted proteins were electrophoresed in
+4–20% Criterion Precast Midi Protein Gels (Bio Rad), transferred to
+PVDF membranes, and membranes were blotted with mouse Flag antibody, HO2
+antibody or INSR antibody.Western blot analysisProteins were extracted from cells using sonication in RIPA buffer
+(Sigma) supplemented with 1 mM PMSF, protease inhibitor cocktail and
+phosphatase inhibitor cocktail. Muscle samples were ground with a mortar and
+pestle under liquid nitrogen, then the powder added to RIPA buffer as above,
+and mechanically homogenized using a bead beater. Extracts were clarified by
+centrifugation (20,000 × g, 4°C, 20 min, ×2), and
+protein concentration was determined by bicinchoninic acid assay. The
+extracts were electrophoresed in 4–20% Criterion Precast Midi Protein
+Gels and transferred to PVDF membranes. Membranes were incubated overnight
+at 4°C with primary antibodies, washed with PBS containing 0.1%
+Tween-20, incubated with HRP-conjugated secondary antibody for 1 hour,
+washed, and detected by chemiluminescent detection (ECL) using X-ray film
+developer system (JPI, Filmprocessor) or a digital imager system
+(Kwikquant). Antibodies employed in western blotting included: rabbit
+polyclonal rabbit Anti-BLVRB (13151-R009, Sino Biological Inc), mouse
+monoclonal Anti-HO2 (H00003163, Abnova), rabbit polyclonal Anti-IRS1
+(06–248, EMD Millipore), rabbit polyclonal Anti-INSRβ (sc-711,
+Santa Cruz), rabbit monoclonal Anti-INSRβ (phospho-Y1163,1164)
+(MA5–15148, Invitrogen), rabbit Anti-IRS1 phospho-Tyr608 (09432, EMD
+Millipore), rabbit monoclonal Anti-NOS2 (D9A5L, Cell Signaling), rabbit
+Anti-eNOS (phospho-S1177) (PA597371, Invitrogen), rabbit monoclonal Anti-AKT
+(C67E7, Cell Signaling), rabbit Anti-AKT (phospho-S473) (9271, Cell
+Signaling), mouse monoclonal p97 (10R-P104A, Fitzgerald), rabbit monoclonal
+GAPDH (Ab181602, abcam), rabbit monoclonal Anti-AS160 (MA5–14840,
+Invitrogen), rabbit Anti-AS160 (phospho-T642) (44–1071G, Invitrogen)
+and mouse monoclonal FLAG-M2 (F3165, Sigma) (see Key Resources). Protein levels were quantified
+by semi-quantitative analysis from western blots using ImageJ (NIH).Identification of SNO site of INSR by mass spectrometryThe pcDNA-INSR-FLAG plasmid (GenScript) was transfected into HEK293
+cells using PolyJet. Cells were harvested and lysed in EBC lysis buffer.
+INSR-FLAG was purified from lysate with anti-FLAG M2 affinity gel (Sigma)
+and eluted with 100 mM phosphate buffer, pH 7.4 containing 100 μg/mL
+FLAG peptide (Sigma), 100 μM EDTA and 100 μM DTPA. Purified
+INSR was subsequently treated with 100 μM freshly prepared SNO-CoA
+for 20 minutes at room temperature in the dark. Following treatment with
+SNO-CoA, protein was supplemented with 100 μg bovine serum albumin
+carrier, mixed with 3 volumes ice cold 100% acetone, and kept at
+−20°C for 30 minutes. Following cold incubation, the sample
+was spun at 14000 × g for 15 minutes to precipitate protein. Pelleted
+protein was washed 3 times with ice cold 70% acetone, air dried, and
+resuspended in 400 μL of HENS buffer. Unreacted SNO-CoA was removed
+using Zeba desalting spin columns (Thermo Fisher) preequilibrated with HENS
+buffer. Following filtration, 1 M MMTS and 25% SDS were added into the
+protein solution (final 20mM MMTS and 2.5% SDS) and the solution was
+vortexed. The solution was incubated for 20 minutes at 50°C to block
+free thiols. Protein was again precipitated with 3 volumes ice cold 100%
+acetone with incubation for 1 hour at −20°C. Following
+incubation, precipitated proteins were collected by centrifugation at 10000
+× g for 10 minutes at 4°C. Supernatant was removed from
+precipitated protein pellets, and pellets allowed to dry at room temperature
+for 10 minutes. Proteins were resuspended in HENS buffer and labeled with
+iodoTMT (Thermo Fisher) in the presence of 20 mM sodium ascorbate for 1 hour
+at room temperature in the dark. Reactions were quenched with 20 mM DTT for
+15 minutes at room temperature in the dark. Protein was precipitated with 3
+volumes ice cold 100% acetone at −20°C for 1 hour, then
+centrifuged at 10000 × g for 10 minutes at 4°C. Supernatant
+was removed, and the protein pellet dried for 10 minutes. Protein was
+resuspended in HENS buffer and treated with 16.67 mM iodoacetamide for 1
+hour at room temperature in the dark. Protein was again precipitated as
+above, supernatant removed, and protein pellet dried. Precipitated protein
+was then resuspended in 50 mM ammonium bicarbonate buffer, pH 8.0. Proteins
+were then serially digested with 25 μg/mg protein using Lys-c (4
+hours at 37°C) then 20 μg/mg protein using trypsin overnight
+at 37°C. Following digestion, samples were acidified with 25
+μL of 10% TFA. Peptides were processed through a C18 SPE column and
+then frozen and lyophilized. Lyophilized peptides were resuspended in TBS
+and enriched using anti-TMT resin (Thermo Fisher) following the
+manufacturer’s instructions, and subsequently frozen and lyophilized.
+Samples were resuspended in 5% acetonitrile, 0.1% formic acid and run
+through a 0.22 μm filter to remove any excess anti-TMT resin.
+Peptides were then injected into LC-MS/MS system for analysis.Purification of proteinsThe recombinant HO2, SCAN-WT or SCAN-QTG-NAA proteins were purified
+from BL21-CodonPlus Competent E. coli cells (Agilent).
+Overnight E. coli cultures were sub-cultured into 1 L of LB
+medium at 5%. At OD600 of 0.5, cultures were induced with 100 mM IPTG and
+grown 4 hours at 28°C. Cultures were centrifuged at 4000 × g
+for 10 min to harvest the cells. Cell pellets from 1 L cultures were lysed
+by sonication in 10 mL of PBS buffer containing 1 mM PMSF and
+protease-inhibitor cocktail. After centrifugation at 14500 × g for 20
+min, the supernatant was collected and diluted (up to 30 ml) with PBS buffer
+containing 1 mM PMSF and protease-inhibitor cocktail. This lysate was
+incubated with 1 mL of Ni-NTA agarose at 4°C for 1 hour with
+rotation. The slurry was then poured into an empty PD-10 column (GE
+Healthcare), and the beads washed with 100 mL of 50 mM
+NaH2PO4, 300 mM NaCl buffer containing 20 mM
+imidazole. Elution was done with 2 mL of 50 mM
+NaH2PO4, 300 mM NaCl, 250 mM imidazole. Eluate buffer
+was exchanged with modified Roeder D [(20mM HEPES (pH 7.9), 20% (v/v)
+glycerol, 0.1M KCL, 0.2mM EDTA)] using a Microcon centrifugal filter device
+(Millipore).IRS1-FLAG and INSR-FLAG were purified from HEK cells. Briefly, HEK
+cells were transfected with pcDNA-Flag-hIRS1 or pcDNA-Flag-hINSR plasmid
+using PolyJet transfection reagent (SignaGen) per manufacturer’s
+instructions and grown for 48 hours. After 48 hours, cells were harvested in
+IP wash buffer (as above) supplemented with 0.5% Triton X-100 and protease
+inhibitor cocktail. Cells were lysed by sonication and lysate clarified by
+centrifugation at 15000 × g for 15 minutes. Anti-FLAG agarose
+affinity gel was equilibrated into IP wash buffer, and clarified lysate was
+applied to anti-FLAG agarose affinity gel. After 4 hours incubation in
+4°C, beads were washed 5 times with IP wash buffer. Proteins were
+eluted in 300μL 1xPBS containing 100 μg/mL 3X FLAG peptide.
+Protein concentration was determined using BCA.Tyrosine kinase activityTyrosine kinase activity of INSR was measured using InsR Kinase
+Enzyme System-coupled with ADP-Glo™ Assay (Promega). To
+purify the INSR-FLAG from HEK cells, the same procedure was used in above
+“Purification of proteins” except INSR-FLAG complex was eluted
+in 200μL reaction buffer A (provided in InsR Kinase Enzyme System)
+containing 100 μg/mL 3X FLAG peptide and 2mM MnCl2. Ten
+μl (100ng/μl) purified INSR-FLAG complex was treated with
+control Tris buffer or 500 μM SNO-CoA (5 μl) for 30 min at
+37°C. Ten μl AxLtide (substrate, 1mg/ml)+ATP (125 μM)
+mixture was added into the reaction. After 60 min incubation at 25°C,
+25 μl ADP-Glo™ Reagent was added into the reaction.
+Fifty μl kinase detection reagent was added after 40 min incubation
+at 25°C, and the luminescence read after 30 min incubation at
+25°C in a Promega GloMax Luminometer.ImmunostainingHEK293 cells were grown in 2 mL culture medium to approximately 50%
+confluency on cover slips in 6-well plates. For studying insulin
+stimulation, cells were starved in DMEM medium (+5% BSA) for 16 hours. Human
+insulin was added into medium to 100 nM final concentration for 10min. Media
+was aspirated, and 1mL cold 4% PFA in PBS was used to fix cells for 15 min
+at room temperature. After each incubation step, cells were washed 3x with
+PBS. Cells were permeabilized with PBS +.05% Triton X100 for 5 min, washed,
+blocked with 8% BSA in PBS for 20min, washed and incubated with primary
+antibodies diluted in blocking buffer for 2 hours. Primary antibodies rabbit
+anti-SCAN (Sino Biological Inc), mouse anti-Cytochrome C (Cell Signaling)
+and mouse anti-AKR1A1 (Origene TA500740 clone 9F1) were used in
+immunostaining. After washing, secondary antibodies were added for 2 hours
+at room temperature. Secondary antibodies used were A11001 (Invitrogen,
+AF488 anti-mouse IgG at 1:1000) and A11036 (AF568 anti-rabbit IgG at
+1:1000). DAPI (Biotium, 5mg/ml) was used to stain nuclei. Samples were
+washed once again, mounted with Fluoromount G onto slides and imaged with a
+Nikon Eclipse Ti2 microscope using a 60x objective. TIFF images were
+processed in FIJI/ImageJ with the JaCoP plugin used to calculate
+Pearson’s and M1/M2 coefficients.
+
+METHOD DETAILS
+
+Plasmids, Cloning and MutagenesisHuman cDNA of HO2 and cDNA of SCAN were cloned through reverse
+transcriptase–polymerase chain reaction (RT-PCR). The mammalian cell
+expression plasmids pCS2-flag-hHO2 and pcDNA-myc-hSCAN were generated
+through inserting cDNA of HO2 and SCAN into vector pCS2-flag and
+pcDNA3.1-myc, respectively. The pcDNA-flag-hIRS1 and pcDNA-flag-hINSR were
+obtained from GenScript. pCS2-flag-hHO2-C127R, pCS2-flag-hHO2-C265R,
+pCS2-flag-hHO2-C282R, pcDNA-myc-hSCAN-QTG/NAA, pcDNA-myc-hSCAN-C109R,
+pcDNA-myc-hSCAN-C188R and pcDNA-myc-hSCAN-C109/188R, pcDNA-flag-hINSR-C825A,
+pcDNA-flag-hINSR-C834A and pcDNA-flag-hINSR-C1083 mutants were generated by
+QuikChange II Site-Directed Mutagenesis Kit (Agilent). The mammalian cell
+expression plasmids containing truncated hHO2(1–296),
+hHO2(65–316), hHO2(130–316) or hHO2(195–316) were
+generated subcloning PCR bands of HO2 truncations into pCS2-flag. Primers
+are listed in Table
+S5. For purification of recombinant hHO2, hHO2(195–316),
+hSCAN-WT or hSCAN-QTG/NAA and hSCAN-C109/188R, cDNA encoding human HO2,
+hHO2(195–316), SCAN-WT, SCAN-QTG/NAA and hSCAN-C109/188R gene were
+subcloned into the pET21b vector to introduce a C-terminal 6xHis tag on the
+expressed protein. FGFR1 in pDONR221 vector was purchased from DNASU. All
+others (VEGFR2/KDR #23925, PDGFRa #23892, PDGFRb #23893, HER3 #23874) in
+pDONR223 vector were purchased from Addgene. These entry vectors were cloned
+into pcDNA-DEST40 Gateway destination vectors (Invitrogen) using Gateway LR
+clonase II reaction, generating mammalian expression plasmids with terminal
+V5 tag. All plasmids and mutations were confirmed by DNA sequencing.
+
+Plasmids, Cloning and Mutagenesis
+
+Human cDNA of HO2 and cDNA of SCAN were cloned through reverse
+transcriptase–polymerase chain reaction (RT-PCR). The mammalian cell
+expression plasmids pCS2-flag-hHO2 and pcDNA-myc-hSCAN were generated
+through inserting cDNA of HO2 and SCAN into vector pCS2-flag and
+pcDNA3.1-myc, respectively. The pcDNA-flag-hIRS1 and pcDNA-flag-hINSR were
+obtained from GenScript. pCS2-flag-hHO2-C127R, pCS2-flag-hHO2-C265R,
+pCS2-flag-hHO2-C282R, pcDNA-myc-hSCAN-QTG/NAA, pcDNA-myc-hSCAN-C109R,
+pcDNA-myc-hSCAN-C188R and pcDNA-myc-hSCAN-C109/188R, pcDNA-flag-hINSR-C825A,
+pcDNA-flag-hINSR-C834A and pcDNA-flag-hINSR-C1083 mutants were generated by
+QuikChange II Site-Directed Mutagenesis Kit (Agilent). The mammalian cell
+expression plasmids containing truncated hHO2(1–296),
+hHO2(65–316), hHO2(130–316) or hHO2(195–316) were
+generated subcloning PCR bands of HO2 truncations into pCS2-flag. Primers
+are listed in Table
+S5. For purification of recombinant hHO2, hHO2(195–316),
+hSCAN-WT or hSCAN-QTG/NAA and hSCAN-C109/188R, cDNA encoding human HO2,
+hHO2(195–316), SCAN-WT, SCAN-QTG/NAA and hSCAN-C109/188R gene were
+subcloned into the pET21b vector to introduce a C-terminal 6xHis tag on the
+expressed protein. FGFR1 in pDONR221 vector was purchased from DNASU. All
+others (VEGFR2/KDR #23925, PDGFRa #23892, PDGFRb #23893, HER3 #23874) in
+pDONR223 vector were purchased from Addgene. These entry vectors were cloned
+into pcDNA-DEST40 Gateway destination vectors (Invitrogen) using Gateway LR
+clonase II reaction, generating mammalian expression plasmids with terminal
+V5 tag. All plasmids and mutations were confirmed by DNA sequencing.
+
+SNO-CoA agarose bead pull downCoenzyme A–agarose (50% slurry) was prepared by suspending
+Coenzyme A–agarose powder (Sigma) in water overnight at 4°C.
+To generate SNO-CoA beads, CoA beads were washed twice with 30 volumes of 10
+mM HCl and supernatant was aspirated. Pelleted CoA beads were resuspended in
+0.5 ml of 10 mM HCl, and 0.5 ml of 10 mM NaNO2 was added to the
+suspension to generate SNO-CoA. Immediately following NaNO2
+addition, 10 ml of washing buffer (150 mM NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM
+neocuproine (Sigma) and 50 mM borate buffer, pH 8.0) was added to dilute the
+SNO-CoA beads. The SNO-CoA beads were washed three times with washing
+buffer. For pulldown experiments, bovine liver tissue (5g) was suspended in
+25 mL of lysis buffer (150 mM NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM
+neocuproine, 50 mM borate buffer, pH 8.0, 1 mM PMSF and protease inhibitor
+mixture) and lysed in a blender, followed by homogenization with a Dounce
+homogenizer (Wheaton). Following centrifugation twice at 60,000 × g
+for 45 min, the supernatant was collected. The low-molecular weight cofactor
+NADPH was removed from the lysate using Amicon Ultra 3K Centrifugal Filter
+Devices. To pre-clear the CoA-binding proteins in the lysate, 10 ml of
+lysate (30 mg/ml) was incubated with 0.3 ml CoA–agarose beads for 2
+hours in the cold room in the dark. The pre-cleared lysate was incubated
+with 0.1 ml SNO-CoA beads for 2 hours at 4°C in the dark. After
+incubation, the beads were washed six times with washing buffer (150 mM
+NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM neocuproine, and 50 mM borate buffer, pH
+8.0), and SNO-CoA-binding proteins were eluted with excess SNO-CoA (20 mM,
+prepared as for SNO-CoA beads).For in vitro binding experiments, 1 μg of recombinant BLVRB
+protein diluted in 1 ml of binding buffer (150 mM NaCl, 1 mM EDTA, 1 mM
+DPTA, 0.1 mM neocuproine, and 50 mM borate buffer, pH 8.0) was incubated
+with 30 μl of 50% amylose resin (BioLabs), activated thiol Sepharose
+4B (Cytiva GE Healthcare), thiopropyl Sepharose 6B (GE healthcare),
+glutathione–agarose (Invitrogen), SNO-modified activated thiol
+(GSNO)–Sepharose 4B, SNO-CoA–agarose or CoA–agarose for
+2 hours at 4°C in the dark. For in vivo binding experiments, 1 ml of
+HEK cell lysate (1 mg/ml) was incubated with 30 μl of 50%
+GSH–agarose, GSNO–Sepharose 4B, CoA–agarose,
+Acetyl-CoA–agarose, SNO-CoA–agarose or Palmitoyl-Coenzyme
+A–agarose (Sigma) for 2 hours at 4°C in the dark. Beads were
+washed six times with binding buffer, and bound proteins were eluted with 50
+μl of 1X SDS loading dye (Invitrogen) containing 5% 2-mercaptoethanol
+(Sigma).
+
+SNO-CoA agarose bead pull down
+
+Coenzyme A–agarose (50% slurry) was prepared by suspending
+Coenzyme A–agarose powder (Sigma) in water overnight at 4°C.
+To generate SNO-CoA beads, CoA beads were washed twice with 30 volumes of 10
+mM HCl and supernatant was aspirated. Pelleted CoA beads were resuspended in
+0.5 ml of 10 mM HCl, and 0.5 ml of 10 mM NaNO2 was added to the
+suspension to generate SNO-CoA. Immediately following NaNO2
+addition, 10 ml of washing buffer (150 mM NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM
+neocuproine (Sigma) and 50 mM borate buffer, pH 8.0) was added to dilute the
+SNO-CoA beads. The SNO-CoA beads were washed three times with washing
+buffer. For pulldown experiments, bovine liver tissue (5g) was suspended in
+25 mL of lysis buffer (150 mM NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM
+neocuproine, 50 mM borate buffer, pH 8.0, 1 mM PMSF and protease inhibitor
+mixture) and lysed in a blender, followed by homogenization with a Dounce
+homogenizer (Wheaton). Following centrifugation twice at 60,000 × g
+for 45 min, the supernatant was collected. The low-molecular weight cofactor
+NADPH was removed from the lysate using Amicon Ultra 3K Centrifugal Filter
+Devices. To pre-clear the CoA-binding proteins in the lysate, 10 ml of
+lysate (30 mg/ml) was incubated with 0.3 ml CoA–agarose beads for 2
+hours in the cold room in the dark. The pre-cleared lysate was incubated
+with 0.1 ml SNO-CoA beads for 2 hours at 4°C in the dark. After
+incubation, the beads were washed six times with washing buffer (150 mM
+NaCl, 1 mM EDTA, 1 mM DPTA, 0.1 mM neocuproine, and 50 mM borate buffer, pH
+8.0), and SNO-CoA-binding proteins were eluted with excess SNO-CoA (20 mM,
+prepared as for SNO-CoA beads).
+
+For in vitro binding experiments, 1 μg of recombinant BLVRB
+protein diluted in 1 ml of binding buffer (150 mM NaCl, 1 mM EDTA, 1 mM
+DPTA, 0.1 mM neocuproine, and 50 mM borate buffer, pH 8.0) was incubated
+with 30 μl of 50% amylose resin (BioLabs), activated thiol Sepharose
+4B (Cytiva GE Healthcare), thiopropyl Sepharose 6B (GE healthcare),
+glutathione–agarose (Invitrogen), SNO-modified activated thiol
+(GSNO)–Sepharose 4B, SNO-CoA–agarose or CoA–agarose for
+2 hours at 4°C in the dark. For in vivo binding experiments, 1 ml of
+HEK cell lysate (1 mg/ml) was incubated with 30 μl of 50%
+GSH–agarose, GSNO–Sepharose 4B, CoA–agarose,
+Acetyl-CoA–agarose, SNO-CoA–agarose or Palmitoyl-Coenzyme
+A–agarose (Sigma) for 2 hours at 4°C in the dark. Beads were
+washed six times with binding buffer, and bound proteins were eluted with 50
+μl of 1X SDS loading dye (Invitrogen) containing 5% 2-mercaptoethanol
+(Sigma).
+
+SNO-RACSNO-RAC was carried out as described previously 52. Mouse skeletal muscle and human
+skeletal muscle were manually homogenized in liquid nitrogen with mortar and
+pestle. Ground skeletal muscle or human adipose tissue were homogenized in
+lysis buffer (1 mg/5 μl lysis buffer) containing 100 mM Hepes, 1 mM
+EDTA, 100 μM neocuproine (HEN), 50 mM NaCl, 0.1% (vol/vol) Nonidet
+P-40, 0.2% S-methylmethanethiosulfonate (MMTS) as a free thiol-blocking
+agent, 1 mM PMSF and protease inhibitors using Beadbeater (BioSpec). After
+centrifugation (20,000 × g, 4 °C, 20 min, ×2), SDS and
+MMTS were added to the supernatants to 2.5% and 0.2% respectively, and
+incubated at 50°C for 20 min. Proteins were precipitated with
+−20°C acetone, and re-dissolved in 1 mL of HEN, 1% SDS.
+Precipitation of proteins were repeated with −20°C acetone and
+the final pellets were resuspended in HEN, 1% SDS buffer, and protein
+concentrations were determined using the Bicinchoninic Acid (BCA) method.
+Total lysates (2 mg) were incubated with freshly prepared 50 mM ascorbate
+and 50 μl thiopropyl-Sepharose (50% slurry) and rotated end-over-end
+in the dark for 4 h. The bound SNO-proteins were sequentially washed with
+HEN, 1% SDS and then 10% HEN, 0.1% SDS buffers; SNO-proteins were eluted
+with 10% HEN, 1% SDS, 10% β-meracaptoethanol and analyzed by SDS/PAGE
+and immunoblotting.
+
+SNO-RAC was carried out as described previously 52. Mouse skeletal muscle and human
+skeletal muscle were manually homogenized in liquid nitrogen with mortar and
+pestle. Ground skeletal muscle or human adipose tissue were homogenized in
+lysis buffer (1 mg/5 μl lysis buffer) containing 100 mM Hepes, 1 mM
+EDTA, 100 μM neocuproine (HEN), 50 mM NaCl, 0.1% (vol/vol) Nonidet
+P-40, 0.2% S-methylmethanethiosulfonate (MMTS) as a free thiol-blocking
+agent, 1 mM PMSF and protease inhibitors using Beadbeater (BioSpec). After
+centrifugation (20,000 × g, 4 °C, 20 min, ×2), SDS and
+MMTS were added to the supernatants to 2.5% and 0.2% respectively, and
+incubated at 50°C for 20 min. Proteins were precipitated with
+−20°C acetone, and re-dissolved in 1 mL of HEN, 1% SDS.
+Precipitation of proteins were repeated with −20°C acetone and
+the final pellets were resuspended in HEN, 1% SDS buffer, and protein
+concentrations were determined using the Bicinchoninic Acid (BCA) method.
+Total lysates (2 mg) were incubated with freshly prepared 50 mM ascorbate
+and 50 μl thiopropyl-Sepharose (50% slurry) and rotated end-over-end
+in the dark for 4 h. The bound SNO-proteins were sequentially washed with
+HEN, 1% SDS and then 10% HEN, 0.1% SDS buffers; SNO-proteins were eluted
+with 10% HEN, 1% SDS, 10% β-meracaptoethanol and analyzed by SDS/PAGE
+and immunoblotting.
+
+In vitro S-nitrosylation assayFor in vitro assay of S-nitrosylation of HO2, two master tubes were
+prepared. The control reaction tube contained 5 μg of
+HO2–6xHis, 5 μg GST and 2000 μL assay buffer (phosphate
+buffer pH 7.0 supplemented with 100 μM EDTA, 100 μM DTPA and
+0.1% NP-40). The enzyme reaction tube contained 5 μg of
+HO2–6xHis, 5 μg SCAN and 2000 μL assay buffer. The
+master mixture was separated into 5 tubes (400 μl/tube). 20 μl
+of SNO-CoA dilutions (0, 2 μM, 20 μM, 200 μM or 2 mM)
+were added into pairs of control and enzyme tubes.For in vitro assay of S-nitrosylation of HO2 mediated by mutant
+SCAN, two master tubes were prepared. The control reaction tube contained 4
+μg of HO2–6xHis, 4 μg GST and 1600 μL assay
+buffer. The enzyme reaction tube contained 4 μg of HO2–6xHis,
+4 μg SCAN-QTG/NAA, SCAN-C109/188R and 1600 μL assay buffer.
+Master mixture was split into 4 assay tubes (400μl/each tube), and
+20μl SNO-CoA dilutions were added into individual tubes to final
+concentrations of 0, 20 μM, 200 μM or 2 mM. For in vitro
+S-nitrosylation of IRS1 and INSR, two master tubes were prepared. Control
+reaction tube contained 1 μg of IRS1-FLAG or 1 μg of
+INSR-FLAG, 5 μg GST and 2000 μL assay buffer. Enzyme reaction
+tube contained 1 μg IRS1-FLAG or 1 μg INSR-FLAG, 5 μg
+SCAN and 2000 μL assay buffer. The master mixture was equally
+separated into 5 tubes (400 μl/each tube). 20 μl SNO-CoA (0,
+20 μM, 200 μM, 2 mM or 4 mM) was respectively added into the
+tubes. Reaction tubes were incubated at 37°C for 30 minutes in the
+dark. Reactions were quenched by the addition of 3 volumes ice cold 100%
+acetone. Following quenching, 50 μL 2 μg/μL BSA was
+added to samples. Proteins were precipitated at −20°C for 30
+minutes, pelleted at 4500 g for 8 minutes, and washed 4X with 70% acetone.
+Protein pellets were resuspended in 300 μL HEN buffer containing 2.5%
+SDS and 0.3% MMTS. Resuspended proteins were processed by SNO-RAC as
+described above.
+
+In vitro S-nitrosylation assay
+
+For in vitro assay of S-nitrosylation of HO2, two master tubes were
+prepared. The control reaction tube contained 5 μg of
+HO2–6xHis, 5 μg GST and 2000 μL assay buffer (phosphate
+buffer pH 7.0 supplemented with 100 μM EDTA, 100 μM DTPA and
+0.1% NP-40). The enzyme reaction tube contained 5 μg of
+HO2–6xHis, 5 μg SCAN and 2000 μL assay buffer. The
+master mixture was separated into 5 tubes (400 μl/tube). 20 μl
+of SNO-CoA dilutions (0, 2 μM, 20 μM, 200 μM or 2 mM)
+were added into pairs of control and enzyme tubes.
+
+For in vitro assay of S-nitrosylation of HO2 mediated by mutant
+SCAN, two master tubes were prepared. The control reaction tube contained 4
+μg of HO2–6xHis, 4 μg GST and 1600 μL assay
+buffer. The enzyme reaction tube contained 4 μg of HO2–6xHis,
+4 μg SCAN-QTG/NAA, SCAN-C109/188R and 1600 μL assay buffer.
+Master mixture was split into 4 assay tubes (400μl/each tube), and
+20μl SNO-CoA dilutions were added into individual tubes to final
+concentrations of 0, 20 μM, 200 μM or 2 mM. For in vitro
+S-nitrosylation of IRS1 and INSR, two master tubes were prepared. Control
+reaction tube contained 1 μg of IRS1-FLAG or 1 μg of
+INSR-FLAG, 5 μg GST and 2000 μL assay buffer. Enzyme reaction
+tube contained 1 μg IRS1-FLAG or 1 μg INSR-FLAG, 5 μg
+SCAN and 2000 μL assay buffer. The master mixture was equally
+separated into 5 tubes (400 μl/each tube). 20 μl SNO-CoA (0,
+20 μM, 200 μM, 2 mM or 4 mM) was respectively added into the
+tubes. Reaction tubes were incubated at 37°C for 30 minutes in the
+dark. Reactions were quenched by the addition of 3 volumes ice cold 100%
+acetone. Following quenching, 50 μL 2 μg/μL BSA was
+added to samples. Proteins were precipitated at −20°C for 30
+minutes, pelleted at 4500 g for 8 minutes, and washed 4X with 70% acetone.
+Protein pellets were resuspended in 300 μL HEN buffer containing 2.5%
+SDS and 0.3% MMTS. Resuspended proteins were processed by SNO-RAC as
+described above.
+
+Glucose uptake measurementIn vitro glucose uptake measurement was performed as previously
+described 68. Naïve
+SCAN+/+ and SCAN−/− mice (5 male and
+5 female) per group were euthanized by isoflurane anesthesia. Soleus muscles
+were dissected tendon-to-tendon and rapidly rinsed in ice-cold 1X
+Krebs–Henseleit buffer. Muscles were recovered in vials including the
+recovery buffer (1X Krebs–Henseleit buffer, 0.1% BSA, 2 mM sodium
+pyruvate, 32 mM mannitol, 8 mM glucose supplemented with human-effective
+insulin dose (12 nM) or without insulin (basal)), shaken at 45 revolutions
+per minute while continuously gassed (95% O2–5%
+CO2) in a heated water bath (35°C) for 60 minutes.
+Muscles were subsequently washed twice for 10 minutes with at 35°C
+for 10 minutes in washing buffer (1X Krebs–Henseleit buffer, 0.1%
+BSA, 2mM sodium pyruvate and 32 mM Mannitol). Muscles were transferred to a
+vial containing 5 ml incubation buffer (1X Krebs–Henseleit buffer,
+0.1% BSA, 2 mM sodium pyruvate, 32 mM mannitol, 4 mM 2-deoxyglucose, 2
+μCi/ml 3H-2-deoxyglucose, and 0.3 μCi/ml
+14C-mannitol). Separate incubations were performed with
+insulin (12 nM) or without insulin (basal). Vials were shaken at 45
+revolutions per minute while continuously gassed (95%
+O2–5% CO2) in a heated water bath (35°C)
+for 20 minutes. Following this step, muscles were rinsed quickly in 1X
+Krebs–Henseleit buffer once and dried on filter paper and weighed.
+Muscle was digested with 1:10 (1 mg/10 μl) 1 M NaOH at 60°C
+for 1 hour. The samples were centrifuged 15,000 × g for 15 minutes at
+4°C. Supernatants (150 μl) were transferred to new tubes and
+neutralized with 150 μl of 1M HCl. Fifty μl of each
+neutralized sample was placed in a scintillation vial and the 3H
+and 14C counts determined in a scintillation counter
+(PerkinElmer). Extracellular volume was calculated using disintegrations per
+minute (DPM) of the 14C-mannitol, which is not membrane permeant.
+Intracellular 2-DG levels were then determined after accounting for
+3H DPM in the extracellular space, and 2-DG uptake rates were
+expressed as nmol 2-DG/100 mg muscle/20 minutes.
+
+Glucose uptake measurement
+
+In vitro glucose uptake measurement was performed as previously
+described 68. Naïve
+SCAN+/+ and SCAN−/− mice (5 male and
+5 female) per group were euthanized by isoflurane anesthesia. Soleus muscles
+were dissected tendon-to-tendon and rapidly rinsed in ice-cold 1X
+Krebs–Henseleit buffer. Muscles were recovered in vials including the
+recovery buffer (1X Krebs–Henseleit buffer, 0.1% BSA, 2 mM sodium
+pyruvate, 32 mM mannitol, 8 mM glucose supplemented with human-effective
+insulin dose (12 nM) or without insulin (basal)), shaken at 45 revolutions
+per minute while continuously gassed (95% O2–5%
+CO2) in a heated water bath (35°C) for 60 minutes.
+Muscles were subsequently washed twice for 10 minutes with at 35°C
+for 10 minutes in washing buffer (1X Krebs–Henseleit buffer, 0.1%
+BSA, 2mM sodium pyruvate and 32 mM Mannitol). Muscles were transferred to a
+vial containing 5 ml incubation buffer (1X Krebs–Henseleit buffer,
+0.1% BSA, 2 mM sodium pyruvate, 32 mM mannitol, 4 mM 2-deoxyglucose, 2
+μCi/ml 3H-2-deoxyglucose, and 0.3 μCi/ml
+14C-mannitol). Separate incubations were performed with
+insulin (12 nM) or without insulin (basal). Vials were shaken at 45
+revolutions per minute while continuously gassed (95%
+O2–5% CO2) in a heated water bath (35°C)
+for 20 minutes. Following this step, muscles were rinsed quickly in 1X
+Krebs–Henseleit buffer once and dried on filter paper and weighed.
+Muscle was digested with 1:10 (1 mg/10 μl) 1 M NaOH at 60°C
+for 1 hour. The samples were centrifuged 15,000 × g for 15 minutes at
+4°C. Supernatants (150 μl) were transferred to new tubes and
+neutralized with 150 μl of 1M HCl. Fifty μl of each
+neutralized sample was placed in a scintillation vial and the 3H
+and 14C counts determined in a scintillation counter
+(PerkinElmer). Extracellular volume was calculated using disintegrations per
+minute (DPM) of the 14C-mannitol, which is not membrane permeant.
+Intracellular 2-DG levels were then determined after accounting for
+3H DPM in the extracellular space, and 2-DG uptake rates were
+expressed as nmol 2-DG/100 mg muscle/20 minutes.
+
+Intraperitoneal glucose tolerance test (IPGTT), intraperitoneal insulin
+tolerance test (IPITT) and acute hypoglycemiaIPGTT and IPITT were performed according to the standard protocol of
+the International Mouse Phenotyping Consortium (https://www.mousephenotype.org). Mice
+were fasted for 16 hours for IPGTT or 5 hours for IPITT in clean cages with
+no food or feces in the bedding, in the standard light–dark cycle and
+with free access to water. Blood was collected from the tail tip directly
+onto a glucose test strip and read immediately using a calibrated
+glucometer. For IPGTT, glucose was injected i.p. at 2 g of glucose/kg of
+body weight. Blood drawn from sequential tail tip cuts was used to measure
+glucose at 15, 30, 60, 90 and 120 min after glucose injection. For IPITT,
+insulin was injected i.p at 1 unit insulin/kg of body weight. Glucose levels
+in tail tip blood were measured at 15, 30, 60, 90 and 120 min after insulin
+injection. Insulin-induced acute hypoglycemia (“severe” ITT)
+in mice was produced according to a published protocol 69. Insulin (2.5 units/kg body weight)
+was injected i.p. into 3 h-fasted mice, producing blood glucose <40
+mg/dl when measured at 90 min after injection and without leading to
+unconsciousness, seizures, or death. Blood glucose was measured before
+insulin injection and after 30, 90, 120,180 and 240 min via tail tip
+bleed.
+
+Intraperitoneal glucose tolerance test (IPGTT), intraperitoneal insulin
+tolerance test (IPITT) and acute hypoglycemia
+
+IPGTT and IPITT were performed according to the standard protocol of
+the International Mouse Phenotyping Consortium (https://www.mousephenotype.org). Mice
+were fasted for 16 hours for IPGTT or 5 hours for IPITT in clean cages with
+no food or feces in the bedding, in the standard light–dark cycle and
+with free access to water. Blood was collected from the tail tip directly
+onto a glucose test strip and read immediately using a calibrated
+glucometer. For IPGTT, glucose was injected i.p. at 2 g of glucose/kg of
+body weight. Blood drawn from sequential tail tip cuts was used to measure
+glucose at 15, 30, 60, 90 and 120 min after glucose injection. For IPITT,
+insulin was injected i.p at 1 unit insulin/kg of body weight. Glucose levels
+in tail tip blood were measured at 15, 30, 60, 90 and 120 min after insulin
+injection. Insulin-induced acute hypoglycemia (“severe” ITT)
+in mice was produced according to a published protocol 69. Insulin (2.5 units/kg body weight)
+was injected i.p. into 3 h-fasted mice, producing blood glucose <40
+mg/dl when measured at 90 min after injection and without leading to
+unconsciousness, seizures, or death. Blood glucose was measured before
+insulin injection and after 30, 90, 120,180 and 240 min via tail tip
+bleed.
+
+Insulin, bilirubin, free hemin, and blood testsBlood (50 μl) was collected from the mouse facial vein. To
+measure insulin, bilirubin and free hemin in serum, blood was placed in BD
+Microtainer tubes with Serum Separator, and centrifuged at 4°C at
+2000 × g for 10 min to obtain serum. Insulin
+concentration was measured following the protocol of Ultra Sensitive Mouse
+Insulin ELISA Kit (Crystal Chem). Mice were fasted for 5 hours prior to
+basal insulin measurement. Hematology analyses were performed using HESKA
+HemaTrue System. Blood was placed in heparin-treated 1.5ml microtube. Twenty
+μl blood was used for measurement of 17 parameters including total
+red blood cell count, total white blood cell count, total platelet count,
+hemoglobin concentration, lymphocyte percentage, mid-sized cells (e.g.,
+monocytes) percentage, and granulocyte percentage.
+
+Insulin, bilirubin, free hemin, and blood tests
+
+Blood (50 μl) was collected from the mouse facial vein. To
+measure insulin, bilirubin and free hemin in serum, blood was placed in BD
+Microtainer tubes with Serum Separator, and centrifuged at 4°C at
+2000 × g for 10 min to obtain serum. Insulin
+concentration was measured following the protocol of Ultra Sensitive Mouse
+Insulin ELISA Kit (Crystal Chem). Mice were fasted for 5 hours prior to
+basal insulin measurement. Hematology analyses were performed using HESKA
+HemaTrue System. Blood was placed in heparin-treated 1.5ml microtube. Twenty
+μl blood was used for measurement of 17 parameters including total
+red blood cell count, total white blood cell count, total platelet count,
+hemoglobin concentration, lymphocyte percentage, mid-sized cells (e.g.,
+monocytes) percentage, and granulocyte percentage.
+
+Insulin treatmentFor L6 cell treatment, L6 cells at 50–70% confluence on 10 cm
+plates were starved in DMEM medium (+5% BSA) for 16 hours. Human insulin was
+added into medium to 100 nM final. Following 10-minute insulin treatment,
+cells were washed three times using warm 1X PBS, and complete DMEM medium
+(+10% FBS and 1% Pen-Strep) was added. L6 cells were collected at 1, 30, 60,
+120 and 240 minutes after media change and stored −80°C. For
+mouse treatment, human insulin (1 U/kg body weight) was intraperitoneally
+injected into mice that had been fasted for five hours. After 30 or 60
+minutes, mice were euthanized by isoflurane anesthesia. Skeletal muscle
+(lateral gastrocnemius) was collected and quickly frozen in liquid
+nitrogen.
+
+Insulin treatment
+
+For L6 cell treatment, L6 cells at 50–70% confluence on 10 cm
+plates were starved in DMEM medium (+5% BSA) for 16 hours. Human insulin was
+added into medium to 100 nM final. Following 10-minute insulin treatment,
+cells were washed three times using warm 1X PBS, and complete DMEM medium
+(+10% FBS and 1% Pen-Strep) was added. L6 cells were collected at 1, 30, 60,
+120 and 240 minutes after media change and stored −80°C. For
+mouse treatment, human insulin (1 U/kg body weight) was intraperitoneally
+injected into mice that had been fasted for five hours. After 30 or 60
+minutes, mice were euthanized by isoflurane anesthesia. Skeletal muscle
+(lateral gastrocnemius) was collected and quickly frozen in liquid
+nitrogen.
+
+iTRAQ-Coupled SNO-RACiTRAQ-Coupled SNO-RAC was carried out as described previously
+5.
+HEK-BLVRB−/− and HEK-BLVRB+/+
+(control) lysates were prepared, and SNO-RAC (4 mg of protein per sample)
+was carried out as described above. SDS/PAGE gels were Coomassie-blue
+stained, and lanes were separated into eight segments top-to-bottom and
+collected in two 1.5 ml tubes. Five hundred μl of 50% acetonitrile
+(ACN)/50% 100 mM ammonium bicarbonate was used to wash gel bands for more
+than 5 hours while vortexing. After removal of washing buffer, 400 μl
+of 100% acetonitrile was added to gel pieces and vortexed for 10 min. After
+removal of ACN, gel pieces were dried in a speed vacuum dryer for 10 min.
+Two hundred μl of 10 mM dithiothreitol (DTT) was added to dry gel
+pieces and vortexed for 45 min. After removal of DTT buffer, 200 μl
+of 55 mM iodoacetamide (IAA) was added to the gel pieces and incubated for
+45 min in the dark. After removal of IAA buffer, 400 μl of 1x iTRAQ
+dissolution solution and 400 μl ACN were used to wash the gel pieces
+twice. Gel pieces were dried for 10 min in a speed vacuum dryer. 500 ng
+trypsin in 150 μl 1x iTRAQ buffer was added to dried gel pieces on
+ice for 30 mins to rehydrate, and then incubated overnight at 37°C.
+Supernatant from the digested protein solution was transferred to a 1.5 ml
+tube using gel-loading tips. 200 μl extraction buffer (60% ACN/5%
+formic acid) were added to gel pieces, vortexed for 30 min, and sonicated
+for 15 min. The supernatant containing peptide extracts was transferred to
+the same 1.5 ml tube, and extractions were repeated two more times. The
+final digested solution pool was dried completely in a speed vacuum
+dryer.iTRAQ labeling was performed according to the instructions of iTRAQ
+Reagents - 4plex Applications Kit. Briefly, 30 μl of iTRAQ
+dissolution buffer (10x) was added to each sample tube (pH > 7), and
+then one iTraq labeling reagent (mass 114, 115, 116 or 117) was added to
+individual sample tubes. Reactions were incubated for more than 5 hours at
+room temperature with vortexing to ensure complete labeling. The four
+labeled samples were mixed together and dried. One hundred sixty μl
+of 5% ACN containing 0.5% TFA was added to the labeled sample mix, and the
+solution cleaned using C18 ziptips. Briefly, C18 tips were wetted 5 times
+with 20 μl of 50% ACN, and equilibrated with 100 μl of 5% ACN
+containing 0.5% TFA. Samples were then loaded to the tip by drawing and
+expelling 50 cycles to ensure complete binding. The tips were then washed
+with 20 μl of 5% ACN containing 0.5% TFA 10 times. Peptides were
+eluted from tips in 3× 20 μl of 60% ACN containing 0.1% formic
+acid, and eluates combined and dried for LC-MS/MS Analysis.
+
+iTRAQ-Coupled SNO-RAC
+
+iTRAQ-Coupled SNO-RAC was carried out as described previously
+5.
+HEK-BLVRB−/− and HEK-BLVRB+/+
+(control) lysates were prepared, and SNO-RAC (4 mg of protein per sample)
+was carried out as described above. SDS/PAGE gels were Coomassie-blue
+stained, and lanes were separated into eight segments top-to-bottom and
+collected in two 1.5 ml tubes. Five hundred μl of 50% acetonitrile
+(ACN)/50% 100 mM ammonium bicarbonate was used to wash gel bands for more
+than 5 hours while vortexing. After removal of washing buffer, 400 μl
+of 100% acetonitrile was added to gel pieces and vortexed for 10 min. After
+removal of ACN, gel pieces were dried in a speed vacuum dryer for 10 min.
+Two hundred μl of 10 mM dithiothreitol (DTT) was added to dry gel
+pieces and vortexed for 45 min. After removal of DTT buffer, 200 μl
+of 55 mM iodoacetamide (IAA) was added to the gel pieces and incubated for
+45 min in the dark. After removal of IAA buffer, 400 μl of 1x iTRAQ
+dissolution solution and 400 μl ACN were used to wash the gel pieces
+twice. Gel pieces were dried for 10 min in a speed vacuum dryer. 500 ng
+trypsin in 150 μl 1x iTRAQ buffer was added to dried gel pieces on
+ice for 30 mins to rehydrate, and then incubated overnight at 37°C.
+Supernatant from the digested protein solution was transferred to a 1.5 ml
+tube using gel-loading tips. 200 μl extraction buffer (60% ACN/5%
+formic acid) were added to gel pieces, vortexed for 30 min, and sonicated
+for 15 min. The supernatant containing peptide extracts was transferred to
+the same 1.5 ml tube, and extractions were repeated two more times. The
+final digested solution pool was dried completely in a speed vacuum
+dryer.
+
+iTRAQ labeling was performed according to the instructions of iTRAQ
+Reagents - 4plex Applications Kit. Briefly, 30 μl of iTRAQ
+dissolution buffer (10x) was added to each sample tube (pH > 7), and
+then one iTraq labeling reagent (mass 114, 115, 116 or 117) was added to
+individual sample tubes. Reactions were incubated for more than 5 hours at
+room temperature with vortexing to ensure complete labeling. The four
+labeled samples were mixed together and dried. One hundred sixty μl
+of 5% ACN containing 0.5% TFA was added to the labeled sample mix, and the
+solution cleaned using C18 ziptips. Briefly, C18 tips were wetted 5 times
+with 20 μl of 50% ACN, and equilibrated with 100 μl of 5% ACN
+containing 0.5% TFA. Samples were then loaded to the tip by drawing and
+expelling 50 cycles to ensure complete binding. The tips were then washed
+with 20 μl of 5% ACN containing 0.5% TFA 10 times. Peptides were
+eluted from tips in 3× 20 μl of 60% ACN containing 0.1% formic
+acid, and eluates combined and dried for LC-MS/MS Analysis.
+
+LC-MS/MS AnalysisDigested peptides were separated by UPLC (Waters, Milford, MA) with
+a Nano-ACQUITY UPLC BEH300 C18 column. Separated peptides were continuously
+injected into an Orbitrap Elite hybrid mass spectrometer (Thermo Finnigan,
+San Jose, CA) by a nanospray emitter (10 μm, New Objective). Peptides
+were eluted using a linear gradient using mobile phase A (0.1% formic acid
+in water) and B (100% acetonitrile) was used at a flow rate of 0.3
+μl/min, starting with 1% mobile phase B and increasing to 40% B at 65
+min for protein interaction identification, or increasing to 40% B at 130
+min for iTRAQ experiments. All mass spectrometry data were acquired in
+positive ion mode. For protein interaction identification, a full MS scan
+(m/z 350–1800) at resolution of 120,000 was conducted, twenty MS2
+scans (m/z 350–1800) were selected using the twenty most intense
+peptide peaks of full MS scans. CID cleavage mode was performed at
+normalized collision energy of 35%. For iTRAQ experiments, a full MS scan
+(m/z 300–1800) at resolution of 120,000 was conducted, and ten MS2
+scans (m/z 100–1600) were activated from the five most intense
+peptide peaks of full MS scans. CID and HCD cleavage modes were performed
+alternatively of the same peptides selected from full MS scans. MS2
+resolution of HCD is 15,000. Bioinformatic software MassMatrix was used to
+search MS data against a database composed of sequences of mouse proteins
+from Uniprot and their reversed sequences as a decoy database. Modifications
+including oxidation of methionine and labeling of cysteine (IA
+modifications) were selected as variable modifications in searching. For
+iTRAQ labeling searching, MS tag of N terminus, Lys and/or Tyr were selected
+as variable modification to test labeling efficiency and fixed modification
+for iTRAQ quantitation analysis. Trypsin was selected as the in-silico
+enzyme to cleave proteins after Lys and Arg. Precursor ion searching was
+within 10 ppm mass accuracy and product ions within 0.8 Da for CID cleavage
+mode and 0.02 Da for HCD cleavage mode. 95% confidence interval was required
+for protein identification.
+
+LC-MS/MS Analysis
+
+Digested peptides were separated by UPLC (Waters, Milford, MA) with
+a Nano-ACQUITY UPLC BEH300 C18 column. Separated peptides were continuously
+injected into an Orbitrap Elite hybrid mass spectrometer (Thermo Finnigan,
+San Jose, CA) by a nanospray emitter (10 μm, New Objective). Peptides
+were eluted using a linear gradient using mobile phase A (0.1% formic acid
+in water) and B (100% acetonitrile) was used at a flow rate of 0.3
+μl/min, starting with 1% mobile phase B and increasing to 40% B at 65
+min for protein interaction identification, or increasing to 40% B at 130
+min for iTRAQ experiments. All mass spectrometry data were acquired in
+positive ion mode. For protein interaction identification, a full MS scan
+(m/z 350–1800) at resolution of 120,000 was conducted, twenty MS2
+scans (m/z 350–1800) were selected using the twenty most intense
+peptide peaks of full MS scans. CID cleavage mode was performed at
+normalized collision energy of 35%. For iTRAQ experiments, a full MS scan
+(m/z 300–1800) at resolution of 120,000 was conducted, and ten MS2
+scans (m/z 100–1600) were activated from the five most intense
+peptide peaks of full MS scans. CID and HCD cleavage modes were performed
+alternatively of the same peptides selected from full MS scans. MS2
+resolution of HCD is 15,000. Bioinformatic software MassMatrix was used to
+search MS data against a database composed of sequences of mouse proteins
+from Uniprot and their reversed sequences as a decoy database. Modifications
+including oxidation of methionine and labeling of cysteine (IA
+modifications) were selected as variable modifications in searching. For
+iTRAQ labeling searching, MS tag of N terminus, Lys and/or Tyr were selected
+as variable modification to test labeling efficiency and fixed modification
+for iTRAQ quantitation analysis. Trypsin was selected as the in-silico
+enzyme to cleave proteins after Lys and Arg. Precursor ion searching was
+within 10 ppm mass accuracy and product ions within 0.8 Da for CID cleavage
+mode and 0.02 Da for HCD cleavage mode. 95% confidence interval was required
+for protein identification.
+
+ImmunoprecipitationTo investigate the interaction of SCAN and IRS1, Myc-SCAN and
+IRS1-Flag were co-expressed in HEK293 cells. To investigate the effect of
+insulin stimulation, disruption of SNO-CoA binding, mutation of SNO site
+C109/188 and of SCoR, Myc-SCAN, Myc-SCAN-QTG/NAA or Myc-SCAN-C109/188R were
+co-expressed with INSR-Flag in parental or SCoR-knockout HEK cells or L6
+cells. HEK cells or L6 cells were treated with NO donor DPTA (200μM)
+for 20 hours as required. Anti-rabbit C-Myc Agarose Affinity Gel (Sigma) was
+used for immunoprecipitation. To investigate the interaction of endogenous
+SCAN with HO2 or INSR, 10 μg of BLVRB Rabbit monoclonal antibody
+(Sino Biological) was incubated with 50 μl of Protein G Sepharose
+(GE) (1:1 slurry) at 4°C overnight, then washed with NETN buffer (150
+mM NaCl, 20 mM Tris-Cl (pH 8.0), 0.5 mM EDTA, 0.5% (v/v) Nonidet P-40) three
+times to prepare for immunoprecipitation. HEK cells or L6 cells were
+homogenized in EBC lysis buffer (120 mM NaCl, 20 mM Tris-Cl (pH 8.0), 0.5 mM
+EDTA, 0.5% (v/v) NP-40, 1 mM PMSF and protease inhibitor cocktail). After
+centrifugation (20,000 × g, 4°C, 20 min, ×2), 2 ml (2
+mg/ml) supernatant was pre-cleared by incubation with 50 μl Protein G
+Sepharose (1:1 slurry) for 1 hour at 4 °C. After spinning at 1000
+× g for 1 min, the supernatant was transferred into new tubes and
+incubated with 50 μl anti BLVRB antibody-Protein G Sepharose or with
+anti c-Myc-Agarose (1:1 slurry) for 5 hours at 4°C. Beads were washed
+by NETN buffer and proteins were eluted with 50 μl 1X SDS loading dye
+containing 5% 2-mercaptoethanol. Eluted proteins were electrophoresed in
+4–20% Criterion Precast Midi Protein Gels (Bio Rad), transferred to
+PVDF membranes, and membranes were blotted with mouse Flag antibody, HO2
+antibody or INSR antibody.
+
+Immunoprecipitation
+
+To investigate the interaction of SCAN and IRS1, Myc-SCAN and
+IRS1-Flag were co-expressed in HEK293 cells. To investigate the effect of
+insulin stimulation, disruption of SNO-CoA binding, mutation of SNO site
+C109/188 and of SCoR, Myc-SCAN, Myc-SCAN-QTG/NAA or Myc-SCAN-C109/188R were
+co-expressed with INSR-Flag in parental or SCoR-knockout HEK cells or L6
+cells. HEK cells or L6 cells were treated with NO donor DPTA (200μM)
+for 20 hours as required. Anti-rabbit C-Myc Agarose Affinity Gel (Sigma) was
+used for immunoprecipitation. To investigate the interaction of endogenous
+SCAN with HO2 or INSR, 10 μg of BLVRB Rabbit monoclonal antibody
+(Sino Biological) was incubated with 50 μl of Protein G Sepharose
+(GE) (1:1 slurry) at 4°C overnight, then washed with NETN buffer (150
+mM NaCl, 20 mM Tris-Cl (pH 8.0), 0.5 mM EDTA, 0.5% (v/v) Nonidet P-40) three
+times to prepare for immunoprecipitation. HEK cells or L6 cells were
+homogenized in EBC lysis buffer (120 mM NaCl, 20 mM Tris-Cl (pH 8.0), 0.5 mM
+EDTA, 0.5% (v/v) NP-40, 1 mM PMSF and protease inhibitor cocktail). After
+centrifugation (20,000 × g, 4°C, 20 min, ×2), 2 ml (2
+mg/ml) supernatant was pre-cleared by incubation with 50 μl Protein G
+Sepharose (1:1 slurry) for 1 hour at 4 °C. After spinning at 1000
+× g for 1 min, the supernatant was transferred into new tubes and
+incubated with 50 μl anti BLVRB antibody-Protein G Sepharose or with
+anti c-Myc-Agarose (1:1 slurry) for 5 hours at 4°C. Beads were washed
+by NETN buffer and proteins were eluted with 50 μl 1X SDS loading dye
+containing 5% 2-mercaptoethanol. Eluted proteins were electrophoresed in
+4–20% Criterion Precast Midi Protein Gels (Bio Rad), transferred to
+PVDF membranes, and membranes were blotted with mouse Flag antibody, HO2
+antibody or INSR antibody.
+
+Western blot analysisProteins were extracted from cells using sonication in RIPA buffer
+(Sigma) supplemented with 1 mM PMSF, protease inhibitor cocktail and
+phosphatase inhibitor cocktail. Muscle samples were ground with a mortar and
+pestle under liquid nitrogen, then the powder added to RIPA buffer as above,
+and mechanically homogenized using a bead beater. Extracts were clarified by
+centrifugation (20,000 × g, 4°C, 20 min, ×2), and
+protein concentration was determined by bicinchoninic acid assay. The
+extracts were electrophoresed in 4–20% Criterion Precast Midi Protein
+Gels and transferred to PVDF membranes. Membranes were incubated overnight
+at 4°C with primary antibodies, washed with PBS containing 0.1%
+Tween-20, incubated with HRP-conjugated secondary antibody for 1 hour,
+washed, and detected by chemiluminescent detection (ECL) using X-ray film
+developer system (JPI, Filmprocessor) or a digital imager system
+(Kwikquant). Antibodies employed in western blotting included: rabbit
+polyclonal rabbit Anti-BLVRB (13151-R009, Sino Biological Inc), mouse
+monoclonal Anti-HO2 (H00003163, Abnova), rabbit polyclonal Anti-IRS1
+(06–248, EMD Millipore), rabbit polyclonal Anti-INSRβ (sc-711,
+Santa Cruz), rabbit monoclonal Anti-INSRβ (phospho-Y1163,1164)
+(MA5–15148, Invitrogen), rabbit Anti-IRS1 phospho-Tyr608 (09432, EMD
+Millipore), rabbit monoclonal Anti-NOS2 (D9A5L, Cell Signaling), rabbit
+Anti-eNOS (phospho-S1177) (PA597371, Invitrogen), rabbit monoclonal Anti-AKT
+(C67E7, Cell Signaling), rabbit Anti-AKT (phospho-S473) (9271, Cell
+Signaling), mouse monoclonal p97 (10R-P104A, Fitzgerald), rabbit monoclonal
+GAPDH (Ab181602, abcam), rabbit monoclonal Anti-AS160 (MA5–14840,
+Invitrogen), rabbit Anti-AS160 (phospho-T642) (44–1071G, Invitrogen)
+and mouse monoclonal FLAG-M2 (F3165, Sigma) (see Key Resources). Protein levels were quantified
+by semi-quantitative analysis from western blots using ImageJ (NIH).
+
+Western blot analysis
+
+Proteins were extracted from cells using sonication in RIPA buffer
+(Sigma) supplemented with 1 mM PMSF, protease inhibitor cocktail and
+phosphatase inhibitor cocktail. Muscle samples were ground with a mortar and
+pestle under liquid nitrogen, then the powder added to RIPA buffer as above,
+and mechanically homogenized using a bead beater. Extracts were clarified by
+centrifugation (20,000 × g, 4°C, 20 min, ×2), and
+protein concentration was determined by bicinchoninic acid assay. The
+extracts were electrophoresed in 4–20% Criterion Precast Midi Protein
+Gels and transferred to PVDF membranes. Membranes were incubated overnight
+at 4°C with primary antibodies, washed with PBS containing 0.1%
+Tween-20, incubated with HRP-conjugated secondary antibody for 1 hour,
+washed, and detected by chemiluminescent detection (ECL) using X-ray film
+developer system (JPI, Filmprocessor) or a digital imager system
+(Kwikquant). Antibodies employed in western blotting included: rabbit
+polyclonal rabbit Anti-BLVRB (13151-R009, Sino Biological Inc), mouse
+monoclonal Anti-HO2 (H00003163, Abnova), rabbit polyclonal Anti-IRS1
+(06–248, EMD Millipore), rabbit polyclonal Anti-INSRβ (sc-711,
+Santa Cruz), rabbit monoclonal Anti-INSRβ (phospho-Y1163,1164)
+(MA5–15148, Invitrogen), rabbit Anti-IRS1 phospho-Tyr608 (09432, EMD
+Millipore), rabbit monoclonal Anti-NOS2 (D9A5L, Cell Signaling), rabbit
+Anti-eNOS (phospho-S1177) (PA597371, Invitrogen), rabbit monoclonal Anti-AKT
+(C67E7, Cell Signaling), rabbit Anti-AKT (phospho-S473) (9271, Cell
+Signaling), mouse monoclonal p97 (10R-P104A, Fitzgerald), rabbit monoclonal
+GAPDH (Ab181602, abcam), rabbit monoclonal Anti-AS160 (MA5–14840,
+Invitrogen), rabbit Anti-AS160 (phospho-T642) (44–1071G, Invitrogen)
+and mouse monoclonal FLAG-M2 (F3165, Sigma) (see Key Resources). Protein levels were quantified
+by semi-quantitative analysis from western blots using ImageJ (NIH).
+
+Identification of SNO site of INSR by mass spectrometryThe pcDNA-INSR-FLAG plasmid (GenScript) was transfected into HEK293
+cells using PolyJet. Cells were harvested and lysed in EBC lysis buffer.
+INSR-FLAG was purified from lysate with anti-FLAG M2 affinity gel (Sigma)
+and eluted with 100 mM phosphate buffer, pH 7.4 containing 100 μg/mL
+FLAG peptide (Sigma), 100 μM EDTA and 100 μM DTPA. Purified
+INSR was subsequently treated with 100 μM freshly prepared SNO-CoA
+for 20 minutes at room temperature in the dark. Following treatment with
+SNO-CoA, protein was supplemented with 100 μg bovine serum albumin
+carrier, mixed with 3 volumes ice cold 100% acetone, and kept at
+−20°C for 30 minutes. Following cold incubation, the sample
+was spun at 14000 × g for 15 minutes to precipitate protein. Pelleted
+protein was washed 3 times with ice cold 70% acetone, air dried, and
+resuspended in 400 μL of HENS buffer. Unreacted SNO-CoA was removed
+using Zeba desalting spin columns (Thermo Fisher) preequilibrated with HENS
+buffer. Following filtration, 1 M MMTS and 25% SDS were added into the
+protein solution (final 20mM MMTS and 2.5% SDS) and the solution was
+vortexed. The solution was incubated for 20 minutes at 50°C to block
+free thiols. Protein was again precipitated with 3 volumes ice cold 100%
+acetone with incubation for 1 hour at −20°C. Following
+incubation, precipitated proteins were collected by centrifugation at 10000
+× g for 10 minutes at 4°C. Supernatant was removed from
+precipitated protein pellets, and pellets allowed to dry at room temperature
+for 10 minutes. Proteins were resuspended in HENS buffer and labeled with
+iodoTMT (Thermo Fisher) in the presence of 20 mM sodium ascorbate for 1 hour
+at room temperature in the dark. Reactions were quenched with 20 mM DTT for
+15 minutes at room temperature in the dark. Protein was precipitated with 3
+volumes ice cold 100% acetone at −20°C for 1 hour, then
+centrifuged at 10000 × g for 10 minutes at 4°C. Supernatant
+was removed, and the protein pellet dried for 10 minutes. Protein was
+resuspended in HENS buffer and treated with 16.67 mM iodoacetamide for 1
+hour at room temperature in the dark. Protein was again precipitated as
+above, supernatant removed, and protein pellet dried. Precipitated protein
+was then resuspended in 50 mM ammonium bicarbonate buffer, pH 8.0. Proteins
+were then serially digested with 25 μg/mg protein using Lys-c (4
+hours at 37°C) then 20 μg/mg protein using trypsin overnight
+at 37°C. Following digestion, samples were acidified with 25
+μL of 10% TFA. Peptides were processed through a C18 SPE column and
+then frozen and lyophilized. Lyophilized peptides were resuspended in TBS
+and enriched using anti-TMT resin (Thermo Fisher) following the
+manufacturer’s instructions, and subsequently frozen and lyophilized.
+Samples were resuspended in 5% acetonitrile, 0.1% formic acid and run
+through a 0.22 μm filter to remove any excess anti-TMT resin.
+Peptides were then injected into LC-MS/MS system for analysis.
+
+Identification of SNO site of INSR by mass spectrometry
+
+The pcDNA-INSR-FLAG plasmid (GenScript) was transfected into HEK293
+cells using PolyJet. Cells were harvested and lysed in EBC lysis buffer.
+INSR-FLAG was purified from lysate with anti-FLAG M2 affinity gel (Sigma)
+and eluted with 100 mM phosphate buffer, pH 7.4 containing 100 μg/mL
+FLAG peptide (Sigma), 100 μM EDTA and 100 μM DTPA. Purified
+INSR was subsequently treated with 100 μM freshly prepared SNO-CoA
+for 20 minutes at room temperature in the dark. Following treatment with
+SNO-CoA, protein was supplemented with 100 μg bovine serum albumin
+carrier, mixed with 3 volumes ice cold 100% acetone, and kept at
+−20°C for 30 minutes. Following cold incubation, the sample
+was spun at 14000 × g for 15 minutes to precipitate protein. Pelleted
+protein was washed 3 times with ice cold 70% acetone, air dried, and
+resuspended in 400 μL of HENS buffer. Unreacted SNO-CoA was removed
+using Zeba desalting spin columns (Thermo Fisher) preequilibrated with HENS
+buffer. Following filtration, 1 M MMTS and 25% SDS were added into the
+protein solution (final 20mM MMTS and 2.5% SDS) and the solution was
+vortexed. The solution was incubated for 20 minutes at 50°C to block
+free thiols. Protein was again precipitated with 3 volumes ice cold 100%
+acetone with incubation for 1 hour at −20°C. Following
+incubation, precipitated proteins were collected by centrifugation at 10000
+× g for 10 minutes at 4°C. Supernatant was removed from
+precipitated protein pellets, and pellets allowed to dry at room temperature
+for 10 minutes. Proteins were resuspended in HENS buffer and labeled with
+iodoTMT (Thermo Fisher) in the presence of 20 mM sodium ascorbate for 1 hour
+at room temperature in the dark. Reactions were quenched with 20 mM DTT for
+15 minutes at room temperature in the dark. Protein was precipitated with 3
+volumes ice cold 100% acetone at −20°C for 1 hour, then
+centrifuged at 10000 × g for 10 minutes at 4°C. Supernatant
+was removed, and the protein pellet dried for 10 minutes. Protein was
+resuspended in HENS buffer and treated with 16.67 mM iodoacetamide for 1
+hour at room temperature in the dark. Protein was again precipitated as
+above, supernatant removed, and protein pellet dried. Precipitated protein
+was then resuspended in 50 mM ammonium bicarbonate buffer, pH 8.0. Proteins
+were then serially digested with 25 μg/mg protein using Lys-c (4
+hours at 37°C) then 20 μg/mg protein using trypsin overnight
+at 37°C. Following digestion, samples were acidified with 25
+μL of 10% TFA. Peptides were processed through a C18 SPE column and
+then frozen and lyophilized. Lyophilized peptides were resuspended in TBS
+and enriched using anti-TMT resin (Thermo Fisher) following the
+manufacturer’s instructions, and subsequently frozen and lyophilized.
+Samples were resuspended in 5% acetonitrile, 0.1% formic acid and run
+through a 0.22 μm filter to remove any excess anti-TMT resin.
+Peptides were then injected into LC-MS/MS system for analysis.
+
+Purification of proteinsThe recombinant HO2, SCAN-WT or SCAN-QTG-NAA proteins were purified
+from BL21-CodonPlus Competent E. coli cells (Agilent).
+Overnight E. coli cultures were sub-cultured into 1 L of LB
+medium at 5%. At OD600 of 0.5, cultures were induced with 100 mM IPTG and
+grown 4 hours at 28°C. Cultures were centrifuged at 4000 × g
+for 10 min to harvest the cells. Cell pellets from 1 L cultures were lysed
+by sonication in 10 mL of PBS buffer containing 1 mM PMSF and
+protease-inhibitor cocktail. After centrifugation at 14500 × g for 20
+min, the supernatant was collected and diluted (up to 30 ml) with PBS buffer
+containing 1 mM PMSF and protease-inhibitor cocktail. This lysate was
+incubated with 1 mL of Ni-NTA agarose at 4°C for 1 hour with
+rotation. The slurry was then poured into an empty PD-10 column (GE
+Healthcare), and the beads washed with 100 mL of 50 mM
+NaH2PO4, 300 mM NaCl buffer containing 20 mM
+imidazole. Elution was done with 2 mL of 50 mM
+NaH2PO4, 300 mM NaCl, 250 mM imidazole. Eluate buffer
+was exchanged with modified Roeder D [(20mM HEPES (pH 7.9), 20% (v/v)
+glycerol, 0.1M KCL, 0.2mM EDTA)] using a Microcon centrifugal filter device
+(Millipore).IRS1-FLAG and INSR-FLAG were purified from HEK cells. Briefly, HEK
+cells were transfected with pcDNA-Flag-hIRS1 or pcDNA-Flag-hINSR plasmid
+using PolyJet transfection reagent (SignaGen) per manufacturer’s
+instructions and grown for 48 hours. After 48 hours, cells were harvested in
+IP wash buffer (as above) supplemented with 0.5% Triton X-100 and protease
+inhibitor cocktail. Cells were lysed by sonication and lysate clarified by
+centrifugation at 15000 × g for 15 minutes. Anti-FLAG agarose
+affinity gel was equilibrated into IP wash buffer, and clarified lysate was
+applied to anti-FLAG agarose affinity gel. After 4 hours incubation in
+4°C, beads were washed 5 times with IP wash buffer. Proteins were
+eluted in 300μL 1xPBS containing 100 μg/mL 3X FLAG peptide.
+Protein concentration was determined using BCA.
+
+Purification of proteins
+
+The recombinant HO2, SCAN-WT or SCAN-QTG-NAA proteins were purified
+from BL21-CodonPlus Competent E. coli cells (Agilent).
+Overnight E. coli cultures were sub-cultured into 1 L of LB
+medium at 5%. At OD600 of 0.5, cultures were induced with 100 mM IPTG and
+grown 4 hours at 28°C. Cultures were centrifuged at 4000 × g
+for 10 min to harvest the cells. Cell pellets from 1 L cultures were lysed
+by sonication in 10 mL of PBS buffer containing 1 mM PMSF and
+protease-inhibitor cocktail. After centrifugation at 14500 × g for 20
+min, the supernatant was collected and diluted (up to 30 ml) with PBS buffer
+containing 1 mM PMSF and protease-inhibitor cocktail. This lysate was
+incubated with 1 mL of Ni-NTA agarose at 4°C for 1 hour with
+rotation. The slurry was then poured into an empty PD-10 column (GE
+Healthcare), and the beads washed with 100 mL of 50 mM
+NaH2PO4, 300 mM NaCl buffer containing 20 mM
+imidazole. Elution was done with 2 mL of 50 mM
+NaH2PO4, 300 mM NaCl, 250 mM imidazole. Eluate buffer
+was exchanged with modified Roeder D [(20mM HEPES (pH 7.9), 20% (v/v)
+glycerol, 0.1M KCL, 0.2mM EDTA)] using a Microcon centrifugal filter device
+(Millipore).
+
+IRS1-FLAG and INSR-FLAG were purified from HEK cells. Briefly, HEK
+cells were transfected with pcDNA-Flag-hIRS1 or pcDNA-Flag-hINSR plasmid
+using PolyJet transfection reagent (SignaGen) per manufacturer’s
+instructions and grown for 48 hours. After 48 hours, cells were harvested in
+IP wash buffer (as above) supplemented with 0.5% Triton X-100 and protease
+inhibitor cocktail. Cells were lysed by sonication and lysate clarified by
+centrifugation at 15000 × g for 15 minutes. Anti-FLAG agarose
+affinity gel was equilibrated into IP wash buffer, and clarified lysate was
+applied to anti-FLAG agarose affinity gel. After 4 hours incubation in
+4°C, beads were washed 5 times with IP wash buffer. Proteins were
+eluted in 300μL 1xPBS containing 100 μg/mL 3X FLAG peptide.
+Protein concentration was determined using BCA.
+
+Tyrosine kinase activityTyrosine kinase activity of INSR was measured using InsR Kinase
+Enzyme System-coupled with ADP-Glo™ Assay (Promega). To
+purify the INSR-FLAG from HEK cells, the same procedure was used in above
+“Purification of proteins” except INSR-FLAG complex was eluted
+in 200μL reaction buffer A (provided in InsR Kinase Enzyme System)
+containing 100 μg/mL 3X FLAG peptide and 2mM MnCl2. Ten
+μl (100ng/μl) purified INSR-FLAG complex was treated with
+control Tris buffer or 500 μM SNO-CoA (5 μl) for 30 min at
+37°C. Ten μl AxLtide (substrate, 1mg/ml)+ATP (125 μM)
+mixture was added into the reaction. After 60 min incubation at 25°C,
+25 μl ADP-Glo™ Reagent was added into the reaction.
+Fifty μl kinase detection reagent was added after 40 min incubation
+at 25°C, and the luminescence read after 30 min incubation at
+25°C in a Promega GloMax Luminometer.
+
+Tyrosine kinase activity
+
+Tyrosine kinase activity of INSR was measured using InsR Kinase
+Enzyme System-coupled with ADP-Glo™ Assay (Promega). To
+purify the INSR-FLAG from HEK cells, the same procedure was used in above
+“Purification of proteins” except INSR-FLAG complex was eluted
+in 200μL reaction buffer A (provided in InsR Kinase Enzyme System)
+containing 100 μg/mL 3X FLAG peptide and 2mM MnCl2. Ten
+μl (100ng/μl) purified INSR-FLAG complex was treated with
+control Tris buffer or 500 μM SNO-CoA (5 μl) for 30 min at
+37°C. Ten μl AxLtide (substrate, 1mg/ml)+ATP (125 μM)
+mixture was added into the reaction. After 60 min incubation at 25°C,
+25 μl ADP-Glo™ Reagent was added into the reaction.
+Fifty μl kinase detection reagent was added after 40 min incubation
+at 25°C, and the luminescence read after 30 min incubation at
+25°C in a Promega GloMax Luminometer.
+
+ImmunostainingHEK293 cells were grown in 2 mL culture medium to approximately 50%
+confluency on cover slips in 6-well plates. For studying insulin
+stimulation, cells were starved in DMEM medium (+5% BSA) for 16 hours. Human
+insulin was added into medium to 100 nM final concentration for 10min. Media
+was aspirated, and 1mL cold 4% PFA in PBS was used to fix cells for 15 min
+at room temperature. After each incubation step, cells were washed 3x with
+PBS. Cells were permeabilized with PBS +.05% Triton X100 for 5 min, washed,
+blocked with 8% BSA in PBS for 20min, washed and incubated with primary
+antibodies diluted in blocking buffer for 2 hours. Primary antibodies rabbit
+anti-SCAN (Sino Biological Inc), mouse anti-Cytochrome C (Cell Signaling)
+and mouse anti-AKR1A1 (Origene TA500740 clone 9F1) were used in
+immunostaining. After washing, secondary antibodies were added for 2 hours
+at room temperature. Secondary antibodies used were A11001 (Invitrogen,
+AF488 anti-mouse IgG at 1:1000) and A11036 (AF568 anti-rabbit IgG at
+1:1000). DAPI (Biotium, 5mg/ml) was used to stain nuclei. Samples were
+washed once again, mounted with Fluoromount G onto slides and imaged with a
+Nikon Eclipse Ti2 microscope using a 60x objective. TIFF images were
+processed in FIJI/ImageJ with the JaCoP plugin used to calculate
+Pearson’s and M1/M2 coefficients.
+
+Immunostaining
+
+HEK293 cells were grown in 2 mL culture medium to approximately 50%
+confluency on cover slips in 6-well plates. For studying insulin
+stimulation, cells were starved in DMEM medium (+5% BSA) for 16 hours. Human
+insulin was added into medium to 100 nM final concentration for 10min. Media
+was aspirated, and 1mL cold 4% PFA in PBS was used to fix cells for 15 min
+at room temperature. After each incubation step, cells were washed 3x with
+PBS. Cells were permeabilized with PBS +.05% Triton X100 for 5 min, washed,
+blocked with 8% BSA in PBS for 20min, washed and incubated with primary
+antibodies diluted in blocking buffer for 2 hours. Primary antibodies rabbit
+anti-SCAN (Sino Biological Inc), mouse anti-Cytochrome C (Cell Signaling)
+and mouse anti-AKR1A1 (Origene TA500740 clone 9F1) were used in
+immunostaining. After washing, secondary antibodies were added for 2 hours
+at room temperature. Secondary antibodies used were A11001 (Invitrogen,
+AF488 anti-mouse IgG at 1:1000) and A11036 (AF568 anti-rabbit IgG at
+1:1000). DAPI (Biotium, 5mg/ml) was used to stain nuclei. Samples were
+washed once again, mounted with Fluoromount G onto slides and imaged with a
+Nikon Eclipse Ti2 microscope using a 60x objective. TIFF images were
+processed in FIJI/ImageJ with the JaCoP plugin used to calculate
+Pearson’s and M1/M2 coefficients.
+
+QUANTIFICATION AND STATISTICAL ANALYSISStatistics were analyzed using GraphPad Prism 8. Comparisons between
+continuous characteristics of two subject groups were analyzed with two-tailed
+Student’s t-test. For comparisons among more than two groups, one-way
+ANOVA with Tukey post hoc or two-way ANOVA with Sidak’s multiple
+comparisons test were used. Simple linear regression was performed in comparing
+human samples. Bar graphs with the corresponding dot plots were created using
+GraphPad Prism. Results are presented as mean ± SD, and sample sizes or
+number of replicates are indicated in individual figure legends.
+
+QUANTIFICATION AND STATISTICAL ANALYSIS
+
+Statistics were analyzed using GraphPad Prism 8. Comparisons between
+continuous characteristics of two subject groups were analyzed with two-tailed
+Student’s t-test. For comparisons among more than two groups, one-way
+ANOVA with Tukey post hoc or two-way ANOVA with Sidak’s multiple
+comparisons test were used. Simple linear regression was performed in comparing
+human samples. Bar graphs with the corresponding dot plots were created using
+GraphPad Prism. Results are presented as mean ± SD, and sample sizes or
+number of replicates are indicated in individual figure legends.
+
+Supplementary MaterialSupplemental ReferencesSupplemental Tables S1-S5figs1Figure S1. Characterization of BLVRB/SCAN, Related to
+Figure 1. (A) Quantification of binding
+of BLVRB in HEK lysates to seven different types of resins, from Figure 1B upper; n=2. (B) Quantification
+of recombinant BLVRB protein binding to six different types of resins, from
+Figure 1B lower; n=2. (C)
+Recombinant BLVRB does not oxidize NADPH in the presence of SNO-CoA,
+indicating that NADPH-dependent SNO-CoA reductase activity is absent from
+BLVRB. SNO-CoA Reductase (SCoR) was used as positive control; n=5. (D)
+Recombinant BLVRB does not oxidize NADH in the presence of SNO-CoA,
+indicating that NADH-dependent SNO-CoA reductase activity is absent from
+BLVRB; n=5. (E) Immunostaining of SCAN and cytochrome C (mitochondrial
+marker) in HEK cells, with DAPI nuclear staining. Overnight serum-starved
+HEK cells were treated by insulin for 10 min. (F) Expression of SCAN in
+three cellular fractions. ACADVL is a mitochondrial protein; GAPDH is a
+cytosolic protein; Histone3 is a nuclear protein.figs2Figure S2. SCAN/SNO-CoA-dependent S-nitrosylation of HO2,
+Related to
+Figure 1. (A) SNO-HO2 level in
+eNOS-overexpressing HEK cells in the absence or presence of NOS inhibitor
+(L-NMMA, 100 μM). Reaction without ascorbate (-Ascorbate) is used as
+a negative control; n=2. (B) SNO-HO2 level in LPS/interferon-induced
+RAW264.7 cells in the absence or presence of iNOS inhibitor (1400W,
+100μM); n=2. (C) SNO-HO2 in HEK cell lines overexpressing wild-type
+HO2 or four candidate SNO-site HO2 mutants (C127R, C265R, C282R or
+C265/282A); n=3. (D) Interaction between BLVRB and HO2 in HEK cells. Upper
+gel: IP of endogenous proteins with anti-rabbit BLVRB antibody or non-immune
+IgG; IB with anti-mouse HO2 antibody; n=2. Lower gel: interaction between
+expressed BLVRB and HO2 after treatment with the NO donor DPTA (200
+μM for 20 hours). Flag-HO2 and Myc-SCAN were co-expressed in HEK
+cells. IP with anti-rabbit myc antibody or non-immune IgG; probe with
+anti-mouse Flag antibody; n=2. (E) Molecular structures of SNO-CoA,
+SNO-cysteamine and NADPH. (F) S-nitrosylation of HO2 by recombinant SCAN and
+1 μM SNO-CoA in vitro in the presence of increasing
+NAPDH. (G) S-nitrosylation of HO2 by recombinant SCAN and 1 μM
+SNO-CoA in vitro in the presence of increasing NADH. (H)
+Quantification of SNO-HO2 in F and G; n=2. (I) Generation of SCAN-knockout
+HEK cell lines (HEK-SCAN−/−) using CRISPR-Cas9; 6
+lines are shown, and lines 2 and 5 (*) were used as knockout. (J) Generation
+of HEK-SCAN-WT (SCAN-WT) and HEK-SCAN-QTG/NAA (QTG/NAA) re-expressing cell
+lines from SCAN-deficient parental cells; 2 independent lines each are
+shown. (K) SNO-SCAN level in eNOS-overexpressing HEK cells in the absence or
+presence of NOS inhibitor (L-NMMA, 100 μM); n=2. (L) SNO-SCAN level
+in LPS/interferon-induced RAW264 cells in the absence or presence of iNOS
+inhibitor (1400W, 100μM); n=2. (M) Truncated HO2 forms, with retained
+residues indicated. All truncations still contain both SNO sites, C265 and
+C282. (N) Interaction between SCAN and truncated HO2 forms. Myc-SCAN and
+Flag-truncated-HO2 were co-expressed in HEK cells, IP with anti-rabbit myc
+antibody or non-immune IgG, and IB with anti-mouse Flag antibody. (O)
+S-nitrosylation of full-length HO2 (1–316) and truncated,
+non-interacting HO2 (195–316) by recombinant SCAN in
+vitro with increasing SNO-CoA.figs3Figure S3. Characterization of SCAN-deficient mice, Related
+to
+Figure 2. (A) WT BLVRB gene allele and
+targeting vector for deleting exons 2–4 in ES cells to generate
+SCAN-deficient mice. (B) Serum bilirubin level in SCAN+/+ and
+SCAN−/− mice; n=5 mice per group. (C) The
+number of white blood cells (WBCs), red blood cells (RBCs) and platelets in
+1μl blood from SCAN+/+ and
+SCAN−/− mice; n≥13. (D) The percentage
+of lymphocytes, monocytes and granulocytes in white blood cells of
+SCAN+/+ and SCAN−/− mice;
+n≥13. (E) Free heme concentration in the serum of SCAN+/+
+and SCAN−/− mice; n=9. (F) Hemoglobin concentration
+in the blood of SCAN+/+ and SCAN−/−
+mice; n≥13. All results are presented as mean ± SD. Two-tailed
+Student’s t-test was used to detect significance in Fig. S3B–F. *, p<0.05; NS, not
+significant.figs4Figure S4. Interactions and functions of SCAN in purified
+systems, cells and mice, Related to
+Figure 2. (A) NO donor DPTA (200
+μM for 20 hours) promotes the interaction between SCAN and
+INSRβ in L6 cells. IP with anti-rabbit SCAN antibody or non-immune
+IgG; IB with anti-rabbit INSRβ antibody; n=2. (B) Treatment with the
+NO donor DPTA (200 μM for 20 hours) promotes the interaction between
+SCAN and IRS1. Myc-SCAN and Flag-IRS1 were co-expressed in HEK cells, n=2.
+(C) Interaction between SCAN and INSRβ after insulin stimulation
+(100nM for 30min). Myc-SCAN and Flag-INSR were co-expressed in HEK cells,
+n=2. (D) Interaction between INSRβ and SCAN-QTG/NAA or SCAN-C109/188R
+after treatment with the NO donor DPTA (200 μM for 20 hours).
+Flag-INSR and Myc-SCAN, Myc-SCAN-QTG/NAA or Myc-SCAN-C109/188R were
+co-expressed in HEK cells, n=2. In panels B-D, IP with anti-rabbit myc
+antibody or non-immune IgG; probe with anti-mouse Flag antibody. (E) Body
+weight of male SCAN+/+ and SCAN−/− mice
+measured at indicated times during HFD feeding; n=20. ANOVA with Tukey post
+hoc was used to detect significance. (F) S-nitrosylation of INSRβ by
+SCAN in vitro (vs GST control), in the presence of varying SNO-CoA
+concentration; n=2. (G) Km of SCAN for SNO-CoA-dependent S-nitrosylation of
+INSRβ; n=2. (I) Km of SCAN for SNO-CoA-dependent S-nitrosylation of
+IRS1; n=3.figs5Figure S5. Regulation of INSRβ/IRS1 S-nitrosylation by
+NOS, SCAN and SCoR, Related to
+Figure 3. (A) Colocalization of SCAN
+and SCoR in HEK293 cells. Overnight serum-starved HEK cells were treated by
+insulin for 10 min, fixed and immunostained with anti-SCAN and anti-SCoR
+antibodies. (B) Interaction between SCAN and INSRβ in SCoR-knockout
+HEK cells. Myc-SCAN and Flag-INSR were co-expressed in WT HEK cells or
+SCoR-knockout HEK cells. IP with anti-rabbit myc antibody; probe with
+anti-mouse Flag antibody; n=2. (C) SNO-INSRβ, SNO-IRS1 and SNO-SCAN
+in skeletal muscle (gastrocnemius) of 5-hour fasted 12-weeks HFD-fed
+SCoR+/+ and SCoR−/− mice. (D)
+Quantification of SNO-INSRβ, SNO-IRS1 and SNO-SCAN in C; n=4 per
+group. (E) Phosphorylation of AKT(pSer473) and AS160(pThr642) in skeletal
+muscle (gastrocnemius) of 5-hour fasted 12-weeks HFD-fed SCoR+/+
+and SCoR−/− mice. Spliced blots for AKT/p-AKT are
+indicated. (F) Quantification of phosphorylation of AKT(pSer473) and
+AS160(pThr642) in E; n=4. (G) Tyrosine kinase activity of purified INSR
+after SNO-CoA treatment; n=6. (H) Generation of SCAN-knockout L6 cell lines
+(L6-SCAN−/−) using CRISPR-Cas9; 7 lines are
+shown, and lines 4 and 6 (*) were used as knockout. (I-L) Quantification of
+phosphorylation of INSRβ(pTyr1162) (I), IRS1(pTyr608) (J),
+AKT(pSer473) (K) and AS160(pThr642) (L) in overnight-starved L6-WT and
+L6-SCAN−/− cells at 1, 30, 60, 120 and 240 min
+after removal of insulin, following 10-minute insulin treatment (100 nM);
+n=4. Representative gels are shown in Figure
+3F. (M) Phosphorylation of nNOS(pS1412) in overnight
+serum-starved L6 cells at the indicated time after removal of insulin,
+following 10-minute insulin treatment (100 nM). (N) Amount of
+SNO-INSRβ in eNOS, nNOS or iNOS-overexpressing HEK cells. (O) Amount
+of SNO-IRS1 in eNOS, nNOS or iNOS-overexpressing HEK cells. (P-Q)
+Quantification of phosphorylation of AKT(pSer473) (P) and AS160(pThr642) (Q)
+in PBS-treated (control) and L-NMMA-treated (100 μM) L6 cells at 1,
+30, 60, 120 and 240 min after removal of insulin following 10-minute insulin
+treatment (100 nM); n=3. Representative gels are shown in Figure 4K. Two-tailed Student’s t-test was
+used to detect significance in Figures S5D, S5F and S5G. Figure S5I–L and P–Q were analyzed by two-way
+(time × treatment) repeated measures analysis of variance followed by
+Sidak’s multiple comparisons test. *, p<0.05, **,
+p<0.01 and ***, p<0.001.figs6Figure S6. Levels of SCAN and SNO-INSRβ in human
+tissues, and other SNO-RTKs (receptor tyrosine kinases), Related
+to
+Figures 5 and 6 and Table S4. (A) Generation of
+L6-SCAN-WT (SCAN-WT), L6-SCAN-QTG/NAA (QTG/NAA) and L6-SCAN-C109/188R
+(C109/188R) re-expressing cell lines from SCAN-deficient parental cells. (B)
+Modeling of tyrosine kinase domain dimer of INSR. SNO-site C1083 is
+indicated in red. (C) Generation of INSR-knockout L6 cell lines
+(L6-INSR−/−) using CRISPR-Cas9; 6 lines are
+shown, and line 4 (*) was used as knockout. (D) Generation of L6-INSR-WT
+(INSR-WT) and L6-INSR-C1083A (C1083A) re-expressing cell lines from
+INSR-deficient parental cells. (E) Expression of SCAN in 14 human skeletal
+muscle samples (Hm#) from patients with the indicated BMI, and
+quantification (lower panel). (F) Expression of SCAN in 14 human visceral
+adipose samples (Hvad#) with the indicated BMI, and quantification (lower
+panel). GAPDH is used as internal loading control in panels E and F, and
+expression of SCAN was first normalized with expression of internal control
+GAPDH, and then versus the average expression level of SCAN in the same
+group of samples. (G) SNO-INSRβ level in 14 human skeletal muscle
+samples from patients with the indicated BMI, and quantification (lower
+panel). (H) SNO-INSRβ level in 12 human visceral adipose samples from
+patients with the indicated BMI, and quantification (lower). In panels G and
+H, SNO-INSRβ was first normalized with input of INSRβ, and
+versus the average SNO-INSRβ level in the same group of samples. (I)
+S-nitrosylation of fibroblast growth factor receptor (FGFR),
+platelet-derived growth factor receptor alpha (PDGFRα) and
+platelet-derived growth factor receptor beta (PDGFRβ) in ester-CYSNO
+(100 μM)-treated HEK293 cells (upper), and protein expression by
+western blot (lower). (J) S-nitrosylation of vascular endothelial growth
+factor receptor 2 (VEGFR2) in ester-CYSNO (100 μM)-treated HEK293
+cells (upper), and protein expression by western blot (lower). (K)
+S-nitrosylation of human epidermal growth factor receptor 3 (HER3) in
+wild-type HEK293 cells or eNOS-expressing HEK293 cells (upper), and protein
+expression by western blot (lower). Minus (−) ascorbate is used as
+negative control in SNO-RAC assays.
+
+Supplementary Material
+
+Figure S1. Characterization of BLVRB/SCAN, Related to
+Figure 1. (A) Quantification of binding
+of BLVRB in HEK lysates to seven different types of resins, from Figure 1B upper; n=2. (B) Quantification
+of recombinant BLVRB protein binding to six different types of resins, from
+Figure 1B lower; n=2. (C)
+Recombinant BLVRB does not oxidize NADPH in the presence of SNO-CoA,
+indicating that NADPH-dependent SNO-CoA reductase activity is absent from
+BLVRB. SNO-CoA Reductase (SCoR) was used as positive control; n=5. (D)
+Recombinant BLVRB does not oxidize NADH in the presence of SNO-CoA,
+indicating that NADH-dependent SNO-CoA reductase activity is absent from
+BLVRB; n=5. (E) Immunostaining of SCAN and cytochrome C (mitochondrial
+marker) in HEK cells, with DAPI nuclear staining. Overnight serum-starved
+HEK cells were treated by insulin for 10 min. (F) Expression of SCAN in
+three cellular fractions. ACADVL is a mitochondrial protein; GAPDH is a
+cytosolic protein; Histone3 is a nuclear protein.
+
+Figure S2. SCAN/SNO-CoA-dependent S-nitrosylation of HO2,
+Related to
+Figure 1. (A) SNO-HO2 level in
+eNOS-overexpressing HEK cells in the absence or presence of NOS inhibitor
+(L-NMMA, 100 μM). Reaction without ascorbate (-Ascorbate) is used as
+a negative control; n=2. (B) SNO-HO2 level in LPS/interferon-induced
+RAW264.7 cells in the absence or presence of iNOS inhibitor (1400W,
+100μM); n=2. (C) SNO-HO2 in HEK cell lines overexpressing wild-type
+HO2 or four candidate SNO-site HO2 mutants (C127R, C265R, C282R or
+C265/282A); n=3. (D) Interaction between BLVRB and HO2 in HEK cells. Upper
+gel: IP of endogenous proteins with anti-rabbit BLVRB antibody or non-immune
+IgG; IB with anti-mouse HO2 antibody; n=2. Lower gel: interaction between
+expressed BLVRB and HO2 after treatment with the NO donor DPTA (200
+μM for 20 hours). Flag-HO2 and Myc-SCAN were co-expressed in HEK
+cells. IP with anti-rabbit myc antibody or non-immune IgG; probe with
+anti-mouse Flag antibody; n=2. (E) Molecular structures of SNO-CoA,
+SNO-cysteamine and NADPH. (F) S-nitrosylation of HO2 by recombinant SCAN and
+1 μM SNO-CoA in vitro in the presence of increasing
+NAPDH. (G) S-nitrosylation of HO2 by recombinant SCAN and 1 μM
+SNO-CoA in vitro in the presence of increasing NADH. (H)
+Quantification of SNO-HO2 in F and G; n=2. (I) Generation of SCAN-knockout
+HEK cell lines (HEK-SCAN−/−) using CRISPR-Cas9; 6
+lines are shown, and lines 2 and 5 (*) were used as knockout. (J) Generation
+of HEK-SCAN-WT (SCAN-WT) and HEK-SCAN-QTG/NAA (QTG/NAA) re-expressing cell
+lines from SCAN-deficient parental cells; 2 independent lines each are
+shown. (K) SNO-SCAN level in eNOS-overexpressing HEK cells in the absence or
+presence of NOS inhibitor (L-NMMA, 100 μM); n=2. (L) SNO-SCAN level
+in LPS/interferon-induced RAW264 cells in the absence or presence of iNOS
+inhibitor (1400W, 100μM); n=2. (M) Truncated HO2 forms, with retained
+residues indicated. All truncations still contain both SNO sites, C265 and
+C282. (N) Interaction between SCAN and truncated HO2 forms. Myc-SCAN and
+Flag-truncated-HO2 were co-expressed in HEK cells, IP with anti-rabbit myc
+antibody or non-immune IgG, and IB with anti-mouse Flag antibody. (O)
+S-nitrosylation of full-length HO2 (1–316) and truncated,
+non-interacting HO2 (195–316) by recombinant SCAN in
+vitro with increasing SNO-CoA.
+
+Figure S3. Characterization of SCAN-deficient mice, Related
+to
+Figure 2. (A) WT BLVRB gene allele and
+targeting vector for deleting exons 2–4 in ES cells to generate
+SCAN-deficient mice. (B) Serum bilirubin level in SCAN+/+ and
+SCAN−/− mice; n=5 mice per group. (C) The
+number of white blood cells (WBCs), red blood cells (RBCs) and platelets in
+1μl blood from SCAN+/+ and
+SCAN−/− mice; n≥13. (D) The percentage
+of lymphocytes, monocytes and granulocytes in white blood cells of
+SCAN+/+ and SCAN−/− mice;
+n≥13. (E) Free heme concentration in the serum of SCAN+/+
+and SCAN−/− mice; n=9. (F) Hemoglobin concentration
+in the blood of SCAN+/+ and SCAN−/−
+mice; n≥13. All results are presented as mean ± SD. Two-tailed
+Student’s t-test was used to detect significance in Fig. S3B–F. *, p<0.05; NS, not
+significant.
+
+Figure S4. Interactions and functions of SCAN in purified
+systems, cells and mice, Related to
+Figure 2. (A) NO donor DPTA (200
+μM for 20 hours) promotes the interaction between SCAN and
+INSRβ in L6 cells. IP with anti-rabbit SCAN antibody or non-immune
+IgG; IB with anti-rabbit INSRβ antibody; n=2. (B) Treatment with the
+NO donor DPTA (200 μM for 20 hours) promotes the interaction between
+SCAN and IRS1. Myc-SCAN and Flag-IRS1 were co-expressed in HEK cells, n=2.
+(C) Interaction between SCAN and INSRβ after insulin stimulation
+(100nM for 30min). Myc-SCAN and Flag-INSR were co-expressed in HEK cells,
+n=2. (D) Interaction between INSRβ and SCAN-QTG/NAA or SCAN-C109/188R
+after treatment with the NO donor DPTA (200 μM for 20 hours).
+Flag-INSR and Myc-SCAN, Myc-SCAN-QTG/NAA or Myc-SCAN-C109/188R were
+co-expressed in HEK cells, n=2. In panels B-D, IP with anti-rabbit myc
+antibody or non-immune IgG; probe with anti-mouse Flag antibody. (E) Body
+weight of male SCAN+/+ and SCAN−/− mice
+measured at indicated times during HFD feeding; n=20. ANOVA with Tukey post
+hoc was used to detect significance. (F) S-nitrosylation of INSRβ by
+SCAN in vitro (vs GST control), in the presence of varying SNO-CoA
+concentration; n=2. (G) Km of SCAN for SNO-CoA-dependent S-nitrosylation of
+INSRβ; n=2. (I) Km of SCAN for SNO-CoA-dependent S-nitrosylation of
+IRS1; n=3.
+
+Figure S5. Regulation of INSRβ/IRS1 S-nitrosylation by
+NOS, SCAN and SCoR, Related to
+Figure 3. (A) Colocalization of SCAN
+and SCoR in HEK293 cells. Overnight serum-starved HEK cells were treated by
+insulin for 10 min, fixed and immunostained with anti-SCAN and anti-SCoR
+antibodies. (B) Interaction between SCAN and INSRβ in SCoR-knockout
+HEK cells. Myc-SCAN and Flag-INSR were co-expressed in WT HEK cells or
+SCoR-knockout HEK cells. IP with anti-rabbit myc antibody; probe with
+anti-mouse Flag antibody; n=2. (C) SNO-INSRβ, SNO-IRS1 and SNO-SCAN
+in skeletal muscle (gastrocnemius) of 5-hour fasted 12-weeks HFD-fed
+SCoR+/+ and SCoR−/− mice. (D)
+Quantification of SNO-INSRβ, SNO-IRS1 and SNO-SCAN in C; n=4 per
+group. (E) Phosphorylation of AKT(pSer473) and AS160(pThr642) in skeletal
+muscle (gastrocnemius) of 5-hour fasted 12-weeks HFD-fed SCoR+/+
+and SCoR−/− mice. Spliced blots for AKT/p-AKT are
+indicated. (F) Quantification of phosphorylation of AKT(pSer473) and
+AS160(pThr642) in E; n=4. (G) Tyrosine kinase activity of purified INSR
+after SNO-CoA treatment; n=6. (H) Generation of SCAN-knockout L6 cell lines
+(L6-SCAN−/−) using CRISPR-Cas9; 7 lines are
+shown, and lines 4 and 6 (*) were used as knockout. (I-L) Quantification of
+phosphorylation of INSRβ(pTyr1162) (I), IRS1(pTyr608) (J),
+AKT(pSer473) (K) and AS160(pThr642) (L) in overnight-starved L6-WT and
+L6-SCAN−/− cells at 1, 30, 60, 120 and 240 min
+after removal of insulin, following 10-minute insulin treatment (100 nM);
+n=4. Representative gels are shown in Figure
+3F. (M) Phosphorylation of nNOS(pS1412) in overnight
+serum-starved L6 cells at the indicated time after removal of insulin,
+following 10-minute insulin treatment (100 nM). (N) Amount of
+SNO-INSRβ in eNOS, nNOS or iNOS-overexpressing HEK cells. (O) Amount
+of SNO-IRS1 in eNOS, nNOS or iNOS-overexpressing HEK cells. (P-Q)
+Quantification of phosphorylation of AKT(pSer473) (P) and AS160(pThr642) (Q)
+in PBS-treated (control) and L-NMMA-treated (100 μM) L6 cells at 1,
+30, 60, 120 and 240 min after removal of insulin following 10-minute insulin
+treatment (100 nM); n=3. Representative gels are shown in Figure 4K. Two-tailed Student’s t-test was
+used to detect significance in Figures S5D, S5F and S5G. Figure S5I–L and P–Q were analyzed by two-way
+(time × treatment) repeated measures analysis of variance followed by
+Sidak’s multiple comparisons test. *, p<0.05, **,
+p<0.01 and ***, p<0.001.
+
+Figure S6. Levels of SCAN and SNO-INSRβ in human
+tissues, and other SNO-RTKs (receptor tyrosine kinases), Related
+to
+Figures 5 and 6 and Table S4. (A) Generation of
+L6-SCAN-WT (SCAN-WT), L6-SCAN-QTG/NAA (QTG/NAA) and L6-SCAN-C109/188R
+(C109/188R) re-expressing cell lines from SCAN-deficient parental cells. (B)
+Modeling of tyrosine kinase domain dimer of INSR. SNO-site C1083 is
+indicated in red. (C) Generation of INSR-knockout L6 cell lines
+(L6-INSR−/−) using CRISPR-Cas9; 6 lines are
+shown, and line 4 (*) was used as knockout. (D) Generation of L6-INSR-WT
+(INSR-WT) and L6-INSR-C1083A (C1083A) re-expressing cell lines from
+INSR-deficient parental cells. (E) Expression of SCAN in 14 human skeletal
+muscle samples (Hm#) from patients with the indicated BMI, and
+quantification (lower panel). (F) Expression of SCAN in 14 human visceral
+adipose samples (Hvad#) with the indicated BMI, and quantification (lower
+panel). GAPDH is used as internal loading control in panels E and F, and
+expression of SCAN was first normalized with expression of internal control
+GAPDH, and then versus the average expression level of SCAN in the same
+group of samples. (G) SNO-INSRβ level in 14 human skeletal muscle
+samples from patients with the indicated BMI, and quantification (lower
+panel). (H) SNO-INSRβ level in 12 human visceral adipose samples from
+patients with the indicated BMI, and quantification (lower). In panels G and
+H, SNO-INSRβ was first normalized with input of INSRβ, and
+versus the average SNO-INSRβ level in the same group of samples. (I)
+S-nitrosylation of fibroblast growth factor receptor (FGFR),
+platelet-derived growth factor receptor alpha (PDGFRα) and
+platelet-derived growth factor receptor beta (PDGFRβ) in ester-CYSNO
+(100 μM)-treated HEK293 cells (upper), and protein expression by
+western blot (lower). (J) S-nitrosylation of vascular endothelial growth
+factor receptor 2 (VEGFR2) in ester-CYSNO (100 μM)-treated HEK293
+cells (upper), and protein expression by western blot (lower). (K)
+S-nitrosylation of human epidermal growth factor receptor 3 (HER3) in
+wild-type HEK293 cells or eNOS-expressing HEK293 cells (upper), and protein
+expression by western blot (lower). Minus (−) ascorbate is used as
+negative control in SNO-RAC assays.

--- a/publications/PMID_7703255.md
+++ b/publications/PMID_7703255.md
@@ -1,0 +1,60 @@
+---
+pmid: '7703255'
+title: Expression and characterization of truncated human heme oxygenase (hHO-1) and
+  a fusion protein of hHO-1 with human cytochrome P450 reductase.
+authors:
+- Wilks A
+- Black SM
+- Miller WL
+- Ortiz de Montellano PR
+journal: Biochemistry
+year: '1995'
+full_text_available: false
+doi: 10.1021/bi00013a034
+pubmed_publication_types:
+- Journal Article
+- Research Support, U.S. Gov't, P.H.S.
+publication_type: PRIMARY_RESEARCH
+---
+
+# Expression and characterization of truncated human heme oxygenase (hHO-1) and a fusion protein of hHO-1 with human cytochrome P450 reductase.
+**Authors:** Wilks A, Black SM, Miller WL, Ortiz de Montellano PR
+**Journal:** Biochemistry (1995)
+**DOI:** [10.1021/bi00013a034](https://doi.org/10.1021/bi00013a034)
+
+## Abstract
+
+1. Biochemistry. 1995 Apr 4;34(13):4421-7. doi: 10.1021/bi00013a034.
+
+Expression and characterization of truncated human heme oxygenase (hHO-1) and a 
+fusion protein of hHO-1 with human cytochrome P450 reductase.
+
+Wilks A(1), Black SM, Miller WL, Ortiz de Montellano PR.
+
+Author information:
+(1)Department of Pharmaceutical Chemistry, School of Pharmacy, University of 
+California, San Francisco 94143-0446, USA.
+
+A human heme oxygenase (hHO-1) gene without the sequence coding for the last 23 
+amino acids has been expressed in Escherichia coli behind the pho A promoter. 
+The truncated enzyme is obtained in high yields as a soluble, 
+catalytically-active protein, making it available for the first time for 
+detailed mechanistic studies. The purified, truncated hHO-1/heme complex is 
+spectroscopically indistinguishable from that of the rat enzyme and converts 
+heme to biliverdin when reconstituted with rat liver cytochrome P450 reductase. 
+A self-sufficient heme oxygenase system has been obtained by fusing the 
+truncated hHO-1 gene to the gene for human cytochrome P450 reductase without the 
+sequence coding for the 20 amino acid membrane binding domain. Expression of the 
+fusion protein in pCWori+ yields a protein that only requires NADPH for 
+catalytic turnover. The failure of exogenous cytochrome P450 reductase to 
+stimulate turnover and the insensitivity of the catalytic rate toward changes in 
+ionic strength establish that electrons are transferred intramolecularly between 
+the reductase and heme oxygenase domains of the fusion protein. The Vmax for the 
+fusion protein is 2.5 times higher than that for the reconstituted system. 
+Therefore, either the covalent tether does not interfere with normal docking and 
+electron transfer between the flavin and heme domains or alternative but equally 
+efficient electron transfer pathways are available that do not require specific 
+docking.
+
+DOI: 10.1021/bi00013a034
+PMID: 7703255 [Indexed for MEDLINE]

--- a/publications/PMID_7890772.md
+++ b/publications/PMID_7890772.md
@@ -1,0 +1,65 @@
+---
+pmid: '7890772'
+title: Heme oxygenase-2. Properties of the heme complex of the purified tryptic fragment
+  of recombinant human heme oxygenase-2.
+authors:
+- Ishikawa K
+- Takeuchi N
+- Takahashi S
+- Matera KM
+- Sato M
+- Shibahara S
+- Rousseau DL
+- Ikeda-Saito M
+- Yoshida T
+journal: J Biol Chem
+year: '1995'
+full_text_available: false
+doi: 10.1074/jbc.270.11.6345
+pubmed_publication_types:
+- Comparative Study
+- Journal Article
+- Research Support, Non-U.S. Gov't
+- Research Support, U.S. Gov't, P.H.S.
+publication_type: PRIMARY_RESEARCH
+---
+
+# Heme oxygenase-2. Properties of the heme complex of the purified tryptic fragment of recombinant human heme oxygenase-2.
+**Authors:** Ishikawa K, Takeuchi N, Takahashi S, Matera KM, Sato M, Shibahara S, Rousseau DL, Ikeda-Saito M, Yoshida T
+**Journal:** J Biol Chem (1995)
+**DOI:** [10.1074/jbc.270.11.6345](https://doi.org/10.1074/jbc.270.11.6345)
+
+## Abstract
+
+1. J Biol Chem. 1995 Mar 17;270(11):6345-50. doi: 10.1074/jbc.270.11.6345.
+
+Heme oxygenase-2. Properties of the heme complex of the purified tryptic 
+fragment of recombinant human heme oxygenase-2.
+
+Ishikawa K(1), Takeuchi N, Takahashi S, Matera KM, Sato M, Shibahara S, Rousseau 
+DL, Ikeda-Saito M, Yoshida T.
+
+Author information:
+(1)Department of Biochemistry, Yamagata University School of Medicine, Japan.
+
+Recombinant human microsomal heme oxygenase-2 was expressed in Escherichia coli. 
+Tryptic digestion of the membrane fraction, in which the wild-type enzyme was 
+localized, yielded a soluble tryptic peptide of 28 kDa, which retained the 
+ability to accept electrons from NADPH-cytochrome P-450 reductase and the 
+enzymatic activity for conversion of heme to biliverdin. The tryptic fragment, 
+when purified to apparent homogeneity, bound one equivalent of heme to form a 
+substrate-enzyme complex that had spectroscopic properties characteristic of 
+heme proteins, such as myoglobin and hemoglobin. Optical absorption, Raman 
+scattering, and EPR studies of the heme-tryptic fragment complex revealed that 
+the ferric heme was six coordinate high spin at neutral pH and six coordinate 
+low spin at alkaline pH, with a pK alpha value of 8.5. EPR and Raman scattering 
+studies indicated that a neutral imidazole of a histidine residue served as the 
+proximal ligand in the heme-heme oxygenase-2 fragment complex. The reaction with 
+hydrogen peroxide converted the heme of the heme oxygenase-2 fragment complex 
+into a verdoheme-like intermediate, while the reaction with m-chloroperbenzoic 
+acid yielded a oxoferryl species. These spectroscopic properties are similar to 
+those obtained for heme oxygenase-1, and thus the catalytic mechanism of heme 
+oxygenase-2 appears to be similar to that of heme oxygenase-1.
+
+DOI: 10.1074/jbc.270.11.6345
+PMID: 7890772 [Indexed for MEDLINE]

--- a/publications/PMID_7929092.md
+++ b/publications/PMID_7929092.md
@@ -1,0 +1,63 @@
+---
+pmid: '7929092'
+title: Biliverdin-IX alpha reductase and biliverdin-IX beta reductase from human liver.
+  Purification and characterization.
+authors:
+- Yamaguchi T
+- Komoda Y
+- Nakajima H
+journal: J Biol Chem
+year: '1994'
+full_text_available: false
+pubmed_publication_types:
+- Journal Article
+publication_type: PRIMARY_RESEARCH
+---
+
+# Biliverdin-IX alpha reductase and biliverdin-IX beta reductase from human liver. Purification and characterization.
+**Authors:** Yamaguchi T, Komoda Y, Nakajima H
+**Journal:** J Biol Chem (1994)
+
+## Abstract
+
+1. J Biol Chem. 1994 Sep 30;269(39):24343-8.
+
+Biliverdin-IX alpha reductase and biliverdin-IX beta reductase from human liver. 
+Purification and characterization.
+
+Yamaguchi T(1), Komoda Y, Nakajima H.
+
+Author information:
+(1)Department of Biochemical Genetics, Tokyo Medical and Dental University, 
+Japan.
+
+This report describes for the first time the identification of four forms of 
+biliverdin reductase including two biliverdin-IX beta reductases and two 
+biliverdin-IX alpha reductases, designated isozymes I and II and isozymes III 
+and IV, respectively, in human liver cytosolic fractions. The four forms of 
+biliverdin reductase were purified to homogeneity. There was a 7,800-15,000-fold 
+increase in specific activity when compared with the crude preparation, and the 
+recovery was 8-26%. The purified enzymes were monomers with a molecular weight 
+of about 21,000 (isozymes I and II) and 34,000 (isozymes III and IV). The 
+enzymes were strictly specific for biliverdin, and no other oxidoreductase 
+activities were detected in the purified preparations. The purified enzymes used 
+NADPH and NADH as electron donors for the reduction of biliverdin. The apparent 
+Km values of isozymes I, II, III, and IV for NADPH were 35.9, 13.1, 10.9, and 
+34.1 microM, respectively, whereas those for NADH were 5.6, 8.2, 7.9, and 23.4 
+mM, respectively. It was assumed that NADPH rather than NADH was the 
+physiological electron donor in the intracellular reduction of biliverdin. The 
+apparent Km value of isozymes I and II for biliverdin-IX beta in the NADPH 
+system was 0.3 microM whereas those of isozymes III and IV for biliverdin-IX 
+alpha were 1.0 and 0.8 microM, respectively. Isozymes I and II used 
+biliverdin-IX beta, -IX gamma, and -IX delta as substrates but not biliverdin-IX 
+alpha, and isozymes III and IV preferred biliverdin-IX alpha as the most 
+effective substrate among the four biliverdin isomers. The NADPH-dependent 
+enzyme activities were inhibited by substrate concentrations in excess of 3-4 
+microM. The NADPH-dependent enzyme activities, especially isozymes III and IV, 
+were sensitive to SH reagents including iodoacetamide, p-chloromercuribenzoic 
+acid, and N-ethylmaleimide. The optimum pH of the reaction with NADPH for 
+isozymes I and II was 8.2 whereas that for isozymes III and IV was 7.4. The 
+proportion of the total activity of isozymes I and II to that of isozymes III 
+and IV was considerably higher in the fetal than in the adult liver.
+
+PMID: 7929092 [Indexed for MEDLINE]

--- a/publications/PMID_8117274.md
+++ b/publications/PMID_8117274.md
@@ -1,0 +1,49 @@
+---
+pmid: '8117274'
+title: Cloning and nucleotide sequence of a cDNA of the human erythrocyte NADPH-flavin
+  reductase.
+authors:
+- Chikuba K
+- Yubisui T
+- Shirabe K
+- Takeshita M
+journal: Biochem Biophys Res Commun
+year: '1994'
+full_text_available: false
+doi: 10.1006/bbrc.1994.1165
+pubmed_publication_types:
+- Comparative Study
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Cloning and nucleotide sequence of a cDNA of the human erythrocyte NADPH-flavin reductase.
+**Authors:** Chikuba K, Yubisui T, Shirabe K, Takeshita M
+**Journal:** Biochem Biophys Res Commun (1994)
+**DOI:** [10.1006/bbrc.1994.1165](https://doi.org/10.1006/bbrc.1994.1165)
+
+## Abstract
+
+1. Biochem Biophys Res Commun. 1994 Feb 15;198(3):1170-6. doi: 
+10.1006/bbrc.1994.1165.
+
+Cloning and nucleotide sequence of a cDNA of the human erythrocyte NADPH-flavin 
+reductase.
+
+Chikuba K(1), Yubisui T, Shirabe K, Takeshita M.
+
+Author information:
+(1)Department of Biochemistry, Oita Medical University, Japan.
+
+A cDNA of human erythrocyte NADPH-flavin reductase was cloned from a lambda gt 
+11 human reticulocyte cDNA library by polymerase chain reaction using degenerate 
+primers and followed by a plaque hybridization. The nucleotide sequence of the 
+cDNA contains an open reading frame of 621 base pairs which encodes 206 amino 
+acid residues including an initial methionine. The amino acid sequence deduced 
+from the base sequence coincided well with peptide sequence determined for the 
+purified human erythrocyte NADPH-flavin reductase. A homologous sequence to the 
+FMN-binding site of flavodoxins was found at the amino-terminal region.
+
+DOI: 10.1006/bbrc.1994.1165
+PMID: 8117274 [Indexed for MEDLINE]

--- a/publications/PMID_8424666.md
+++ b/publications/PMID_8424666.md
@@ -1,0 +1,64 @@
+---
+pmid: '8424666'
+title: Purification and characterization of human biliverdin reductase.
+authors:
+- Maines MD
+- Trakshel GM
+journal: Arch Biochem Biophys
+year: '1993'
+full_text_available: false
+doi: 10.1006/abbi.1993.1044
+pubmed_publication_types:
+- Comparative Study
+- Journal Article
+- Research Support, Non-U.S. Gov't
+- Research Support, U.S. Gov't, P.H.S.
+publication_type: PRIMARY_RESEARCH
+---
+
+# Purification and characterization of human biliverdin reductase.
+**Authors:** Maines MD, Trakshel GM
+**Journal:** Arch Biochem Biophys (1993)
+**DOI:** [10.1006/abbi.1993.1044](https://doi.org/10.1006/abbi.1993.1044)
+
+## Abstract
+
+1. Arch Biochem Biophys. 1993 Jan;300(1):320-6. doi: 10.1006/abbi.1993.1044.
+
+Purification and characterization of human biliverdin reductase.
+
+Maines MD(1), Trakshel GM.
+
+Author information:
+(1)Department of Biophysics, University of Rochester School of Medicine, New 
+York 14642.
+
+Conversion of biliverdin to bilirubin is catalyzed by the cytosolic enzyme 
+biliverdin reductase. We have purified and characterized the human liver 
+reductase and find it to differ extensively from the previously described rat 
+enzyme (H. Fakhrai and M. D. Maines, 1992, J. Biol. Chem. 267, 4023-4029) in its 
+primary structure/composition, yet share kinetic properties. The human enzyme is 
+substantially larger than the rat enzyme (approximately 41,000-42,000 versus 
+33,000-34,000), is dual cofactor and dual pH dependent, and requires free-SH 
+groups. At pH 6.0-7.0 the NADH was the more effective cofactor, whereas at pH 
+8.5-8.75 NADPH was the preferred cofactor. The activity was inhibited by-SH 
+reagents, 5'-dithiobis(2-nitrobenzoic acid) and p-chloromercuribenzoic acid, and 
+protected from these reagents by cofactors and substrate. On two-dimensional 
+electrophoresis, the purified protein resolved into four distinct isoelectric 
+zones (pI 6.03, 5.83, 5.68, and 5.55) and two molecular weight forms 
+(approximately 40,700 and approximately 39,600). Variants with similar pI values 
+were detected in the purified human kidney reductase, although their relative 
+tissue abundance varied. The tryptic map, amino acid composition, and sequence 
+of NH2 terminus and four tryptic peptides of human reductase were compared with 
+those of the rat. The HPLC profile and amino acid composition of the human and 
+the rat enzymes differed vastly, and two tryptic peptides were present in the 
+human that could not be detected in the predicted amino acid sequence of the rat 
+enzyme. At the same time, the first 21 amino acids of the NH2 terminus of rat 
+and human, except for the substitution of glutamic acid in human for lysine 
+(amino acid 4) in the rat, were found identical and two peptides with 78-87% 
+similarity to the rat reductase were found in the human reductase. Of the seven 
+cysteine residues present in the human, four or five were titratable with 
+5'-dithiobis(2-nitrobenzoic acid).
+
+DOI: 10.1006/abbi.1993.1044
+PMID: 8424666 [Indexed for MEDLINE]

--- a/publications/PMID_8631357.md
+++ b/publications/PMID_8631357.md
@@ -1,0 +1,74 @@
+---
+pmid: '8631357'
+title: Human biliverdin IXalpha reductase is a zinc-metalloprotein. Characterization
+  of purified and Escherichia coli expressed enzymes.
+authors:
+- Maines MD
+- Polevoda BV
+- Huang TJ
+- McCoubrey WK Jr
+journal: Eur J Biochem
+year: '1996'
+full_text_available: false
+doi: 10.1111/j.1432-1033.1996.00372.x
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+- Research Support, U.S. Gov't, P.H.S.
+publication_type: PRIMARY_RESEARCH
+---
+
+# Human biliverdin IXalpha reductase is a zinc-metalloprotein. Characterization of purified and Escherichia coli expressed enzymes.
+**Authors:** Maines MD, Polevoda BV, Huang TJ, McCoubrey WK Jr
+**Journal:** Eur J Biochem (1996)
+**DOI:** [10.1111/j.1432-1033.1996.00372.x](https://doi.org/10.1111/j.1432-1033.1996.00372.x)
+
+## Abstract
+
+1. Eur J Biochem. 1996 Jan 15;235(1-2):372-81. doi: 
+10.1111/j.1432-1033.1996.00372.x.
+
+Human biliverdin IXalpha reductase is a zinc-metalloprotein. Characterization of 
+purified and Escherichia coli expressed enzymes.
+
+Maines MD(1), Polevoda BV, Huang TJ, McCoubrey WK Jr.
+
+Author information:
+(1)Department of Biophysics, University of Rochester School of Medicine, NY, 
+USA.
+
+Biliverdin IXalpha reductase (BVR) catalyzes the conversion of the heme b 
+degradation product, biliverdin, to bilirubin. BVR is unique among enzymes 
+characterized to date in that it has dual pH/cofactor (NADH, NADPH) specificity. 
+A cDNA clone encoding human BVR was isolated from a gamma library using a probe 
+generated via reverse transcription and the polymerase chain reaction from human 
+placental RNA. This approach was taken because the more direct approach of using 
+the previously isolated rat BVR cDNA as the hybridization probe did not succeed. 
+The human cDNA was cloned and sequenced; it was shown to have an open reading 
+frame encoding a 296-amino-acid protein in which could be identified four 
+peptides previously identified by micro-sequencing purified protein. The cDNA 
+hybridized with a single message of approximately 1.2 kb in human kidney 
+poly(A)-rich RNA, and appeared, by Southern blot analysis, to be the product of 
+a single-copy gene. Sequence analysis indicated that the human reductase shows 
+approximately 83% identity, at both the nucleotide and amino acid levels, with 
+rat BVR. In some regions including the carboxyl terminus, protein sequence 
+identity drops to 45%. Also noteworthy is the presence of two additional 
+cysteine residues in the encoded human reductase (five compared to three for 
+rat). The protein produced by an expression plasmid in which the insert was 
+cloned in frame with lacZ sequences was characterized, and demonstrated dual pH 
+and cofactor dependence. However, as suggested by kinetic analysis, the human 
+enzyme may also use NADH as cofactor, as opposed to the rat reductase, which 
+most likely utilizes only NADPH under physiological conditions. Western blot 
+analysis and isoelectric focusing demonstrate that, although migrating as a 
+single band on SDS/PAGE, the expressed protein, like that purified from tissue, 
+consists of several isoelectric charge variants. Atomic absorption spectroscopy 
+indicates that the protein purified from human liver contains Zn at an 
+approximately 1:1 molar ratio. That human BVR is a Zn metalloprotein was further 
+substantiated by 65Zn exchange analysis of both the purified and the fusion 
+protein expressed in Escherichia coli. Exogenous Zn also inhibits 
+NADPH-dependent, but not NADH-dependent, activity. Hence, the NADH and NADPH 
+binding regions are differentiated by their ability to interact with Zn; 
+Fe-hematoporphyrin, however, inhibited both NADH- and NADPH-dependent activity.
+
+DOI: 10.1111/j.1432-1033.1996.00372.x
+PMID: 8631357 [Indexed for MEDLINE]

--- a/publications/PMID_9884342.md
+++ b/publications/PMID_9884342.md
@@ -1,0 +1,70 @@
+---
+pmid: '9884342'
+title: Oxidative stress causes enhanced endothelial cell injury in human heme oxygenase-1
+  deficiency.
+authors:
+- Yachie A
+- Niida Y
+- Wada T
+- Igarashi N
+- Kaneda H
+- Toma T
+- Ohta K
+- Kasahara Y
+- Koizumi S
+journal: J Clin Invest
+year: '1999'
+full_text_available: false
+pmcid: PMC407858
+doi: 10.1172/JCI4165
+pubmed_publication_types:
+- Case Reports
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: CASE_REPORT
+---
+
+# Oxidative stress causes enhanced endothelial cell injury in human heme oxygenase-1 deficiency.
+**Authors:** Yachie A, Niida Y, Wada T, Igarashi N, Kaneda H, Toma T, Ohta K, Kasahara Y, Koizumi S
+**Journal:** J Clin Invest (1999)
+**DOI:** [10.1172/JCI4165](https://doi.org/10.1172/JCI4165)
+**PMC:** [PMC407858](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC407858/)
+
+## Abstract
+
+1. J Clin Invest. 1999 Jan;103(1):129-35. doi: 10.1172/JCI4165.
+
+Oxidative stress causes enhanced endothelial cell injury in human heme 
+oxygenase-1 deficiency.
+
+Yachie A(1), Niida Y, Wada T, Igarashi N, Kaneda H, Toma T, Ohta K, Kasahara Y, 
+Koizumi S.
+
+Author information:
+(1)Department of Laboratory Sciences, School of Health Sciences, Kanazawa 
+University, Japan. yachie@med.kanazawa-u.ac.jp
+
+The first known human case of heme oxygenase-1 (HO-1) deficiency is presented in 
+this report. The patient is a six-year-old boy with severe growth retardation. 
+He has been suffering from persistent hemolytic anemia characterized by marked 
+erythrocyte fragmentation and intravascular hemolysis, with paradoxical increase 
+of serum haptoglobin and low bilirubin. An abnormal coagulation/fibrinolysis 
+system, associated with elevated thrombomodulin and von Willebrand factor, 
+indicated the presence of severe, persistent endothelial damage. Electron 
+microscopy of renal glomeruli revealed detachment of endothelium, with 
+subendothelial deposition of an unidentified material. Iron deposition was noted 
+in renal and hepatic tissue. Immunohistochemistry of hepatic tissue and 
+immunoblotting of a cadmium-stimulated Epstein-Barr virus-transformed 
+lymphoblastoid cell line (LCL) revealed complete absence of HO-1 production. An 
+LCL derived from the patient was extremely sensitive to hemin-induced cell 
+injury. Sequence analysis of the patient's HO-1 gene revealed complete loss of 
+exon-2 of the maternal allele and a two-nucleotide deletion within exon3 of the 
+paternal allele. Growth retardation, anemia, iron deposition, and vulnerability 
+to stressful injury are all characteristics observed in recently described HO-1 
+targeted mice. This study presents not only the first human case of HO-1 
+deficiency but may also provide clues to the key roles played by this important 
+enzyme in vivo.
+
+DOI: 10.1172/JCI4165
+PMCID: PMC407858
+PMID: 9884342 [Indexed for MEDLINE]

--- a/reactome/R-HSA-189384.md
+++ b/reactome/R-HSA-189384.md
@@ -1,0 +1,18 @@
+---
+stable_id: R-HSA-189384
+display_name: BLVRA:Zn2+, BLVRB reduce BV to BIL
+species: Homo sapiens
+summary: Bilirubin (BIL) is the breakdown product of heme, causing death if allowed
+  to accumulate in the blood. It is highly lipophilic and requires conjugation to
+  become more water soluble to aid excretion. BIL is formed from the reduction of
+  biliverdin (BV) by bilverdin reductases BLVRA and BLVRB (Cunningham et al. 2000,
+  Fu et al. 2012, O'Brien et al. 2015).
+---
+
+# BLVRA:Zn2+, BLVRB reduce BV to BIL
+**Reactome ID:** [R-HSA-189384](https://reactome.org/content/detail/R-HSA-189384)
+**Species:** Homo sapiens
+
+## Summary
+
+Bilirubin (BIL) is the breakdown product of heme, causing death if allowed to accumulate in the blood. It is highly lipophilic and requires conjugation to become more water soluble to aid excretion. BIL is formed from the reduction of biliverdin (BV) by bilverdin reductases BLVRA and BLVRB (Cunningham et al. 2000, Fu et al. 2012, O'Brien et al. 2015).

--- a/reactome/R-HSA-189398.md
+++ b/reactome/R-HSA-189398.md
@@ -1,0 +1,20 @@
+---
+stable_id: R-HSA-189398
+display_name: HMOX1 dimer, HMOX2 cleave heme
+species: Homo sapiens
+summary: Heme oxygenases (HMOXs) cleaves the heme ring at the alpha-methene bridge
+  to form bilverdin. This reaction forms the only endogenous source of carbon monoxide.
+  HMOX1 is inducible and is thought to have an antioxidant role as it is activated
+  in virtually all cell types and by many types of "oxidative stress" (Poss & Tonegawa
+  1997). HMOX1 forms dimers/oligomers in the endoplasmatic reticulum. This oligomerization
+  is crucial for the stabilization and function of HMOX1 in the ER (Hwang et al. 2009).
+  HMOX2 is non-inducible.
+---
+
+# HMOX1 dimer, HMOX2 cleave heme
+**Reactome ID:** [R-HSA-189398](https://reactome.org/content/detail/R-HSA-189398)
+**Species:** Homo sapiens
+
+## Summary
+
+Heme oxygenases (HMOXs) cleaves the heme ring at the alpha-methene bridge to form bilverdin. This reaction forms the only endogenous source of carbon monoxide. HMOX1 is inducible and is thought to have an antioxidant role as it is activated in virtually all cell types and by many types of "oxidative stress" (Poss & Tonegawa 1997). HMOX1 forms dimers/oligomers in the endoplasmatic reticulum. This oligomerization is crucial for the stabilization and function of HMOX1 in the ER (Hwang et al. 2009). HMOX2 is non-inducible.

--- a/reactome/R-HSA-6797268.md
+++ b/reactome/R-HSA-6797268.md
@@ -1,0 +1,16 @@
+---
+stable_id: R-HSA-6797268
+display_name: Expression of HMOX1
+species: Homo sapiens
+summary: In human peripheral blood monocytes  Interleukin-4 (IL4) and IL13 significantly
+  upregulate the levels of proteins involved in inflammatory resolution, including
+  the ER membrane protein 15-lipoxygenase (ALOX15) (Chaitidis et al. 2005).
+---
+
+# Expression of HMOX1
+**Reactome ID:** [R-HSA-6797268](https://reactome.org/content/detail/R-HSA-6797268)
+**Species:** Homo sapiens
+
+## Summary
+
+In human peripheral blood monocytes  Interleukin-4 (IL4) and IL13 significantly upregulate the levels of proteins involved in inflammatory resolution, including the ER membrane protein 15-lipoxygenase (ALOX15) (Chaitidis et al. 2005).

--- a/reactome/R-HSA-9707645.md
+++ b/reactome/R-HSA-9707645.md
@@ -1,0 +1,23 @@
+---
+stable_id: R-HSA-9707645
+display_name: HMOX1 gene produces HMOX1 dimer
+species: Homo sapiens
+summary: Transcription regulator protein BACH1 is a critical physiological repressor
+  of heme oxygenase 1 (HMOX1). BACH1 binds to the multiple Maf recognition elements
+  (MAREs) of HMOX1 enhancer MafK in vitro and represses its activity in vivo. BACH1
+  is inducible by hypoxia and IFN-gamma (Kitamuro et al, 2003; Sun et al, 2002).<br><br>NFE2L2
+  (nuclear factor erythroid 2-related factor 2) is a transcription factor that activates
+  transcription of a battery of cytoprotective genes by binding to the ARE (antioxidant
+  response element). It is considered not only as a cytoprotective factor regulating
+  the expression of genes coding for anti-oxidant, anti-inflammatory and detoxifying
+  proteins, but it is also a powerful modulator of species longevity. HMOX1 is one
+  of the genes whose expression it activates (Huang et al, 2000; Reichard et al, 2007).
+---
+
+# HMOX1 gene produces HMOX1 dimer
+**Reactome ID:** [R-HSA-9707645](https://reactome.org/content/detail/R-HSA-9707645)
+**Species:** Homo sapiens
+
+## Summary
+
+Transcription regulator protein BACH1 is a critical physiological repressor of heme oxygenase 1 (HMOX1). BACH1 binds to the multiple Maf recognition elements (MAREs) of HMOX1 enhancer MafK in vitro and represses its activity in vivo. BACH1 is inducible by hypoxia and IFN-gamma (Kitamuro et al, 2003; Sun et al, 2002).<br><br>NFE2L2 (nuclear factor erythroid 2-related factor 2) is a transcription factor that activates transcription of a battery of cytoprotective genes by binding to the ARE (antioxidant response element). It is considered not only as a cytoprotective factor regulating the expression of genes coding for anti-oxidant, anti-inflammatory and detoxifying proteins, but it is also a powerful modulator of species longevity. HMOX1 is one of the genes whose expression it activates (Huang et al, 2000; Reichard et al, 2007).

--- a/reactome/R-HSA-9708457.md
+++ b/reactome/R-HSA-9708457.md
@@ -1,0 +1,17 @@
+---
+stable_id: R-HSA-9708457
+display_name: HM13 cleaves HMOX1 dimer
+species: Homo sapiens
+summary: Cleavage of heme oxygenase 1 (HMOX1) by HM13 (Signal peptide peptidase) takes
+  place in the ER membrane and removes the membrane domain from HMOX1, making it soluble
+  in the cytosol. The reaction only occurs under conditions of hypoxia (Schaefer et
+  al, 2017; Boname et al, 2014).
+---
+
+# HM13 cleaves HMOX1 dimer
+**Reactome ID:** [R-HSA-9708457](https://reactome.org/content/detail/R-HSA-9708457)
+**Species:** Homo sapiens
+
+## Summary
+
+Cleavage of heme oxygenase 1 (HMOX1) by HM13 (Signal peptide peptidase) takes place in the ER membrane and removes the membrane domain from HMOX1, making it soluble in the cytosol. The reaction only occurs under conditions of hypoxia (Schaefer et al, 2017; Boname et al, 2014).

--- a/reactome/R-HSA-9708536.md
+++ b/reactome/R-HSA-9708536.md
@@ -1,0 +1,19 @@
+---
+stable_id: R-HSA-9708536
+display_name: HMOX1 translocates from the cytosol to the nucleoplasm
+species: Homo sapiens
+summary: After exposure to hypoxia and heme or heme/hemopexin, soluble heme oxygenase
+  1 (HMOX1) is detected in the nucleus. Nuclear localization is also associated with
+  reduction of HMOX1 activity. HMOX1 protein, whether it s enzymatically active or
+  not, mediates activation of oxidant-responsive transcription factors, including
+  activator protein-1 (AP-1). Nevertheless, nuclear HMOX1 protects cells against hydrogen
+  peroxide-mediated injury equally as well as cytoplasmic HMOX1 (Lin et al, 2007).
+---
+
+# HMOX1 translocates from the cytosol to the nucleoplasm
+**Reactome ID:** [R-HSA-9708536](https://reactome.org/content/detail/R-HSA-9708536)
+**Species:** Homo sapiens
+
+## Summary
+
+After exposure to hypoxia and heme or heme/hemopexin, soluble heme oxygenase 1 (HMOX1) is detected in the nucleus. Nuclear localization is also associated with reduction of HMOX1 activity. HMOX1 protein, whether it s enzymatically active or not, mediates activation of oxidant-responsive transcription factors, including activator protein-1 (AP-1). Nevertheless, nuclear HMOX1 protects cells against hydrogen peroxide-mediated injury equally as well as cytoplasmic HMOX1 (Lin et al, 2007).

--- a/reactome/R-HSA-9708558.md
+++ b/reactome/R-HSA-9708558.md
@@ -1,0 +1,15 @@
+---
+stable_id: R-HSA-9708558
+display_name: HMOX1 dimer translocates from ER membrane to mitochondrial outer membrane
+species: Homo sapiens
+summary: Heme oxygenase 1 (HMOX1) expression is observed in both microsomes and mitochondria
+  (inner membrane) of rat liver cells (Converso et al, 2006).
+---
+
+# HMOX1 dimer translocates from ER membrane to mitochondrial outer membrane
+**Reactome ID:** [R-HSA-9708558](https://reactome.org/content/detail/R-HSA-9708558)
+**Species:** Homo sapiens
+
+## Summary
+
+Heme oxygenase 1 (HMOX1) expression is observed in both microsomes and mitochondria (inner membrane) of rat liver cells (Converso et al, 2006).

--- a/reactome/R-HSA-9759176.md
+++ b/reactome/R-HSA-9759176.md
@@ -1,0 +1,20 @@
+---
+stable_id: R-HSA-9759176
+display_name: NFE2L2-dependent HMOX1 gene expression
+species: Homo sapiens
+summary: NFE2L2 (nuclear factor erythroid 2-related factor 2) is a transcription factor
+  that activates transcription of a battery of cytoprotective genes by binding to
+  the ARE (antioxidant response element). It is considered not only as a cytoprotective
+  factor regulating the expression of genes coding for anti-oxidant, anti-inflammatory
+  and detoxifying proteins, but it is also a powerful modulator of species longevity.
+  HMOX1 is one of the genes whose expression it activates (Reichard et al, 2007; Ishii
+  et al, 2002; reviewed in Baird and Yamamoto, 2020).
+---
+
+# NFE2L2-dependent HMOX1 gene expression
+**Reactome ID:** [R-HSA-9759176](https://reactome.org/content/detail/R-HSA-9759176)
+**Species:** Homo sapiens
+
+## Summary
+
+NFE2L2 (nuclear factor erythroid 2-related factor 2) is a transcription factor that activates transcription of a battery of cytoprotective genes by binding to the ARE (antioxidant response element). It is considered not only as a cytoprotective factor regulating the expression of genes coding for anti-oxidant, anti-inflammatory and detoxifying proteins, but it is also a powerful modulator of species longevity. HMOX1 is one of the genes whose expression it activates (Reichard et al, 2007; Ishii et al, 2002; reviewed in Baird and Yamamoto, 2020).


### PR DESCRIPTION
## Summary

Adds a **heme degradation** module (heme → biliverdin → bilirubin) plus all 4 member human gene reviews — a compact, fully-unreviewed pathway central to erythrocyte turnover, iron recycling, CO signaling and antioxidant defense.

### Module — `modules/heme_degradation.yaml` (3 nodes)
- **Heme oxidation (ER, rate-limiting):** HMOX1 (inducible) + HMOX2 (constitutive) — GO:0004392 (heme + O2 + NADPH-CPR → biliverdin IXα + CO + Fe²⁺)
- **Biliverdin IXα reduction (cytosol):** BLVRA — GO:0004074 → bilirubin IXα
- **Biliverdin IXβ / flavin reduction (cytosol):** BLVRB — GO:0004074 (fetal isomer + flavins)

Validated: `linkml-validate -C ModuleReview` → no issues; `module_validator` → term labels OK (0 warnings).

### Gene reviews (all `just validate`-clean)
| Gene | UniProt | Core function | Note |
|------|---------|---------------|------|
| HMOX1 | P09601 | GO:0004392 + GO:0020037 heme binding + homodimer | 83 annots; NRF2-inducible; HMOX1 deficiency |
| HMOX2 | P30519 | GO:0004392 + GO:0020037 | constitutive; O2 sensor |
| BLVRA | P53004 | GO:0004074 + GO:0004674 (moonlighting kinase) | IXα; green jaundice |
| BLVRB | P30043 | GO:0004074 + GO:0042602/GO:0052873 flavin reductase + NADPH | IXβ/fetal; thrombopoiesis |

Notable: HMOX1's 83 annotations sorted (heme-oxygenase core kept; downstream stress/inflammation kept non-core; bare "protein binding" IPIs over-annotated); BLVRA's genuine moonlighting Ser/Thr/Tyr-kinase/scaffold role captured as a second core function; BLVRB's broad flavin-reductase + IXβ specificity distinguished from BLVRA. No experimental annotations removed. All `supporting_text` verbatim from cached sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)