### PR TITLE
Fix yeast ACL4 carrier chaperone term label

### DIFF
--- a/genes/yeast/ACL4/ACL4-ai-review.yaml
+++ b/genes/yeast/ACL4/ACL4-ai-review.yaml
@@ -277,7 +277,7 @@ existing_annotations:
     action: ACCEPT
     reason: >-
       QuickGO places GO:0140318 under transporter activity and GO:0140597 under
-      molecular carrier chaperone rather than as a parent-child pair. Retaining
+      molecular carrier activity rather than as a parent-child pair. Retaining
       this SGD IDA annotation is therefore not a redundant parent annotation,
       and the PMID:26447800 evidence supports Acl4 escorting Rpl4 to the
       pre-60S assembly pathway.

--- a/genes/yeast/ACL4/ACL4-ai-review.yaml
+++ b/genes/yeast/ACL4/ACL4-ai-review.yaml
@@ -259,7 +259,7 @@ existing_annotations:
       activity rather than generic binding to unfolded proteins.
     proposed_replacement_terms:
     - id: GO:0140597
-      label: protein carrier activity
+      label: protein carrier chaperone
     supported_by:
     - reference_id: file:yeast/ACL4/ACL4-deep-research-falcon.md
       supporting_text: "Acl4 is a dedicated ribosomal protein chaperone"
@@ -277,7 +277,7 @@ existing_annotations:
     action: ACCEPT
     reason: >-
       QuickGO places GO:0140318 under transporter activity and GO:0140597 under
-      molecular carrier activity rather than as a parent-child pair. Retaining
+      molecular carrier chaperone rather than as a parent-child pair. Retaining
       this SGD IDA annotation is therefore not a redundant parent annotation,
       and the PMID:26447800 evidence supports Acl4 escorting Rpl4 to the
       pre-60S assembly pathway.
@@ -327,7 +327,7 @@ existing_annotations:
 core_functions:
 - molecular_function:
     id: GO:0140597
-    label: protein carrier activity
+    label: protein carrier chaperone
   directly_involved_in:
   - id: GO:0042273
     label: ribosomal large subunit biogenesis


### PR DESCRIPTION
Corrects the canonical GO:0140597 label in the COMPLETE ACL4 review while preserving the ontology hierarchy rationale. Global validation/compliance baseline passed; focused schema, term, PMID, and compliance checks passed with only pre-existing propagation-provenance warnings. An independent AIGR diff review found one wording issue, which was corrected and revalidated.