### PR TITLE
Complete validated 9POAL gene reviews

### DIFF
--- a/genes/9POAL/NCGR_LOCUS1765/NCGR_LOCUS1765-ai-review.yaml
+++ b/genes/9POAL/NCGR_LOCUS1765/NCGR_LOCUS1765-ai-review.yaml
@@ -3,6 +3,7 @@ gene_symbol: NCGR_LOCUS1765
 aliases:
 - CBP80
 - NCBP1
+status: COMPLETE
 taxon:
   id: NCBITaxon:422564
   label: Miscanthus lutarioriparius
@@ -239,9 +240,6 @@ core_functions:
   molecular_function:
     id: GO:0000339
     label: RNA cap binding
-  directly_involved_in:
-  - id: GO:0006397
-    label: mRNA processing
   locations:
   - id: GO:0005634
     label: nucleus

--- a/genes/9POAL/NCGR_LOCUS27674/NCGR_LOCUS27674-ai-review.yaml
+++ b/genes/9POAL/NCGR_LOCUS27674/NCGR_LOCUS27674-ai-review.yaml
@@ -1,6 +1,7 @@
 id: A0A811PC48
 gene_symbol: NCGR_LOCUS27674
 product_type: PROTEIN
+status: COMPLETE
 taxon:
   id: NCBITaxon:422564
   label: Miscanthus lutarioriparius


### PR DESCRIPTION
Marks two fully adjudicated reviews COMPLETE and removes a redundant broad mRNA-processing process from the NCGR_LOCUS1765 cap-binding core. Focused validation and PMID checks passed with zero warnings; compliance gaps are optional enrichment fields. Independent AIGR diff review reported no blocking findings.