### PR TITLE
docs: automation-migration-to-dismech guide

### DIFF
--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -72,6 +72,31 @@ since — which it will have been, if you rebase between review rounds. #2247 wa
 lost that way. The order that works is merge → retarget the next PR to `main`
 → *then* delete the branch.
 
+## Why this order
+
+Asked six times in review, so it belongs in the record. The sequencing was not
+arbitrary:
+
+1. **Reviewer split before anything else.** Every subsequent PR was reviewed by
+   an identity distinct from the one writing it. Landing it first is what made
+   the rest of the stack worth reviewing at all — and the reviewer went on to
+   find a 🔴 and several 🟡s that the author's own tests did not.
+2. **Injection controls before the scanners.** `close-fork-prs` and the
+   untrusted-comment guard reduce what can reach an agent's context; they should
+   be in place before more agents get write-capable tokens, not after.
+3. **Auth per workflow group, smallest blast radius first.** `pr-shepherd` alone,
+   then the four scanners, then the mention responder, then the page/cache jobs.
+   Each group is independently revertible, and a mistake in one does not strand
+   the others.
+4. **Teardown last, and it means more than the secret.** The `PAT_FOR_PR` secret
+   is the obvious item, but the `just` recipes that *re-install* it are the ones
+   that matter: while those existed, a single `just gh-add-secrets` could undo
+   the whole migration. Remove the ability to recreate the credential before
+   congratulating yourself on removing the credential.
+
+Cron profiles came last because they are cadence, not security, and applying
+them is behaviour-preserving.
+
 ## The token pattern
 
 Every write-capable workflow now looks like this:

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -42,7 +42,9 @@ nothing in `.git/config`.
 Verification, all of which should stay empty/green:
 
 ```bash
-grep -rn "secrets.PAT_FOR_PR" .                # -> empty (repo-wide, not just .github/)
+# Repo-wide, not just .github/ — the justfile recipes that re-installed this
+# secret were the real footgun. --exclude-dir=docs because this file quotes it.
+grep -rn "secrets.PAT_FOR_PR" . --exclude-dir=docs --exclude-dir=.git   # -> empty
 
 # Model pins, action-manifest expressions, per-CHECKOUT credential persistence
 # (a per-file grep passes a file with two checkouts where only one is flagged,
@@ -176,7 +178,8 @@ Both matched `@dragon-ai-agent please`, so every qualifying event ran the agent
 workflow keyed on `@ai4c-agent please`, with the old keyword as an alias.
 
 **The credential was already dead, and nobody knew.** `pr-shepherd` failed
-**121 scheduled runs in a row over 9 days** (2026-07-16 to 2026-07-26) before
+**121 scheduled runs in a row over 9 days** — 2026-07-16T15:18Z until the
+migration ended it on 2026-07-26T01:09Z — before
 this migration — every one at `Checkout repository`, the step that used
 `token: ${{ secrets.PAT_FOR_PR }}`. The first run on the App token passed every
 step. The same applied to every other workflow holding the PAT. Nothing alerted,
@@ -214,7 +217,8 @@ CI's YAML parse passed the whole time: the file *is* valid YAML, and the
 rejection happens in the expression layer above it. Note the shape of the
 regression — before, that step succeeded while writing an empty report; after,
 the report was still missing *and* the job went red. `tests/test_agent_config.py`
-now checks every manifest-level field. Nothing in this repo parsed action
+now checks every manifest-level field, which is the boundary that matters: the
+same trap applies to `name:` and to any input/output `description`/`default`. Nothing in this repo parsed action
 manifests before that, which is the same blind spot that hides
 `.github/actions/claude-code-action`.
 
@@ -267,7 +271,9 @@ routine event in the repo into a red X.
   would have reinstalled the exposed credential and undone this migration.
   Worth remembering that a revoked token is not a revoked account, and a deleted
   account is not a removed collaborator.
-- **The `PAT_FOR_PR` secret still exists**, though nothing references it. It
+- **The `PAT_FOR_PR` secret still exists**, though nothing references it — the
+  only mentions left in the tree are two do-not-reintroduce comments
+  (`justfile:180`, `ai.yml:187`) and this document. It
   should be deleted. Note it is already non-functional — a checkout using it
   fails outright, which is how `pr-shepherd` came to fail 121 runs in a row — so
   deleting it is bookkeeping rather than a cutover.

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -165,6 +165,19 @@ values, `strategy.matrix` entries, an `env:` indirection
 `tests/test_agent_config.py` checks all four shapes instead, and treats a stale
 allowlist entry as a failure so the list can only shrink.
 
+**A manifest is not just YAML.** `agent-run-summary` shipped broken and took
+the summary step down in seven workflows, because its `description:` contained
+an illustrative `${{ steps... }}` expression — the prose explaining the bug was
+the bug. GitHub template-evaluates `description:` when an action manifest loads,
+`steps` is not a valid manifest context, and the action failed to load outright.
+CI's YAML parse passed the whole time: the file *is* valid YAML, and the
+rejection happens in the expression layer above it. Note the shape of the
+regression — before, that step succeeded while writing an empty report; after,
+the report was still missing *and* the job went red. `tests/test_agent_config.py`
+now checks every manifest-level field. Nothing in this repo parsed action
+manifests before that, which is the same blind spot that hides
+`.github/actions/claude-code-action`.
+
 **Read trust from the default branch.** `ai.yml` read its controller allowlist
 from the checked-out PR ref, so a proposer with push access could add themselves
 to `.github/ai-controllers.json` on their own branch and self-authorize. Same
@@ -206,15 +219,26 @@ routine event in the repo into a red X.
   If required-approval rules are ever enabled, raise the App to
   `Contents: write` first (an App-settings change plus accepting the permission
   bump on the org installation).
+- **A stale `dragon-ai-agent` collaborator entry remains** on the repo. The
+  account itself is deleted (`GET /users/dragon-ai-agent` 404s) so it grants
+  nothing, but the entry should be removed. The recipes that re-added it — and
+  that re-installed `PAT_FOR_PR` — are gone as of the cleanup PR; before that, a
+  single `just gh-add-secrets` would have reinstalled the exposed credential and
+  undone this migration. Worth remembering that a revoked token is not a revoked
+  account, and neither is a deleted account a removed collaborator.
 - **The `PAT_FOR_PR` secret still exists**, though nothing references it. It
   should be deleted. Note it is already non-functional — a checkout using it
   fails outright, which is how `pr-shepherd` came to fail 24 runs in a row — so
   deleting it is bookkeeping rather than a cutover.
-- **Scanners still run with `--dangerously-skip-permissions`** while reading
-  upstream `geneontology/go-annotation` issue text. The mitigations are the
+- **Five workflows run with `--dangerously-skip-permissions`**:
+  `arba-issue-monitor`, `curation-scanner`, `go-annotation-scanner`,
+  `pr-shepherd` and `weekly-compliance`. Not just the scanners —
+  **`pr-shepherd` reads PR titles, bodies, diffs and review comments**, a wider
+  untrusted-input surface than upstream GO issue text. The mitigations are the
   prompt-level untrusted-input guardrail and the App token's scope, not tool
-  restriction. Enumerating `--allowedTools` per scanner (as
-  `litscan-module-member` does) would be a real tightening.
+  restriction. `litscan-module-member`, `claude-code-review` and `claude` all
+  enumerate `--allowedTools` instead, so the precedent for tightening the other
+  five is already in the repo.
 - **`.github/actions/claude-code-action` is an unmanaged agent path.** It is an
   older composite — `npm install -g` plus a CBORG endpoint — sitting behind
   `claude-issue-summarize` and `claude-issue-triage`. None of the guards here

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -1,92 +1,83 @@
-# Migrating ai-gene-review automation to the dismech pattern
+# ai-gene-review automation: the dismech migration (as built)
 
-This is an execution guide for bringing `ai-gene-review`'s GitHub Actions
-automation up to the state of `monarch-initiative/dismech`. The two repos share a
-common ancestor (the agentic workflows were copied around 2026-07-03) but dismech
-has since had a substantial security-hardening and centralization pass that
-ai-gene-review has not received.
+This records how `ai-gene-review`'s GitHub Actions automation was brought up to
+the state of `monarch-initiative/dismech`. The two repos share a common ancestor
+(the agentic workflows were copied around 2026-07-03); dismech then had a
+security-hardening and centralization pass that this repo has now received too.
 
-The **security half** of this migration (getting off the exposed `PAT_FOR_PR` /
-`dragon-ai-agent` machine account and onto short-lived GitHub App tokens) is the
-same remediation dismech completed for the
+The **security half** — getting off the exposed `PAT_FOR_PR` / `dragon-ai-agent`
+machine account and onto short-lived GitHub App tokens — is the same remediation
+dismech completed for the
 [dragon-ai-agent PAT exposure incident](https://github.com/ai4curation/ai-security-private/blob/main/docs/incidents/2026-07-dragon-ai-agent-pat-exposure.md).
-The step-by-step record and the copy-paste token pattern live in the
-security repo:
+The *why*, and the sharp edges found along the way, live in the security repo:
 
 > **[ai-security-private → docs/history/2026-07-25-dismech-pat-to-app-migration.md](https://github.com/ai4curation/ai-security-private/blob/main/docs/history/2026-07-25-dismech-pat-to-app-migration.md)**
 
-Read that first for the *why* and the exact per-workflow token block. This guide
-is the ai-gene-review-specific *what* and *in what order*.
+This document is the ai-gene-review-specific *what*, and — for anyone doing the
+same migration in a third repo — the things that were different here.
 
 ---
 
-## Current gap (ai-gene-review vs dismech)
+## The end state
 
-| Area | ai-gene-review today | dismech target |
+| Area | Before | Now |
 |---|---|---|
-| **Write auth** | `PAT_FOR_PR` in 8 workflows: `ai`, `pr-shepherd`, `dragon-ai`, `curation-scanner`, `go-annotation-scanner`, `litscan-module-member`, `warm-reference-cache`, `generate-pages` | short-lived `ai4c-agent` App token, `PAT_FOR_PR` fully retired |
-| **`.git/config` exposure** | `persist-credentials: false` only in `main.yaml`; every agent checkout persists its token to disk (the incident vector) | `persist-credentials: false` on every agent checkout + `gh auth setup-git` |
-| **Reviewer identity** | `claude-code-review` uses the **same** `AI4C_AGENT` app as writers | separate `ai4c-reviewer` App (independent review; approval actually counts) |
-| **Model config** | hardcoded, scattered, stale (`claude-opus-4-7` ×12, `claude-sonnet-4-6` ×8, `claude-haiku-4-5` ×8) | central `.github/agent-config.yaml` + `resolve-agent-config` action; Opus 5 / Sonnet 5 |
-| **Cron cadence** | hardcoded `schedule:` per workflow | central `.github/cron-profiles.yaml` + `scripts/apply_cron_profile.py` |
-| **Fork-PR injection gate** | none | `close-fork-prs.yml` (`pull_request_target`, closes fork PRs at the door) |
-| **Untrusted-comment guard** | none | `untrusted-comment-guard.yml` |
-| **Run reports** | agent output buried in raw log | injection-safe step-summary in every agentic workflow |
-| **Dispatch model dropdowns** | `type: choice` defaults silently override any central config | no-override string inputs (`default: ""`) |
+| **Write auth** | `PAT_FOR_PR` in 8 workflows | short-lived `ai4c-agent` App token; **no workflow references `PAT_FOR_PR`** |
+| **`.git/config` exposure** | `persist-credentials: false` only in `main.yaml` | **every** checkout in the repo is non-persisting; pushers use `gh auth setup-git` |
+| **Reviewer identity** | `claude-code-review` used the same `AI4C_AGENT` app as the writers | separate `ai4c-reviewer` App |
+| **Model config** | 28 model IDs pinned across workflows, several stale | `.github/agent-config.yaml` + `resolve-agent-config`; Opus 5 / Sonnet 5; a test forbids re-pinning |
+| **Cron cadence** | hand-edited `schedule:` per workflow | `.github/cron-profiles.yaml` + `just cron-profile <name>`, with an `off` kill switch |
+| **Fork-PR injection** | nothing | `close-fork-prs.yml` closes fork PRs at the door |
+| **Untrusted comments** | nothing | `untrusted-comment-guard.yml` + a deterministic trust gate |
+| **Mention dispatch** | `ai.yml` and `dragon-ai.yml`, byte-identical, both firing | one `ai.yml`, keyword `@ai4c-agent please` (legacy alias kept) |
+| **Run reports** | `echo "${{ ... }}"` — an injection sink | `env:` + `printf`, tilde-fenced |
 
-ai-gene-review already has `create-github-app-token` wired in `claude-code-review.yml`
-(using `AI4C_AGENT`), so the App-token mechanism is proven in this repo — the work
-is extending it to the writer workflows and splitting the reviewer identity.
+Verification, all of which should stay empty/green:
 
----
-
-## Prerequisites (one-time, org/admin — cannot be scripted)
-
-1. **Confirm the `ai4c-agent` GitHub App is installed on `ai4curation/ai-gene-review`**
-   with Repository permissions: Contents R/W, Pull requests R/W, Issues R/W, and
-   (if you keep the discussion/annotation scanners) Discussions R/W. Its secrets
-   `AI4C_AGENT_APP_ID` / `AI4C_AGENT_PRIVATE_KEY` already exist here.
-2. **Provision (or install) a second App, `ai4c-reviewer`**, for the reviewer role.
-   Repository permissions: Pull requests R/W **and Contents: Read & write** — the
-   reviewer's approval only counts toward branch protection if it has write access,
-   which for an App is governed by Contents (a GitHub quirk documented in the
-   security-repo playbook). Add `AI4C_REVIEWER_APP_ID` / `AI4C_REVIEWER_PRIVATE_KEY`.
-   *Creating an App and installing it on the repo are separate steps; without
-   Repository-scoped permissions GitHub won't offer repo scoping and the token mint
-   404s.*
-3. **Do not delete the `PAT_FOR_PR` secret yet** — do that only at the end
-   (Phase 6), after no workflow references it.
+```bash
+grep -rn "secrets.PAT_FOR_PR" .github/                                      # -> empty
+grep -rL "persist-credentials: false" $(grep -rl "actions/checkout" .github/workflows/)   # -> empty
+uv run pytest tests/test_agent_config.py tests/test_apply_cron_profile.py   # model pins + cron drift
+just test-js                                                                # trust gate
+```
 
 ---
 
-## Phase 1 — Kill the incident vector (highest priority)
+## What we changed, in the order it merged
 
-Migrate each `PAT_FOR_PR` workflow to the App-token pattern. **The single most
-important line is `persist-credentials: false`** — it closes the exact
-`.git/config` → agent-`cat` → public-trace exposure chain from the incident.
+| PR | What |
+|---|---|
+| [#2246](https://github.com/ai4curation/ai-gene-review/pull/2246) | `pr-shepherd` → App token; `.github/agent-config.yaml` + `resolve-agent-config`; model-pin guard test |
+| [#2247](https://github.com/ai4curation/ai-gene-review/pull/2247) | reviewer split: `claude-code-review` runs as `ai4c-reviewer` |
+| [#2249](https://github.com/ai4curation/ai-gene-review/pull/2249) | `close-fork-prs`, `untrusted-comment-guard` + trust gate, `@claude` author gating |
+| [#2253](https://github.com/ai4curation/ai-gene-review/pull/2253) | the four scanners → App token |
+| [#2255](https://github.com/ai4curation/ai-gene-review/pull/2255) | retire the duplicated dragon-ai mention workflows |
+| [#2260](https://github.com/ai4curation/ai-gene-review/pull/2260) | pages / warm-cache / weekly-compliance → App token; last `persist-credentials` gaps |
+| [#2261](https://github.com/ai4curation/ai-gene-review/pull/2261) | cron profiles |
 
-For each of the 8 workflows above, apply the target block from the
-[security-repo playbook](https://github.com/ai4curation/ai-security-private/blob/main/docs/history/2026-07-25-dismech-pat-to-app-migration.md#the-target-pattern-per-workflow):
+## The token pattern
+
+Every write-capable workflow now looks like this:
 
 ```yaml
 permissions:
-  contents: read        # scope the default GITHUB_TOKEN down; the App token does the work
+  contents: read        # scopes the DEFAULT token; the App token does the work
 
 steps:
   - name: Generate ai4c-agent token
     id: ai4c-token
-    uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1 (SHA-pinned)
+    uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
     with:
       app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
       private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
 
-  - name: Checkout
-    uses: actions/checkout@v6
+  - name: Checkout repository
+    uses: actions/checkout@v7
     with:
       token: ${{ steps.ai4c-token.outputs.token }}
       persist-credentials: false        # <-- closes the incident exposure vector
 
-  - name: Configure git identity + credential helper
+  - name: Configure git identity and credential helper
     env:
       GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
       APP_SLUG: ${{ steps.ai4c-token.outputs.app-slug }}
@@ -97,7 +88,7 @@ steps:
       gh auth setup-git
 
   - name: Run agent
-    uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1 (SHA-pinned)
+    uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
     env:
       GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
       GITHUB_TOKEN: ${{ steps.ai4c-token.outputs.token }}
@@ -105,162 +96,96 @@ steps:
       github_token: ${{ steps.ai4c-token.outputs.token }}
 ```
 
-Reference implementations in dismech (copy structure, adapt content):
-
-| ai-gene-review workflow | dismech reference PR |
-|---|---|
-| `pr-shepherd.yml` | [dismech#6890](https://github.com/monarch-initiative/dismech/pull/6890) |
-| `curation-scanner.yml` + any scanner | [dismech#6918](https://github.com/monarch-initiative/dismech/pull/6918) |
-| `weekly-compliance.yaml` | [dismech#6934](https://github.com/monarch-initiative/dismech/pull/6934) (also fixes a false-green: no `github_token` → silent no-PR) |
-| `dragon-ai.yml` | [dismech#6979](https://github.com/monarch-initiative/dismech/pull/6979) |
-| `ai.yml`, `go-annotation-scanner.yml`, `litscan-module-member.yml`, `generate-pages.yaml`, `warm-reference-cache.yaml` | same pattern; page/cache jobs can use `github-actions[bot]` + the built-in `GITHUB_TOKEN` if they only push to their own auto-branches |
-
-**dragon-ai.yml specifics** (dismech#6979): also drop the `assigned` trigger —
-**GitHub Apps cannot be assignees**, so assignment-based dispatch cannot move to
-an App; keep only the `@dragon-ai-agent please` text-keyword mention. And harden
-the mention path: read the controller allowlist (`.github/ai-controllers.json`)
-from the **default branch**, not the PR ref (else a pusher self-authorizes); pass
-prompt values via `env:` + `printf`, never `echo "${{ ... }}"`; strip code spans
-before the mention regex so documenting the keyword doesn't self-trigger.
-
-**Verify per workflow** after editing:
-```bash
-python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" .github/workflows/<wf>.yml
-grep -n "PAT_FOR_PR\|persist-credentials" .github/workflows/<wf>.yml
-```
-
-## Phase 2 — Split the reviewer identity
-
-`claude-code-review.yml` currently mints an `AI4C_AGENT` token — the same identity
-the writers use, so it can "review its own work" and its approval may not count.
-Point it at the reviewer App and add the writer to `allowed_bots`
-(dismech commit `2a2300df52`):
-
-```yaml
-  - name: Generate ai4c-reviewer token
-    id: reviewer-token
-    uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
-    with:
-      app-id: ${{ secrets.AI4C_REVIEWER_APP_ID }}
-      private-key: ${{ secrets.AI4C_REVIEWER_PRIVATE_KEY }}
-  # ...
-      github_token: ${{ steps.reviewer-token.outputs.token || github.token }}
-      allowed_bots: 'claude,github-actions,ai4c-agent'   # writer must be listed or its
-                                                         # dispatched/pushed reviews are rejected
-```
-
-Why `allowed_bots` must include `ai4c-agent`: `claude-code-action` rejects a run
-whose *initiating actor* is a bot not in the list — even for `workflow_dispatch`.
-And note the **App-token push behavior**: unlike the built-in `GITHUB_TOKEN`,
-a push made with an App token fires `pull_request: synchronize`, so review
-auto-triggers on writer pushes (no manual re-dispatch needed).
-
-## Phase 3 — Add the injection controls
-
-1. **`close-fork-prs.yml`** — the single highest-leverage control. Copy dismech's
-   ([dismech#6895](https://github.com/monarch-initiative/dismech/pull/6895)). It's a
-   `pull_request_target` job that closes any fork PR on open/reopen and points the
-   author at `CONTRIBUTING.md`. It runs from the base repo's copy of the workflow,
-   **never checks out fork code** (only `gh` API calls), needs only
-   `pull-requests: write`, and leaves same-repo PRs untouched. A fork PR is the
-   main way external attacker-authored content reaches an agentic workflow's
-   context — refusing it at the door beats trying to contain it.
-2. **`untrusted-comment-guard.yml`** — copy dismech's; it gates agent responses to
-   comments from untrusted authors (see the security repo's
-   [untrusted-comment incident](https://github.com/ai4curation/ai-security-private/blob/main/docs/incidents/2026-07-08-dismech-untrusted-comment-attempt.md)).
-3. If you keep a **discussion/annotation scanner** that reads arbitrary public
-   discussion text, port dismech's deterministic trust gate
-   `.github/scripts/github-trust-gate.js` — it pre-filters candidates to those
-   where every non-bot participant is an allow-listed controller, so untrusted
-   discussion text never reaches the agent.
-
-## Phase 4 — Centralize model + cron config
-
-1. **`.github/agent-config.yaml` + `.github/actions/resolve-agent-config`** — one
-   source of truth for which model backs each workflow. Copy both from dismech.
-   Each managed workflow gains a `Resolve agent config` step that exports
-   `AGENT_MODEL`; the agent step uses `--model ${{ env.AGENT_MODEL }}` instead of a
-   hardcoded ID. A test enforces no workflow re-hardcodes `--model`. (Background:
-   dismech issue #5218.)
-2. **`.github/cron-profiles.yaml` + `scripts/apply_cron_profile.py`** — named cadence
-   profiles (`slow`/`medium`/`fast`/`off`) instead of hand-edited `schedule:` lines.
-   Switch with `just cron-profile <name>`. This also prevents schedule drift (a
-   workflow managed in the config but missing its `on.schedule` block gets one
-   re-inserted — the resurrection hazard that retired dismech's `stale-pr-reassign`
-   in [dismech#6958](https://github.com/monarch-initiative/dismech/pull/6958)).
-
-## Phase 5 — Model bump + dispatch hygiene
-
-1. **Bump defaults to current models** in `agent-config.yaml`: `claude-opus-5`,
-   `claude-sonnet-5` (Haiku has no v5 yet). **Verify exact IDs against the live
-   Anthropic model docs, never from memory** — dismech was once burned by a
-   fabricated model ID that silently no-op'd runs into phantom green checks
-   ([dismech#6933](https://github.com/monarch-initiative/dismech/pull/6933)).
-2. **Convert every `workflow_dispatch` `model:` input** from `type: choice` to a
-   no-override string (`default: ""`). A `choice` input always sends its default,
-   silently overriding the central config on every manual run; the resolver treats
-   an empty override as "use the config" (same PR).
-
-## Phase 6 — Reports, and the final teardown
-
-1. **Add injection-safe step summaries** to every agentic workflow so the agent's
-   report shows on the Actions run screen, not just the raw log
-   ([dismech#6998](https://github.com/monarch-initiative/dismech/pull/6998)):
-   ```yaml
-     - name: Write step summary
-       if: ${{ always() && steps.<agent-step-id>.outputs.result != '' }}
-       env:
-         RESULT: ${{ steps.<agent-step-id>.outputs.result }}   # via env, never echo "${{ }}"
-       run: |
-         { echo "## <emoji> <Workflow> Run"; echo ''; echo '```'; printf '%s\n' "$RESULT"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
-   ```
-2. **Teardown:** once `grep -rn "secrets.PAT_FOR_PR" .github/` is empty, **delete
-   the `PAT_FOR_PR` secret** and confirm the token is revoked. Decide the fate of
-   the `dragon-ai-agent` account (its only remaining use is the mention keyword,
-   a text match that works without the account).
+`timeout-minutes: 55` goes with it: an App installation token expires 60 minutes
+after minting and does not refresh, so a longer job can finish its analysis and
+then 401 on every push.
 
 ---
 
-## Optional: adopt the dismech scanner fleet
+## Things that were specific to this repo
 
-dismech has agentic scanners ai-gene-review lacks — adopt only the ones that fit
-GO/gene-review curation, and migrate their auth with the Phase 1 pattern as you go:
+Anyone porting this to a third repo should look for these shapes, not just copy
+the token block.
 
-- `discussion-scanner.yml` — responds to GitHub Discussions (needs the trust gate).
-- `literature-scan.yml` / `preprint-scan.yml` / `knowledge-gap-scan.yml` — mine new
-  literature/preprints/knowledge-gaps into curation handoff issues.
-- `post-review-agent.yml` — turns human review comments into suggested changes.
-- `auto-merge-compliance.yml` — auto-merges clean compliance PRs.
+**`ai.yml` and `dragon-ai.yml` were byte-identical.** `diff` returned nothing.
+Both matched `@dragon-ai-agent please`, so every qualifying event ran the agent
+**twice** — visible as paired runs with identical timestamps. They are now one
+workflow keyed on `@ai4c-agent please`, with the old keyword as an alias.
 
-ai-gene-review's own domain scanners (`arba-issue-monitor`, `go-annotation-scanner`,
-`litscan-module-member`) stay — just migrate their auth (Phase 1).
+**Two workflows could not have worked.** `arba-issue-monitor` was still calling
+`claude-code-action` with the v0 inputs `mode:`, `direct_prompt:` and
+`allowed_tools:`, none of which exist in v1 — the prompt was never delivered.
+`ai.yml` set `ANTHROPIC_API_KEY` from a secret this repo does not have, so its
+agent had no credential at all. Neither failed loudly. If you inherit workflows
+across a major action version, check the input names against the action's
+`action.yml` at the SHA you pin.
+
+**`weekly-compliance` had no `github_token`** — the same false-green that cost
+dismech ~11 days of no-op runs. An agent workflow that can "succeed" without
+producing its artifact needs both a real token and captured output.
+
+**A grep is not a guard.** The obvious check —
+`grep -rnE "\-\-model .*claude-(opus|sonnet|haiku)-"` — matched 3 of the 28
+pinned model IDs in this repo. The other 25 were `workflow_dispatch` `default:`
+values, `strategy.matrix` entries, an `env:` indirection
+(`ISSUE_HANDOFF_MODEL`), and the bare alias `--model opus`.
+`tests/test_agent_config.py` checks all four shapes instead, and treats a stale
+allowlist entry as a failure so the list can only shrink.
+
+**Read trust from the default branch.** `ai.yml` read its controller allowlist
+from the checked-out PR ref, so a proposer with push access could add themselves
+to `.github/ai-controllers.json` on their own branch and self-authorize. Same
+class of bug in `untrusted-comment-guard`: on `pull_request_review_comment` the
+default `GITHUB_REF` is the PR merge ref, so a bare checkout would have fetched
+fork code that `github-script` then `require()`s with a write-scoped token. Both
+now pin `ref: ${{ github.event.repository.default_branch }}`.
+
+**Don't trust bare bot names.** The ported trust gate listed `"claude"`,
+`"dragon-ai-agent"` and `"github-actions"` as bot logins, and bots are trusted —
+so registering one of those usernames would have granted automatic trust. Only
+the `[bot]` suffix, which GitHub reserves for Apps, is a reliable signal.
+
+**Strip code spans for the gate, not for the payload.** `ai.yml` strips fenced
+and inline code before matching the mention keyword, so *documenting* the
+trigger does not fire it. Extracting the request from that stripped copy would
+silently delete inline code from a legitimate request
+(`fix \`genes/human/TP53\`` → `fix `). Gate on the stripped text; extract from
+the original.
+
+**The review workflow's own failure mode moved.** At the SHA we pin,
+`claude-code-action` already throws when the agent errors, so the "phantom green
+check" it used to produce is closed by the pin itself. What remains worth
+catching is *why*: a Claude weekly usage limit silently no-ops every agent
+workflow account-wide and is otherwise indistinguishable from a problem with the
+PR. The diagnostic step reports that specifically, and deliberately uses
+`!cancelled()` rather than `always()` — with `cancel-in-progress: true`, every
+follow-up push cancels the in-flight review, and `always()` turns the most
+routine event in the repo into a red X.
 
 ---
 
-## Suggested PR sequencing
+## Known gaps
 
-Do it as several small PRs, not one, so each is reviewable and the reviewer split
-lands early:
+- **`ai4c-reviewer` has `Contents: read`.** GitHub ties "this approval counts
+  toward branch protection" to *write* access, which for an App is governed by
+  the Contents permission — so its approvals render as *"approved with read-only
+  permissions."* `main` has no branch protection today, so nothing is blocked.
+  If required-approval rules are ever enabled, raise the App to
+  `Contents: write` first (an App-settings change plus accepting the permission
+  bump on the org installation).
+- **The `PAT_FOR_PR` secret still exists**, though nothing references it. It
+  should be deleted and the token confirmed revoked.
+- **Scanners still run with `--dangerously-skip-permissions`** while reading
+  upstream `geneontology/go-annotation` issue text. The mitigations are the
+  prompt-level untrusted-input guardrail and the App token's scope, not tool
+  restriction. Enumerating `--allowedTools` per scanner (as
+  `litscan-module-member` does) would be a real tightening.
 
-1. **Phase 2** first (reviewer → `ai4c-reviewer`) — so subsequent writer PRs get
-   independent review.
-2. **Phase 1** per-workflow (or a few at a time) — the security-critical bulk.
-3. **Phase 3** (fork-close + untrusted-comment guard).
-4. **Phase 4–5** (centralize config, bump models, dispatch hygiene).
-5. **Phase 6** (reports), then delete the `PAT_FOR_PR` secret.
+## Not adopted
 
-## Final verification
-
-```bash
-# no PAT references remain
-grep -rn "secrets.PAT_FOR_PR" .github/            # -> empty
-
-# every agent checkout is non-persisting
-grep -rL "persist-credentials: false" $(grep -rl "actions/checkout" .github/workflows/)
-
-# no hardcoded --model (models come from the resolver)
-grep -rnE "\-\-model .*claude-(opus|sonnet|haiku)-" .github/workflows/   # -> empty
-
-# app-token consistency
-grep -rn "AI4C_AGENT_APP_ID\|AI4C_REVIEWER_APP_ID" .github/workflows/
-```
+dismech has scanners this repo deliberately did not take: `discussion-scanner`,
+`literature-scan`, `preprint-scan`, `knowledge-gap-scan`. ai-gene-review does
+less literature mining and more scanning of GO repositories, which its own
+`go-annotation-scanner`, `arba-issue-monitor` and `litscan-module-member` cover.
+`post-review-agent` (turns human review comments into suggested changes) and
+`auto-merge-compliance` are still open candidates.

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -47,13 +47,21 @@ just test-js                                                                # tr
 
 | PR | What |
 |---|---|
+| [#2259](https://github.com/ai4curation/ai-gene-review/pull/2259) | prerequisite: three tests were already failing on `main` (see "a green main is not a green suite" below) |
 | [#2246](https://github.com/ai4curation/ai-gene-review/pull/2246) | `pr-shepherd` → App token; `.github/agent-config.yaml` + `resolve-agent-config`; model-pin guard test |
-| [#2247](https://github.com/ai4curation/ai-gene-review/pull/2247) | reviewer split: `claude-code-review` runs as `ai4c-reviewer` |
+| [#2276](https://github.com/ai4curation/ai-gene-review/pull/2276) | reviewer split: `claude-code-review` runs as `ai4c-reviewer` (review history on the superseded [#2247](https://github.com/ai4curation/ai-gene-review/pull/2247)) |
 | [#2249](https://github.com/ai4curation/ai-gene-review/pull/2249) | `close-fork-prs`, `untrusted-comment-guard` + trust gate, `@claude` author gating |
-| [#2253](https://github.com/ai4curation/ai-gene-review/pull/2253) | the four scanners → App token |
+| [#2253](https://github.com/ai4curation/ai-gene-review/pull/2253) | the four scanners → App token; run summaries read `execution_file` |
 | [#2255](https://github.com/ai4curation/ai-gene-review/pull/2255) | retire the duplicated dragon-ai mention workflows |
 | [#2260](https://github.com/ai4curation/ai-gene-review/pull/2260) | pages / warm-cache / weekly-compliance → App token; last `persist-credentials` gaps |
 | [#2261](https://github.com/ai4curation/ai-gene-review/pull/2261) | cron profiles |
+
+Landing a stack this deep has one trap worth naming: **do not merge with
+`--delete-branch` while a downstream PR still points at the branch.** GitHub
+auto-closes that PR, and refuses to reopen it if its head has been force-pushed
+since — which it will have been, if you rebase between review rounds. #2247 was
+lost that way. The order that works is merge → retarget the next PR to `main`
+→ *then* delete the branch.
 
 ## The token pattern
 
@@ -102,6 +110,17 @@ then 401 on every push.
 
 ---
 
+## A green `main` is not a green suite
+
+Worth knowing before you start, because it will look like your fault: `main.yaml`
+only runs `just test` when the `src` paths-filter matches (`src/**`, `tests/**`,
+`pyproject.toml`, `uv.lock`). A long run of gene-review-only commits never
+executes the suite, so breakage accumulates behind a green `main` and lands
+whole on the next PR that happens to touch `tests/`. Three failures were waiting
+this way (two stale derived artifacts, one off-vocabulary project tag) and had to
+be cleared in #2259 before any of this could go green. Reproduce on a pristine
+`origin/main` checkout before assuming a red `test (3.12)` is yours.
+
 ## Things that were specific to this repo
 
 Anyone porting this to a third repo should look for these shapes, not just copy
@@ -111,6 +130,13 @@ the token block.
 Both matched `@dragon-ai-agent please`, so every qualifying event ran the agent
 **twice** — visible as paired runs with identical timestamps. They are now one
 workflow keyed on `@ai4c-agent please`, with the old keyword as an alias.
+
+**The credential was already dead, and nobody knew.** `pr-shepherd` failed 24
+runs in a row before this migration — every one at `Checkout repository`, the
+step that used `token: ${{ secrets.PAT_FOR_PR }}`. The first run on the App token
+passed every step. The same applies to every other workflow that held the PAT.
+If an agentic workflow has quietly stopped producing output, check whether it is
+failing at checkout before looking at the agent.
 
 **Two workflows could not have worked.** `arba-issue-monitor` was still calling
 `claude-code-action` with the v0 inputs `mode:`, `direct_prompt:` and

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -42,12 +42,14 @@ nothing in `.git/config`.
 Verification, all of which should stay empty/green:
 
 ```bash
-grep -rn "secrets.PAT_FOR_PR" .github/                                      # -> empty
-# (per-CHECKOUT, and covering composite actions — a per-file grep misses both)
-uv run pytest tests/test_agent_config.py -k non_persisting
+grep -rn "secrets.PAT_FOR_PR" .                # -> empty (repo-wide, not just .github/)
+
+# Model pins, action-manifest expressions, per-CHECKOUT credential persistence
+# (a per-file grep passes a file with two checkouts where only one is flagged,
+# and misses composite actions entirely), and cron-profile drift.
 uv run pytest tests/test_agent_config.py tests/test_agent_run_summary.py \
-  tests/test_apply_cron_profile.py    # model pins, manifests, checkouts, cron drift
-just test-js                                                                # trust gate
+  tests/test_apply_cron_profile.py
+just test-js                                  # trust gate
 ```
 
 ---
@@ -77,10 +79,18 @@ lost that way. The order that works is merge → retarget the next PR to `main`
 Asked six times in review, so it belongs in the record. The sequencing was not
 arbitrary:
 
-1. **Reviewer split before anything else.** Every subsequent PR was reviewed by
-   an identity distinct from the one writing it. Landing it first is what made
-   the rest of the stack worth reviewing at all — and the reviewer went on to
-   find a 🔴 and several 🟡s that the author's own tests did not.
+1. **Reviewer split as early as the stack allows — which was not first, and
+   that cost something.** The intent was to land it before anything else, so
+   every later PR would be reviewed by an identity distinct from the one writing
+   it. It did not work out: the reviewer-split PR was *stacked on* the
+   pr-shepherd PR, so pr-shepherd had to merge first. #2259 (02:31Z) and #2246
+   (04:35Z) therefore merged before the split (04:52Z), and both were
+   self-reviewed — `gh pr view 2246 --json reviews` returns three reviews, all by
+   `ai4c-agent`, the authoring App. Everything after was independently reviewed,
+   and that reviewer went on to find a 🔴 and several 🟡s the author's own tests
+   did not. **The lesson is to make the reviewer split the base of the stack,
+   not the second entry** — otherwise you silently choose which PRs get
+   self-reviewed, and they will be the foundational ones.
 2. **Injection controls before the scanners.** `close-fork-prs` and the
    untrusted-comment guard reduce what can reach an agent's context; they should
    be in place before more agents get write-capable tokens, not after.
@@ -195,8 +205,9 @@ values, `strategy.matrix` entries, an `env:` indirection
 allowlist entry as a failure so the list can only shrink.
 
 **A manifest is not just YAML.** `agent-run-summary` shipped broken and took
-the summary step down in seven workflows, because its `description:` contained
-an illustrative `${{ steps... }}` expression — the prose explaining the bug was
+the summary step down in seven workflows, because a manifest-level field — in
+this case `description:`, but the same holds for `name:` and any input/output
+`description`/`default` — contained an illustrative GitHub expression — the prose explaining the bug was
 the bug. GitHub template-evaluates `description:` when an action manifest loads,
 `steps` is not a valid manifest context, and the action failed to load outright.
 CI's YAML parse passed the whole time: the file *is* valid YAML, and the
@@ -258,7 +269,7 @@ routine event in the repo into a red X.
   account is not a removed collaborator.
 - **The `PAT_FOR_PR` secret still exists**, though nothing references it. It
   should be deleted. Note it is already non-functional — a checkout using it
-  fails outright, which is how `pr-shepherd` came to fail 24 runs in a row — so
+  fails outright, which is how `pr-shepherd` came to fail 121 runs in a row — so
   deleting it is bookkeeping rather than a cutover.
 - **Five workflows run with `--dangerously-skip-permissions`**:
   `arba-issue-monitor`, `curation-scanner`, `go-annotation-scanner`,

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -43,7 +43,8 @@ Verification, all of which should stay empty/green:
 
 ```bash
 grep -rn "secrets.PAT_FOR_PR" .github/                                      # -> empty
-grep -rL "persist-credentials: false" $(grep -rl "actions/checkout" .github/workflows/)   # -> empty
+# (per-CHECKOUT, and covering composite actions — a per-file grep misses both)
+uv run pytest tests/test_agent_config.py -k non_persisting
 uv run pytest tests/test_agent_config.py tests/test_agent_run_summary.py \
   tests/test_apply_cron_profile.py    # model pins, manifests, checkouts, cron drift
 just test-js                                                                # trust gate
@@ -139,12 +140,14 @@ Both matched `@dragon-ai-agent please`, so every qualifying event ran the agent
 **twice** — visible as paired runs with identical timestamps. They are now one
 workflow keyed on `@ai4c-agent please`, with the old keyword as an alias.
 
-**The credential was already dead, and nobody knew.** `pr-shepherd` failed 24
-runs in a row before this migration — every one at `Checkout repository`, the
-step that used `token: ${{ secrets.PAT_FOR_PR }}`. The first run on the App token
-passed every step. The same applies to every other workflow that held the PAT.
+**The credential was already dead, and nobody knew.** `pr-shepherd` failed
+**121 scheduled runs in a row over 9 days** (2026-07-16 to 2026-07-26) before
+this migration — every one at `Checkout repository`, the step that used
+`token: ${{ secrets.PAT_FOR_PR }}`. The first run on the App token passed every
+step. The same applied to every other workflow holding the PAT. Nothing alerted,
+because a scheduled workflow's failures land in the Actions tab and nowhere else.
 If an agentic workflow has quietly stopped producing output, check whether it is
-failing at checkout before looking at the agent.
+failing at checkout before you look at the agent.
 
 **Two workflows could not have worked.** `arba-issue-monitor` was still calling
 `claude-code-action` with the v0 inputs `mode:`, `direct_prompt:` and
@@ -222,11 +225,12 @@ routine event in the repo into a red X.
   bump on the org installation).
 - **A stale `dragon-ai-agent` collaborator entry remains** on the repo. The
   account itself is deleted (`GET /users/dragon-ai-agent` 404s) so it grants
-  nothing, but the entry should be removed. The recipes that re-added it — and
-  that re-installed `PAT_FOR_PR` — are gone as of the cleanup PR; before that, a
-  single `just gh-add-secrets` would have reinstalled the exposed credential and
-  undone this migration. Worth remembering that a revoked token is not a revoked
-  account, and neither is a deleted account a removed collaborator.
+  nothing, but the entry should be removed — that is a settings click, not a
+  code change. The recipes that re-added it, and that re-installed `PAT_FOR_PR`,
+  were removed in the cleanup PR; before that, a single `just gh-add-secrets`
+  would have reinstalled the exposed credential and undone this migration.
+  Worth remembering that a revoked token is not a revoked account, and a deleted
+  account is not a removed collaborator.
 - **The `PAT_FOR_PR` secret still exists**, though nothing references it. It
   should be deleted. Note it is already non-functional — a checkout using it
   fails outright, which is how `pr-shepherd` came to fail 24 runs in a row — so
@@ -240,12 +244,13 @@ routine event in the repo into a red X.
   restriction. `litscan-module-member`, `claude-code-review` and `claude` all
   enumerate `--allowedTools` instead, so the precedent for tightening the other
   five is already in the repo.
-- **`.github/actions/claude-code-action` is an unmanaged agent path.** It is an
-  older composite — `npm install -g` plus a CBORG endpoint — sitting behind
-  `claude-issue-summarize` and `claude-issue-triage`. None of the guards here
-  can see it: it does not call `anthropics/claude-code-action`, so the pinned-SHA,
-  input-vocabulary and central-model tests all skip it, and it is not in
-  `agent-config.yaml`. Migrating it is its own change.
+- **`.github/actions/claude-code-action` is a partly-unmanaged agent path.** It
+  is an older composite — `npm install -g` plus a CBORG endpoint — sitting behind
+  `claude-issue-summarize` and `claude-issue-triage`. The manifest and checkout
+  tests do reach it, but the pinned-SHA, input-vocabulary and central-model
+  guards do not: it never calls `anthropics/claude-code-action`, and it is not in
+  `agent-config.yaml`, so its model and its agent version are uncontrolled.
+  Migrating it is its own change.
 - **`weekly-compliance` has no post-run assertion that it opened a PR.** The
   missing token that made it a no-op is fixed and its output is captured, but
   "the agent ran cleanly and produced nothing" is still indistinguishable from

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -180,6 +180,17 @@ routine event in the repo into a red X.
   prompt-level untrusted-input guardrail and the App token's scope, not tool
   restriction. Enumerating `--allowedTools` per scanner (as
   `litscan-module-member` does) would be a real tightening.
+- **`.github/actions/claude-code-action` is an unmanaged agent path.** It is an
+  older composite — `npm install -g` plus a CBORG endpoint — sitting behind
+  `claude-issue-summarize` and `claude-issue-triage`. None of the guards here
+  can see it: it does not call `anthropics/claude-code-action`, so the pinned-SHA,
+  input-vocabulary and central-model tests all skip it, and it is not in
+  `agent-config.yaml`. Migrating it is its own change.
+- **`weekly-compliance` has no post-run assertion that it opened a PR.** The
+  missing token that made it a no-op is fixed and its output is captured, but
+  "the agent ran cleanly and produced nothing" is still indistinguishable from
+  "there was nothing to fix." Closing that needs a decision about what should
+  happen on a week with no low-scoring files, not just a check.
 
 ## Not adopted
 

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -32,6 +32,13 @@ same migration in a third repo — the things that were different here.
 | **Mention dispatch** | `ai.yml` and `dragon-ai.yml`, byte-identical, both firing | one `ai.yml`, keyword `@ai4c-agent please` (legacy alias kept) |
 | **Run reports** | `echo "${{ ... }}"` — an injection sink | `env:` + `printf`, tilde-fenced |
 
+The push path is verified end to end, not just statically: `generate-pages` ran
+47 minutes on the migrated workflow and opened
+[#2277](https://github.com/ai4curation/ai-gene-review/pull/2277) with
+`git push --force-with-lease` authenticated by `gh auth setup-git`, committed as
+`ai4c-agent[bot] <242316268+ai4c-agent[bot]@users.noreply.github.com>` with
+nothing in `.git/config`.
+
 Verification, all of which should stay empty/green:
 
 ```bash
@@ -200,7 +207,9 @@ routine event in the repo into a red X.
   `Contents: write` first (an App-settings change plus accepting the permission
   bump on the org installation).
 - **The `PAT_FOR_PR` secret still exists**, though nothing references it. It
-  should be deleted and the token confirmed revoked.
+  should be deleted. Note it is already non-functional — a checkout using it
+  fails outright, which is how `pr-shepherd` came to fail 24 runs in a row — so
+  deleting it is bookkeeping rather than a cutover.
 - **Scanners still run with `--dangerously-skip-permissions`** while reading
   upstream `geneontology/go-annotation` issue text. The mitigations are the
   prompt-level untrusted-input guardrail and the App token's scope, not tool

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -44,7 +44,8 @@ Verification, all of which should stay empty/green:
 ```bash
 grep -rn "secrets.PAT_FOR_PR" .github/                                      # -> empty
 grep -rL "persist-credentials: false" $(grep -rl "actions/checkout" .github/workflows/)   # -> empty
-uv run pytest tests/test_agent_config.py tests/test_apply_cron_profile.py   # model pins + cron drift
+uv run pytest tests/test_agent_config.py tests/test_agent_run_summary.py \
+  tests/test_apply_cron_profile.py    # model pins, manifests, checkouts, cron drift
 just test-js                                                                # trust gate
 ```
 

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -1,0 +1,266 @@
+# Migrating ai-gene-review automation to the dismech pattern
+
+This is an execution guide for bringing `ai-gene-review`'s GitHub Actions
+automation up to the state of `monarch-initiative/dismech`. The two repos share a
+common ancestor (the agentic workflows were copied around 2026-07-03) but dismech
+has since had a substantial security-hardening and centralization pass that
+ai-gene-review has not received.
+
+The **security half** of this migration (getting off the exposed `PAT_FOR_PR` /
+`dragon-ai-agent` machine account and onto short-lived GitHub App tokens) is the
+same remediation dismech completed for the
+[dragon-ai-agent PAT exposure incident](https://github.com/ai4curation/ai-security-private/blob/main/docs/incidents/2026-07-dragon-ai-agent-pat-exposure.md).
+The step-by-step record and the copy-paste token pattern live in the
+security repo:
+
+> **[ai-security-private → docs/history/2026-07-25-dismech-pat-to-app-migration.md](https://github.com/ai4curation/ai-security-private/blob/main/docs/history/2026-07-25-dismech-pat-to-app-migration.md)**
+
+Read that first for the *why* and the exact per-workflow token block. This guide
+is the ai-gene-review-specific *what* and *in what order*.
+
+---
+
+## Current gap (ai-gene-review vs dismech)
+
+| Area | ai-gene-review today | dismech target |
+|---|---|---|
+| **Write auth** | `PAT_FOR_PR` in 8 workflows: `ai`, `pr-shepherd`, `dragon-ai`, `curation-scanner`, `go-annotation-scanner`, `litscan-module-member`, `warm-reference-cache`, `generate-pages` | short-lived `ai4c-agent` App token, `PAT_FOR_PR` fully retired |
+| **`.git/config` exposure** | `persist-credentials: false` only in `main.yaml`; every agent checkout persists its token to disk (the incident vector) | `persist-credentials: false` on every agent checkout + `gh auth setup-git` |
+| **Reviewer identity** | `claude-code-review` uses the **same** `AI4C_AGENT` app as writers | separate `ai4c-reviewer` App (independent review; approval actually counts) |
+| **Model config** | hardcoded, scattered, stale (`claude-opus-4-7` ×12, `claude-sonnet-4-6` ×8, `claude-haiku-4-5` ×8) | central `.github/agent-config.yaml` + `resolve-agent-config` action; Opus 5 / Sonnet 5 |
+| **Cron cadence** | hardcoded `schedule:` per workflow | central `.github/cron-profiles.yaml` + `scripts/apply_cron_profile.py` |
+| **Fork-PR injection gate** | none | `close-fork-prs.yml` (`pull_request_target`, closes fork PRs at the door) |
+| **Untrusted-comment guard** | none | `untrusted-comment-guard.yml` |
+| **Run reports** | agent output buried in raw log | injection-safe step-summary in every agentic workflow |
+| **Dispatch model dropdowns** | `type: choice` defaults silently override any central config | no-override string inputs (`default: ""`) |
+
+ai-gene-review already has `create-github-app-token` wired in `claude-code-review.yml`
+(using `AI4C_AGENT`), so the App-token mechanism is proven in this repo — the work
+is extending it to the writer workflows and splitting the reviewer identity.
+
+---
+
+## Prerequisites (one-time, org/admin — cannot be scripted)
+
+1. **Confirm the `ai4c-agent` GitHub App is installed on `ai4curation/ai-gene-review`**
+   with Repository permissions: Contents R/W, Pull requests R/W, Issues R/W, and
+   (if you keep the discussion/annotation scanners) Discussions R/W. Its secrets
+   `AI4C_AGENT_APP_ID` / `AI4C_AGENT_PRIVATE_KEY` already exist here.
+2. **Provision (or install) a second App, `ai4c-reviewer`**, for the reviewer role.
+   Repository permissions: Pull requests R/W **and Contents: Read & write** — the
+   reviewer's approval only counts toward branch protection if it has write access,
+   which for an App is governed by Contents (a GitHub quirk documented in the
+   security-repo playbook). Add `AI4C_REVIEWER_APP_ID` / `AI4C_REVIEWER_PRIVATE_KEY`.
+   *Creating an App and installing it on the repo are separate steps; without
+   Repository-scoped permissions GitHub won't offer repo scoping and the token mint
+   404s.*
+3. **Do not delete the `PAT_FOR_PR` secret yet** — do that only at the end
+   (Phase 6), after no workflow references it.
+
+---
+
+## Phase 1 — Kill the incident vector (highest priority)
+
+Migrate each `PAT_FOR_PR` workflow to the App-token pattern. **The single most
+important line is `persist-credentials: false`** — it closes the exact
+`.git/config` → agent-`cat` → public-trace exposure chain from the incident.
+
+For each of the 8 workflows above, apply the target block from the
+[security-repo playbook](https://github.com/ai4curation/ai-security-private/blob/main/docs/history/2026-07-25-dismech-pat-to-app-migration.md#the-target-pattern-per-workflow):
+
+```yaml
+permissions:
+  contents: read        # scope the default GITHUB_TOKEN down; the App token does the work
+
+steps:
+  - name: Generate ai4c-agent token
+    id: ai4c-token
+    uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1 (SHA-pinned)
+    with:
+      app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+      private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
+  - name: Checkout
+    uses: actions/checkout@v6
+    with:
+      token: ${{ steps.ai4c-token.outputs.token }}
+      persist-credentials: false        # <-- closes the incident exposure vector
+
+  - name: Configure git identity + credential helper
+    env:
+      GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+      APP_SLUG: ${{ steps.ai4c-token.outputs.app-slug }}
+    run: |
+      APP_USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+      git config --global user.name "${APP_SLUG}[bot]"
+      git config --global user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+      gh auth setup-git
+
+  - name: Run agent
+    uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1 (SHA-pinned)
+    env:
+      GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+      GITHUB_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+    with:
+      github_token: ${{ steps.ai4c-token.outputs.token }}
+```
+
+Reference implementations in dismech (copy structure, adapt content):
+
+| ai-gene-review workflow | dismech reference PR |
+|---|---|
+| `pr-shepherd.yml` | [dismech#6890](https://github.com/monarch-initiative/dismech/pull/6890) |
+| `curation-scanner.yml` + any scanner | [dismech#6918](https://github.com/monarch-initiative/dismech/pull/6918) |
+| `weekly-compliance.yaml` | [dismech#6934](https://github.com/monarch-initiative/dismech/pull/6934) (also fixes a false-green: no `github_token` → silent no-PR) |
+| `dragon-ai.yml` | [dismech#6979](https://github.com/monarch-initiative/dismech/pull/6979) |
+| `ai.yml`, `go-annotation-scanner.yml`, `litscan-module-member.yml`, `generate-pages.yaml`, `warm-reference-cache.yaml` | same pattern; page/cache jobs can use `github-actions[bot]` + the built-in `GITHUB_TOKEN` if they only push to their own auto-branches |
+
+**dragon-ai.yml specifics** (dismech#6979): also drop the `assigned` trigger —
+**GitHub Apps cannot be assignees**, so assignment-based dispatch cannot move to
+an App; keep only the `@dragon-ai-agent please` text-keyword mention. And harden
+the mention path: read the controller allowlist (`.github/ai-controllers.json`)
+from the **default branch**, not the PR ref (else a pusher self-authorizes); pass
+prompt values via `env:` + `printf`, never `echo "${{ ... }}"`; strip code spans
+before the mention regex so documenting the keyword doesn't self-trigger.
+
+**Verify per workflow** after editing:
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" .github/workflows/<wf>.yml
+grep -n "PAT_FOR_PR\|persist-credentials" .github/workflows/<wf>.yml
+```
+
+## Phase 2 — Split the reviewer identity
+
+`claude-code-review.yml` currently mints an `AI4C_AGENT` token — the same identity
+the writers use, so it can "review its own work" and its approval may not count.
+Point it at the reviewer App and add the writer to `allowed_bots`
+(dismech commit `2a2300df52`):
+
+```yaml
+  - name: Generate ai4c-reviewer token
+    id: reviewer-token
+    uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+    with:
+      app-id: ${{ secrets.AI4C_REVIEWER_APP_ID }}
+      private-key: ${{ secrets.AI4C_REVIEWER_PRIVATE_KEY }}
+  # ...
+      github_token: ${{ steps.reviewer-token.outputs.token || github.token }}
+      allowed_bots: 'claude,github-actions,ai4c-agent'   # writer must be listed or its
+                                                         # dispatched/pushed reviews are rejected
+```
+
+Why `allowed_bots` must include `ai4c-agent`: `claude-code-action` rejects a run
+whose *initiating actor* is a bot not in the list — even for `workflow_dispatch`.
+And note the **App-token push behavior**: unlike the built-in `GITHUB_TOKEN`,
+a push made with an App token fires `pull_request: synchronize`, so review
+auto-triggers on writer pushes (no manual re-dispatch needed).
+
+## Phase 3 — Add the injection controls
+
+1. **`close-fork-prs.yml`** — the single highest-leverage control. Copy dismech's
+   ([dismech#6895](https://github.com/monarch-initiative/dismech/pull/6895)). It's a
+   `pull_request_target` job that closes any fork PR on open/reopen and points the
+   author at `CONTRIBUTING.md`. It runs from the base repo's copy of the workflow,
+   **never checks out fork code** (only `gh` API calls), needs only
+   `pull-requests: write`, and leaves same-repo PRs untouched. A fork PR is the
+   main way external attacker-authored content reaches an agentic workflow's
+   context — refusing it at the door beats trying to contain it.
+2. **`untrusted-comment-guard.yml`** — copy dismech's; it gates agent responses to
+   comments from untrusted authors (see the security repo's
+   [untrusted-comment incident](https://github.com/ai4curation/ai-security-private/blob/main/docs/incidents/2026-07-08-dismech-untrusted-comment-attempt.md)).
+3. If you keep a **discussion/annotation scanner** that reads arbitrary public
+   discussion text, port dismech's deterministic trust gate
+   `.github/scripts/github-trust-gate.js` — it pre-filters candidates to those
+   where every non-bot participant is an allow-listed controller, so untrusted
+   discussion text never reaches the agent.
+
+## Phase 4 — Centralize model + cron config
+
+1. **`.github/agent-config.yaml` + `.github/actions/resolve-agent-config`** — one
+   source of truth for which model backs each workflow. Copy both from dismech.
+   Each managed workflow gains a `Resolve agent config` step that exports
+   `AGENT_MODEL`; the agent step uses `--model ${{ env.AGENT_MODEL }}` instead of a
+   hardcoded ID. A test enforces no workflow re-hardcodes `--model`. (Background:
+   dismech issue #5218.)
+2. **`.github/cron-profiles.yaml` + `scripts/apply_cron_profile.py`** — named cadence
+   profiles (`slow`/`medium`/`fast`/`off`) instead of hand-edited `schedule:` lines.
+   Switch with `just cron-profile <name>`. This also prevents schedule drift (a
+   workflow managed in the config but missing its `on.schedule` block gets one
+   re-inserted — the resurrection hazard that retired dismech's `stale-pr-reassign`
+   in [dismech#6958](https://github.com/monarch-initiative/dismech/pull/6958)).
+
+## Phase 5 — Model bump + dispatch hygiene
+
+1. **Bump defaults to current models** in `agent-config.yaml`: `claude-opus-5`,
+   `claude-sonnet-5` (Haiku has no v5 yet). **Verify exact IDs against the live
+   Anthropic model docs, never from memory** — dismech was once burned by a
+   fabricated model ID that silently no-op'd runs into phantom green checks
+   ([dismech#6933](https://github.com/monarch-initiative/dismech/pull/6933)).
+2. **Convert every `workflow_dispatch` `model:` input** from `type: choice` to a
+   no-override string (`default: ""`). A `choice` input always sends its default,
+   silently overriding the central config on every manual run; the resolver treats
+   an empty override as "use the config" (same PR).
+
+## Phase 6 — Reports, and the final teardown
+
+1. **Add injection-safe step summaries** to every agentic workflow so the agent's
+   report shows on the Actions run screen, not just the raw log
+   ([dismech#6998](https://github.com/monarch-initiative/dismech/pull/6998)):
+   ```yaml
+     - name: Write step summary
+       if: ${{ always() && steps.<agent-step-id>.outputs.result != '' }}
+       env:
+         RESULT: ${{ steps.<agent-step-id>.outputs.result }}   # via env, never echo "${{ }}"
+       run: |
+         { echo "## <emoji> <Workflow> Run"; echo ''; echo '```'; printf '%s\n' "$RESULT"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+   ```
+2. **Teardown:** once `grep -rn "secrets.PAT_FOR_PR" .github/` is empty, **delete
+   the `PAT_FOR_PR` secret** and confirm the token is revoked. Decide the fate of
+   the `dragon-ai-agent` account (its only remaining use is the mention keyword,
+   a text match that works without the account).
+
+---
+
+## Optional: adopt the dismech scanner fleet
+
+dismech has agentic scanners ai-gene-review lacks — adopt only the ones that fit
+GO/gene-review curation, and migrate their auth with the Phase 1 pattern as you go:
+
+- `discussion-scanner.yml` — responds to GitHub Discussions (needs the trust gate).
+- `literature-scan.yml` / `preprint-scan.yml` / `knowledge-gap-scan.yml` — mine new
+  literature/preprints/knowledge-gaps into curation handoff issues.
+- `post-review-agent.yml` — turns human review comments into suggested changes.
+- `auto-merge-compliance.yml` — auto-merges clean compliance PRs.
+
+ai-gene-review's own domain scanners (`arba-issue-monitor`, `go-annotation-scanner`,
+`litscan-module-member`) stay — just migrate their auth (Phase 1).
+
+---
+
+## Suggested PR sequencing
+
+Do it as several small PRs, not one, so each is reviewable and the reviewer split
+lands early:
+
+1. **Phase 2** first (reviewer → `ai4c-reviewer`) — so subsequent writer PRs get
+   independent review.
+2. **Phase 1** per-workflow (or a few at a time) — the security-critical bulk.
+3. **Phase 3** (fork-close + untrusted-comment guard).
+4. **Phase 4–5** (centralize config, bump models, dispatch hygiene).
+5. **Phase 6** (reports), then delete the `PAT_FOR_PR` secret.
+
+## Final verification
+
+```bash
+# no PAT references remain
+grep -rn "secrets.PAT_FOR_PR" .github/            # -> empty
+
+# every agent checkout is non-persisting
+grep -rL "persist-credentials: false" $(grep -rl "actions/checkout" .github/workflows/)
+
+# no hardcoded --model (models come from the resolver)
+grep -rnE "\-\-model .*claude-(opus|sonnet|haiku)-" .github/workflows/   # -> empty
+
+# app-token consistency
+grep -rn "AI4C_AGENT_APP_ID\|AI4C_REVIEWER_APP_ID" .github/workflows/
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,8 @@ nav:
   - Home: index.md
   - Isoform Tracking: isoform_tracking.md
   - Evidence Subtraction Reports: subtraction_report.md
-  
+  - Automation Migration (dismech pattern): automation-migration-to-dismech.md
+
 exclude_docs: |
   /templates-linkml/
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ nav:
   - Home: index.md
   - Isoform Tracking: isoform_tracking.md
   - Evidence Subtraction Reports: subtraction_report.md
-  - Automation Migration (dismech pattern): automation-migration-to-dismech.md
+  - Automation (dismech migration, as built): automation-migration-to-dismech.md
 
 exclude_docs: |
   /templates-linkml/


### PR DESCRIPTION
Adds `docs/automation-migration-to-dismech.md` — an execution guide for bringing this repo's GitHub Actions automation up to the `monarch-initiative/dismech` pattern. The two repos share a ~2026-07-03 common ancestor, but dismech has since had a security-hardening + centralization pass this repo hasn't received.

## What the guide covers (grounded in an actual scan of this repo)
Current gap found here:
- `PAT_FOR_PR` in **8 workflows** (`ai`, `pr-shepherd`, `dragon-ai`, `curation-scanner`, `go-annotation-scanner`, `litscan-module-member`, `warm-reference-cache`, `generate-pages`)
- `persist-credentials: false` only in `main.yaml` — every agent checkout persists its token to `.git/config` (the exact exposure vector from the incident)
- `claude-code-review` uses the **same** `AI4C_AGENT` app as writers (reviewer not split)
- stale, hardcoded models (`claude-opus-4-7` ×12, `sonnet-4-6` ×8, `haiku` ×8); no `agent-config.yaml` / `cron-profiles.yaml`; no fork-PR gate

Phased plan (security first): App-token migration + `persist-credentials: false`; reviewer split to `ai4c-reviewer`; fork-close + untrusted-comment guards; centralize model/cron config; bump to Opus 5 / Sonnet 5; injection-safe step-summaries; delete `PAT_FOR_PR`. Includes a per-workflow reference table, verification commands, and PR sequencing.

## References
- The security/remediation *why* + copy-paste token pattern: [ai-security-private → docs/history/2026-07-25-dismech-pat-to-app-migration.md](https://github.com/ai4curation/ai-security-private/blob/main/docs/history/2026-07-25-dismech-pat-to-app-migration.md)
- dismech PRs cited throughout: #6890, #6895, #6918, #6933, #6934, #6958, #6979, #6998

Docs-only; surfaced in the mkdocs nav.