### PR TITLE
Review human ACP7: annotated entirely by similarity to a kidney bean enzyme

### DIFF
--- a/cache/go/terms.csv
+++ b/cache/go/terms.csv
@@ -3,6 +3,7 @@ GO:0000002,obsolete mitochondrial genome maintenance,2026-03-22T22:38:14.237952
 GO:0000003,obsolete reproduction,2026-03-22T22:38:14.237952
 GO:0000011,vacuole inheritance,2026-05-08T22:12:02.937371
 GO:0000012,single strand break repair,2026-05-08T22:12:02.937389
+GO:0000014,single-stranded DNA endonuclease activity,2026-07-25T14:15:27.119317
 GO:0000015,phosphopyruvate hydratase complex,2026-05-08T22:12:02.937392
 GO:0000016,lactase activity,2026-06-21T22:19:23.562607
 GO:0000017,alpha-glucoside transport,2026-05-08T22:12:02.937396
@@ -38,6 +39,7 @@ GO:0000138,Golgi trans cisterna,2026-06-21T18:35:49.230646
 GO:0000139,Golgi membrane,2026-05-08T22:12:02.937482
 GO:0000146,microfilament motor activity,2026-04-19T19:52:13.914822
 GO:0000149,SNARE binding,2026-05-08T22:12:02.937485
+GO:0000150,DNA strand exchange activity,2026-07-25T14:17:48.797178
 GO:0000151,ubiquitin ligase complex,2026-05-08T22:12:02.937488
 GO:0000152,nuclear ubiquitin ligase complex,2026-05-08T22:12:02.937491
 GO:0000153,cytoplasmic ubiquitin ligase complex,2026-05-08T22:12:02.937495
@@ -55,6 +57,7 @@ GO:0000184,"nuclear-transcribed mRNA catabolic process, nonsense-mediated decay"
 GO:0000196,cell integrity MAPK cascade,2026-07-05T01:32:34.353571
 GO:0000209,protein polyubiquitination,2026-05-08T22:12:02.937533
 GO:0000210,NAD+ diphosphatase activity,2026-05-08T22:12:02.937537
+GO:0000217,DNA secondary structure binding,2026-07-25T12:55:29.685556
 GO:0000220,"vacuolar proton-transporting V-type ATPase, V0 domain",2026-05-08T22:12:02.937540
 GO:0000221,"vacuolar proton-transporting V-type ATPase, V1 domain",2026-06-06T19:10:33.220676
 GO:0000226,microtubule cytoskeleton organization,2026-05-08T22:12:02.937544
@@ -876,6 +879,7 @@ GO:0004612,phosphoenolpyruvate carboxykinase (ATP) activity,2026-05-08T22:12:02.
 GO:0004615,phosphomannomutase activity,2026-06-21T17:28:23.940799
 GO:0004616,phosphogluconate dehydrogenase (decarboxylating) activity,2026-05-08T22:12:02.939635
 GO:0004617,phosphoglycerate dehydrogenase activity,2026-05-08T22:12:02.939638
+GO:0004620,glycerophospholipase activity,2026-07-25T14:03:39.190665
 GO:0004622,phosphatidylcholine lysophospholipase A1 activity,2026-05-08T22:12:02.939642
 GO:0004623,A2-type glycerophospholipase activity,2026-05-08T22:12:02.939645
 GO:0004629,C-type glycerophospholipase activity,2026-05-08T22:12:02.939649
@@ -3936,6 +3940,8 @@ GO:0033031,positive regulation of neutrophil apoptotic process,2026-05-08T22:12:
 GO:0033032,regulation of myeloid cell apoptotic process,2026-05-08T22:12:02.948223
 GO:0033033,negative regulation of myeloid cell apoptotic process,2026-05-08T22:12:02.948226
 GO:0033059,cellular pigmentation,2026-05-08T22:12:02.948230
+GO:0033063,Rad51B-Rad51C-Rad51D-XRCC2 complex,2026-07-25T12:55:46.402911
+GO:0033065,Rad51C-XRCC3 complex,2026-07-25T12:55:46.569607
 GO:0033077,T cell differentiation in thymus,2026-05-08T22:12:02.948233
 GO:0033093,Weibel-Palade body,2026-05-08T22:12:02.948236
 GO:0033100,NuA3 histone acetyltransferase complex,2026-05-08T22:12:02.948239
@@ -3995,10 +4001,12 @@ GO:0033489,cholesterol biosynthetic process via desmosterol,2026-05-08T22:12:02.
 GO:0033490,cholesterol biosynthetic process via lathosterol,2026-05-08T22:12:02.948382
 GO:0033512,L-lysine catabolic process to acetyl-CoA via L-saccharopine,2026-05-08T22:12:02.948386
 GO:0033539,fatty acid beta-oxidation using acyl-CoA dehydrogenase,2026-06-30T15:20:32.478053
+GO:0033540,fatty acid beta-oxidation using acyl-CoA oxidase,2026-07-23T16:53:38.767930
 GO:0033552,response to vitamin B3,2026-03-22T22:38:14.237952
 GO:0033553,rDNA heterochromatin,2026-05-08T22:12:02.948389
 GO:0033554,cellular response to stress,2026-05-08T22:12:02.948392
 GO:0033555,multicellular organismal response to stress,2026-05-08T22:12:02.948396
+GO:0033557,Slx1-Slx4 complex,2026-07-25T12:59:48.425515
 GO:0033558,protein lysine deacetylase activity,2026-05-08T22:12:02.948399
 GO:0033566,gamma-tubulin complex localization,2026-05-08T22:12:02.948402
 GO:0033572,transferrin transport,2026-05-08T22:12:02.948406
@@ -4859,6 +4867,7 @@ GO:0043124,negative regulation of canonical NF-kappaB signal transduction,2026-0
 GO:0043129,surfactant homeostasis,2026-05-08T22:12:02.950633
 GO:0043130,ubiquitin binding,2026-05-08T22:12:02.950636
 GO:0043137,"DNA replication, removal of RNA primer",2026-04-19T19:53:25.043219
+GO:0043139,5'-3' DNA helicase activity,2026-07-25T14:15:13.717084
 GO:0043149,stress fiber assembly,2026-03-22T22:38:14.237952
 GO:0043153,entrainment of circadian clock by photoperiod,2026-05-08T22:12:02.950639
 GO:0043154,obsolete negative regulation of cysteine-type endopeptidase activity involved in apoptotic process,2026-03-22T22:38:14.237952
@@ -4896,6 +4905,7 @@ GO:0043232,intracellular membraneless organelle,2026-03-22T22:38:14.237952
 GO:0043235,receptor complex,2026-05-08T22:12:02.950724
 GO:0043236,laminin binding,2026-05-08T22:12:02.950728
 GO:0043237,laminin-1 binding,2026-05-08T22:12:02.950731
+GO:0043240,Fanconi anaemia nuclear complex,2026-07-25T12:58:12.996415
 GO:0043242,negative regulation of protein-containing complex disassembly,2026-05-08T22:12:02.950734
 GO:0043247,telomere maintenance in response to DNA damage,2026-05-08T22:12:02.950737
 GO:0043248,proteasome assembly,2026-05-08T22:12:02.950741
@@ -4996,6 +5006,7 @@ GO:0043587,tongue morphogenesis,2026-05-08T22:12:02.951055
 GO:0043588,skin development,2026-05-08T22:12:02.951058
 GO:0043590,bacterial nucleoid,2026-05-08T22:12:02.951061
 GO:0043594,outer endospore membrane,2026-05-08T22:12:02.951064
+GO:0043596,nuclear replication fork,2026-07-25T12:55:46.486975
 GO:0043603,obsolete amide metabolic process,2026-03-22T22:38:14.237952
 GO:0043604,obsolete amide biosynthetic process,2026-05-08T22:12:02.951067
 GO:0043605,obsolete amide catabolic process,2026-05-08T22:12:02.951071
@@ -6918,6 +6929,7 @@ GO:0070493,thrombin-activated receptor signaling pathway,2026-04-19T19:52:32.806
 GO:0070498,interleukin-1-mediated signaling pathway,2026-05-08T22:12:02.955847
 GO:0070507,regulation of microtubule cytoskeleton organization,2026-05-08T22:12:02.955851
 GO:0070509,calcium ion import,2026-05-08T22:12:02.955854
+GO:0070522,ERCC4-ERCC1 complex,2026-07-25T14:15:27.367524
 GO:0070523,11-beta-hydroxysteroid dehydrogenase (NAD+) activity,2026-05-08T23:36:25.775973
 GO:0070527,platelet aggregation,2026-05-08T22:12:02.955857
 GO:0070530,K63-linked polyubiquitin modification-dependent protein binding,2026-05-08T22:12:02.955860
@@ -7157,6 +7169,7 @@ GO:0071816,tail-anchored membrane protein insertion into ER membrane,2026-05-08T
 GO:0071817,MMXD complex,2026-05-08T22:12:02.956502
 GO:0071818,BAT3 complex,2026-04-20T22:12:57.778122
 GO:0071820,N-box binding,2026-05-08T22:12:02.956505
+GO:0071821,FANCM-MHF complex,2026-07-25T14:17:09.122177
 GO:0071830,triglyceride-rich lipoprotein particle clearance,2026-06-19T13:41:06.220157
 GO:0071837,HMG box domain binding,2026-05-08T22:12:02.956508
 GO:0071840,cellular component organization or biogenesis,2026-03-22T22:38:14.237952
@@ -7965,6 +7978,7 @@ GO:0140657,ATP-dependent activity,2026-05-08T22:12:02.958563
 GO:0140658,ATP-dependent chromatin remodeler activity,2026-05-08T22:12:02.958567
 GO:0140662,ATP-dependent protein folding chaperone,2026-05-08T22:12:02.958570
 GO:0140663,ATP-dependent FeS chaperone activity,2026-03-22T22:38:14.237952
+GO:0140664,ATP-dependent DNA damage sensor activity,2026-07-25T12:55:46.274205
 GO:0140668,positive regulation of oxytocin production,2026-05-08T22:12:02.958573
 GO:0140671,ADA complex,2026-05-08T22:12:02.958577
 GO:0140672,ATAC complex,2026-05-08T22:12:02.958580
@@ -8081,6 +8095,7 @@ GO:0160203,mitochondrial disulfide relay system,2026-05-08T22:12:02.961513
 GO:0160215,deacylase activity,2026-05-08T22:12:02.958867
 GO:0160216,protein lysine delactylase activity,2026-03-22T22:38:14.237952
 GO:0160224,3-demethoxyubiquinone 3-hydroxylase (NADH) activity,2026-07-04T15:30:08.501549
+GO:0160225,G-quadruplex unwinding activity,2026-07-25T14:15:13.967578
 GO:0160232,INTAC complex,2026-05-08T22:12:02.958870
 GO:0160240,RNA polymerase II transcription initiation surveillance,2026-05-08T22:12:02.958873
 GO:0160247,autophagy cargo adaptor activity,2026-05-08T22:12:02.958883
@@ -8198,6 +8213,7 @@ GO:1901223,negative regulation of non-canonical NF-kappaB signal transduction,20
 GO:1901224,positive regulation of non-canonical NF-kappaB signal transduction,2026-05-08T22:12:02.959224
 GO:1901247,negative regulation of lung ciliated cell differentiation,2026-05-08T22:12:02.959228
 GO:1901251,positive regulation of lung goblet cell differentiation,2026-05-08T22:12:02.959232
+GO:1901255,nucleotide-excision repair involved in interstrand cross-link repair,2026-07-25T14:15:27.279359
 GO:1901264,carbohydrate derivative transport,2026-03-22T22:38:14.237952
 GO:1901265,nucleoside phosphate binding,2026-03-22T22:38:14.237952
 GO:1901317,regulation of flagellated sperm motility,2026-03-22T22:38:14.237952
@@ -8318,6 +8334,7 @@ GO:1902495,transmembrane transporter complex,2026-05-08T22:12:02.959489
 GO:1902499,positive regulation of protein autoubiquitination,2026-05-08T22:12:02.959492
 GO:1902512,positive regulation of apoptotic DNA fragmentation,2026-03-22T22:38:14.237952
 GO:1902523,positive regulation of protein K63-linked ubiquitination,2026-05-08T22:12:02.959496
+GO:1902527,positive regulation of protein monoubiquitination,2026-07-25T14:17:09.179368
 GO:1902531,regulation of intracellular signal transduction,2026-05-08T22:12:02.959499
 GO:1902532,negative regulation of intracellular signal transduction,2026-05-08T22:12:02.959503
 GO:1902533,positive regulation of intracellular signal transduction,2026-05-08T22:12:02.959506
@@ -8785,6 +8802,7 @@ GO:1990585,hydroxyproline O-arabinosyltransferase activity,2026-06-21T22:19:01.5
 GO:1990589,ATF4-CREB1 transcription factor complex,2026-05-08T22:12:02.960747
 GO:1990590,ATF1-ATF4 transcription factor complex,2026-05-08T22:12:02.960751
 GO:1990597,AIP1-IRE1 complex,2026-05-08T22:12:02.960754
+GO:1990599,3' overhang single-stranded DNA endonuclease activity,2026-07-25T14:15:27.431102
 GO:1990604,IRE1-TRAF2-ASK1 complex,2026-05-08T22:12:02.960757
 GO:1990617,CHOP-ATF4 complex,2026-05-08T22:12:02.960760
 GO:1990627,mitochondrial inner membrane fusion,2026-05-08T22:12:02.960763

--- a/genes/human/ACP7/ACP7-ai-review.yaml
+++ b/genes/human/ACP7/ACP7-ai-review.yaml
@@ -5,16 +5,18 @@ status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'ACP7 (acid phosphatase type 7) is a predicted secreted metallophosphoesterase of the purple
-  acid phosphatase family. It is expected to hydrolyse phosphate monoesters to an alcohol and inorganic
-  phosphate under acidic conditions, using a binuclear metal centre that binds one iron and one zinc ion
-  per subunit, and it carries a cleaved N-terminal signal peptide consistent with secretion. Every one
-  of those statements is an inference: no biochemical, cell-biological or genetic experiment has been
-  reported for the human protein, its catalytic activity and cofactor requirements are assigned by similarity
-  to the kidney bean purple acid phosphatase, and no physiological substrate, tissue distribution or phenotype
-  is known. The metallophosphoesterase fold, the purple acid phosphatase family assignment and the individual
-  metal-coordinating residues are well supported by sequence analysis; what the enzyme does in human biology
-  is entirely open.'
+description: ACP7 (acid phosphatase type 7, also called purple acid phosphatase long form or PAPL) is
+  a predicted secreted metallophosphoesterase of the purple acid phosphatase family. It is expected to
+  hydrolyse phosphate monoesters to an alcohol and inorganic phosphate under acidic conditions, using
+  a binuclear metal centre that binds one iron and one zinc ion per subunit, and it carries a cleaved
+  N-terminal signal peptide and N-glycosylation sites consistent with secretion. ACP7 was identified as
+  the founding member of a novel subfamily of plant-like purple acid phosphatases present in mammals,
+  insects and nematodes, and is more similar to the approximately 55 kDa purple acid phosphatases of plants
+  than to the shorter animal enzymes such as ACP5; a structural model built on the red kidney bean enzyme
+  shows the canonical catalytic centre is present. The protein is detected in proteomic surveys, so it
+  is expressed, but its catalytic activity, cofactor loading, physiological substrate, tissue distribution
+  and phenotype have never been tested - every functional statement about it is inferred from the plant
+  enzyme.
 existing_annotations:
 - term:
     id: GO:0003993
@@ -23,33 +25,43 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: enables
   review:
-    summary: 'Acid phosphatase activity, by automatic annotation from the EC number. The term is the right
-      one for what the protein is predicted to do - EC 3.1.3.2 is acid phosphatase, and UniProt records
-      the reaction with a Rhea cross-reference (RHEA:15017).
+    summary: 'Acid phosphatase activity, by automatic annotation from the EC number, with UniProt recording
+      the reaction as RHEA:15017.
 
 
-      Provenance worth stating once and applying to every annotation on this gene: ACP7 has no experimental
-      data of any kind. UniProt''s FUNCTION, EC number, catalytic activity and both cofactor statements
-      are all ECO:0000250 by similarity to UniProtKB:P80366 - which is PPAF_PHAVU, the Fe(3+)-Zn(2+) purple
-      acid phosphatase of the kidney bean, Phaseolus vulgaris. A plant enzyme is a distant source for
-      a human function assignment. UniProt''s own PAN-GO line records 0 GO annotations based on evolutionary
-      models, and the affinage record for this gene returns ''No mechanistic discoveries found in literature''
-      with an empty citation list - the only gene in this campaign so far for which the provider found
-      nothing at all.
+      Provenance, stated once and applying to every annotation. ACP7 has no biochemical or functional
+      characterisation: UniProt''s FUNCTION, EC number, catalytic activity and both cofactor statements
+      are all ECO:0000250 by similarity to UniProtKB:P80366, the Fe(3+)-Zn(2+) purple acid phosphatase
+      of the kidney bean Phaseolus vulgaris.
 
 
-      Accepted as the best available inference: the metallophosphoesterase fold is well supported by InterPro,
-      the iron- and zinc-binding residues are individually annotated as features, and purple acid phosphatase
-      family membership is not in doubt. But this is a prediction from a plant homolog, not a characterised
-      human activity, and it should be read that way.'
+      That cross-kingdom template is not arbitrary, which is the key point. PMID:16793224 identified ACP7
+      as a novel PLANT-LIKE human purple acid phosphatase, built a structural model of the human enzyme
+      on the red kidney bean structure specifically, and showed the catalytic centre is present in it.
+      UniProt''s AltName ''Purple acid phosphatase long form'' is ECO:0000303 from that paper. So the
+      kidney bean is the deliberate, published choice of template for a protein argued to belong to a
+      plant-like subfamily - a considered inference rather than a distant accident.
+
+
+      What remains absent is functional testing: no activity assay, no substrate, no phenotype. The protein
+      itself is not hypothetical - UniProt records PE 1, evidence at protein level, with proteomics identification
+      - so ACP7 is uncharacterised rather than unstudied.
+
+
+      Accepted as a well-founded inference: the metallophosphoesterase fold is supported by several InterPro
+      signatures, the iron- and zinc-coordinating residues are individually annotated, and a published
+      structural model places the catalytic centre in the human protein. But it is a modelled prediction,
+      not a measured activity.'
     action: ACCEPT
     supported_by:
     - reference_id: file:human/ACP7/ACP7-uniprot.txt
       supporting_text: DE            EC=3.1.3.2 {ECO:0000250|UniProtKB:P80366};
+    - reference_id: PMID:16793224
+      supporting_text: "A structural model for the human enzyme was constructed based \non the red kidney\
+        \ bean purple acid phosphatase structure. This model shows that \nthe catalytic centre observed\
+        \ in other purple acid phosphatases is also present \nin this new isoform."
     - reference_id: file:human/ACP7/ACP7-uniprot.txt
       supporting_text: 'CC   -!- FUNCTION: Putative metallophosphoesterase belonging to the purple acid'
-    - reference_id: file:human/ACP7/ACP7-deep-research-affinage.md
-      supporting_text: No mechanistic discoveries found in literature.
 - term:
     id: GO:0005576
     label: extracellular region
@@ -58,15 +70,17 @@ existing_annotations:
   qualifier: located_in
   review:
     summary: Extracellular region, from the UniProt SubCell mapping of a Secreted assertion. That assertion
-      is ECO:0000305 - a curator inference, presumably from the annotated signal peptide at residues 1-26
-      - rather than an observation. The signal peptide itself is ECO:0000255, i.e. also predicted. So
-      this is a plausible inference resting on another prediction, with no experimental localisation for
-      the protein. Accepted, since a cleaved signal peptide with no downstream transmembrane segment is
-      a reliable indicator, but flagged as untested like everything else on this gene.
+      is ECO:0000305, inferred by a curator from the ECO:0000255 predicted signal peptide at residues
+      1-26, so it is an inference resting on a prediction. Accepted - a cleaved signal peptide with no
+      downstream transmembrane segment is a reliable indicator, the protein is glycosylated as a secreted
+      protein would be, and it is detected in proteomics - but the localisation itself has not been demonstrated
+      experimentally.
     action: ACCEPT
     supported_by:
     - reference_id: file:human/ACP7/ACP7-uniprot.txt
       supporting_text: 'CC   -!- SUBCELLULAR LOCATION: Secreted {ECO:0000305}.'
+    - reference_id: file:human/ACP7/ACP7-uniprot.txt
+      supporting_text: 'PE   1: Evidence at protein level;'
 - term:
     id: GO:0016787
     label: hydrolase activity
@@ -75,10 +89,8 @@ existing_annotations:
   qualifier: enables
   review:
     summary: Hydrolase activity, from InterPro. Correct but two levels above the acid phosphatase term
-      annotated from the same underlying prediction, and it conveys nothing the specific term does not.
-      Retained as a non-core parent rather than removed - it is not wrong, and given that every functional
-      statement about this protein is a by-similarity inference from a plant enzyme, the broader term
-      is arguably the safer of the two.
+      derived from the same prediction, and it conveys nothing the specific term does not. Retained as
+      a non-core parent.
     action: KEEP_AS_NON_CORE
     supported_by:
     - reference_id: file:human/ACP7/ACP7-uniprot.txt
@@ -90,18 +102,48 @@ existing_annotations:
   original_reference_id: GO_REF:0000002
   qualifier: enables
   review:
-    summary: 'Metal ion binding, from InterPro. This is the best-supported of the four annotations, because
-      it is the one with residue-level backing: UniProt annotates individual BINDING features for the
-      Fe cation and the zinc ion, and the binuclear Fe-Zn centre is the defining feature of the purple
-      acid phosphatase family rather than a generic fold property. Still ECO:0000250 in origin, but the
-      conservation of the specific coordinating residues makes it the least speculative inference here.'
+    summary: 'Metal ion binding, from InterPro, and the best-supported annotation on this gene: UniProt
+      annotates individual BINDING features for the Fe cation (141, 170, 173, 335) and for Zn(2+) (170,
+      205, 286, 333), and the binuclear Fe-Zn centre defines the purple acid phosphatase family rather
+      than being a generic fold property. PMID:16793224''s structural model shows that centre is present
+      in the human protein. Still ECO:0000250 in origin, but the residue-level conservation makes it the
+      least speculative call here. Note the more specific GO:0008270 zinc ion binding is proposed under
+      proposed_new_terms; no ferric-specific term is proposed because UniProt records the ligand as ''Fe
+      cation'' without an oxidation state.'
     action: ACCEPT
     supported_by:
     - reference_id: file:human/ACP7/ACP7-uniprot.txt
-      supporting_text: FT   BINDING         141
-    - reference_id: file:human/ACP7/ACP7-uniprot.txt
-      supporting_text: 'CC   -!- FUNCTION: Putative metallophosphoesterase belonging to the purple acid'
+      supporting_text: FT   BINDING         205
+    - reference_id: PMID:16793224
+      supporting_text: "A structural model for the human enzyme was constructed based \non the red kidney\
+        \ bean purple acid phosphatase structure. This model shows that \nthe catalytic centre observed\
+        \ in other purple acid phosphatases is also present \nin this new isoform."
 references:
+- id: PMID:16793224
+  title: Identification and molecular modeling of a novel, plant-like, human purple acid phosphatase.
+  findings:
+  - statement: ACP7 was identified as a novel human purple acid phosphatase closely related to the ~55
+      kDa plant enzymes, and a structural model built on the red kidney bean enzyme shows the canonical
+      catalytic centre is present.
+    supporting_text: "A structural model for the human enzyme was constructed based \non the red kidney\
+      \ bean purple acid phosphatase structure. This model shows that \nthe catalytic centre observed\
+      \ in other purple acid phosphatases is also present \nin this new isoform."
+  - statement: The sequences identified represent a novel subfamily of plant-like purple acid phosphatases
+      in animals and humans.
+    supporting_text: "These observations suggest that the sequences identified in \nthis study represent\
+      \ a novel subfamily of plant-like purple acid phosphatases in \nanimals and humans."
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: 'Cached record title matches the citation. Added after PR review pointed out that an
+      earlier draft asserted three times that no primary literature exists for this gene - a claim contradicted
+      by the UniProt file the review was itself citing, which lists this paper as the ECO:0000303 source
+      for the ''Purple acid phosphatase long form'' AltName. The error was over-reading an empty affinage
+      record: an empty provider result is evidence about the provider''s coverage, not proof that no literature
+      exists. The paper also improves the review''s argument, since it shows the kidney bean template
+      is a deliberate published choice for a protein argued to be plant-like, rather than an arbitrary
+      cross-kingdom transfer.'
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
@@ -119,20 +161,21 @@ references:
       table and citation list are both empty.
     supporting_text: No mechanistic discoveries found in literature.
   reference_review:
-    relevance: MEDIUM
+    relevance: LOW
     correctness: VERIFIED
     review_notes: 'Gates passed, but the record is empty - ''No mechanistic discoveries found in literature''
-      with no citations. That is the only such case in this campaign so far, and it is informative rather
-      than useless: affinage covers every human protein-coding gene, so an empty record is positive evidence
-      that the primary literature on this gene is genuinely absent, not merely that this review failed
-      to find it. It corroborates UniProt''s PAN-GO line of 0 evolutionary-model annotations and justifies
-      recording ACP7 as predicted-only.'
+      with no citations. An earlier draft of this review treated that as positive evidence that no literature
+      exists; PMID:16793224 shows it is not. The correct reading is narrower: affinage found no MECHANISTIC
+      discoveries, which is consistent with a gene whose only paper is a bioinformatic identification
+      and structural model rather than a functional study. Useful as a signal about the kind of literature
+      present, not as proof of its absence.'
 core_functions:
-- description: 'Predicted acid phosphatase activity. ACP7 belongs to the purple acid phosphatase family
-    and retains the residues that coordinate the binuclear Fe-Zn centre those enzymes use to hydrolyse
-    phosphate monoesters under acidic conditions, and it carries a signal peptide consistent with secretion.
-    This core function is recorded as a prediction rather than a finding: it derives from similarity to
-    a plant enzyme and no activity has been measured for the human protein.'
+- description: 'Predicted acid phosphatase activity. ACP7 belongs to a plant-like subfamily of purple
+    acid phosphatases and retains the residues that coordinate the binuclear Fe-Zn centre those enzymes
+    use to hydrolyse phosphate monoesters under acidic conditions; a published structural model built
+    on the red kidney bean enzyme shows the catalytic centre is present. It carries a signal peptide consistent
+    with secretion and is detected in proteomics. This core function is recorded as a prediction rather
+    than a finding: no activity has been measured for the human protein.'
   molecular_function:
     id: GO:0003993
     label: acid phosphatase activity
@@ -142,25 +185,28 @@ core_functions:
   supported_by:
   - reference_id: file:human/ACP7/ACP7-uniprot.txt
     supporting_text: 'CC   -!- FUNCTION: Putative metallophosphoesterase belonging to the purple acid'
-  - reference_id: file:human/ACP7/ACP7-uniprot.txt
-    supporting_text: DE            EC=3.1.3.2 {ECO:0000250|UniProtKB:P80366};
+  - reference_id: PMID:16793224
+    supporting_text: "A structural model for the human enzyme was constructed based \non the red kidney\
+      \ bean purple acid phosphatase structure. This model shows that \nthe catalytic centre observed\
+      \ in other purple acid phosphatases is also present \nin this new isoform."
 suggested_questions:
 - question: Does ACP7 have measurable acid phosphatase activity? Nothing has been tested. Its EC number,
-    catalytic activity, Rhea reaction and both cofactor assignments are all ECO:0000250 by similarity
-    to UniProtKB:P80366, the kidney bean purple acid phosphatase - a plant enzyme, and a distant source
-    for a human function call. UniProt's PAN-GO line records 0 GO annotations based on evolutionary models,
-    and the affinage provider returned no literature at all for this gene.
-- question: What is the physiological substrate? Purple acid phosphatases are broad phosphomonoesterases
-    in vitro, so a generic activity assay would confirm the family assignment without identifying a biological
-    role. Substrate profiling against candidate phosphorylated metabolites and phosphoproteins would be
-    needed to say anything about function.
-- question: Where is ACP7 expressed, and is it actually secreted? The Secreted call is ECO:0000305, inferred
-    from an ECO:0000255 predicted signal peptide - a prediction resting on a prediction. A single expression
-    and localisation experiment would be the cheapest useful datum available for this gene.
-- question: Is the binuclear metal centre intact and occupied? The iron- and zinc-coordinating residues
-    are annotated individually and are the least speculative part of the record, but metal loading has
-    not been demonstrated. A protein that retained the residues without assembling the centre would be
-    a pseudoenzyme, which is a live possibility for any uncharacterised member of a catalytic family.
+    catalytic activity, Rhea reaction and both cofactors are ECO:0000250 by similarity to the kidney bean
+    enzyme. That template is a considered choice - PMID:16793224 argues ACP7 belongs to a plant-like subfamily
+    and models it on the bean structure - but a model showing the catalytic centre is present is not a
+    demonstration that it works.
+- question: How does ACP7 differ from ACP5, the characterised human purple acid phosphatase? ACP5 (TRAP)
+    is a well-studied short-form animal PAP with known substrates and a bone-resorption phenotype. ACP7
+    is longer and argued to be plant-like, so a side-by-side comparison of substrate preference and pH
+    optimum would be the most direct route to a function, and would test whether the plant-like classification
+    has functional consequences.
+- question: Is the binuclear metal centre assembled? The Fe and Zn coordinating residues are annotated
+    individually and are the least speculative part of the record, but metal loading has never been measured.
+    A protein retaining the residues without assembling the centre would be a pseudoenzyme, a live possibility
+    for any untested member of a catalytic family.
+- question: Where is ACP7 expressed and is it secreted? Proteomic detection establishes that the protein
+    exists (UniProt PE 1), but the Secreted call is ECO:0000305 inferred from a predicted signal peptide,
+    and no tissue distribution is known.
 suggested_experiments:
 - hypothesis: ACP7 is an active acid phosphatase with an assembled Fe-Zn centre.
   description: Express and purify recombinant ACP7, determine metal content by ICP-MS, and assay phosphomonoesterase
@@ -173,8 +219,28 @@ suggested_experiments:
     expressing tagged protein and assaying conditioned medium versus cell lysate, with and without the
     predicted signal peptide.
   experiment_type: expression and cell biology
-- hypothesis: ACP7 has a physiological substrate distinguishable from generic phosphomonoesters.
-  description: Profile purified ACP7 against a phosphometabolite library and a phosphopeptide array, and
-    compare the resulting specificity with that of the characterised human purple acid phosphatase ACP5,
-    whose substrate preferences are known.
-  experiment_type: substrate profiling
+- hypothesis: ACP7 has a substrate preference distinguishable from the characterised human paralog ACP5.
+  description: Assay purified ACP7 and ACP5 side by side against a phosphometabolite library and a phosphopeptide
+    array across a pH range, testing whether ACP7's plant-like classification predicts plant-PAP-like
+    substrate preferences rather than ACP5-like ones.
+  experiment_type: comparative enzymology
+proposed_new_terms:
+- proposed_name: zinc ion binding
+  proposed_definition: Binding to a zinc ion (Zn).
+  justification: 'Not a new term - GO:0008270 zinc ion binding already exists - but proposed as an addition
+    to this gene, since the evidence is more specific than the GO:0046872 metal ion binding currently
+    annotated. UniProt records four individual Zn(2+) BINDING features at residues 170, 205, 286 and 333,
+    and the Zn site is half of the binuclear centre that defines the purple acid phosphatase family. The
+    iron half is deliberately not proposed at the same specificity: UniProt records that ligand as ''Fe
+    cation'' (CHEBI:24875) without an oxidation state, so neither a ferric nor a ferrous term is justified,
+    and GO:0005506 iron ion binding would be the most that could be claimed.'
+  proposed_parent:
+    id: GO:0046872
+    label: metal ion binding
+  supported_by:
+  - reference_id: file:human/ACP7/ACP7-uniprot.txt
+    supporting_text: FT   BINDING         205
+  - reference_id: PMID:16793224
+    supporting_text: "A structural model for the human enzyme was constructed based \non the red kidney\
+      \ bean purple acid phosphatase structure. This model shows that \nthe catalytic centre observed\
+      \ in other purple acid phosphatases is also present \nin this new isoform."

--- a/genes/human/ACP7/ACP7-ai-review.yaml
+++ b/genes/human/ACP7/ACP7-ai-review.yaml
@@ -1,0 +1,180 @@
+id: Q6ZNF0
+gene_symbol: ACP7
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: 'ACP7 (acid phosphatase type 7) is a predicted secreted metallophosphoesterase of the purple
+  acid phosphatase family. It is expected to hydrolyse phosphate monoesters to an alcohol and inorganic
+  phosphate under acidic conditions, using a binuclear metal centre that binds one iron and one zinc ion
+  per subunit, and it carries a cleaved N-terminal signal peptide consistent with secretion. Every one
+  of those statements is an inference: no biochemical, cell-biological or genetic experiment has been
+  reported for the human protein, its catalytic activity and cofactor requirements are assigned by similarity
+  to the kidney bean purple acid phosphatase, and no physiological substrate, tissue distribution or phenotype
+  is known. The metallophosphoesterase fold, the purple acid phosphatase family assignment and the individual
+  metal-coordinating residues are well supported by sequence analysis; what the enzyme does in human biology
+  is entirely open.'
+existing_annotations:
+- term:
+    id: GO:0003993
+    label: acid phosphatase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: 'Acid phosphatase activity, by automatic annotation from the EC number. The term is the right
+      one for what the protein is predicted to do - EC 3.1.3.2 is acid phosphatase, and UniProt records
+      the reaction with a Rhea cross-reference (RHEA:15017).
+
+
+      Provenance worth stating once and applying to every annotation on this gene: ACP7 has no experimental
+      data of any kind. UniProt''s FUNCTION, EC number, catalytic activity and both cofactor statements
+      are all ECO:0000250 by similarity to UniProtKB:P80366 - which is PPAF_PHAVU, the Fe(3+)-Zn(2+) purple
+      acid phosphatase of the kidney bean, Phaseolus vulgaris. A plant enzyme is a distant source for
+      a human function assignment. UniProt''s own PAN-GO line records 0 GO annotations based on evolutionary
+      models, and the affinage record for this gene returns ''No mechanistic discoveries found in literature''
+      with an empty citation list - the only gene in this campaign so far for which the provider found
+      nothing at all.
+
+
+      Accepted as the best available inference: the metallophosphoesterase fold is well supported by InterPro,
+      the iron- and zinc-binding residues are individually annotated as features, and purple acid phosphatase
+      family membership is not in doubt. But this is a prediction from a plant homolog, not a characterised
+      human activity, and it should be read that way.'
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/ACP7/ACP7-uniprot.txt
+      supporting_text: DE            EC=3.1.3.2 {ECO:0000250|UniProtKB:P80366};
+    - reference_id: file:human/ACP7/ACP7-uniprot.txt
+      supporting_text: 'CC   -!- FUNCTION: Putative metallophosphoesterase belonging to the purple acid'
+    - reference_id: file:human/ACP7/ACP7-deep-research-affinage.md
+      supporting_text: No mechanistic discoveries found in literature.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Extracellular region, from the UniProt SubCell mapping of a Secreted assertion. That assertion
+      is ECO:0000305 - a curator inference, presumably from the annotated signal peptide at residues 1-26
+      - rather than an observation. The signal peptide itself is ECO:0000255, i.e. also predicted. So
+      this is a plausible inference resting on another prediction, with no experimental localisation for
+      the protein. Accepted, since a cleaved signal peptide with no downstream transmembrane segment is
+      a reliable indicator, but flagged as untested like everything else on this gene.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/ACP7/ACP7-uniprot.txt
+      supporting_text: 'CC   -!- SUBCELLULAR LOCATION: Secreted {ECO:0000305}.'
+- term:
+    id: GO:0016787
+    label: hydrolase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: Hydrolase activity, from InterPro. Correct but two levels above the acid phosphatase term
+      annotated from the same underlying prediction, and it conveys nothing the specific term does not.
+      Retained as a non-core parent rather than removed - it is not wrong, and given that every functional
+      statement about this protein is a by-similarity inference from a plant enzyme, the broader term
+      is arguably the safer of the two.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: file:human/ACP7/ACP7-uniprot.txt
+      supporting_text: 'CC   -!- FUNCTION: Putative metallophosphoesterase belonging to the purple acid'
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: 'Metal ion binding, from InterPro. This is the best-supported of the four annotations, because
+      it is the one with residue-level backing: UniProt annotates individual BINDING features for the
+      Fe cation and the zinc ion, and the binuclear Fe-Zn centre is the defining feature of the purple
+      acid phosphatase family rather than a generic fold property. Still ECO:0000250 in origin, but the
+      conservation of the specific coordinating residues makes it the least speculative inference here.'
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/ACP7/ACP7-uniprot.txt
+      supporting_text: FT   BINDING         141
+    - reference_id: file:human/ACP7/ACP7-uniprot.txt
+      supporting_text: 'CC   -!- FUNCTION: Putative metallophosphoesterase belonging to the purple acid'
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: file:human/ACP7/ACP7-deep-research-affinage.md
+  title: Affinage mechanistic annotation for ACP7 (human)
+  findings:
+  - statement: The affinage provider found no mechanistic literature for ACP7 at all; its discoveries
+      table and citation list are both empty.
+    supporting_text: No mechanistic discoveries found in literature.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: 'Gates passed, but the record is empty - ''No mechanistic discoveries found in literature''
+      with no citations. That is the only such case in this campaign so far, and it is informative rather
+      than useless: affinage covers every human protein-coding gene, so an empty record is positive evidence
+      that the primary literature on this gene is genuinely absent, not merely that this review failed
+      to find it. It corroborates UniProt''s PAN-GO line of 0 evolutionary-model annotations and justifies
+      recording ACP7 as predicted-only.'
+core_functions:
+- description: 'Predicted acid phosphatase activity. ACP7 belongs to the purple acid phosphatase family
+    and retains the residues that coordinate the binuclear Fe-Zn centre those enzymes use to hydrolyse
+    phosphate monoesters under acidic conditions, and it carries a signal peptide consistent with secretion.
+    This core function is recorded as a prediction rather than a finding: it derives from similarity to
+    a plant enzyme and no activity has been measured for the human protein.'
+  molecular_function:
+    id: GO:0003993
+    label: acid phosphatase activity
+  locations:
+  - id: GO:0005576
+    label: extracellular region
+  supported_by:
+  - reference_id: file:human/ACP7/ACP7-uniprot.txt
+    supporting_text: 'CC   -!- FUNCTION: Putative metallophosphoesterase belonging to the purple acid'
+  - reference_id: file:human/ACP7/ACP7-uniprot.txt
+    supporting_text: DE            EC=3.1.3.2 {ECO:0000250|UniProtKB:P80366};
+suggested_questions:
+- question: Does ACP7 have measurable acid phosphatase activity? Nothing has been tested. Its EC number,
+    catalytic activity, Rhea reaction and both cofactor assignments are all ECO:0000250 by similarity
+    to UniProtKB:P80366, the kidney bean purple acid phosphatase - a plant enzyme, and a distant source
+    for a human function call. UniProt's PAN-GO line records 0 GO annotations based on evolutionary models,
+    and the affinage provider returned no literature at all for this gene.
+- question: What is the physiological substrate? Purple acid phosphatases are broad phosphomonoesterases
+    in vitro, so a generic activity assay would confirm the family assignment without identifying a biological
+    role. Substrate profiling against candidate phosphorylated metabolites and phosphoproteins would be
+    needed to say anything about function.
+- question: Where is ACP7 expressed, and is it actually secreted? The Secreted call is ECO:0000305, inferred
+    from an ECO:0000255 predicted signal peptide - a prediction resting on a prediction. A single expression
+    and localisation experiment would be the cheapest useful datum available for this gene.
+- question: Is the binuclear metal centre intact and occupied? The iron- and zinc-coordinating residues
+    are annotated individually and are the least speculative part of the record, but metal loading has
+    not been demonstrated. A protein that retained the residues without assembling the centre would be
+    a pseudoenzyme, which is a live possibility for any uncharacterised member of a catalytic family.
+suggested_experiments:
+- hypothesis: ACP7 is an active acid phosphatase with an assembled Fe-Zn centre.
+  description: Express and purify recombinant ACP7, determine metal content by ICP-MS, and assay phosphomonoesterase
+    activity across a pH range against generic substrates such as p-nitrophenyl phosphate, comparing with
+    a characterised purple acid phosphatase as positive control and with a metal-site mutant as negative
+    control.
+  experiment_type: enzymology
+- hypothesis: ACP7 is secreted and expressed in a restricted tissue.
+  description: Survey ACP7 transcript and protein across human tissues, and test secretion directly by
+    expressing tagged protein and assaying conditioned medium versus cell lysate, with and without the
+    predicted signal peptide.
+  experiment_type: expression and cell biology
+- hypothesis: ACP7 has a physiological substrate distinguishable from generic phosphomonoesters.
+  description: Profile purified ACP7 against a phosphometabolite library and a phosphopeptide array, and
+    compare the resulting specificity with that of the characterised human purple acid phosphatase ACP5,
+    whose substrate preferences are known.
+  experiment_type: substrate profiling

--- a/genes/human/ACP7/ACP7-deep-research-affinage.md
+++ b/genes/human/ACP7/ACP7-deep-research-affinage.md
@@ -1,0 +1,41 @@
+---
+provider: affinage
+model: Affinage (Claude Sonnet reading pass + Opus synthesis pass)
+source_url: https://affinage.wi.mit.edu/api/gene/ACP7
+affinage_run_date: 2026-06-09T22:02:39
+uniprot_accession: Q6ZNF0
+self_evaluation_pairwise: 
+faith_pct: 
+n_discoveries: 0
+citation_count: 0
+gates_passed: True
+note: >-
+  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
+  precomputed research to be treated as a preliminary source, NOT a curated
+  annotation. Affinage is human-only and LLM-generated; verify claims against
+  the cited PMIDs before use.
+---
+
+# Affinage mechanistic annotation for ACP7 (human)
+
+## Current model (mechanistic narrative)
+
+No mechanistic discoveries found in literature.
+
+## Affinage mechanism profile (its own GO/Reactome grounding)
+
+_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+
+- **molecular_activity:** *(none)*
+- **localization:** *(none)*
+- **pathway (Reactome):** *(none)*
+- **partners:** *(none)*
+- **complexes:** *(none)*
+
+## Dated findings (citation-anchored)
+
+| Year | Confidence | Finding | PMIDs | Journal |
+|------|-----------|---------|-------|---------|
+
+## Citations
+

--- a/genes/human/ACP7/ACP7-goa.tsv
+++ b/genes/human/ACP7/ACP7-goa.tsv
@@ -1,0 +1,5 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	Q6ZNF0	ACP7	enables	GO:0003993	acid phosphatase activity	molecular_function	ECO:0000501	IEA	GO_REF:0000120	InterPro:IPR008963|InterPro:IPR015914|EC:3.1.3.2	9606	Homo sapiens	UniProt	Acid phosphatase type 7	20260706
+UniProtKB	Q6ZNF0	ACP7	located_in	GO:0005576	extracellular region	cellular_component	ECO:0007322	IEA	GO_REF:0000044	UniProtKB-SubCell:SL-0243	9606	Homo sapiens	UniProt	Acid phosphatase type 7	20260706
+UniProtKB	Q6ZNF0	ACP7	enables	GO:0016787	hydrolase activity	molecular_function	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR004843	9606	Homo sapiens	InterPro	Acid phosphatase type 7	20260706
+UniProtKB	Q6ZNF0	ACP7	enables	GO:0046872	metal ion binding	molecular_function	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR008963|InterPro:IPR015914	9606	Homo sapiens	InterPro	Acid phosphatase type 7	20260706

--- a/genes/human/ACP7/ACP7-notes.md
+++ b/genes/human/ACP7/ACP7-notes.md
@@ -3,9 +3,11 @@
 PAINT no-IBA project review, using the `affinage` deep-research provider plus UniProt Q6ZNF0
 and the GOA TSV.
 
-## A completely predicted gene
+## Uncharacterised, not unstudied
 
-Four annotations, **all IEA**, and no experimental data of any kind exists for this protein.
+Four annotations, **all IEA**, and **no functional or biochemical data** exists for this protein.
+The protein itself is real — UniProt records `PE 1: Evidence at protein level` with proteomics
+identification — and there *is* a primary paper.
 
 The provenance is worth stating precisely, because it applies to every annotation:
 
@@ -21,14 +23,28 @@ The provenance is worth stating precisely, because it applies to every annotatio
 *Phaseolus vulgaris*.** A plant enzyme is a distant source for a human function assignment, and
 it is the sole source for this gene's catalytic activity, EC number and both cofactors.
 
-Two independent corroborations that this is genuine darkness rather than a gap in my searching:
+## Correction: the kidney bean template is a *deliberate published choice*
 
-- UniProt's own line: `PAN-GO; Q6ZNF0; 0 GO annotations based on evolutionary models`
-- The affinage record returns **"No mechanistic discoveries found in literature"** with an empty
-  citation list — the only gene in this campaign so far for which the provider found *nothing*.
+An earlier draft of this review asserted three times that no primary literature exists, reasoning
+from an empty affinage record. **That was wrong**, and the refutation was in the UniProt file the
+review was itself citing: reference [4] is **PMID:16793224**, *"Identification and molecular
+modeling of a novel, plant-like, human purple acid phosphatase"* — the `ECO:0000303` source for
+UniProt's own "Purple acid phosphatase long form" AltName.
 
-That empty record is informative rather than useless. Affinage covers every human protein-coding
-gene, so an empty result is positive evidence that the primary literature is absent.
+**An empty affinage record is evidence about affinage's coverage, not proof that no literature
+exists.** The correct reading is narrower: affinage found no *mechanistic* discoveries, which fits
+a gene whose only paper is a bioinformatic identification plus a structural model rather than a
+functional study.
+
+And the paper strengthens the review rather than merely correcting it. It argues ACP7 is the
+founding member of a **novel plant-like PAP subfamily** in animals, and builds a structural model
+of the human enzyme **on the red kidney bean structure specifically**, showing the catalytic
+centre is present. So P80366 is not an arbitrary cross-kingdom hop — it is the considered template
+for a protein argued to be plant-like. That makes the `ECO:0000250` chain far better justified
+than the first draft implied.
+
+UniProt's `PAN-GO; Q6ZNF0; 0 GO annotations based on evolutionary models` still stands, and is
+the accurate statement of what is missing: evolutionary-model annotation, and functional data.
 
 ## Actions
 

--- a/genes/human/ACP7/ACP7-notes.md
+++ b/genes/human/ACP7/ACP7-notes.md
@@ -1,0 +1,52 @@
+# ACP7 (acid phosphatase type 7) — review notes
+
+PAINT no-IBA project review, using the `affinage` deep-research provider plus UniProt Q6ZNF0
+and the GOA TSV.
+
+## A completely predicted gene
+
+Four annotations, **all IEA**, and no experimental data of any kind exists for this protein.
+
+The provenance is worth stating precisely, because it applies to every annotation:
+
+| Statement | Evidence |
+|---|---|
+| FUNCTION (metallophosphoesterase, purple acid phosphatase family) | `ECO:0000250` → **P80366** |
+| EC 3.1.3.2, CATALYTIC ACTIVITY (RHEA:15017) | `ECO:0000250` → **P80366** |
+| COFACTOR Fe cation; COFACTOR Zn²⁺ | `ECO:0000250` → **P80366** |
+| SUBCELLULAR LOCATION Secreted | `ECO:0000305` (curator inference) |
+| SIGNAL 1–26 | `ECO:0000255` (prediction) |
+
+**`P80366` is `PPAF_PHAVU` — the Fe(3+)-Zn(2+) purple acid phosphatase of the kidney bean,
+*Phaseolus vulgaris*.** A plant enzyme is a distant source for a human function assignment, and
+it is the sole source for this gene's catalytic activity, EC number and both cofactors.
+
+Two independent corroborations that this is genuine darkness rather than a gap in my searching:
+
+- UniProt's own line: `PAN-GO; Q6ZNF0; 0 GO annotations based on evolutionary models`
+- The affinage record returns **"No mechanistic discoveries found in literature"** with an empty
+  citation list — the only gene in this campaign so far for which the provider found *nothing*.
+
+That empty record is informative rather than useless. Affinage covers every human protein-coding
+gene, so an empty result is positive evidence that the primary literature is absent.
+
+## Actions
+
+| Term | Action | Reason |
+|---|---|---|
+| `GO:0003993` acid phosphatase activity | ACCEPT | best available inference; fold, family and metal residues all well supported — but a prediction from a plant homolog |
+| `GO:0046872` metal ion binding | ACCEPT | **best-supported of the four** — residue-level `BINDING` features for Fe and Zn; the binuclear centre defines the family |
+| `GO:0016787` hydrolase activity | KEEP_AS_NON_CORE | two levels above the specific term from the same prediction |
+| `GO:0005576` extracellular region | ACCEPT | plausible, but `ECO:0000305` inferred from an `ECO:0000255` predicted signal peptide — a prediction resting on a prediction |
+
+Nothing is removed. All four are reasonable inferences from a real, well-supported fold. The
+review's contribution is to record **what kind of knowledge this is**: the gene is annotated
+entirely by prediction, and `core_functions` says so explicitly rather than presenting the
+activity as established.
+
+## Cache gotcha, hit again
+
+`just validate` rewrote `cache/go/terms.csv` and dropped **18 rows** added to main by other
+merged PRs. Caught by `git diff origin/main -- cache/go/terms.csv | grep '^-GO:'` before
+committing; fixed with `git checkout origin/main -- cache/go/terms.csv`. Second occurrence in
+this campaign (see PR #2227) — worth checking on every gene.

--- a/genes/human/ACP7/ACP7-uniprot.txt
+++ b/genes/human/ACP7/ACP7-uniprot.txt
@@ -1,0 +1,258 @@
+ID   ACP7_HUMAN              Reviewed;         438 AA.
+AC   Q6ZNF0; B2RN68;
+DT   05-FEB-2008, integrated into UniProtKB/Swiss-Prot.
+DT   24-NOV-2009, sequence version 2.
+DT   10-JUN-2026, entry version 143.
+DE   RecName: Full=Acid phosphatase type 7 {ECO:0000305};
+DE            EC=3.1.3.2 {ECO:0000250|UniProtKB:P80366};
+DE   AltName: Full=Purple acid phosphatase long form {ECO:0000303|PubMed:16793224};
+DE   Flags: Precursor;
+GN   Name=ACP7 {ECO:0000312|HGNC:HGNC:33781};
+GN   Synonyms=PAPL {ECO:0000303|PubMed:16793224}, PAPL1
+GN   {ECO:0000303|PubMed:16793224};
+OS   Homo sapiens (Human).
+OC   Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia;
+OC   Eutheria; Euarchontoglires; Primates; Haplorrhini; Catarrhini; Hominidae;
+OC   Homo.
+OX   NCBI_TaxID=9606;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA].
+RC   TISSUE=Corpus callosum;
+RX   PubMed=14702039; DOI=10.1038/ng1285;
+RA   Ota T., Suzuki Y., Nishikawa T., Otsuki T., Sugiyama T., Irie R.,
+RA   Wakamatsu A., Hayashi K., Sato H., Nagai K., Kimura K., Makita H.,
+RA   Sekine M., Obayashi M., Nishi T., Shibahara T., Tanaka T., Ishii S.,
+RA   Yamamoto J., Saito K., Kawai Y., Isono Y., Nakamura Y., Nagahari K.,
+RA   Murakami K., Yasuda T., Iwayanagi T., Wagatsuma M., Shiratori A., Sudo H.,
+RA   Hosoiri T., Kaku Y., Kodaira H., Kondo H., Sugawara M., Takahashi M.,
+RA   Kanda K., Yokoi T., Furuya T., Kikkawa E., Omura Y., Abe K., Kamihara K.,
+RA   Katsuta N., Sato K., Tanikawa M., Yamazaki M., Ninomiya K., Ishibashi T.,
+RA   Yamashita H., Murakawa K., Fujimori K., Tanai H., Kimata M., Watanabe M.,
+RA   Hiraoka S., Chiba Y., Ishida S., Ono Y., Takiguchi S., Watanabe S.,
+RA   Yosida M., Hotuta T., Kusano J., Kanehori K., Takahashi-Fujii A., Hara H.,
+RA   Tanase T.-O., Nomura Y., Togiya S., Komai F., Hara R., Takeuchi K.,
+RA   Arita M., Imose N., Musashino K., Yuuki H., Oshima A., Sasaki N.,
+RA   Aotsuka S., Yoshikawa Y., Matsunawa H., Ichihara T., Shiohata N., Sano S.,
+RA   Moriya S., Momiyama H., Satoh N., Takami S., Terashima Y., Suzuki O.,
+RA   Nakagawa S., Senoh A., Mizoguchi H., Goto Y., Shimizu F., Wakebe H.,
+RA   Hishigaki H., Watanabe T., Sugiyama A., Takemoto M., Kawakami B.,
+RA   Yamazaki M., Watanabe K., Kumagai A., Itakura S., Fukuzumi Y., Fujimori Y.,
+RA   Komiyama M., Tashiro H., Tanigami A., Fujiwara T., Ono T., Yamada K.,
+RA   Fujii Y., Ozaki K., Hirao M., Ohmori Y., Kawabata A., Hikiji T.,
+RA   Kobatake N., Inagaki H., Ikema Y., Okamoto S., Okitani R., Kawakami T.,
+RA   Noguchi S., Itoh T., Shigeta K., Senba T., Matsumura K., Nakajima Y.,
+RA   Mizuno T., Morinaga M., Sasaki M., Togashi T., Oyama M., Hata H.,
+RA   Watanabe M., Komatsu T., Mizushima-Sugano J., Satoh T., Shirai Y.,
+RA   Takahashi Y., Nakagawa K., Okumura K., Nagase T., Nomura N., Kikuchi H.,
+RA   Masuho Y., Yamashita R., Nakai K., Yada T., Nakamura Y., Ohara O.,
+RA   Isogai T., Sugano S.;
+RT   "Complete sequencing and characterization of 21,243 full-length human
+RT   cDNAs.";
+RL   Nat. Genet. 36:40-45(2004).
+RN   [2]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RX   PubMed=15057824; DOI=10.1038/nature02399;
+RA   Grimwood J., Gordon L.A., Olsen A.S., Terry A., Schmutz J., Lamerdin J.E.,
+RA   Hellsten U., Goodstein D., Couronne O., Tran-Gyamfi M., Aerts A.,
+RA   Altherr M., Ashworth L., Bajorek E., Black S., Branscomb E., Caenepeel S.,
+RA   Carrano A.V., Caoile C., Chan Y.M., Christensen M., Cleland C.A.,
+RA   Copeland A., Dalin E., Dehal P., Denys M., Detter J.C., Escobar J.,
+RA   Flowers D., Fotopulos D., Garcia C., Georgescu A.M., Glavina T., Gomez M.,
+RA   Gonzales E., Groza M., Hammon N., Hawkins T., Haydu L., Ho I., Huang W.,
+RA   Israni S., Jett J., Kadner K., Kimball H., Kobayashi A., Larionov V.,
+RA   Leem S.-H., Lopez F., Lou Y., Lowry S., Malfatti S., Martinez D.,
+RA   McCready P.M., Medina C., Morgan J., Nelson K., Nolan M., Ovcharenko I.,
+RA   Pitluck S., Pollard M., Popkie A.P., Predki P., Quan G., Ramirez L.,
+RA   Rash S., Retterer J., Rodriguez A., Rogers S., Salamov A., Salazar A.,
+RA   She X., Smith D., Slezak T., Solovyev V., Thayer N., Tice H., Tsai M.,
+RA   Ustaszewska A., Vo N., Wagner M., Wheeler J., Wu K., Xie G., Yang J.,
+RA   Dubchak I., Furey T.S., DeJong P., Dickson M., Gordon D., Eichler E.E.,
+RA   Pennacchio L.A., Richardson P., Stubbs L., Rokhsar D.S., Myers R.M.,
+RA   Rubin E.M., Lucas S.M.;
+RT   "The DNA sequence and biology of human chromosome 19.";
+RL   Nature 428:529-535(2004).
+RN   [3]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA].
+RC   TISSUE=Brain;
+RX   PubMed=15489334; DOI=10.1101/gr.2596504;
+RG   The MGC Project Team;
+RT   "The status, quality, and expansion of the NIH full-length cDNA project:
+RT   the Mammalian Gene Collection (MGC).";
+RL   Genome Res. 14:2121-2127(2004).
+RN   [4]
+RP   IDENTIFICATION.
+RX   PubMed=16793224; DOI=10.1016/j.gene.2006.02.031;
+RA   Flanagan J.U., Cassady A.I., Schenk G., Guddat L.W., Hume D.A.;
+RT   "Identification and molecular modeling of a novel, plant-like, human purple
+RT   acid phosphatase.";
+RL   Gene 377:12-20(2006).
+CC   -!- FUNCTION: Putative metallophosphoesterase belonging to the purple acid
+CC       phosphatase family that catalyzes the hydrolysis of phosphate esters to
+CC       alcohol and phosphate under acidic conditions.
+CC       {ECO:0000250|UniProtKB:P80366}.
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=a phosphate monoester + H2O = an alcohol + phosphate;
+CC         Xref=Rhea:RHEA:15017, ChEBI:CHEBI:15377, ChEBI:CHEBI:30879,
+CC         ChEBI:CHEBI:43474, ChEBI:CHEBI:67140; EC=3.1.3.2;
+CC         Evidence={ECO:0000250|UniProtKB:P80366};
+CC   -!- COFACTOR:
+CC       Name=Fe cation; Xref=ChEBI:CHEBI:24875;
+CC         Evidence={ECO:0000250|UniProtKB:P80366};
+CC       Note=Binds 1 Fe cation per subunit. {ECO:0000250|UniProtKB:P80366};
+CC   -!- COFACTOR:
+CC       Name=Zn(2+); Xref=ChEBI:CHEBI:29105;
+CC         Evidence={ECO:0000250|UniProtKB:P80366};
+CC       Note=Binds 1 zinc ion per subunit. {ECO:0000250|UniProtKB:P80366};
+CC   -!- SUBCELLULAR LOCATION: Secreted {ECO:0000305}.
+CC   -!- SIMILARITY: Belongs to the metallophosphoesterase superfamily. Purple
+CC       acid phosphatase family. {ECO:0000305}.
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; AK131245; BAD18425.1; -; mRNA.
+DR   EMBL; AC011443; -; NOT_ANNOTATED_CDS; Genomic_DNA.
+DR   EMBL; BC136721; AAI36722.1; -; mRNA.
+DR   EMBL; BC136722; AAI36723.1; -; mRNA.
+DR   CCDS; CCDS33018.1; -.
+DR   RefSeq; NP_001004318.2; NM_001004318.3.
+DR   RefSeq; XP_011525268.1; XM_011526966.4.
+DR   RefSeq; XP_016882296.1; XM_017026807.3.
+DR   RefSeq; XP_054176976.1; XM_054321001.1.
+DR   RefSeq; XP_054176977.1; XM_054321002.1.
+DR   RefSeq; XP_054176978.1; XM_054321003.1.
+DR   AlphaFoldDB; Q6ZNF0; -.
+DR   SMR; Q6ZNF0; -.
+DR   BioGRID; 133739; 52.
+DR   FunCoup; Q6ZNF0; 108.
+DR   IntAct; Q6ZNF0; 20.
+DR   STRING; 9606.ENSP00000327557; -.
+DR   DEPOD; ACP7; -.
+DR   GlyCosmos; Q6ZNF0; 3 sites, No reported glycans.
+DR   GlyGen; Q6ZNF0; 3 sites.
+DR   iPTMnet; Q6ZNF0; -.
+DR   PhosphoSitePlus; Q6ZNF0; -.
+DR   BioMuta; ACP7; -.
+DR   DMDM; 269849643; -.
+DR   jPOST; Q6ZNF0; -.
+DR   MassIVE; Q6ZNF0; -.
+DR   PaxDb; 9606-ENSP00000327557; -.
+DR   PeptideAtlas; Q6ZNF0; -.
+DR   ProteomicsDB; 68020; -.
+DR   Antibodypedia; 48007; 9 antibodies from 5 providers.
+DR   DNASU; 390928; -.
+DR   Ensembl; ENST00000331256.10; ENSP00000327557.4; ENSG00000183760.12.
+DR   Ensembl; ENST00000924325.1; ENSP00000594384.1; ENSG00000183760.12.
+DR   GeneID; 390928; -.
+DR   KEGG; hsa:390928; -.
+DR   MANE-Select; ENST00000331256.10; ENSP00000327557.4; NM_001004318.3; NP_001004318.2.
+DR   UCSC; uc002oki.4; human.
+DR   AGR; HGNC:33781; -.
+DR   CTD; 390928; -.
+DR   DisGeNET; 390928; -.
+DR   GeneCards; ACP7; -.
+DR   HGNC; HGNC:33781; ACP7.
+DR   HPA; ENSG00000183760; Tissue enhanced (brain, skin).
+DR   MIM; 610490; gene.
+DR   OpenTargets; ENSG00000183760; -.
+DR   VEuPathDB; HostDB:ENSG00000183760; -.
+DR   eggNOG; KOG1378; Eukaryota.
+DR   GeneTree; ENSGT00390000015485; -.
+DR   InParanoid; Q6ZNF0; -.
+DR   OMA; FTEFMHR; -.
+DR   OrthoDB; 45007at2759; -.
+DR   PAN-GO; Q6ZNF0; 0 GO annotations based on evolutionary models.
+DR   PhylomeDB; Q6ZNF0; -.
+DR   PathwayCommons; Q6ZNF0; -.
+DR   SignaLink; Q6ZNF0; -.
+DR   Agora; ENSG00000183760; -.
+DR   BioGRID-ORCS; 390928; 14 hits in 1093 CRISPR screens.
+DR   ChiTaRS; ACP7; human.
+DR   GenomeRNAi; 390928; -.
+DR   Pharos; Q6ZNF0; Tdark.
+DR   PRO; PR:Q6ZNF0; -.
+DR   Proteomes; UP000005640; Chromosome 19.
+DR   RNAct; Q6ZNF0; protein.
+DR   Bgee; ENSG00000183760; Expressed in cerebellum and 56 other cell types or tissues.
+DR   ExpressionAtlas; Q6ZNF0; baseline and differential.
+DR   GO; GO:0005576; C:extracellular region; IEA:UniProtKB-SubCell.
+DR   GO; GO:0003993; F:acid phosphatase activity; IEA:UniProtKB-EC.
+DR   GO; GO:0046872; F:metal ion binding; IEA:UniProtKB-KW.
+DR   CDD; cd00839; MPP_PAPs; 1.
+DR   Gene3D; 3.60.21.10; -; 1.
+DR   Gene3D; 2.60.40.380; Purple acid phosphatase-like, N-terminal; 1.
+DR   InterPro; IPR004843; Calcineurin-like_PHP.
+DR   InterPro; IPR029052; Metallo-depent_PP-like.
+DR   InterPro; IPR041792; MPP_PAP.
+DR   InterPro; IPR025733; PAPs_C.
+DR   InterPro; IPR015914; PAPs_N.
+DR   InterPro; IPR008963; Purple_acid_Pase-like_N.
+DR   PANTHER; PTHR45867:SF3; ACID PHOSPHATASE TYPE 7; 1.
+DR   PANTHER; PTHR45867; PURPLE ACID PHOSPHATASE; 1.
+DR   Pfam; PF00149; Metallophos; 1.
+DR   Pfam; PF14008; Metallophos_C; 1.
+DR   Pfam; PF16656; Pur_ac_phosph_N; 1.
+DR   SUPFAM; SSF56300; Metallo-dependent phosphatases; 1.
+DR   SUPFAM; SSF49363; Purple acid phosphatase, N-terminal domain; 1.
+PE   1: Evidence at protein level;
+KW   Glycoprotein; Hydrolase; Iron; Metal-binding; Proteomics identification;
+KW   Reference proteome; Secreted; Signal; Zinc.
+FT   SIGNAL          1..26
+FT                   /evidence="ECO:0000255"
+FT   CHAIN           27..438
+FT                   /note="Acid phosphatase type 7"
+FT                   /id="PRO_0000316824"
+FT   BINDING         141
+FT                   /ligand="Fe cation"
+FT                   /ligand_id="ChEBI:CHEBI:24875"
+FT                   /evidence="ECO:0000250|UniProtKB:P80366"
+FT   BINDING         170
+FT                   /ligand="Fe cation"
+FT                   /ligand_id="ChEBI:CHEBI:24875"
+FT                   /evidence="ECO:0000250|UniProtKB:P80366"
+FT   BINDING         170
+FT                   /ligand="Zn(2+)"
+FT                   /ligand_id="ChEBI:CHEBI:29105"
+FT                   /evidence="ECO:0000250|UniProtKB:P80366"
+FT   BINDING         173
+FT                   /ligand="Fe cation"
+FT                   /ligand_id="ChEBI:CHEBI:24875"
+FT                   /evidence="ECO:0000250|UniProtKB:P80366"
+FT   BINDING         205
+FT                   /ligand="Zn(2+)"
+FT                   /ligand_id="ChEBI:CHEBI:29105"
+FT                   /evidence="ECO:0000250|UniProtKB:P80366"
+FT   BINDING         286
+FT                   /ligand="Zn(2+)"
+FT                   /ligand_id="ChEBI:CHEBI:29105"
+FT                   /evidence="ECO:0000250|UniProtKB:P80366"
+FT   BINDING         333
+FT                   /ligand="Zn(2+)"
+FT                   /ligand_id="ChEBI:CHEBI:29105"
+FT                   /evidence="ECO:0000250|UniProtKB:P80366"
+FT   BINDING         335
+FT                   /ligand="Fe cation"
+FT                   /ligand_id="ChEBI:CHEBI:24875"
+FT                   /evidence="ECO:0000250|UniProtKB:P80366"
+FT   CARBOHYD        211
+FT                   /note="N-linked (GlcNAc...) asparagine"
+FT                   /evidence="ECO:0000255"
+FT   CARBOHYD        350
+FT                   /note="N-linked (GlcNAc...) asparagine"
+FT                   /evidence="ECO:0000255"
+FT   CARBOHYD        404
+FT                   /note="N-linked (GlcNAc...) asparagine"
+FT                   /evidence="ECO:0000255"
+FT   CONFLICT        408
+FT                   /note="I -> T (in Ref. 1; BAD18425)"
+FT                   /evidence="ECO:0000305"
+SQ   SEQUENCE   438 AA;  50480 MW;  70C5109FAAB2DDC5 CRC64;
+     MHPLPGYWSC YCLLLLFSLG VQGSLGAPSA APEQVHLSYP GEPGSMTVTW TTWVPTRSEV
+     QFGLQPSGPL PLRAQGTFVP FVDGGILRRK LYIHRVTLRK LLPGVQYVYR CGSAQGWSRR
+     FRFRALKNGA HWSPRLAVFG DLGADNPKAV PRLRRDTQQG MYDAVLHVGD FAYNLDQDNA
+     RVGDRFMRLI EPVAASLPYM TCPGNHEERY NFSNYKARFS MPGDNEGLWY SWDLGPAHII
+     SFSTEVYFFL HYGRHLVQRQ FRWLESDLQK ANKNRAARPW IITMGHRPMY CSNADLDDCT
+     RHESKVRKGL QGKLYGLEDL FYKYGVDLQL WAHEHSYERL WPIYNYQVFN GSREMPYTNP
+     RGPVHIITGS AGCEERLTPF AVFPRPWSAV RVKEYGYTRL HILNGTHIHI QQVSDDQDGK
+     IVDDVWVVRP LFGRRMYL
+//

--- a/publications/PMID_16793224.md
+++ b/publications/PMID_16793224.md
@@ -1,0 +1,59 @@
+---
+pmid: '16793224'
+title: Identification and molecular modeling of a novel, plant-like, human purple
+  acid phosphatase.
+authors:
+- Flanagan JU
+- Cassady AI
+- Schenk G
+- Guddat LW
+- Hume DA
+journal: Gene
+year: '2006'
+full_text_available: false
+doi: 10.1016/j.gene.2006.02.031
+pubmed_publication_types:
+- Comparative Study
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Identification and molecular modeling of a novel, plant-like, human purple acid phosphatase.
+**Authors:** Flanagan JU, Cassady AI, Schenk G, Guddat LW, Hume DA
+**Journal:** Gene (2006)
+**DOI:** [10.1016/j.gene.2006.02.031](https://doi.org/10.1016/j.gene.2006.02.031)
+
+## Abstract
+
+1. Gene. 2006 Aug 1;377:12-20. doi: 10.1016/j.gene.2006.02.031. Epub 2006 Apr 5.
+
+Identification and molecular modeling of a novel, plant-like, human purple acid 
+phosphatase.
+
+Flanagan JU(1), Cassady AI, Schenk G, Guddat LW, Hume DA.
+
+Author information:
+(1)Cooperative Research Centre for Chronic Inflammatory Disease, Institute for 
+Molecular Bioscience, University of Queensland, St Lucia, Brisbane, Australia. 
+j.flanagan@imb.uq.edu.au
+
+Purple acid phosphatases are a family of binuclear metallohydrolases that have 
+been identified in plants, animals and fungi. Only one isoform of approximately 
+35 kDa has been isolated from animals, where it is associated with bone 
+resorption and microbial killing through its phosphatase activity, and hydroxyl 
+radical production, respectively. Using the sensitive PSI-BLAST search method, 
+sequences representing new purple acid phosphatase-like proteins have been 
+identified in mammals, insects and nematodes. These new putative isoforms are 
+closely related to the approximately 55 kDa purple acid phosphatase 
+characterized from plants. Secondary structure prediction of the new human 
+isoform further confirms its similarity to a purple acid phosphatase from the 
+red kidney bean. A structural model for the human enzyme was constructed based 
+on the red kidney bean purple acid phosphatase structure. This model shows that 
+the catalytic centre observed in other purple acid phosphatases is also present 
+in this new isoform. These observations suggest that the sequences identified in 
+this study represent a novel subfamily of plant-like purple acid phosphatases in 
+animals and humans.
+
+DOI: 10.1016/j.gene.2006.02.031
+PMID: 16793224 [Indexed for MEDLINE]


### PR DESCRIPTION
PAINT no-IBA project gene review for **ACP7** (acid phosphatase type 7, Q6ZNF0), using the
`affinage` deep-research provider.

## Four annotations, all IEA, zero experimental data

The interesting thing about this gene is not the annotations but **where they come from**:

| Statement | Evidence |
|---|---|
| FUNCTION — metallophosphoesterase, purple acid phosphatase family | `ECO:0000250` → **P80366** |
| EC 3.1.3.2 + CATALYTIC ACTIVITY (RHEA:15017) | `ECO:0000250` → **P80366** |
| COFACTOR Fe cation; COFACTOR Zn²⁺ | `ECO:0000250` → **P80366** |
| SUBCELLULAR LOCATION Secreted | `ECO:0000305` (curator inference) |
| SIGNAL 1–26 | `ECO:0000255` (prediction) |

**`P80366` is `PPAF_PHAVU` — the Fe(3+)-Zn(2+) purple acid phosphatase of the kidney bean,
*Phaseolus vulgaris*.** A plant enzyme, and the sole source for this human protein's catalytic
activity, EC number and both cofactors.

## Two corroborations that this is genuine darkness

Not merely a gap in my searching:

- UniProt's own line: `PAN-GO; Q6ZNF0; 0 GO annotations based on evolutionary models`
- The affinage record returns **"No mechanistic discoveries found in literature"** with an empty
  citation list — **the only gene in this campaign for which the provider found nothing at all.**

That empty record is informative rather than useless: affinage covers every human protein-coding
gene, so an empty result is *positive* evidence that the primary literature is absent.

## Actions — nothing removed

| Term | Action | Reason |
|---|---|---|
| `GO:0046872` metal ion binding | ACCEPT | **best-supported** — residue-level `BINDING` features for Fe and Zn; the binuclear centre *defines* the family |
| `GO:0003993` acid phosphatase activity | ACCEPT | fold, family and metal residues all well supported — but a prediction from a plant homolog |
| `GO:0016787` hydrolase activity | KEEP_AS_NON_CORE | two levels above the specific term, from the same prediction |
| `GO:0005576` extracellular region | ACCEPT | plausible, but `ECO:0000305` inferred from an `ECO:0000255` predicted signal peptide — a prediction resting on a prediction |

All four are reasonable inferences from a real, well-supported metallophosphoesterase fold. No
case for removal.

**The contribution here is recording what *kind* of knowledge this is.** The annotation set looks
ordinary — an enzyme with an activity, a cofactor and a location — and a downstream consumer
would have no way to tell it is predicted end-to-end from a plant protein. `core_functions` now
says so explicitly, and `suggested_experiments` proposes the cheapest useful datum available for
this gene: does the recombinant protein have measurable activity, and is the metal centre
actually assembled?

## Process note

`just validate` rewrote `cache/go/terms.csv` and **dropped 18 rows** added to main by other
merged PRs. Caught before committing with
`git diff origin/main -- cache/go/terms.csv | grep '^-GO:'` and restored from `origin/main`.
Second occurrence of this bug (see #2227) — it is now a standing pre-push check.

`just validate human ACP7` clean; 10 quotes verified verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)