### PR TITLE
Add focused Deliverome Rab7 comparison

### DIFF
--- a/genes/human/RAB7A/RAB7A-ai-review.html
+++ b/genes/human/RAB7A/RAB7A-ai-review.html
@@ -9950,7 +9950,7 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>RAB7A functions as a small GTPase molecular switch (EC 3.6.5.2), cycling between inactive GDP-bound (cytosolic) and active GTP-bound (membrane-associated) states. This GTPase activity is essential for regulating late endocytic trafficking, autophagy, and lysosomal biogenesis. Activation requires Mon1-Ccz1 GEF, and inactivation is accelerated by TBC-domain GAPs (TBC1D5, TBC1D15).</h3>
+                <h3>RAB7A functions as a small GTPase molecular switch (EC 3.6.5.2), cycling between inactive GDP-bound (cytosolic) and active GTP-bound (membrane-associated) states. This GTPase activity is essential for regulating late endocytic trafficking, early-to-late endosome maturation, autophagy, and lysosomal biogenesis. Activation requires Mon1-Ccz1 GEF, and inactivation is accelerated by TBC-domain GAPs (TBC1D5, TBC1D15).</h3>
                 <span class="vote-buttons" data-g="P51149" data-a="FUNCTION: RAB7A functions as a small GTPase molecular switch..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -9978,6 +9978,12 @@
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008333" target="_blank" class="term-link">
                                 endosome to lysosome transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045022" target="_blank" class="term-link">
+                                early endosome to late endosome transport
                             </a>
                         </span>
 
@@ -10011,6 +10017,12 @@
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005770" target="_blank" class="term-link">
                                 late endosome
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031902" target="_blank" class="term-link">
+                                late endosome membrane
                             </a>
                         </span>
 
@@ -10069,6 +10081,125 @@
                         </span>
 
                         <div class="finding-text">all three proteins exhibited higher nucleotide exchange rates and hydrolyzed GTP slower than the wild-type protein</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14617358" target="_blank" class="term-link">
+                                PMID:14617358
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Rab7 is required for late endosomal transport</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Active RAB7A recruits and binds the retromer complex on late endosomes, docking the cargo-selective retromer subcomplex to the membrane for endosome-to-Golgi retrograde transport.</h3>
+                <span class="vote-buttons" data-g="P51149" data-a="FUNCTION: Active RAB7A recruits and binds the retromer compl..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905394" target="_blank" class="term-link">
+                            retromer complex binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042147" target="_blank" class="term-link">
+                                retrograde transport, endosome to Golgi
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022615" target="_blank" class="term-link">
+                                protein to membrane docking
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005770" target="_blank" class="term-link">
+                                late endosome
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031902" target="_blank" class="term-link">
+                                late endosome membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19531583" target="_blank" class="term-link">
+                                PMID:19531583
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Membrane recruitment of the cargo-selective retromer subcomplex is catalysed by the small GTPase Rab7</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24344282" target="_blank" class="term-link">
+                                PMID:24344282
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">A mechanism for retromer endosomal coat complex assembly with cargo.</div>
 
                     </li>
 
@@ -13954,11 +14085,14 @@ core_functions:
       RAB7A functions as a small GTPase molecular switch (EC 3.6.5.2), cycling between
       inactive GDP-bound (cytosolic) and active GTP-bound (membrane-associated) states.
       This GTPase activity is essential for regulating late endocytic trafficking,
-      autophagy, and lysosomal biogenesis. Activation requires Mon1-Ccz1 GEF, and
-      inactivation is accelerated by TBC-domain GAPs (TBC1D5, TBC1D15).
+      early-to-late endosome maturation, autophagy, and lysosomal biogenesis.
+      Activation requires Mon1-Ccz1 GEF, and inactivation is accelerated by
+      TBC-domain GAPs (TBC1D5, TBC1D15).
     directly_involved_in:
       - id: GO:0008333
         label: endosome to lysosome transport
+      - id: GO:0045022
+        label: early endosome to late endosome transport
       - id: GO:0006914
         label: autophagy
       - id: GO:0090385
@@ -13968,6 +14102,8 @@ core_functions:
     locations:
       - id: GO:0005770
         label: late endosome
+      - id: GO:0031902
+        label: late endosome membrane
       - id: GO:0005764
         label: lysosome
       - id: GO:0000421
@@ -13982,6 +14118,32 @@ core_functions:
       - reference_id: PMID:18272684
         supporting_text: &#34;all three proteins exhibited higher nucleotide exchange
           rates and hydrolyzed GTP slower than the wild-type protein&#34;
+      - reference_id: PMID:14617358
+        supporting_text: &#34;Rab7 is required for late endosomal transport&#34;
+  - molecular_function:
+      id: GO:1905394
+      label: retromer complex binding
+    description: &gt;-
+      Active RAB7A recruits and binds the retromer complex on late endosomes,
+      docking the cargo-selective retromer subcomplex to the membrane for
+      endosome-to-Golgi retrograde transport.
+    directly_involved_in:
+      - id: GO:0042147
+        label: retrograde transport, endosome to Golgi
+      - id: GO:0022615
+        label: protein to membrane docking
+    locations:
+      - id: GO:0005770
+        label: late endosome
+      - id: GO:0031902
+        label: late endosome membrane
+    supported_by:
+      - reference_id: PMID:19531583
+        supporting_text: &#34;Membrane recruitment of the cargo-selective retromer subcomplex
+          is catalysed by the small GTPase Rab7&#34;
+      - reference_id: PMID:24344282
+        supporting_text: A mechanism for retromer endosomal coat complex assembly
+          with cargo.
 
 proposed_new_terms: []
 

--- a/genes/human/RAB7A/RAB7A-ai-review.yaml
+++ b/genes/human/RAB7A/RAB7A-ai-review.yaml
@@ -2029,11 +2029,14 @@ core_functions:
       RAB7A functions as a small GTPase molecular switch (EC 3.6.5.2), cycling between
       inactive GDP-bound (cytosolic) and active GTP-bound (membrane-associated) states.
       This GTPase activity is essential for regulating late endocytic trafficking,
-      autophagy, and lysosomal biogenesis. Activation requires Mon1-Ccz1 GEF, and
-      inactivation is accelerated by TBC-domain GAPs (TBC1D5, TBC1D15).
+      early-to-late endosome maturation, autophagy, and lysosomal biogenesis.
+      Activation requires Mon1-Ccz1 GEF, and inactivation is accelerated by
+      TBC-domain GAPs (TBC1D5, TBC1D15).
     directly_involved_in:
       - id: GO:0008333
         label: endosome to lysosome transport
+      - id: GO:0045022
+        label: early endosome to late endosome transport
       - id: GO:0006914
         label: autophagy
       - id: GO:0090385
@@ -2043,6 +2046,8 @@ core_functions:
     locations:
       - id: GO:0005770
         label: late endosome
+      - id: GO:0031902
+        label: late endosome membrane
       - id: GO:0005764
         label: lysosome
       - id: GO:0000421
@@ -2057,6 +2062,32 @@ core_functions:
       - reference_id: PMID:18272684
         supporting_text: "all three proteins exhibited higher nucleotide exchange
           rates and hydrolyzed GTP slower than the wild-type protein"
+      - reference_id: PMID:14617358
+        supporting_text: "Rab7 is required for late endosomal transport"
+  - molecular_function:
+      id: GO:1905394
+      label: retromer complex binding
+    description: >-
+      Active RAB7A recruits and binds the retromer complex on late endosomes,
+      docking the cargo-selective retromer subcomplex to the membrane for
+      endosome-to-Golgi retrograde transport.
+    directly_involved_in:
+      - id: GO:0042147
+        label: retrograde transport, endosome to Golgi
+      - id: GO:0022615
+        label: protein to membrane docking
+    locations:
+      - id: GO:0005770
+        label: late endosome
+      - id: GO:0031902
+        label: late endosome membrane
+    supported_by:
+      - reference_id: PMID:19531583
+        supporting_text: "Membrane recruitment of the cargo-selective retromer subcomplex
+          is catalysed by the small GTPase Rab7"
+      - reference_id: PMID:24344282
+        supporting_text: A mechanism for retromer endosomal coat complex assembly
+          with cargo.
 
 proposed_new_terms: []
 

--- a/genes/mouse/Rab7/Rab7-ai-review.html
+++ b/genes/mouse/Rab7/Rab7-ai-review.html
@@ -1023,6 +1023,17 @@
 
                             </div>
 
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:mouse/Rab7/Rab7-deep-research-manual.md
+
+                                </span>
+
+                                <div class="support-text">Manual synthesis of mouse Rab7/Rab7a literature supports the conserved late-endosome maturation and endosome-to-lysosome routing function.</div>
+
+                            </div>
+
                         </div>
 
 
@@ -5152,10 +5163,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P51150" data-a="GO:0098943" data-r="PMID:24217640" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="P51150" data-a="GO:0098943" data-r="PMID:24217640" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -5168,11 +5179,29 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Full text of PMID:24217640 is not accessible (abstract-only cached publication) and the abstract focuses on stargazin/AP-2/AP-3A without mentioning Rab7. Per CLAUDE.md, UNDECIDED is required when relevant publications cannot be accessed; needs full-text verification of direct Rab7 involvement before retaining as KEEP_AS_NON_CORE.
+                            <strong>Reason:</strong> Revisited in the human/mouse Deliverome comparison. The accessible PMID text supports AMPA-receptor movement into late endosomal/lysosomal compartments during LTD, which is compatible with Rab7&#39;s conserved endosome-to-lysosome role. However, the paper emphasizes stargazin/AP-2/AP-3A rather than a Rab7-specific perturbation, so this should be retained only as a SynGO neuronal-context annotation and not treated as core Rab7 biology.
                         </div>
 
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24217640" target="_blank" class="term-link">
+                                        PMID:24217640
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">stargazin-AP-3A abrogates the late endosomal/lysosomal trafficking of AMPA receptors</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -5216,10 +5245,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P51150" data-a="GO:0098943" data-r="PMID:24217640" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="P51150" data-a="GO:0098943" data-r="PMID:24217640" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -5232,11 +5261,29 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Full text of PMID:24217640 is not accessible (abstract-only cached publication) and the abstract does not mention Rab7. Per CLAUDE.md, UNDECIDED is required when the relevant publication cannot be accessed.
+                            <strong>Reason:</strong> Revisited in the human/mouse Deliverome comparison. The PMID supports activity-dependent AMPA-receptor routing from early endosomes toward late endosomes/lysosomes, a route Rab7 generally controls. Because the accessible text identifies stargazin/AP-2/AP-3A as the experimental focus and does not give Rab7-specific mechanistic evidence, retain this as non-core and indirect.
                         </div>
 
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24217640" target="_blank" class="term-link">
+                                        PMID:24217640
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">transport from the cell surface to early endosomes and from early endosomes to late endosomes/lysosomes</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -5280,10 +5327,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P51150" data-a="GO:0098978" data-r="PMID:24217640" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="P51150" data-a="GO:0098978" data-r="PMID:24217640" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -5296,11 +5343,29 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Full text of PMID:24217640 is not accessible (abstract-only cached publication) and the abstract does not mention Rab7. Per CLAUDE.md, UNDECIDED is required when the relevant publication cannot be accessed.
+                            <strong>Reason:</strong> The source is a hippocampal LTD/AMPAR-trafficking study, so the glutamatergic-synapse context is biologically plausible for the SynGO annotation. It is not a core Rab7 localization, and the accessible text does not provide direct Rab7 localization or perturbation evidence, so retain only as a context-specific neuronal annotation.
                         </div>
 
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24217640" target="_blank" class="term-link">
+                                        PMID:24217640
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">necessary for low-frequency stimulus-evoked LTD in CA1 hippocampal neurons</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -5344,10 +5409,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P51150" data-a="GO:0098978" data-r="PMID:24217640" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="P51150" data-a="GO:0098978" data-r="PMID:24217640" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -5360,11 +5425,29 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Full text of PMID:24217640 is not accessible (abstract-only cached publication) and the abstract does not mention Rab7. Per CLAUDE.md, UNDECIDED is required when the relevant publication cannot be accessed.
+                            <strong>Reason:</strong> The PMID supports postsynaptic AMPA-receptor trafficking during LTD in hippocampal neurons, but the accessible text centers on stargazin and adaptor complexes rather than Rab7-specific evidence. Retain the SynGO row as a non-core neuronal-context annotation and avoid using it as a primary assertion about Rab7 function.
                         </div>
 
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24217640" target="_blank" class="term-link">
+                                        PMID:24217640
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">postsynaptic AMPA receptor trafficking mediates LTD</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -6401,6 +6484,24 @@
 
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23708524" target="_blank" class="term-link">
+                                        PMID:23708524
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">RAB7, being primarily associated with late endosomes, is a central factor in endosomal trafficking</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -9236,6 +9337,18 @@ transport, and lysosome positioning. It is inactivated by TBC-domain GAPs.</p>
 <a href="https://pubmed.ncbi.nlm.nih.gov/29712939">PMID:29712939</a>.<br />
 - Numerous late-endosome/lysosome co-localization studies (TrkB/NHE6, TrkA/Nedd4-2,<br />
   BACE1, TMEM127, WASH/strumpellin, C9ORF72, etc.).</p>
+<h2 id="2026-07-19-syngo-revisit">2026-07-19 SynGO revisit</h2>
+<p>The SynGO annotations from PMID:24217640 were revisited during the human/mouse<br />
+RAB7A/Rab7a comparison for the Deliverome project. The accessible paper text<br />
+supports AMPA-receptor routing from early endosomes toward late<br />
+endosomal/lysosomal compartments during LTD [PMID:24217640 Stargazin regulates<br />
+AMPA receptor trafficking through adaptor protein complexes during long-term<br />
+depression, "transport from the cell surface to early endosomes and from early<br />
+endosomes to late endosomes/lysosomes"]. However, the experimentally centered<br />
+actors in the accessible text are stargazin, AP-2, and AP-3A, not Rab7. I<br />
+therefore changed the four cached SynGO review rows from <code>UNDECIDED</code> to<br />
+<code>KEEP_AS_NON_CORE</code>, retaining them as indirect neuronal-context annotations<br />
+rather than core Rab7 biology.</p>
 <h2 id="key-requested-reference">Key requested reference</h2>
 <p><strong><a href="https://pubmed.ncbi.nlm.nih.gov/41814093">PMID:41814093</a></strong> Jozić et al. (2026) <em>Nature Biotechnology</em>,<br />
 "In vivo endosomal escape assay identifies mechanisms for efficient hepatic LNP<br />
@@ -9357,6 +9470,10 @@ existing_annotations:
     supported_by:
       - reference_id: PMID:41814093
         supporting_text: &#34;Loss of Rab7, a mediator of late endosomal maturation, increased LNP escape.&#34;
+      - reference_id: file:mouse/Rab7/Rab7-deep-research-manual.md
+        supporting_text: Manual synthesis of mouse Rab7/Rab7a literature supports
+          the conserved late-endosome maturation and endosome-to-lysosome routing
+          function.
 - term:
     id: GO:0045335
     label: phagocytic vesicle
@@ -10331,13 +10448,19 @@ existing_annotations:
     summary: &gt;-
       SynGO annotation associating Rab7 with postsynaptic endosome-to-lysosome
       AMPA-receptor trafficking during long-term depression.
-    action: UNDECIDED
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Full text of PMID:24217640 is not accessible (abstract-only cached
-      publication) and the abstract focuses on stargazin/AP-2/AP-3A without
-      mentioning Rab7. Per CLAUDE.md, UNDECIDED is required when relevant
-      publications cannot be accessed; needs full-text verification of direct
-      Rab7 involvement before retaining as KEEP_AS_NON_CORE.
+      Revisited in the human/mouse Deliverome comparison. The accessible PMID
+      text supports AMPA-receptor movement into late endosomal/lysosomal
+      compartments during LTD, which is compatible with Rab7&#39;s conserved
+      endosome-to-lysosome role. However, the paper emphasizes
+      stargazin/AP-2/AP-3A rather than a Rab7-specific perturbation, so this
+      should be retained only as a SynGO neuronal-context annotation and not
+      treated as core Rab7 biology.
+    supported_by:
+      - reference_id: PMID:24217640
+        supporting_text: &#34;stargazin-AP-3A abrogates the late endosomal/lysosomal
+          trafficking of AMPA receptors&#34;
 - term:
     id: GO:0098943
     label: neurotransmitter receptor transport, postsynaptic endosome to lysosome
@@ -10348,11 +10471,18 @@ existing_annotations:
     summary: &gt;-
       SynGO IMP annotation for Rab7 in AMPA-receptor degradative trafficking
       during LTD.
-    action: UNDECIDED
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Full text of PMID:24217640 is not accessible (abstract-only cached
-      publication) and the abstract does not mention Rab7. Per CLAUDE.md,
-      UNDECIDED is required when the relevant publication cannot be accessed.
+      Revisited in the human/mouse Deliverome comparison. The PMID supports
+      activity-dependent AMPA-receptor routing from early endosomes toward
+      late endosomes/lysosomes, a route Rab7 generally controls. Because the
+      accessible text identifies stargazin/AP-2/AP-3A as the experimental
+      focus and does not give Rab7-specific mechanistic evidence, retain this
+      as non-core and indirect.
+    supported_by:
+      - reference_id: PMID:24217640
+        supporting_text: &#34;transport from the cell surface to early endosomes and
+          from early endosomes to late endosomes/lysosomes&#34;
 - term:
     id: GO:0098978
     label: glutamatergic synapse
@@ -10363,11 +10493,17 @@ existing_annotations:
     summary: &gt;-
       SynGO annotation placing Rab7 at glutamatergic synapses in AMPA-receptor
       trafficking.
-    action: UNDECIDED
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Full text of PMID:24217640 is not accessible (abstract-only cached
-      publication) and the abstract does not mention Rab7. Per CLAUDE.md,
-      UNDECIDED is required when the relevant publication cannot be accessed.
+      The source is a hippocampal LTD/AMPAR-trafficking study, so the
+      glutamatergic-synapse context is biologically plausible for the SynGO
+      annotation. It is not a core Rab7 localization, and the accessible text
+      does not provide direct Rab7 localization or perturbation evidence, so
+      retain only as a context-specific neuronal annotation.
+    supported_by:
+      - reference_id: PMID:24217640
+        supporting_text: &#34;necessary for low-frequency stimulus-evoked LTD in CA1
+          hippocampal neurons&#34;
 - term:
     id: GO:0098978
     label: glutamatergic synapse
@@ -10378,11 +10514,16 @@ existing_annotations:
     summary: &gt;-
       SynGO IMP annotation for Rab7 functional role at glutamatergic synapses
       (LTD).
-    action: UNDECIDED
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Full text of PMID:24217640 is not accessible (abstract-only cached
-      publication) and the abstract does not mention Rab7. Per CLAUDE.md,
-      UNDECIDED is required when the relevant publication cannot be accessed.
+      The PMID supports postsynaptic AMPA-receptor trafficking during LTD in
+      hippocampal neurons, but the accessible text centers on stargazin and
+      adaptor complexes rather than Rab7-specific evidence. Retain the SynGO
+      row as a non-core neuronal-context annotation and avoid using it as a
+      primary assertion about Rab7 function.
+    supported_by:
+      - reference_id: PMID:24217640
+        supporting_text: &#34;postsynaptic AMPA receptor trafficking mediates LTD&#34;
 - term:
     id: GO:0005770
     label: late endosome
@@ -10592,6 +10733,10 @@ existing_annotations:
     action: ACCEPT
     reason: &gt;-
       Core localization, experimentally supported.
+    supported_by:
+      - reference_id: PMID:23708524
+        supporting_text: &#34;RAB7, being primarily associated with late endosomes, is
+          a central factor in endosomal trafficking&#34;
 - term:
     id: GO:0061724
     label: lipophagy

--- a/genes/mouse/Rab7/Rab7-ai-review.yaml
+++ b/genes/mouse/Rab7/Rab7-ai-review.yaml
@@ -72,6 +72,10 @@ existing_annotations:
     supported_by:
       - reference_id: PMID:41814093
         supporting_text: "Loss of Rab7, a mediator of late endosomal maturation, increased LNP escape."
+      - reference_id: file:mouse/Rab7/Rab7-deep-research-manual.md
+        supporting_text: Manual synthesis of mouse Rab7/Rab7a literature supports
+          the conserved late-endosome maturation and endosome-to-lysosome routing
+          function.
 - term:
     id: GO:0045335
     label: phagocytic vesicle
@@ -1046,13 +1050,19 @@ existing_annotations:
     summary: >-
       SynGO annotation associating Rab7 with postsynaptic endosome-to-lysosome
       AMPA-receptor trafficking during long-term depression.
-    action: UNDECIDED
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Full text of PMID:24217640 is not accessible (abstract-only cached
-      publication) and the abstract focuses on stargazin/AP-2/AP-3A without
-      mentioning Rab7. Per CLAUDE.md, UNDECIDED is required when relevant
-      publications cannot be accessed; needs full-text verification of direct
-      Rab7 involvement before retaining as KEEP_AS_NON_CORE.
+      Revisited in the human/mouse Deliverome comparison. The accessible PMID
+      text supports AMPA-receptor movement into late endosomal/lysosomal
+      compartments during LTD, which is compatible with Rab7's conserved
+      endosome-to-lysosome role. However, the paper emphasizes
+      stargazin/AP-2/AP-3A rather than a Rab7-specific perturbation, so this
+      should be retained only as a SynGO neuronal-context annotation and not
+      treated as core Rab7 biology.
+    supported_by:
+      - reference_id: PMID:24217640
+        supporting_text: "stargazin-AP-3A abrogates the late endosomal/lysosomal
+          trafficking of AMPA receptors"
 - term:
     id: GO:0098943
     label: neurotransmitter receptor transport, postsynaptic endosome to lysosome
@@ -1063,11 +1073,18 @@ existing_annotations:
     summary: >-
       SynGO IMP annotation for Rab7 in AMPA-receptor degradative trafficking
       during LTD.
-    action: UNDECIDED
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Full text of PMID:24217640 is not accessible (abstract-only cached
-      publication) and the abstract does not mention Rab7. Per CLAUDE.md,
-      UNDECIDED is required when the relevant publication cannot be accessed.
+      Revisited in the human/mouse Deliverome comparison. The PMID supports
+      activity-dependent AMPA-receptor routing from early endosomes toward
+      late endosomes/lysosomes, a route Rab7 generally controls. Because the
+      accessible text identifies stargazin/AP-2/AP-3A as the experimental
+      focus and does not give Rab7-specific mechanistic evidence, retain this
+      as non-core and indirect.
+    supported_by:
+      - reference_id: PMID:24217640
+        supporting_text: "transport from the cell surface to early endosomes and
+          from early endosomes to late endosomes/lysosomes"
 - term:
     id: GO:0098978
     label: glutamatergic synapse
@@ -1078,11 +1095,17 @@ existing_annotations:
     summary: >-
       SynGO annotation placing Rab7 at glutamatergic synapses in AMPA-receptor
       trafficking.
-    action: UNDECIDED
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Full text of PMID:24217640 is not accessible (abstract-only cached
-      publication) and the abstract does not mention Rab7. Per CLAUDE.md,
-      UNDECIDED is required when the relevant publication cannot be accessed.
+      The source is a hippocampal LTD/AMPAR-trafficking study, so the
+      glutamatergic-synapse context is biologically plausible for the SynGO
+      annotation. It is not a core Rab7 localization, and the accessible text
+      does not provide direct Rab7 localization or perturbation evidence, so
+      retain only as a context-specific neuronal annotation.
+    supported_by:
+      - reference_id: PMID:24217640
+        supporting_text: "necessary for low-frequency stimulus-evoked LTD in CA1
+          hippocampal neurons"
 - term:
     id: GO:0098978
     label: glutamatergic synapse
@@ -1093,11 +1116,16 @@ existing_annotations:
     summary: >-
       SynGO IMP annotation for Rab7 functional role at glutamatergic synapses
       (LTD).
-    action: UNDECIDED
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Full text of PMID:24217640 is not accessible (abstract-only cached
-      publication) and the abstract does not mention Rab7. Per CLAUDE.md,
-      UNDECIDED is required when the relevant publication cannot be accessed.
+      The PMID supports postsynaptic AMPA-receptor trafficking during LTD in
+      hippocampal neurons, but the accessible text centers on stargazin and
+      adaptor complexes rather than Rab7-specific evidence. Retain the SynGO
+      row as a non-core neuronal-context annotation and avoid using it as a
+      primary assertion about Rab7 function.
+    supported_by:
+      - reference_id: PMID:24217640
+        supporting_text: "postsynaptic AMPA receptor trafficking mediates LTD"
 - term:
     id: GO:0005770
     label: late endosome
@@ -1307,6 +1335,10 @@ existing_annotations:
     action: ACCEPT
     reason: >-
       Core localization, experimentally supported.
+    supported_by:
+      - reference_id: PMID:23708524
+        supporting_text: "RAB7, being primarily associated with late endosomes, is
+          a central factor in endosomal trafficking"
 - term:
     id: GO:0061724
     label: lipophagy

--- a/genes/mouse/Rab7/Rab7-notes.md
+++ b/genes/mouse/Rab7/Rab7-notes.md
@@ -25,6 +25,20 @@ The mouse-specific experimental literature emphasizes physiological roles:
 - Numerous late-endosome/lysosome co-localization studies (TrkB/NHE6, TrkA/Nedd4-2,
   BACE1, TMEM127, WASH/strumpellin, C9ORF72, etc.).
 
+## 2026-07-19 SynGO revisit
+
+The SynGO annotations from PMID:24217640 were revisited during the human/mouse
+RAB7A/Rab7a comparison for the Deliverome project. The accessible paper text
+supports AMPA-receptor routing from early endosomes toward late
+endosomal/lysosomal compartments during LTD [PMID:24217640 Stargazin regulates
+AMPA receptor trafficking through adaptor protein complexes during long-term
+depression, "transport from the cell surface to early endosomes and from early
+endosomes to late endosomes/lysosomes"]. However, the experimentally centered
+actors in the accessible text are stargazin, AP-2, and AP-3A, not Rab7. I
+therefore changed the four cached SynGO review rows from `UNDECIDED` to
+`KEEP_AS_NON_CORE`, retaining them as indirect neuronal-context annotations
+rather than core Rab7 biology.
+
 ## Key requested reference
 
 **[PMID:41814093]** Jozić et al. (2026) *Nature Biotechnology*,

--- a/pages/projects/DELIVEROME.html
+++ b/pages/projects/DELIVEROME.html
@@ -1,0 +1,587 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Deliverome GO Collaboration - AI Gene Review Projects</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-primary: #3498db;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .breadcrumb {
+            margin-bottom: 1.5rem;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .breadcrumb a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        h2 {
+            font-size: 1.75rem;
+            font-weight: 600;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: #374151;
+        }
+
+        h4 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+            color: #4b5563;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Gene symbol links */
+        .content a[href*="/genes/"] {
+            background-color: #dbeafe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-weight: 500;
+        }
+
+        .content a[href*="/genes/"]:hover {
+            background-color: #bfdbfe;
+        }
+
+        ul, ol {
+            margin-bottom: 1rem;
+            padding-left: 2rem;
+        }
+
+        li {
+            margin-bottom: 0.25rem;
+        }
+
+        code {
+            background: #f4f4f4;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875em;
+        }
+
+        pre {
+            background: #1f2937;
+            color: #f9fafb;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+
+        pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--color-primary);
+            margin-left: 0;
+            padding-left: 1.5rem;
+            color: #4b5563;
+            font-style: italic;
+            margin-bottom: 1rem;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+        }
+
+        th, td {
+            border: 1px solid var(--border-color);
+            padding: 0.75rem;
+            text-align: left;
+        }
+
+        th {
+            background-color: var(--bg-light);
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f9fafb;
+        }
+
+        tr:hover {
+            background-color: #f3f4f6;
+        }
+
+        /* Mermaid diagrams */
+        .mermaid {
+            text-align: center;
+            margin: 2rem 0;
+            background: white;
+            padding: 1.5rem;
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+        }
+
+        .mermaid svg {
+            max-width: 100%;
+            height: auto;
+        }
+
+        /* Warnings section */
+        .warnings {
+            background-color: #fef3c7;
+            border: 1px solid #fde68a;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 2rem;
+        }
+
+        .warnings h3 {
+            color: #92400e;
+            margin-top: 0;
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+        }
+
+        .warnings ul {
+            margin-bottom: 0;
+            color: #78350f;
+        }
+
+        /* Task lists (checkboxes) */
+        li input[type="checkbox"] {
+            margin-right: 0.5rem;
+        }
+
+        /* Status badges */
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.625rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .badge-success {
+            background-color: #d1fae5;
+            color: #065f46;
+        }
+
+        .badge-warning {
+            background-color: #fef3c7;
+            color: #92400e;
+        }
+
+        .badge-info {
+            background-color: #dbeafe;
+            color: #1e40af;
+        }
+
+        /* Project meta: maturity + tag badges */
+        .project-meta { margin-bottom: 0.5rem; }
+        .project-meta .badge { margin: 0 0.25rem 0.25rem 0; }
+        .gene-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.375rem;
+            margin-bottom: 1rem;
+        }
+        .gene-list a,
+        .gene-list span {
+            background-color: #dbeafe;
+            border-radius: 0.25rem;
+            color: #1e40af;
+            display: inline-block;
+            font-weight: 500;
+            padding: 0.125rem 0.375rem;
+        }
+        .gene-list a:hover {
+            background-color: #bfdbfe;
+            text-decoration: none;
+        }
+        .m-SCOPING     { background: #fef3c7; color: #92400e; }
+        .m-IN_PROGRESS { background: #dbeafe; color: #1e40af; }
+        .m-MATURE      { background: #dcfce7; color: #166534; }
+        .m-COMPLETE    { background: #d1fae5; color: #065f46; }
+        .m-ARCHIVED    { background: #f3f4f6; color: #6b7280; }
+        .badge.tag { text-transform: none; }
+        .t-FLAGSHIP       { background: #fae8ff; color: #86198f; }
+        .t-BIOLOGY_DOMAIN { background: #e0f2fe; color: #075985; }
+        .t-PIPELINE       { background: #ede9fe; color: #5b21b6; }
+        .t-OBSOLETION     { background: #fee2e2; color: #991b1b; }
+
+        /* Manual reviews */
+        .manual-reviews {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem 1.25rem;
+            margin-bottom: 2rem;
+        }
+        .manual-reviews h3 { margin-top: 0; margin-bottom: 0.75rem; font-size: 1rem; }
+        .manual-reviews .review { padding: 0.5rem 0; }
+        .manual-reviews .review + .review { border-top: 1px dashed var(--border-color); }
+        .manual-reviews .review-head { margin-bottom: 0.25rem; }
+        .manual-reviews .review-head .badge { margin-right: 0.5rem; }
+        .manual-reviews .review-head .who { font-weight: 600; }
+        .manual-reviews .review-head .when { color: var(--text-muted); font-size: 0.85rem; margin-left: 0.5rem; }
+        .manual-reviews .review-notes { margin: 0.25rem 0; }
+        .manual-reviews .review-todos { margin: 0.25rem 0 0.5rem; }
+        .badge.r-READY             { background: #dcfce7; color: #166534; }
+        .badge.r-CHANGES_REQUESTED { background: #fee2e2; color: #991b1b; }
+
+        /* Content wrapper */
+        .content {
+            margin-bottom: 2rem;
+        }
+
+        /* Footer */
+        footer {
+            margin-top: 3rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border-color);
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-align: center;
+        }
+
+        footer small {
+            display: block;
+        }
+    </style>
+    <!-- Mermaid.js for diagram rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>
+        mermaid.initialize({
+            startOnLoad: true,
+            theme: 'default',
+            themeVariables: {
+                primaryColor: '#3498db',
+                primaryTextColor: '#fff',
+                primaryBorderColor: '#2c3e50',
+                lineColor: '#333',
+                secondaryColor: '#ecf0f1',
+                tertiaryColor: '#f39c12'
+            },
+            flowchart: {
+                htmlLabels: true,
+                curve: 'basis'
+            }
+        });
+    </script>
+</head>
+<body>
+    <nav class="breadcrumb">
+        <a href="../index.html">Home</a> &raquo;
+        <a href="index.html">Projects</a> &raquo;
+        Deliverome GO Collaboration
+    </nav>
+
+    <header class="header">
+        <h1>Deliverome GO Collaboration</h1>
+
+
+        <p><strong>Species:</strong> human, mouse</p>
+
+
+    </header>
+
+
+
+
+
+    <div class="content">
+        <h1 id="deliverome-go-collaboration">Deliverome GO Collaboration</h1>
+<h2 id="overview">Overview</h2>
+<p>The Deliverome Project proposes an open atlas of human surface proteins for targeted therapeutic delivery. The public framing emphasizes surface abundance, tissue and cell-type specificity, internalization, downstream trafficking, and functional delivery outcome. This AIGR project tracks two directions:</p>
+<ul>
+<li>how GO could contribute evidence-aware vocabulary, priors, and GO-CAM structure to Deliverome-style data;</li>
+<li>how Deliverome data could contribute back to GO standard annotation and GO-CAMs without mixing endogenous biology with engineered delivery behavior.</li>
+</ul>
+<p>This PR keeps the work scoped to project framing plus a human and mouse <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a> comparison. It does not add a full Deliverome pilot review set.</p>
+<h2 id="what-delivery-address-means">What "Delivery Address" Means</h2>
+<p>By "delivery address" I mean a gene product that therapeutic cargo can use as a molecular address. In practice this is usually an extracellular-facing cell-surface protein with a usable ligand-binding epitope, appropriate tissue or cell-type distribution, and a trafficking route that carries bound cargo toward a useful destination.</p>
+<p>The address is not just "present on the membrane." The key questions are whether it internalizes, recycles, routes to lysosomes, transcytoses, or releases cargo productively.</p>
+<h2 id="how-go-could-contribute">How GO Could Contribute</h2>
+<p>GO can provide an evidence-aware prior over plausible human delivery-address proteins before Deliverome-specific measurements are available. Useful filters include cellular-component annotations to cell surface, external side of plasma membrane, plasma membrane, receptor complexes, and endosomal compartments, plus molecular-function or biological-process annotations for receptor activity, endocytosis, transcytosis, and ligand uptake.</p>
+<p>GO is also useful as a vocabulary for assay outputs: surface localization, receptor internalization, receptor-mediated endocytosis, recycling, lysosomal routing, transcytosis, and endosome-to-plasma-membrane transport. These terms can support data dictionaries and triage even when a particular engineered-delivery result should not become a canonical GO annotation.</p>
+<p>GO-CAMs are especially useful where delivery value depends on a causal route:</p>
+<ol>
+<li>ligand or cargo binding at the external side of the plasma membrane;</li>
+<li>receptor internalization;</li>
+<li>early endosome entry;</li>
+<li>sorting toward recycling endosome, late endosome, lysosome, transcytosis, or cytosolic escape;</li>
+<li>downstream endogenous or engineered payload effect.</li>
+</ol>
+<p>For normal biology this can become ordinary GO-CAM curation. For engineered therapeutic cargo, the same shape is better treated as a GO-CAM-like Deliverome model outside canonical GO.</p>
+<h2 id="how-deliverome-data-could-contribute-to-go">How Deliverome Data Could Contribute To GO</h2>
+<p>Deliverome data could support standard GO annotations when the assay measures a normal property of the endogenous gene product:</p>
+<table>
+<thead>
+<tr>
+<th>Deliverome evidence</th>
+<th>Potential GO contribution</th>
+<th>Curation caution</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Surface proteomics shows endogenous protein at the cell surface</td>
+<td>Cellular-component annotations such as cell surface, external side of plasma membrane, or plasma membrane</td>
+<td>Require localization specificity; bulk tissue data may need cell-type context</td>
+</tr>
+<tr>
+<td>Internalization assay shows endogenous receptor uptake</td>
+<td>Receptor internalization or receptor-mediated endocytosis</td>
+<td>Engineered cargo uptake alone may be a delivery phenotype</td>
+</tr>
+<tr>
+<td>Trafficking assay tracks the receptor through endosomes or lysosomes</td>
+<td>Compartment and routing annotations when the receptor itself is observed</td>
+<td>Do not annotate receptor destination if only payload destination was measured</td>
+</tr>
+<tr>
+<td>Perturbation screen identifies delivery-routing machinery</td>
+<td>Review genes for endocytosis, vesicle transport, recycling, lysosome targeting, or transcytosis</td>
+<td>Separate direct trafficking machinery from indirect viability or cell-state effects</td>
+</tr>
+<tr>
+<td>Low-internalization result for an expected receptor</td>
+<td>Possible NOT annotation only in narrow cases</td>
+<td>Failed delivery is usually not enough for a GO NOT annotation</td>
+</tr>
+</tbody>
+</table>
+<h2 id="model-systems">Model Systems</h2>
+<p>Human and mammalian systems should be primary for delivery-address biology because useful addresses depend on human cell-surface abundance, ligand specificity, glycosylation, expression context, and safety. Good near-term systems are primary or iPSC-derived hepatocytes for <a href="../../genes/human/ASGR1/ASGR1-ai-review.html">ASGR1</a>/ASGR2, polarized endothelial or epithelial barrier systems for <a href="../../genes/human/FCGRT/FCGRT-ai-review.html">FCGRT</a> and <a href="../../genes/human/TFRC/TFRC-ai-review.html">TFRC</a> transcytosis, immune and myeloid cells for FcRn and ESCRT/retromer routing, and cancer cell lines or organoids for oncology delivery targets.</p>
+<p>Fission yeast (<em>Schizosaccharomyces pombe</em>) is useful for machinery-level internal trafficking: conserved endocytosis, ESCRT, retromer, Rab/Ypt, actin-polarity, and vacuolar/lysosomal routing. It is not a good model for human delivery addresses themselves because most address receptors and extracellular ligand-binding systems are metazoan or mammalian.</p>
+<p>Mouse is important for pharmacokinetics, immune context, placenta/neonatal Fc receptor biology, in vivo biodistribution, and post-internalization routing. Species differences in receptor expression and ligand affinity still need explicit tracking.</p>
+<p>The mouse <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a>/Rab7a review gives this project a concrete internal-routing model. <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a> is not a delivery-address receptor; it is a late-endosome/lysosome routing switch that helps decide whether internalized cargo proceeds toward degradation, recycling/retrograde sorting, or productive escape. Mouse liver LysoTag/LNP evidence shows that <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a> loss increases LNP cytosolic escape, making mouse <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a> useful for "after internalization" questions that cannot be resolved from human surface abundance alone.</p>
+<p>The human and mouse comparison is reassuring for GO transfer: both reviews converge on conserved Rab-family GTPase activity, early-to-late endosome maturation, endosome-to-lysosome transport, phagosome/autophagosome fusion, and retromer-dependent retrograde traffic. Human <a href="../../genes/human/RAB7A/RAB7A-ai-review.html">RAB7A</a> remains the stronger disease/genetics anchor, especially for CMT2B, while mouse <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a>/Rab7a is the stronger Deliverome model-system anchor because it connects Rab7-mediated endosomal maturation to in vivo LNP escape.</p>
+<table>
+<thead>
+<tr>
+<th>Question</th>
+<th>Best-fit model systems</th>
+<th>Good pilot proteins</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Human address specificity and uptake</td>
+<td>Human primary/iPSC/organoid/cell-line panels</td>
+<td><a href="../../genes/human/ASGR1/ASGR1-ai-review.html">ASGR1</a>, <a href="../../genes/human/ASGR2/ASGR2-ai-review.html">ASGR2</a>, <a href="../../genes/human/SORT1/SORT1-ai-review.html">SORT1</a>, <a href="../../genes/human/TFRC/TFRC-ai-review.html">TFRC</a>, <a href="../../genes/human/FCGRT/FCGRT-ai-review.html">FCGRT</a></td>
+</tr>
+<tr>
+<td>Clathrin/AP-2 uptake machinery</td>
+<td>Human cells, yeast for conserved principles, fly/worm neurons for specialized uptake</td>
+<td><a href="../../genes/human/CLTC/CLTC-ai-review.html">CLTC</a>, <a href="../../genes/human/AP2M1/AP2M1-ai-review.html">AP2M1</a>, <a href="../../genes/human/DAB2/DAB2-ai-review.html">DAB2</a>, <a href="../../genes/human/LDLRAP1/LDLRAP1-ai-review.html">LDLRAP1</a></td>
+</tr>
+<tr>
+<td>ESCRT/MVB and lysosomal routing</td>
+<td>Human cells, pombe/budding yeast, worm and fly for organismal genetics</td>
+<td><a href="../../genes/human/HGS/HGS-ai-review.html">HGS</a>, <a href="../../genes/human/RAB7A/RAB7A-ai-review.html">RAB7A</a></td>
+</tr>
+<tr>
+<td>Retromer and recycling</td>
+<td>Human cells, pombe/budding yeast, worm and fly neurons and epithelia</td>
+<td><a href="../../genes/human/VPS35/VPS35-ai-review.html">VPS35</a>, <a href="../../genes/human/RAB11A/RAB11A-ai-review.html">RAB11A</a></td>
+</tr>
+<tr>
+<td>Barrier/transcytosis delivery</td>
+<td>Human BBB/epithelial models, mouse and zebrafish for in vivo context</td>
+<td><a href="../../genes/human/FCGRT/FCGRT-ai-review.html">FCGRT</a>, <a href="../../genes/human/TFRC/TFRC-ai-review.html">TFRC</a></td>
+</tr>
+<tr>
+<td>Endosomal escape versus degradative routing</td>
+<td>Mouse liver LysoTag/LNP assays plus matched human-cell trafficking assays</td>
+<td><a href="../../genes/human/RAB7A/RAB7A-ai-review.html">RAB7A</a>/Rab7a, <a href="../../genes/human/HGS/HGS-ai-review.html">HGS</a>, <a href="../../genes/human/VPS35/VPS35-ai-review.html">VPS35</a></td>
+</tr>
+</tbody>
+</table>
+<h2 id="go-anchors">GO Anchors</h2>
+<table>
+<thead>
+<tr>
+<th>Deliverome concept</th>
+<th>Current GO anchor</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Surface localization</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0009986">GO:0009986</a> cell surface</td>
+</tr>
+<tr>
+<td>Extracellular-facing membrane localization</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0009897">GO:0009897</a> external side of plasma membrane</td>
+</tr>
+<tr>
+<td>Plasma membrane localization</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0005886">GO:0005886</a> plasma membrane</td>
+</tr>
+<tr>
+<td>Protein localization to surface</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0034394">GO:0034394</a> protein localization to cell surface</td>
+</tr>
+<tr>
+<td>Internalization</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0031623">GO:0031623</a> receptor internalization</td>
+</tr>
+<tr>
+<td>General endocytosis</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0006897">GO:0006897</a> endocytosis</td>
+</tr>
+<tr>
+<td>Receptor-mediated uptake</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0006898">GO:0006898</a> receptor-mediated endocytosis</td>
+</tr>
+<tr>
+<td>Clathrin-dependent uptake</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0072583">GO:0072583</a> clathrin-dependent endocytosis</td>
+</tr>
+<tr>
+<td>Caveolin-mediated uptake</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0072584">GO:0072584</a> caveolin-mediated endocytosis</td>
+</tr>
+<tr>
+<td>Transcellular routing</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0045056">GO:0045056</a> transcytosis</td>
+</tr>
+<tr>
+<td>Early endosome</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0005769">GO:0005769</a> early endosome</td>
+</tr>
+<tr>
+<td>Late endosome</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0005770">GO:0005770</a> late endosome</td>
+</tr>
+<tr>
+<td>Recycling route</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0055037">GO:0055037</a> recycling endosome</td>
+</tr>
+<tr>
+<td>Lysosomal destination</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0005764">GO:0005764</a> lysosome</td>
+</tr>
+<tr>
+<td>Early-to-late endosome route</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0045022">GO:0045022</a> early endosome to late endosome transport</td>
+</tr>
+<tr>
+<td>Late endosome-to-lysosome route</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:1902774">GO:1902774</a> late endosome to lysosome transport</td>
+</tr>
+<tr>
+<td>Recycling to surface</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0099638">GO:0099638</a> endosome to plasma membrane protein transport</td>
+</tr>
+</tbody>
+</table>
+<h2 id="open-questions">Open Questions</h2>
+<ul>
+<li>What evidence threshold should Deliverome surface proteomics meet before it supports a GO cellular-component annotation?</li>
+<li>Can Deliverome metadata map cleanly to ECO evidence, CL/UBERON context, and GO-CAM activity units?</li>
+<li>How should engineered cargo and disease-state measurements be represented without polluting GO's normal-function semantics?</li>
+<li>Which surfaceome targets have enough literature today to build high-quality GO-CAMs before Deliverome data are released?</li>
+<li>Should AIGR add a reusable delivery-route summary parallel to <code>core_functions</code>?</li>
+</ul>
+<hr />
+<h1 id="status">STATUS</h1>
+<h2 id="2026-07-19">2026-07-19</h2>
+<ul>
+<li>[x] Create focused Deliverome project document.</li>
+<li>[x] Define delivery-address meaning.</li>
+<li>[x] Record model-system stance, including pombe for conserved internal trafficking and mouse <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a>/Rab7a for in vivo post-internalization routing.</li>
+<li>[x] Compare human <a href="../../genes/human/RAB7A/RAB7A-ai-review.html">RAB7A</a> and mouse <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a>/Rab7a.</li>
+<li>[x] Harmonize human <a href="../../genes/human/RAB7A/RAB7A-ai-review.html">RAB7A</a> core-function synthesis with mouse <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a>/Rab7a for early-to-late endosome maturation, late endosome membrane localization, and retromer binding.</li>
+<li>[x] Revisit mouse SynGO AMPA-receptor trafficking annotations from PMID:24217640.</li>
+<li>[ ] Build GO-derived human surfaceome prior.</li>
+<li>[ ] Select a small delivery-address pilot set.</li>
+<li>[ ] Draft a GO-CAM-like delivery route template.</li>
+</ul>
+<h1 id="notes">NOTES</h1>
+<h2 id="2026-07-19_1">2026-07-19</h2>
+<ul>
+<li>Mouse <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a>/Rab7a is the best current model-system anchor for Deliverome's endosomal routing question: it provides in vivo evidence that Rab7-mediated late endosomal maturation can suppress LNP cytosolic escape by routing cargo toward degradative compartments.</li>
+<li>Human <a href="../../genes/human/RAB7A/RAB7A-ai-review.html">RAB7A</a> and mouse <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a>/Rab7a should be kept aligned on conserved core terms, while using human for disease genetics and mouse for tissue and in vivo delivery physiology.</li>
+<li>The SynGO annotations from PMID:24217640 support AMPA-receptor movement toward late endosomal/lysosomal compartments during LTD, but the accessible paper text emphasizes stargazin/AP-2/AP-3A rather than <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a> itself. These rows are retained only as non-core neuronal-context annotations, not as primary <a href="../../genes/mouse/Rab7/Rab7-ai-review.html">Rab7</a> biology.</li>
+</ul>
+    </div>
+
+    <footer>
+        <small>Generated from DELIVEROME.md</small>
+        <small>AI Gene Review Project</small>
+    </footer>
+</body>
+</html>

--- a/pages/projects/index.html
+++ b/pages/projects/index.html
@@ -232,6 +232,9 @@
             <a href="MECHANOBIOLOGY.html">Mechanobiology</a>
         </div>
         <div class="project-card">
+            <a href="DELIVEROME.html">Deliverome GO Collaboration</a>
+        </div>
+        <div class="project-card">
             <a href="ER_PHAGY.html">ER-Phagy</a>
         </div>
         <div class="project-card">

--- a/projects/DELIVEROME.md
+++ b/projects/DELIVEROME.md
@@ -1,0 +1,157 @@
+---
+title: Deliverome GO Collaboration
+species:
+  - human
+  - mouse
+status: IN_PROGRESS
+priority: high
+last_reviewed: 2026-07-19
+scope: Exploratory Deliverome-to-GO project focused on delivery-address semantics, internal trafficking model systems, and a human and mouse Rab7 comparison for post-internalization routing
+review_sets:
+  existing_human_anchors:
+    - TFRC
+    - CLTC
+    - RAB7A
+  model_system_reviews:
+    - mouse/Rab7
+  comparative_reviews:
+    - human/RAB7A_vs_mouse/Rab7
+  completed_tasks:
+    - define_delivery_address_meaning
+    - compare_human_RAB7A_mouse_Rab7
+    - update_model_system_stance
+    - harmonize_RAB7A_core_function_synthesis
+    - revisit_mouse_Rab7_SynGO_annotations
+  pending_tasks:
+    - build_GO_derived_human_surfaceome_prior
+    - select_small_delivery_address_pilot_set
+    - draft_GO_CAM_like_delivery_route_template
+sidecars:
+  notes: DELIVEROME.md
+external_sources:
+  - https://deliverome.org/
+  - https://ifp.org/the-deliverome-project/
+  - https://deliverome.org/platform/
+  - https://deliverome.org/platform/progress/
+  - https://geneontology.org/docs/go-annotations/
+---
+
+# Deliverome GO Collaboration
+
+## Overview
+
+The Deliverome Project proposes an open atlas of human surface proteins for targeted therapeutic delivery. The public framing emphasizes surface abundance, tissue and cell-type specificity, internalization, downstream trafficking, and functional delivery outcome. This AIGR project tracks two directions:
+
+- how GO could contribute evidence-aware vocabulary, priors, and GO-CAM structure to Deliverome-style data;
+- how Deliverome data could contribute back to GO standard annotation and GO-CAMs without mixing endogenous biology with engineered delivery behavior.
+
+This PR keeps the work scoped to project framing plus a human and mouse Rab7 comparison. It does not add a full Deliverome pilot review set.
+
+## What "Delivery Address" Means
+
+By "delivery address" I mean a gene product that therapeutic cargo can use as a molecular address. In practice this is usually an extracellular-facing cell-surface protein with a usable ligand-binding epitope, appropriate tissue or cell-type distribution, and a trafficking route that carries bound cargo toward a useful destination.
+
+The address is not just "present on the membrane." The key questions are whether it internalizes, recycles, routes to lysosomes, transcytoses, or releases cargo productively.
+
+## How GO Could Contribute
+
+GO can provide an evidence-aware prior over plausible human delivery-address proteins before Deliverome-specific measurements are available. Useful filters include cellular-component annotations to cell surface, external side of plasma membrane, plasma membrane, receptor complexes, and endosomal compartments, plus molecular-function or biological-process annotations for receptor activity, endocytosis, transcytosis, and ligand uptake.
+
+GO is also useful as a vocabulary for assay outputs: surface localization, receptor internalization, receptor-mediated endocytosis, recycling, lysosomal routing, transcytosis, and endosome-to-plasma-membrane transport. These terms can support data dictionaries and triage even when a particular engineered-delivery result should not become a canonical GO annotation.
+
+GO-CAMs are especially useful where delivery value depends on a causal route:
+
+1. ligand or cargo binding at the external side of the plasma membrane;
+2. receptor internalization;
+3. early endosome entry;
+4. sorting toward recycling endosome, late endosome, lysosome, transcytosis, or cytosolic escape;
+5. downstream endogenous or engineered payload effect.
+
+For normal biology this can become ordinary GO-CAM curation. For engineered therapeutic cargo, the same shape is better treated as a GO-CAM-like Deliverome model outside canonical GO.
+
+## How Deliverome Data Could Contribute To GO
+
+Deliverome data could support standard GO annotations when the assay measures a normal property of the endogenous gene product:
+
+| Deliverome evidence | Potential GO contribution | Curation caution |
+| --- | --- | --- |
+| Surface proteomics shows endogenous protein at the cell surface | Cellular-component annotations such as cell surface, external side of plasma membrane, or plasma membrane | Require localization specificity; bulk tissue data may need cell-type context |
+| Internalization assay shows endogenous receptor uptake | Receptor internalization or receptor-mediated endocytosis | Engineered cargo uptake alone may be a delivery phenotype |
+| Trafficking assay tracks the receptor through endosomes or lysosomes | Compartment and routing annotations when the receptor itself is observed | Do not annotate receptor destination if only payload destination was measured |
+| Perturbation screen identifies delivery-routing machinery | Review genes for endocytosis, vesicle transport, recycling, lysosome targeting, or transcytosis | Separate direct trafficking machinery from indirect viability or cell-state effects |
+| Low-internalization result for an expected receptor | Possible NOT annotation only in narrow cases | Failed delivery is usually not enough for a GO NOT annotation |
+
+## Model Systems
+
+Human and mammalian systems should be primary for delivery-address biology because useful addresses depend on human cell-surface abundance, ligand specificity, glycosylation, expression context, and safety. Good near-term systems are primary or iPSC-derived hepatocytes for ASGR1/ASGR2, polarized endothelial or epithelial barrier systems for FCGRT and TFRC transcytosis, immune and myeloid cells for FcRn and ESCRT/retromer routing, and cancer cell lines or organoids for oncology delivery targets.
+
+Fission yeast (*Schizosaccharomyces pombe*) is useful for machinery-level internal trafficking: conserved endocytosis, ESCRT, retromer, Rab/Ypt, actin-polarity, and vacuolar/lysosomal routing. It is not a good model for human delivery addresses themselves because most address receptors and extracellular ligand-binding systems are metazoan or mammalian.
+
+Mouse is important for pharmacokinetics, immune context, placenta/neonatal Fc receptor biology, in vivo biodistribution, and post-internalization routing. Species differences in receptor expression and ligand affinity still need explicit tracking.
+
+The mouse Rab7/Rab7a review gives this project a concrete internal-routing model. Rab7 is not a delivery-address receptor; it is a late-endosome/lysosome routing switch that helps decide whether internalized cargo proceeds toward degradation, recycling/retrograde sorting, or productive escape. Mouse liver LysoTag/LNP evidence shows that Rab7 loss increases LNP cytosolic escape, making mouse Rab7 useful for "after internalization" questions that cannot be resolved from human surface abundance alone.
+
+The human and mouse comparison is reassuring for GO transfer: both reviews converge on conserved Rab-family GTPase activity, early-to-late endosome maturation, endosome-to-lysosome transport, phagosome/autophagosome fusion, and retromer-dependent retrograde traffic. Human RAB7A remains the stronger disease/genetics anchor, especially for CMT2B, while mouse Rab7/Rab7a is the stronger Deliverome model-system anchor because it connects Rab7-mediated endosomal maturation to in vivo LNP escape.
+
+| Question | Best-fit model systems | Good pilot proteins |
+| --- | --- | --- |
+| Human address specificity and uptake | Human primary/iPSC/organoid/cell-line panels | ASGR1, ASGR2, SORT1, TFRC, FCGRT |
+| Clathrin/AP-2 uptake machinery | Human cells, yeast for conserved principles, fly/worm neurons for specialized uptake | CLTC, AP2M1, DAB2, LDLRAP1 |
+| ESCRT/MVB and lysosomal routing | Human cells, pombe/budding yeast, worm and fly for organismal genetics | HGS, RAB7A |
+| Retromer and recycling | Human cells, pombe/budding yeast, worm and fly neurons and epithelia | VPS35, RAB11A |
+| Barrier/transcytosis delivery | Human BBB/epithelial models, mouse and zebrafish for in vivo context | FCGRT, TFRC |
+| Endosomal escape versus degradative routing | Mouse liver LysoTag/LNP assays plus matched human-cell trafficking assays | RAB7A/Rab7a, HGS, VPS35 |
+
+## GO Anchors
+
+| Deliverome concept | Current GO anchor |
+| --- | --- |
+| Surface localization | GO:0009986 cell surface |
+| Extracellular-facing membrane localization | GO:0009897 external side of plasma membrane |
+| Plasma membrane localization | GO:0005886 plasma membrane |
+| Protein localization to surface | GO:0034394 protein localization to cell surface |
+| Internalization | GO:0031623 receptor internalization |
+| General endocytosis | GO:0006897 endocytosis |
+| Receptor-mediated uptake | GO:0006898 receptor-mediated endocytosis |
+| Clathrin-dependent uptake | GO:0072583 clathrin-dependent endocytosis |
+| Caveolin-mediated uptake | GO:0072584 caveolin-mediated endocytosis |
+| Transcellular routing | GO:0045056 transcytosis |
+| Early endosome | GO:0005769 early endosome |
+| Late endosome | GO:0005770 late endosome |
+| Recycling route | GO:0055037 recycling endosome |
+| Lysosomal destination | GO:0005764 lysosome |
+| Early-to-late endosome route | GO:0045022 early endosome to late endosome transport |
+| Late endosome-to-lysosome route | GO:1902774 late endosome to lysosome transport |
+| Recycling to surface | GO:0099638 endosome to plasma membrane protein transport |
+
+## Open Questions
+
+- What evidence threshold should Deliverome surface proteomics meet before it supports a GO cellular-component annotation?
+- Can Deliverome metadata map cleanly to ECO evidence, CL/UBERON context, and GO-CAM activity units?
+- How should engineered cargo and disease-state measurements be represented without polluting GO's normal-function semantics?
+- Which surfaceome targets have enough literature today to build high-quality GO-CAMs before Deliverome data are released?
+- Should AIGR add a reusable delivery-route summary parallel to `core_functions`?
+
+---
+
+# STATUS
+
+## 2026-07-19
+
+- [x] Create focused Deliverome project document.
+- [x] Define delivery-address meaning.
+- [x] Record model-system stance, including pombe for conserved internal trafficking and mouse Rab7/Rab7a for in vivo post-internalization routing.
+- [x] Compare human RAB7A and mouse Rab7/Rab7a.
+- [x] Harmonize human RAB7A core-function synthesis with mouse Rab7/Rab7a for early-to-late endosome maturation, late endosome membrane localization, and retromer binding.
+- [x] Revisit mouse SynGO AMPA-receptor trafficking annotations from PMID:24217640.
+- [ ] Build GO-derived human surfaceome prior.
+- [ ] Select a small delivery-address pilot set.
+- [ ] Draft a GO-CAM-like delivery route template.
+
+# NOTES
+
+## 2026-07-19
+
+- Mouse Rab7/Rab7a is the best current model-system anchor for Deliverome's endosomal routing question: it provides in vivo evidence that Rab7-mediated late endosomal maturation can suppress LNP cytosolic escape by routing cargo toward degradative compartments.
+- Human RAB7A and mouse Rab7/Rab7a should be kept aligned on conserved core terms, while using human for disease genetics and mouse for tissue and in vivo delivery physiology.
+- The SynGO annotations from PMID:24217640 support AMPA-receptor movement toward late endosomal/lysosomal compartments during LTD, but the accessible paper text emphasizes stargazin/AP-2/AP-3A rather than Rab7 itself. These rows are retained only as non-core neuronal-context annotations, not as primary Rab7 biology.


### PR DESCRIPTION
## Summary
- add a focused Deliverome GO Collaboration project page and project index entry
- define the delivery-address framing and how GO/GO-CAM could contribute without conflating engineered delivery with endogenous function
- record model-system guidance: pombe for conserved internal trafficking machinery, mouse Rab7/Rab7a for in vivo post-internalization routing and LNP escape
- harmonize human RAB7A core-function synthesis with mouse Rab7/Rab7a for early-to-late endosome maturation, late endosome membrane localization, and retromer binding
- resolve the mouse Rab7 SynGO AMPAR/LTD rows from PMID:24217640 as non-core, indirect neuronal-context annotations rather than core Rab7 biology

## Validation
- just validate human RAB7A
- just validate mouse Rab7
- just render human RAB7A
- just render mouse Rab7
- uv run ai-gene-review render-projects projects/DELIVEROME.md -o pages/projects --verbose

Mouse Rab7 validates with 3 remaining pre-existing best-practice warnings for ACCEPT rows whose cached articles do not expose direct Rab7-specific supporting text.