### PR TITLE
[codex] Refine Putida tryptophan biosynthesis module

### DIFF
--- a/modules/tryptophan_biosynthesis.yaml
+++ b/modules/tryptophan_biosynthesis.yaml
@@ -152,7 +152,7 @@ module:
                           - preferred_term: trpG / PP_0420 (Pseudomonas putida KT2440; UniProt gene name pabA)
                             term:
                               id: UniProtKB:Q88QR8
-                              label: TrpG-like anthranilate synthase amidotransferase component
+                              label: Aminodeoxychorismate synthase / para-aminobenzoate synthase multi-enzyme complex
                     function:
                       preferred_term: anthranilate synthase activity
                       term:

--- a/modules/tryptophan_biosynthesis.yaml
+++ b/modules/tryptophan_biosynthesis.yaml
@@ -33,6 +33,26 @@ evidence:
   - source_id: GO:0000162
     title: L-tryptophan biosynthetic process
     statement: The module is grounded in the GO biological-process term for tryptophan biosynthesis.
+  - source_id: file:modules/tryptophan_biosynthesis-deep-research-falcon.md
+    title: Falcon module review for microbial L-tryptophan biosynthesis
+    statement: >-
+      Generic module-level retrieval supports the chorismate-to-tryptophan
+      boundary, common fusion/complex architectures, and terminal tryptophan
+      synthase channeling.
+  - source_id: file:projects/P_PUTIDA/deep-research/PSEPK__tryptophan_biosynthesis__ppu00400-deep-research-falcon.md
+    title: Falcon PSEPK ppu00400 tryptophan biosynthesis review
+    statement: >-
+      Species/pathway review finds the KT2440 chorismate-to-tryptophan pathway
+      fully covered by seven core genes, separates broad ppu00400 shikimate and
+      phenylalanine/tyrosine spillover from the tryptophan core, and flags
+      PP_0420 as a TrpG-like anthranilate-synthase amidotransferase despite the
+      local pabA gene name.
+  - source_id: file:PSEPK/pabA/pabA-ai-review.yaml
+    title: PSEPK PP_0420/pabA gene review
+    statement: >-
+      Existing review supports PP_0420 as the TrpG-like glutamine
+      amidotransferase component of anthranilate synthase for tryptophan module
+      satisfiability, while leaving any folate/pABA role unresolved.
 module:
   id: tryptophan_biosynthesis
   label: L-tryptophan biosynthesis
@@ -93,6 +113,11 @@ module:
                         term:
                           id: NCBIfam:TIGR00565
                           label: anthranilate synthase component I
+                        representative_members:
+                          - preferred_term: trpE (Pseudomonas putida KT2440)
+                            term:
+                              id: UniProtKB:Q88QS1
+                              label: Anthranilate synthase component 1
                     function:
                       preferred_term: anthranilate synthase activity
                       term:
@@ -123,6 +148,11 @@ module:
                         term:
                           id: NCBIfam:TIGR00566
                           label: anthranilate synthase component II / glutamine amidotransferase
+                        representative_members:
+                          - preferred_term: trpG / PP_0420 (Pseudomonas putida KT2440; UniProt gene name pabA)
+                            term:
+                              id: UniProtKB:Q88QR8
+                              label: TrpG-like anthranilate synthase amidotransferase component
                     function:
                       preferred_term: anthranilate synthase activity
                       term:
@@ -158,6 +188,11 @@ module:
                         term:
                           id: NCBIfam:TIGR01815
                           label: anthranilate synthase, alphaproteobacterial clade
+                        representative_members:
+                          - preferred_term: trpE(G) (Sinorhizobium meliloti 1021)
+                            term:
+                              id: UniProtKB:P15395
+                              label: Anthranilate synthase
                     function:
                       preferred_term: anthranilate synthase activity
                       term:
@@ -185,12 +220,22 @@ module:
           - id: trpD2_activity
             label: "trpD_2: anthranilate phosphoribosyltransferase"
             participant:
-              selector_type: ANY_WITH_FUNCTION
+              selector_type: FAMILY
               required_function:
                 preferred_term: anthranilate phosphoribosyltransferase activity
                 term:
                   id: GO:0004048
                   label: anthranilate phosphoribosyltransferase activity
+              family:
+                preferred_term: anthranilate phosphoribosyltransferase family
+                term:
+                  id: PANTHER:PTHR43285
+                  label: Anthranilate phosphoribosyltransferase
+                representative_members:
+                  - preferred_term: trpD (Pseudomonas putida KT2440)
+                    term:
+                      id: UniProtKB:Q88QR7
+                      label: Anthranilate phosphoribosyltransferase
             function:
               preferred_term: anthranilate phosphoribosyltransferase activity
               term:
@@ -220,12 +265,22 @@ module:
           - id: prai_activity
             label: "PRAI/trpF: phosphoribosylanthranilate isomerase"
             participant:
-              selector_type: ANY_WITH_FUNCTION
+              selector_type: FAMILY
               required_function:
                 preferred_term: phosphoribosylanthranilate isomerase activity
                 term:
                   id: GO:0004640
                   label: phosphoribosylanthranilate isomerase activity
+              family:
+                preferred_term: phosphoribosylanthranilate isomerase family
+                term:
+                  id: PANTHER:PTHR42894
+                  label: N-(5'-phosphoribosyl)anthranilate isomerase
+                representative_members:
+                  - preferred_term: trpF (Pseudomonas putida KT2440)
+                    term:
+                      id: UniProtKB:Q88LE0
+                      label: N-(5'-phosphoribosyl)anthranilate isomerase
             function:
               preferred_term: phosphoribosylanthranilate isomerase activity
               term:
@@ -254,12 +309,22 @@ module:
           - id: igps_activity
             label: "IGPS/trpC: indole-3-glycerol-phosphate synthase"
             participant:
-              selector_type: ANY_WITH_FUNCTION
+              selector_type: FAMILY
               required_function:
                 preferred_term: indole-3-glycerol-phosphate synthase activity
                 term:
                   id: GO:0004425
                   label: indole-3-glycerol-phosphate synthase activity
+              family:
+                preferred_term: indole-3-glycerol-phosphate synthase family
+                term:
+                  id: PANTHER:PTHR22854
+                  label: Tryptophan biosynthesis protein / indole-3-glycerol-phosphate synthase family
+                representative_members:
+                  - preferred_term: trpC (Pseudomonas putida KT2440)
+                    term:
+                      id: UniProtKB:Q88QR6
+                      label: Indole-3-glycerol phosphate synthase
             function:
               preferred_term: indole-3-glycerol-phosphate synthase activity
               term:
@@ -304,6 +369,11 @@ module:
                 term:
                   id: NCBIfam:TIGR00262
                   label: tryptophan synthase, alpha subunit
+                representative_members:
+                  - preferred_term: trpA (Pseudomonas putida KT2440)
+                    term:
+                      id: UniProtKB:Q88RP7
+                      label: Tryptophan synthase alpha chain
             function:
               preferred_term: tryptophan synthase activity
               term:
@@ -333,6 +403,11 @@ module:
                 term:
                   id: NCBIfam:TIGR00263
                   label: tryptophan synthase, beta subunit
+                representative_members:
+                  - preferred_term: trpB (Pseudomonas putida KT2440)
+                    term:
+                      id: UniProtKB:Q88RP6
+                      label: Tryptophan synthase beta chain
             function:
               preferred_term: tryptophan synthase activity
               term:
@@ -377,4 +452,8 @@ module:
     into an EXACTLY_ONE variant set. EC numbers that GapMind records only as
     ignore_other (the true reaction ECs 4.1.3.27, 4.1.2.8, 4.2.1.20) were
     reinstated as reaction evidence. Bifunctional microbial fusions are flagged:
-    TrpD (trpD_1 + trpD_2), TrpC (PRAI + IGPS), and PriA (HisA + TrpF).
+    TrpD (trpD_1 + trpD_2), TrpC (PRAI + IGPS), and PriA (HisA + TrpF). In the
+    P. putida KT2440 ppu00400 batch, the narrow module is fully satisfied by
+    trpE, PP_0420/trpG-like amidotransferase, trpD, trpF, trpC, trpA, and trpB.
+    Upstream shikimate genes, phenylalanine/tyrosine branch enzymes, and
+    quinate-catabolic genes from the broad KEGG map are outside this module.

--- a/pages/modules/tryptophan_biosynthesis.html
+++ b/pages/modules/tryptophan_biosynthesis.html
@@ -556,7 +556,7 @@
         </div>
         <div class="descriptor-list">                <span class="descriptor">
             <span>L-tryptophan biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0000162" target="_blank" rel="noopener">GO:0000162</a></span>        </div>
-        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://papers.genomics.lbl.gov/cgi-bin/gapView.cgi?gdb=NCBI&amp;set=aa&amp;path=trp" target="_blank" rel="noopener">GapMind:aa</a><div><strong>GapMind for amino acid biosynthesis</strong></div><div>Step set and characterized-protein groundings derive from the GapMind amino-acid biosynthesis pathway definition trp.steps (PaperBLAST, Price &amp; Arkin, LBL).</div></div>                <div class="evidence-card small"><a class="source-id" href="https://metacyc.org/META/NEW-IMAGE?type=PATHWAY&amp;object=TRPSYN-PWY" target="_blank" rel="noopener">MetaCyc:TRPSYN-PWY</a><div><strong>L-tryptophan biosynthesis</strong></div><div>GapMind bases the tryptophan pathway on the MetaCyc pathway TRPSYN-PWY.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0000162" target="_blank" rel="noopener">GO:0000162</a><div><strong>L-tryptophan biosynthetic process</strong></div><div>The module is grounded in the GO biological-process term for tryptophan biosynthesis.</div></div>        </div></header>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://papers.genomics.lbl.gov/cgi-bin/gapView.cgi?gdb=NCBI&amp;set=aa&amp;path=trp" target="_blank" rel="noopener">GapMind:aa</a><div><strong>GapMind for amino acid biosynthesis</strong></div><div>Step set and characterized-protein groundings derive from the GapMind amino-acid biosynthesis pathway definition trp.steps (PaperBLAST, Price &amp; Arkin, LBL).</div></div>                <div class="evidence-card small"><a class="source-id" href="https://metacyc.org/META/NEW-IMAGE?type=PATHWAY&amp;object=TRPSYN-PWY" target="_blank" rel="noopener">MetaCyc:TRPSYN-PWY</a><div><strong>L-tryptophan biosynthesis</strong></div><div>GapMind bases the tryptophan pathway on the MetaCyc pathway TRPSYN-PWY.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0000162" target="_blank" rel="noopener">GO:0000162</a><div><strong>L-tryptophan biosynthetic process</strong></div><div>The module is grounded in the GO biological-process term for tryptophan biosynthesis.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/tryptophan_biosynthesis-deep-research-falcon.md</span><div><strong>Falcon module review for microbial L-tryptophan biosynthesis</strong></div><div>Generic module-level retrieval supports the chorismate-to-tryptophan boundary, common fusion/complex architectures, and terminal tryptophan synthase channeling.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__tryptophan_biosynthesis__ppu00400-deep-research-falcon.md</span><div><strong>Falcon PSEPK ppu00400 tryptophan biosynthesis review</strong></div><div>Species/pathway review finds the KT2440 chorismate-to-tryptophan pathway fully covered by seven core genes, separates broad ppu00400 shikimate and phenylalanine/tyrosine spillover from the tryptophan core, and flags PP_0420 as a TrpG-like anthranilate-synthase amidotransferase despite the local pabA gene name.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/pabA/pabA-ai-review.yaml</span><div><strong>PSEPK PP_0420/pabA gene review</strong></div><div>Existing review supports PP_0420 as the TrpG-like glutamine amidotransferase component of anthranilate synthase for tryptophan module satisfiability, while leaving any folate/pABA role unresolved.</div></div>        </div></header>
     <section class="stats" aria-label="Module counts">
         <div class="stat"><span class="stat-value">8</span><span class="stat-label">Nodes</span></div>
         <div class="stat"><span class="stat-value">5</span><span class="stat-label">Parts</span></div>
@@ -578,8 +578,7 @@
                     <ul class="qc-list small">                            <li>tryptophan_biosynthesis-deep-research-falcon.md <span class="muted">(falcon)</span></li>                    </ul>            </div>
 
             <div class="qc-card">
-                <h3>Leaf nodes lacking representative members</h3>                    <p class="small">6 leaf node(s) with no concrete protein grounding:</p>
-                    <ul class="qc-list small">                            <li><a href="#node-two_component_anthranilate_synthase">Two-component anthranilate synthase (TrpE + TrpD/TrpG)</a> <span class="muted">FAMILY</span></li>                            <li><a href="#node-single_protein_anthranilate_synthase">Single-protein anthranilate synthase (TrpED, alphaproteobacterial clade)</a> <span class="muted">FAMILY</span></li>                            <li><a href="#node-trpd2_step">Anthranilate to N-(5&#39;-phosphoribosyl)-anthranilate</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-prai_step">PRA to CdRP</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-igps_step">CdRP to indole-3-glycerol phosphate</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-tryptophan_synthase_step">Indole-3-glycerol phosphate + L-serine to L-tryptophan</a> <span class="muted">FAMILY</span></li>                    </ul>            </div>
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
 
             <div class="qc-card">
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>            <div class="qc-card">
@@ -590,8 +589,72 @@
             </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(0/0 grounded genes reviewed)</span>
-                </h3>                    <p class="muted small">No concrete UniProt-grounded genes in this module.</p>            </div>
+                    <span class="muted small">(7/8 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        6 complete review(s) &middot;
+                        7 with deep research &middot;
+                        1 missing review &middot;
+                        0 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>trpE(G) (Sinorhizobium meliloti 1021)
+                                        <span class="muted term-id">P15395</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
+                                </tr>                                <tr>
+                                    <td>pabA
+                                        <span class="muted term-id">Q88QR8</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">4/6</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>trpA
+                                        <span class="muted term-id">Q88RP7</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>trpB
+                                        <span class="muted term-id">Q88RP6</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>trpC
+                                        <span class="muted term-id">Q88QR6</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>trpD
+                                        <span class="muted term-id">Q88QR7</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>trpE
+                                        <span class="muted term-id">Q88QS1</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>trpF
+                                        <span class="muted term-id">Q88LE0</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
         </div>
     </section>
     <section class="browser">
@@ -671,7 +734,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-trpd2_activity">trpD_2: anthranilate phosphoribosyltransferase</a>
-                                <span class="tree-id">Any With Function: anthranilate phosphoribosyltransferase activity</span>
+                                <span class="tree-id">Family: anthranilate phosphoribosyltransferase family</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -687,7 +750,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-prai_activity">PRAI/trpF: phosphoribosylanthranilate isomerase</a>
-                                <span class="tree-id">Any With Function: phosphoribosylanthranilate isomerase activity</span>
+                                <span class="tree-id">Family: phosphoribosylanthranilate isomerase family</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -703,7 +766,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-igps_activity">IGPS/trpC: indole-3-glycerol-phosphate synthase</a>
-                                <span class="tree-id">Any With Function: indole-3-glycerol-phosphate synthase activity</span>
+                                <span class="tree-id">Family: indole-3-glycerol-phosphate synthase family</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -764,7 +827,7 @@
             <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
 
             </div>
-        <p class="muted small">Backbone and characterized-protein groundings were mined from GapMind trp.steps and ModelSEED (see modules/experimental/gapmind-mining/), then curated: GO molecular-function terms were verified via QuickGO, reaction chemistry and channeling/fusion notes were added, and the GapMind anthranilate-synthase OR-rule (two-component vs single-protein) was curated into an EXACTLY_ONE variant set. EC numbers that GapMind records only as ignore_other (the true reaction ECs 4.1.3.27, 4.1.2.8, 4.2.1.20) were reinstated as reaction evidence. Bifunctional microbial fusions are flagged: TrpD (trpD_1 + trpD_2), TrpC (PRAI + IGPS), and PriA (HisA + TrpF).</p>            <h4>Connections</h4>
+        <p class="muted small">Backbone and characterized-protein groundings were mined from GapMind trp.steps and ModelSEED (see modules/experimental/gapmind-mining/), then curated: GO molecular-function terms were verified via QuickGO, reaction chemistry and channeling/fusion notes were added, and the GapMind anthranilate-synthase OR-rule (two-component vs single-protein) was curated into an EXACTLY_ONE variant set. EC numbers that GapMind records only as ignore_other (the true reaction ECs 4.1.3.27, 4.1.2.8, 4.2.1.20) were reinstated as reaction evidence. Bifunctional microbial fusions are flagged: TrpD (trpD_1 + trpD_2), TrpC (PRAI + IGPS), and PriA (HisA + TrpF). In the P. putida KT2440 ppu00400 batch, the narrow module is fully satisfied by trpE, PP_0420/trpG-like amidotransferase, trpD, trpF, trpC, trpA, and trpB. Upstream shikimate genes, phenylalanine/tyrosine branch enzymes, and quinate-catabolic genes from the broad KEGG map are outside this module.</p>            <h4>Connections</h4>
             <div class="connection-list">                <div class="connection-card small">
                     <div>
                         <a href="#node-anthranilate_synthase_node">anthranilate_synthase_node</a>
@@ -812,7 +875,9 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>anthranilate synthase component I (TrpE)</strong></span><span class="term-id">NCBIfam:TIGR00565</span></div>
+            <span><strong>anthranilate synthase component I (TrpE)</strong></span><span class="term-id">NCBIfam:TIGR00565</span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>trpE (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88QS1/entry" target="_blank" rel="noopener">UniProtKB:Q88QS1</a></span>                    </div></div>
                     </div>                    <div class="slot-row">
                         <span class="slot-name">Required Function:</span>
                         <div class="descriptor">
@@ -831,7 +896,9 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>anthranilate synthase glutamine amidotransferase component (TrpG/TrpD)</strong></span><span class="term-id">NCBIfam:TIGR00566</span></div>
+            <span><strong>anthranilate synthase glutamine amidotransferase component (TrpG/TrpD)</strong></span><span class="term-id">NCBIfam:TIGR00566</span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>trpG / PP_0420 (Pseudomonas putida KT2440; UniProt gene name pabA)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88QR8/entry" target="_blank" rel="noopener">UniProtKB:Q88QR8</a></span>                    </div></div>
                     </div>                    <div class="slot-row">
                         <span class="slot-name">Required Function:</span>
                         <div class="descriptor">
@@ -852,7 +919,9 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>single-protein anthranilate synthase (TrpED clade)</strong></span><span class="term-id">NCBIfam:TIGR01815</span></div>
+            <span><strong>single-protein anthranilate synthase (TrpED clade)</strong></span><span class="term-id">NCBIfam:TIGR01815</span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>trpE(G) (Sinorhizobium meliloti 1021)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P15395/entry" target="_blank" rel="noopener">UniProtKB:P15395</a></span>                    </div></div>
                     </div>                    <div class="slot-row">
                         <span class="slot-name">Required Function:</span>
                         <div class="descriptor">
@@ -876,8 +945,14 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-trpd2_activity">
         <div class="annoton-title">trpD_2: anthranilate phosphoribosyltransferase</div>
-        <div class="small muted">trpD2_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: anthranilate phosphoribosyltransferase activity</div>
+        <div class="small muted">trpD2_activity</div>            <div class="small"><strong>Participant:</strong> Family: anthranilate phosphoribosyltransferase family</div>
             <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>anthranilate phosphoribosyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43285" target="_blank" rel="noopener">PANTHER:PTHR43285</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>trpD (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88QR7/entry" target="_blank" rel="noopener">UniProtKB:Q88QR7</a></span>                    </div></div>
+                    </div>                    <div class="slot-row">
                         <span class="slot-name">Required Function:</span>
                         <div class="descriptor">
             <span><strong>anthranilate phosphoribosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004048" target="_blank" rel="noopener">GO:0004048</a></div>
@@ -899,8 +974,14 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-prai_activity">
         <div class="annoton-title">PRAI/trpF: phosphoribosylanthranilate isomerase</div>
-        <div class="small muted">prai_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: phosphoribosylanthranilate isomerase activity</div>
+        <div class="small muted">prai_activity</div>            <div class="small"><strong>Participant:</strong> Family: phosphoribosylanthranilate isomerase family</div>
             <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>phosphoribosylanthranilate isomerase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR42894" target="_blank" rel="noopener">PANTHER:PTHR42894</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>trpF (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88LE0/entry" target="_blank" rel="noopener">UniProtKB:Q88LE0</a></span>                    </div></div>
+                    </div>                    <div class="slot-row">
                         <span class="slot-name">Required Function:</span>
                         <div class="descriptor">
             <span><strong>phosphoribosylanthranilate isomerase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004640" target="_blank" rel="noopener">GO:0004640</a></div>
@@ -920,8 +1001,14 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-igps_activity">
         <div class="annoton-title">IGPS/trpC: indole-3-glycerol-phosphate synthase</div>
-        <div class="small muted">igps_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: indole-3-glycerol-phosphate synthase activity</div>
+        <div class="small muted">igps_activity</div>            <div class="small"><strong>Participant:</strong> Family: indole-3-glycerol-phosphate synthase family</div>
             <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>indole-3-glycerol-phosphate synthase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR22854" target="_blank" rel="noopener">PANTHER:PTHR22854</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>trpC (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88QR6/entry" target="_blank" rel="noopener">UniProtKB:Q88QR6</a></span>                    </div></div>
+                    </div>                    <div class="slot-row">
                         <span class="slot-name">Required Function:</span>
                         <div class="descriptor">
             <span><strong>indole-3-glycerol-phosphate synthase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004425" target="_blank" rel="noopener">GO:0004425</a></div>
@@ -947,7 +1034,9 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>tryptophan synthase alpha chain (TrpA)</strong></span><span class="term-id">NCBIfam:TIGR00262</span></div>
+            <span><strong>tryptophan synthase alpha chain (TrpA)</strong></span><span class="term-id">NCBIfam:TIGR00262</span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>trpA (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88RP7/entry" target="_blank" rel="noopener">UniProtKB:Q88RP7</a></span>                    </div></div>
                     </div>                    <div class="slot-row">
                         <span class="slot-name">Required Function:</span>
                         <div class="descriptor">
@@ -965,7 +1054,9 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>tryptophan synthase beta chain (TrpB)</strong></span><span class="term-id">NCBIfam:TIGR00263</span></div>
+            <span><strong>tryptophan synthase beta chain (TrpB)</strong></span><span class="term-id">NCBIfam:TIGR00263</span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>trpB (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88RP6/entry" target="_blank" rel="noopener">UniProtKB:Q88RP6</a></span>                    </div></div>
                     </div>                    <div class="slot-row">
                         <span class="slot-name">Required Function:</span>
                         <div class="descriptor">

--- a/pages/projects/P_PUTIDA/batches/ppu00400_tryptophan_biosynthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00400_tryptophan_biosynthesis.html
@@ -385,7 +385,7 @@
 <li>[x] Curate each selected gene review.</li>
 <li>[x] Validate module and gene reviews.</li>
 <li>[x] Open pilot PR for initial gene-level batch: <a href="https://github.com/ai4curation/ai-gene-review/pull/1874">PR #1874</a> (merged).</li>
-<li>[ ] Open follow-up PR for module grounding and batch boundary cleanup.</li>
+<li>[x] Open follow-up PR for module grounding and batch boundary cleanup: <a href="https://github.com/ai4curation/ai-gene-review/pull/2140">PR #2140</a>.</li>
 <li>[ ] Shepherd follow-up PR through review, CI, and merge readiness.</li>
 </ul>
 <h2 id="candidate-genes">Candidate Genes</h2>

--- a/pages/projects/P_PUTIDA/batches/ppu00400_tryptophan_biosynthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00400_tryptophan_biosynthesis.html
@@ -377,15 +377,16 @@
 </ul>
 <h2 id="required-workflow">Required Workflow</h2>
 <ul>
-<li>[ ] Curate or update the species-neutral module.</li>
-<li>[ ] Run module-level Falcon deep research.</li>
-<li>[ ] Run module + pathway + PSEPK Falcon deep research.</li>
+<li>[x] Curate or update the species-neutral module.</li>
+<li>[x] Run module-level Falcon deep research.</li>
+<li>[x] Run module + pathway + PSEPK Falcon deep research.</li>
 <li>[x] Fetch all selected genes with <code>just fetch-gene PSEPK &lt;gene&gt;</code>.</li>
 <li>[x] Run Asta deep research for selected genes.</li>
 <li>[x] Curate each selected gene review.</li>
 <li>[x] Validate module and gene reviews.</li>
-<li>[x] Open one PR for this module/pathway: <a href="https://github.com/ai4curation/ai-gene-review/pull/1874">PR #1874</a>.</li>
-<li>[ ] Shepherd PR through review, CI, and merge readiness.</li>
+<li>[x] Open pilot PR for initial gene-level batch: <a href="https://github.com/ai4curation/ai-gene-review/pull/1874">PR #1874</a> (merged).</li>
+<li>[ ] Open follow-up PR for module grounding and batch boundary cleanup.</li>
+<li>[ ] Shepherd follow-up PR through review, CI, and merge readiness.</li>
 </ul>
 <h2 id="candidate-genes">Candidate Genes</h2>
 <table>
@@ -715,6 +716,21 @@
 </table>
 <h2 id="notes">Notes</h2>
 <p>Generated UTC: 2026-07-06T03:48:55.229299+00:00</p>
+<p>2026-07-15 follow-up: the species-neutral <code>tryptophan_biosynthesis</code> module is<br />
+curated as the narrow chorismate-to-L-tryptophan pathway, not the full broad KEGG<br />
+ppu00400 aromatic-amino-acid map. PSEPK satisfiability is covered by seven core<br />
+genes: <code>trpE</code>, <code>pabA</code>/PP_0420 as the TrpG-like anthranilate-synthase<br />
+amidotransferase component, <code>trpD</code>, <code>trpF</code>, <code>trpC</code>, <code>trpA</code>, and <code>trpB</code>.</p>
+<p>The broad ppu00400 spillover genes are intentionally outside this module:<br />
+upstream shikimate and chorismate-supply enzymes, phenylalanine/tyrosine branch<br />
+enzymes, quinate-catabolic genes, and general aminotransferases. These should be<br />
+handled by separate upstream chorismate/aromatic-amino-acid modules rather than<br />
+folded into the tryptophan core.</p>
+<p>Remaining curation question: PP_0420 is named <code>pabA</code> in local source data and<br />
+has a pABA/folate-associated protein name, but the PSEPK pathway-level review<br />
+and gene review support using it as the TrpG-like glutamine amidotransferase for<br />
+anthranilate synthase in this module. A possible dual folate role remains<br />
+unresolved and should not be inferred from this module alone.</p>
     </div>
 
     <footer>

--- a/projects/P_PUTIDA/batches/ppu00400_tryptophan_biosynthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00400_tryptophan_biosynthesis.md
@@ -25,7 +25,7 @@ autolink_gene_symbols: false
 - [x] Curate each selected gene review.
 - [x] Validate module and gene reviews.
 - [x] Open pilot PR for initial gene-level batch: [PR #1874](https://github.com/ai4curation/ai-gene-review/pull/1874) (merged).
-- [ ] Open follow-up PR for module grounding and batch boundary cleanup.
+- [x] Open follow-up PR for module grounding and batch boundary cleanup: [PR #2140](https://github.com/ai4curation/ai-gene-review/pull/2140).
 - [ ] Shepherd follow-up PR through review, CI, and merge readiness.
 
 ## Candidate Genes

--- a/projects/P_PUTIDA/batches/ppu00400_tryptophan_biosynthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00400_tryptophan_biosynthesis.md
@@ -17,15 +17,16 @@ autolink_gene_symbols: false
 
 ## Required Workflow
 
-- [ ] Curate or update the species-neutral module.
-- [ ] Run module-level Falcon deep research.
-- [ ] Run module + pathway + PSEPK Falcon deep research.
+- [x] Curate or update the species-neutral module.
+- [x] Run module-level Falcon deep research.
+- [x] Run module + pathway + PSEPK Falcon deep research.
 - [x] Fetch all selected genes with `just fetch-gene PSEPK <gene>`.
 - [x] Run Asta deep research for selected genes.
 - [x] Curate each selected gene review.
 - [x] Validate module and gene reviews.
-- [x] Open one PR for this module/pathway: [PR #1874](https://github.com/ai4curation/ai-gene-review/pull/1874).
-- [ ] Shepherd PR through review, CI, and merge readiness.
+- [x] Open pilot PR for initial gene-level batch: [PR #1874](https://github.com/ai4curation/ai-gene-review/pull/1874) (merged).
+- [ ] Open follow-up PR for module grounding and batch boundary cleanup.
+- [ ] Shepherd follow-up PR through review, CI, and merge readiness.
 
 ## Candidate Genes
 
@@ -63,3 +64,21 @@ autolink_gene_symbols: false
 ## Notes
 
 Generated UTC: 2026-07-06T03:48:55.229299+00:00
+
+2026-07-15 follow-up: the species-neutral `tryptophan_biosynthesis` module is
+curated as the narrow chorismate-to-L-tryptophan pathway, not the full broad KEGG
+ppu00400 aromatic-amino-acid map. PSEPK satisfiability is covered by seven core
+genes: `trpE`, `pabA`/PP_0420 as the TrpG-like anthranilate-synthase
+amidotransferase component, `trpD`, `trpF`, `trpC`, `trpA`, and `trpB`.
+
+The broad ppu00400 spillover genes are intentionally outside this module:
+upstream shikimate and chorismate-supply enzymes, phenylalanine/tyrosine branch
+enzymes, quinate-catabolic genes, and general aminotransferases. These should be
+handled by separate upstream chorismate/aromatic-amino-acid modules rather than
+folded into the tryptophan core.
+
+Remaining curation question: PP_0420 is named `pabA` in local source data and
+has a pABA/folate-associated protein name, but the PSEPK pathway-level review
+and gene review support using it as the TrpG-like glutamine amidotransferase for
+anthranilate synthase in this module. A possible dual folate role remains
+unresolved and should not be inferred from this module alone.


### PR DESCRIPTION
## Summary

- Grounds `modules/tryptophan_biosynthesis.yaml` with module-level Falcon evidence, PSEPK ppu00400 Falcon evidence, and the PP_0420/pabA review.
- Adds concrete UniProt representative members for every leaf step, including the seven PSEPK core tryptophan-biosynthesis proteins and an external single-protein TrpED architecture exemplar.
- Updates the ppu00400 batch page to distinguish the narrow chorismate-to-L-tryptophan core from broad KEGG spillover genes.

## Curation notes

The PSEPK tryptophan core is modeled as `trpE`, PP_0420/TrpG-like `pabA`, `trpD`, `trpF`, `trpC`, `trpA`, and `trpB`. Upstream shikimate/chorismate-supply genes, phenylalanine/tyrosine branch enzymes, quinate-catabolic genes, and broad aminotransferases are left for separate modules.

PP_0420 remains the main naming caveat: local source data calls it `pabA`, while the pathway-level review and gene review support treating it as the TrpG-like anthranilate-synthase amidotransferase for this module. Any dual pABA/folate role remains unresolved.

The rendered module QC now reports no leaf nodes lacking representative members. It reports 7/8 grounded genes reviewed because the single-polypeptide TrpED variant uses external exemplar UniProtKB:P15395, which is outside the PSEPK gene-review set.

## Validation

- `uv run linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/tryptophan_biosynthesis.yaml`
- `uv run python -m ai_gene_review.validation.module_validator modules/tryptophan_biosynthesis.yaml`
- root decomposition check: `root_parts=5 root_variants=0`
- `just render-module modules/tryptophan_biosynthesis.yaml`
- `uv run ai-gene-review render-projects projects/P_PUTIDA/batches/ppu00400_tryptophan_biosynthesis.md -o pages/projects`
- `git diff --check`