### PR TITLE
Correct rat Akt1 reference titles

### DIFF
--- a/genes/rat/Akt1/Akt1-ai-review.html
+++ b/genes/rat/Akt1/Akt1-ai-review.html
@@ -19866,7 +19866,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
 
 
             </div>
@@ -19882,7 +19882,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
 
 
             </div>
@@ -19898,7 +19898,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
 
 
             </div>
@@ -19914,7 +19914,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
 
 
             </div>
@@ -19930,7 +19930,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">Automatic Gene Ontology annotation based on Rhea mapping</div>
 
 
             </div>
@@ -19946,7 +19946,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
 
 
             </div>
@@ -19962,7 +19962,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
 
 
             </div>
@@ -19978,7 +19978,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">RGD ISO annotations to rat from other mammalian species</div>
 
 
             </div>
@@ -20616,7 +20616,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">Akt translocates to the nucleus</div>
 
 
             </div>
@@ -20630,7 +20630,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">Akt1 phosphorylates GSK3</div>
 
 
             </div>
@@ -20644,7 +20644,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">PDK1 activates PKC zeta</div>
 
 
             </div>
@@ -20658,7 +20658,7 @@
                     </span>
                 </div>
 
-                <div class="reference-title">TODO: Fetch title</div>
+                <div class="reference-title">PDK1 binds PKC zeta</div>
 
 
             </div>
@@ -24307,28 +24307,28 @@ references:
       AKT signaling is terminated at two levels: **PTEN** removes the lipid signal by dephosphorylating **PIP3 to PI(4,5)P2**, preventing membrane recruitment; **PP2A** and **PHLPP** dephosphorylate AKT at key regulatory residues, especially after membrane dissociation.
     reference_section_type: OTHER
 - id: GO_REF:0000002
-  title: &#39;TODO: Fetch title&#39;
+  title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
 - id: GO_REF:0000024
-  title: &#39;TODO: Fetch title&#39;
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity
   findings: []
 - id: GO_REF:0000033
-  title: &#39;TODO: Fetch title&#39;
+  title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: &#39;TODO: Fetch title&#39;
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000116
-  title: &#39;TODO: Fetch title&#39;
+  title: Automatic Gene Ontology annotation based on Rhea mapping
   findings: []
 - id: GO_REF:0000117
-  title: &#39;TODO: Fetch title&#39;
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
   findings: []
 - id: GO_REF:0000120
-  title: &#39;TODO: Fetch title&#39;
+  title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: GO_REF:0000121
-  title: &#39;TODO: Fetch title&#39;
+  title: RGD ISO annotations to rat from other mammalian species
   findings: []
 - id: PMID:10400692
   title: Requirement for Akt (protein kinase B) in insulin-induced activation of glycogen synthase and phosphorylation of 4E-BP1 (PHAS-1).
@@ -24448,16 +24448,16 @@ references:
   title: &#39;Akt kinases and 2-deoxyglucose uptake in rat skeletal muscles in vivo: study with insulin and exercise.&#39;
   findings: []
 - id: Reactome:R-RNO-198333
-  title: &#39;TODO: Fetch title&#39;
+  title: Akt translocates to the nucleus
   findings: []
 - id: Reactome:R-RNO-198601
-  title: &#39;TODO: Fetch title&#39;
+  title: Akt1 phosphorylates GSK3
   findings: []
 - id: Reactome:R-RNO-437185
-  title: &#39;TODO: Fetch title&#39;
+  title: PDK1 activates PKC zeta
   findings: []
 - id: Reactome:R-RNO-437189
-  title: &#39;TODO: Fetch title&#39;
+  title: PDK1 binds PKC zeta
   findings: []
 core_functions:
 - description: AKT1 is the rat RAC-alpha/PKB alpha serine/threonine kinase that transduces phosphatidylinositol 3-kinase signals to regulate insulin-responsive metabolism, growth, and survival programs through phosphorylation of downstream substrates.

--- a/genes/rat/Akt1/Akt1-ai-review.yaml
+++ b/genes/rat/Akt1/Akt1-ai-review.yaml
@@ -3176,28 +3176,28 @@ references:
       AKT signaling is terminated at two levels: **PTEN** removes the lipid signal by dephosphorylating **PIP3 to PI(4,5)P2**, preventing membrane recruitment; **PP2A** and **PHLPP** dephosphorylate AKT at key regulatory residues, especially after membrane dissociation.
     reference_section_type: OTHER
 - id: GO_REF:0000002
-  title: 'TODO: Fetch title'
+  title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
 - id: GO_REF:0000024
-  title: 'TODO: Fetch title'
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity
   findings: []
 - id: GO_REF:0000033
-  title: 'TODO: Fetch title'
+  title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: 'TODO: Fetch title'
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000116
-  title: 'TODO: Fetch title'
+  title: Automatic Gene Ontology annotation based on Rhea mapping
   findings: []
 - id: GO_REF:0000117
-  title: 'TODO: Fetch title'
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
   findings: []
 - id: GO_REF:0000120
-  title: 'TODO: Fetch title'
+  title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: GO_REF:0000121
-  title: 'TODO: Fetch title'
+  title: RGD ISO annotations to rat from other mammalian species
   findings: []
 - id: PMID:10400692
   title: Requirement for Akt (protein kinase B) in insulin-induced activation of glycogen synthase and phosphorylation of 4E-BP1 (PHAS-1).
@@ -3317,16 +3317,16 @@ references:
   title: 'Akt kinases and 2-deoxyglucose uptake in rat skeletal muscles in vivo: study with insulin and exercise.'
   findings: []
 - id: Reactome:R-RNO-198333
-  title: 'TODO: Fetch title'
+  title: Akt translocates to the nucleus
   findings: []
 - id: Reactome:R-RNO-198601
-  title: 'TODO: Fetch title'
+  title: Akt1 phosphorylates GSK3
   findings: []
 - id: Reactome:R-RNO-437185
-  title: 'TODO: Fetch title'
+  title: PDK1 activates PKC zeta
   findings: []
 - id: Reactome:R-RNO-437189
-  title: 'TODO: Fetch title'
+  title: PDK1 binds PKC zeta
   findings: []
 core_functions:
 - description: AKT1 is the rat RAC-alpha/PKB alpha serine/threonine kinase that transduces phosphatidylinositol 3-kinase signals to regulate insulin-responsive metabolism, growth, and survival programs through phosphorylation of downstream substrates.


### PR DESCRIPTION
Replaces eight GO reference placeholders and four Reactome placeholders with exact authoritative titles in the COMPLETE Akt1 review and rendered HTML. Focused schema, term, PMID, compliance, render, and diff checks passed; retained propagation warnings are pre-existing and lack inspected source-node evidence. Independent AIGR review verified all 12 titles and reported no blocking findings.