### PR TITLE
Refine PSEPK wspR biofilm evidence

### DIFF
--- a/cache/go/terms.csv
+++ b/cache/go/terms.csv
@@ -6184,6 +6184,7 @@ GO:0052542,defense response by callose deposition,2026-03-22T22:38:14.237952
 GO:0052543,callose deposition in cell wall,2026-03-22T22:38:14.237952
 GO:0052544,defense response by callose deposition in cell wall,2026-05-08T22:12:02.954351
 GO:0052614,uracil oxygenase activity,2026-06-20T02:05:19.516828
+GO:0052621,diguanylate cyclase activity,2026-07-19T04:20:11.141673
 GO:0052629,"phosphatidylinositol-3,5-bisphosphate 3-phosphatase activity",2026-05-08T22:12:02.954355
 GO:0052689,carboxylic ester hydrolase activity,2026-05-08T22:12:02.954358
 GO:0052691,UDP-arabinopyranose mutase activity,2026-06-21T22:19:01.373908

--- a/genes/PSEPK/wspR/wspR-ai-review.yaml
+++ b/genes/PSEPK/wspR/wspR-ai-review.yaml
@@ -113,7 +113,7 @@ existing_annotations:
     id: GO:0090606
     label: single-species surface biofilm formation
   evidence_type: IMP
-  original_reference_id: PMID:35178858
+  original_reference_id: PMID:39589111
   review:
     summary: WspR-mediated c-di-GMP synthesis promotes surface-associated biofilm
       formation in KT2440 across surface-growth and antibiotic-stress contexts.

--- a/genes/PSEPK/wspR/wspR-notes.md
+++ b/genes/PSEPK/wspR/wspR-notes.md
@@ -15,3 +15,7 @@
   - `GO:0000160 phosphorelay signal transduction system` -> keep
   - `GO:0006355 regulation of DNA-templated transcription` -> over-annotation; downstream phenotype is indirect via c-di-GMP and FleQ/FleN
   - `GO:0005886 plasma membrane` -> remove; WspR itself is not membrane-spanning
+
+## 2026-07-19 evidence reconciliation
+
+- Retained the review's `ISS`/`IMP` evidence coding. For `GO:0090606 single-species surface biofilm formation`, PMID:39589111 is the more specific original reference because it directly compares the KT2440 `delta-wspR` mutant with wild type. [PMID:39589111 Tetracycline induces wsp operon expression to promote biofilm formation in Pseudomonas putida, "Besides, the biofilm formation of ΔwspR was the lowest among the tested strains, with the average biomass of ΔwspR being approximately 1/3 of that of WT"]


### PR DESCRIPTION
## Summary

- Use PMID:39589111 as the original IMP reference for WspR-dependent biofilm formation in Pseudomonas putida KT2440.
- Record the direct delta-wspR biofilm phenotype evidence in the gene notes.
- Add GO:0052621 diguanylate cyclase activity to the validator-generated GO term cache.

## Validation

- just validate PSEPK wspR
- Result: all validations passed.

## Test plan

- [x] Run full schema, term, reference, GOA, and best-practice validation.
- [x] Confirm the PR excludes derived publication files.
- [x] Run git diff --check.