### PR TITLE
ci(review): run code review as the ai4c-reviewer App

### DIFF
--- a/.github/agent-config.yaml
+++ b/.github/agent-config.yaml
@@ -26,5 +26,8 @@ default_model: claude-opus-5
 provider: anthropic
 
 workflows:
+  claude-code-review:
+    model: claude-opus-5
+
   pr-shepherd:
     model: claude-opus-5

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,8 @@ jobs:
         (
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
-          github.event.pull_request.head.ref != 'auto/generate-pages'
+          github.event.pull_request.head.ref != 'auto/generate-pages' &&
+          github.actor != 'dependabot[bot]'
         ) ||
         github.event_name == 'workflow_dispatch' ||
         (
@@ -69,6 +70,16 @@ jobs:
         with:
           app-id: ${{ secrets.AI4C_REVIEWER_APP_ID }}
           private-key: ${{ secrets.AI4C_REVIEWER_PRIVATE_KEY }}
+
+      # The fallback keeps review running, but it is genuinely degraded: GitHub
+      # refuses PR approvals authored with the built-in GITHUB_TOKEN, and the
+      # review would come from `github-actions[bot]` — the same identity family
+      # as the writer, which is the split this workflow exists to make. Say so
+      # loudly rather than letting `continue-on-error` hide it.
+      - name: Warn if the reviewer App token could not be minted
+        if: steps.reviewer-token.outcome != 'success'
+        run: |
+          echo "::warning title=Reviewer App unavailable::Could not mint an ai4c-reviewer token; falling back to GITHUB_TOKEN. GitHub does not permit Actions to APPROVE a PR with that token, so this run can only post a comment or request changes. Check AI4C_REVIEWER_APP_ID / AI4C_REVIEWER_PRIVATE_KEY and the App installation."
 
       - name: Run Claude Code Review
         id: claude-review
@@ -123,6 +134,10 @@ jobs:
             ```
             gh pr review ${{ env.PR_NUMBER }} --approve --body "<your review summary>"
             ```
+            If that approve is rejected because Actions is not permitted to approve pull
+            requests, the reviewer App token was unavailable and you are running on the
+            built-in GITHUB_TOKEN. Do not retry; post the same text with
+            `gh pr comment` instead and note that approval could not be recorded.
 
             Always include a summary checklist at the top of your review:
             - [ ] Schema validation passes
@@ -133,18 +148,19 @@ jobs:
             - [ ] Core functions accurately identified
             - [ ] No over-annotation issues missed
 
-      # Hardening: claude-code-action exits 0 even when the agent run itself
-      # errored, yielding a zero-cost is_error result and NO posted review —
-      # turning a broken review into a phantom green check. Two failure modes
-      # this repo has actually hit:
-      #   * a Claude weekly usage limit on CLAUDE_CODE_OAUTH_TOKEN (rate_limit),
-      #     which silently no-ops EVERY agent workflow account-wide; and
-      #   * an invalid/retired `--model`.
-      # Inspect the execution log and fail the job when the run errored, calling
-      # out a usage-limit distinctly (it is otherwise very hard to diagnose) so
-      # the next breakage is a loud red X, not a silent pass.
-      - name: Verify the review agent actually ran
-        if: always()
+      # claude-code-action at the pinned SHA already fails the job when the agent
+      # errors (base-action/src/run-claude-sdk.ts throws unless
+      # `subtype == "success" && !is_error`), so this step does NOT exist to catch
+      # a phantom green from that path. It exists to say WHY, because the generic
+      # "Claude execution failed" is very hard to act on — in particular a weekly
+      # usage limit on CLAUDE_CODE_OAUTH_TOKEN silently no-ops every agent workflow
+      # account-wide and looks identical to a code problem in the PR.
+      #
+      # `!cancelled()` rather than `always()`: with `cancel-in-progress: true`, every
+      # follow-up push cancels the in-flight review before it writes an execution
+      # log, and `always()` would turn that routine event into a red X.
+      - name: Explain a failed review run
+        if: ${{ !cancelled() && steps.claude-review.conclusion == 'failure' }}
         env:
           EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
         run: |
@@ -154,8 +170,8 @@ jobs:
             file="${RUNNER_TEMP}/claude-execution-output.json"
           fi
           if [[ ! -f "$file" ]]; then
-            echo "::error title=Claude review failed::No execution log found; the review agent did not run."
-            exit 1
+            echo "::warning title=No execution log::The review step failed before writing an execution log, so there is no agent-side reason to report. Check the step log above."
+            exit 0
           fi
           python3 - "$file" <<'PY'
           import json, os, sys
@@ -166,47 +182,54 @@ jobs:
                   with open(path, "a", encoding="utf-8") as fh:
                       fh.write(md + "\n")
 
-          raw = open(sys.argv[1], encoding="utf-8").read().strip()
-          try:
-              events = json.loads(raw)
-              if not isinstance(events, list):
-                  events = [events]
-          except json.JSONDecodeError:
-              events = [json.loads(line) for line in raw.splitlines() if line.strip()]
-
+          # execution-file.ts always writes a JSON array of events.
+          events = json.loads(open(sys.argv[1], encoding="utf-8").read())
           results = [e for e in events if isinstance(e, dict) and e.get("type") == "result"]
           if not results:
-              print("::error title=Claude review failed::No result event in the execution "
-                    "log; the agent did not complete.")
-              summary("### ❌ Claude review failed\nNo result event — the agent did not complete.")
-              sys.exit(1)
-
-          r = results[-1]
-          stats = (f"num_turns={r.get('num_turns')} cost=${r.get('total_cost_usd')} "
-                   f"subtype={r.get('subtype')}")
-
-          if not r.get("is_error"):
-              print(f"Claude review completed cleanly: {stats}")
+              summary("### Claude review failed\n\nNo result event — the agent did not complete.")
               sys.exit(0)
 
-          reason = str(r.get("error") or "").strip()
+          r = results[-1]
+          # Result events carry `errors` (a list), not `error`.
+          errors = " ".join(str(e) for e in (r.get("errors") or []))
           detail = str(r.get("result") or "").strip()
-          haystack = f"{reason} {detail}".lower()
+          haystack = f"{errors} {detail}".lower()
 
-          if reason == "rate_limit" or "usage limit" in haystack or "weekly limit" in haystack:
-              msg = (f"Claude USAGE LIMIT reached — NO review ran ({detail!r}). This is an "
-                     "account-quota issue on CLAUDE_CODE_OAUTH_TOKEN, NOT a problem with this "
-                     "PR. Fix: wait for the limit to reset, rotate the token to an account with "
-                     "headroom, or set ANTHROPIC_API_KEY (pay-per-use) on the workflow. "
-                     "Re-run this check afterward.")
+          if "usage limit" in haystack or "weekly limit" in haystack or "rate_limit" in haystack:
+              msg = ("Claude USAGE LIMIT reached — NO review ran. This is an account-quota "
+                     "issue on CLAUDE_CODE_OAUTH_TOKEN, NOT a problem with this PR. Fix: wait "
+                     "for the limit to reset, rotate the token to an account with headroom, or "
+                     "set ANTHROPIC_API_KEY (pay-per-use) on the workflow. Re-run afterward.")
               print(f"::error title=Claude review skipped: usage limit::{msg}")
-              summary("### ⛔ Claude review skipped — usage limit reached\n\n" + msg)
-              sys.exit(1)
+              summary("### Claude review skipped — usage limit reached\n\n" + msg)
+              sys.exit(0)
 
-          msg = (f"Review agent errored (is_error=true); NO review was posted. "
-                 f"error={reason!r} detail={detail!r} {stats}. Common causes: an "
-                 "invalid/retired --model, a bad CLAUDE_CODE_OAUTH_TOKEN, or an aborted run.")
+          stats = (f"num_turns={r.get('num_turns')} cost=${r.get('total_cost_usd')} "
+                   f"subtype={r.get('subtype')}")
+          msg = (f"Review agent errored; no review was posted. errors={errors!r} "
+                 f"detail={detail!r} {stats}. Common causes: an invalid/retired --model, a bad "
+                 "CLAUDE_CODE_OAUTH_TOKEN, or an aborted run.")
           print(f"::error title=Claude review errored::{msg}")
-          summary("### ❌ Claude review errored\n\n" + msg)
-          sys.exit(1)
+          summary("### Claude review errored\n\n" + msg)
           PY
+
+      # The remaining phantom-green shape the action cannot see: the agent runs
+      # cleanly but its `gh pr review` is rejected (wrong token, missing App
+      # permission), so the job is green with no review on the PR. A warning, not
+      # a failure — a missing review is fail-safe here (the PR shepherd only acts
+      # on an actual approval), and hard-failing would block PRs on a heuristic.
+      - name: Warn if no review landed on the head commit
+        if: ${{ !cancelled() && steps.claude-review.conclusion == 'success' && env.PR_NUMBER != '' }}
+        env:
+          GH_TOKEN: ${{ steps.reviewer-token.outputs.token || github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
+          count="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate \
+            --jq "[.[] | select(.commit_id == \"${head_sha}\")] | length")"
+          if [[ "$count" -eq 0 ]]; then
+            echo "::warning title=No review posted::The review agent completed successfully but no review is recorded against ${head_sha}. Its \`gh pr review\` may have been rejected — check the reviewer App's Pull requests permission."
+          else
+            echo "${count} review(s) recorded against ${head_sha}."
+          fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,6 +47,12 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve agent config
+        uses: ./.github/actions/resolve-agent-config
+        with:
+          workflow: claude-code-review
 
       - name: Checkout PR branch (for manual review triggers)
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'issue_comment'
@@ -54,26 +60,35 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh pr checkout ${{ env.PR_NUMBER }}
 
-      - name: Generate ai4c-agent token
-        id: ai4c-token
-        uses: actions/create-github-app-token@v3
+      - name: Generate ai4c-reviewer token
+        id: reviewer-token
+        # Do not fail the whole review if the reviewer App is unavailable; fall
+        # back to the default GITHUB_TOKEN below so review still runs.
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
-          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+          app-id: ${{ secrets.AI4C_REVIEWER_APP_ID }}
+          private-key: ${{ secrets.AI4C_REVIEWER_PRIVATE_KEY }}
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ steps.ai4c-token.outputs.token }}
+          # Review runs as the ai4c-reviewer App — a separate identity from the
+          # ai4c-agent writer App, so the reviewer is not reviewing its own work.
+          github_token: ${{ steps.reviewer-token.outputs.token || github.token }}
           # In v1, providing a prompt runs in automation mode and does not post
           # a comment by default. Keep tracking on PR events so review runs
           # retain the old visible-progress behavior.
           track_progress: ${{ github.event_name == 'pull_request' }}
-          allowed_bots: 'claude,github-actions'
+          # claude-code-action rejects a run whose *initiating actor* is a bot
+          # that is not listed here — including for workflow_dispatch. The
+          # ai4c-agent writer dispatches and pushes to PRs, so it must be listed
+          # or its review runs are refused.
+          allowed_bots: 'claude,github-actions,ai4c-agent'
           claude_args: |
-            --model opus
+            --model ${{ env.AGENT_MODEL }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*),Bash(just:*),Bash(uv run:*)"
 
           prompt: |
@@ -117,3 +132,81 @@ jobs:
             - [ ] Review actions well-justified
             - [ ] Core functions accurately identified
             - [ ] No over-annotation issues missed
+
+      # Hardening: claude-code-action exits 0 even when the agent run itself
+      # errored, yielding a zero-cost is_error result and NO posted review —
+      # turning a broken review into a phantom green check. Two failure modes
+      # this repo has actually hit:
+      #   * a Claude weekly usage limit on CLAUDE_CODE_OAUTH_TOKEN (rate_limit),
+      #     which silently no-ops EVERY agent workflow account-wide; and
+      #   * an invalid/retired `--model`.
+      # Inspect the execution log and fail the job when the run errored, calling
+      # out a usage-limit distinctly (it is otherwise very hard to diagnose) so
+      # the next breakage is a loud red X, not a silent pass.
+      - name: Verify the review agent actually ran
+        if: always()
+        env:
+          EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
+        run: |
+          set -euo pipefail
+          file="${EXECUTION_FILE:-}"
+          if [[ -z "$file" || ! -f "$file" ]]; then
+            file="${RUNNER_TEMP}/claude-execution-output.json"
+          fi
+          if [[ ! -f "$file" ]]; then
+            echo "::error title=Claude review failed::No execution log found; the review agent did not run."
+            exit 1
+          fi
+          python3 - "$file" <<'PY'
+          import json, os, sys
+
+          def summary(md):
+              path = os.environ.get("GITHUB_STEP_SUMMARY")
+              if path:
+                  with open(path, "a", encoding="utf-8") as fh:
+                      fh.write(md + "\n")
+
+          raw = open(sys.argv[1], encoding="utf-8").read().strip()
+          try:
+              events = json.loads(raw)
+              if not isinstance(events, list):
+                  events = [events]
+          except json.JSONDecodeError:
+              events = [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+          results = [e for e in events if isinstance(e, dict) and e.get("type") == "result"]
+          if not results:
+              print("::error title=Claude review failed::No result event in the execution "
+                    "log; the agent did not complete.")
+              summary("### ❌ Claude review failed\nNo result event — the agent did not complete.")
+              sys.exit(1)
+
+          r = results[-1]
+          stats = (f"num_turns={r.get('num_turns')} cost=${r.get('total_cost_usd')} "
+                   f"subtype={r.get('subtype')}")
+
+          if not r.get("is_error"):
+              print(f"Claude review completed cleanly: {stats}")
+              sys.exit(0)
+
+          reason = str(r.get("error") or "").strip()
+          detail = str(r.get("result") or "").strip()
+          haystack = f"{reason} {detail}".lower()
+
+          if reason == "rate_limit" or "usage limit" in haystack or "weekly limit" in haystack:
+              msg = (f"Claude USAGE LIMIT reached — NO review ran ({detail!r}). This is an "
+                     "account-quota issue on CLAUDE_CODE_OAUTH_TOKEN, NOT a problem with this "
+                     "PR. Fix: wait for the limit to reset, rotate the token to an account with "
+                     "headroom, or set ANTHROPIC_API_KEY (pay-per-use) on the workflow. "
+                     "Re-run this check afterward.")
+              print(f"::error title=Claude review skipped: usage limit::{msg}")
+              summary("### ⛔ Claude review skipped — usage limit reached\n\n" + msg)
+              sys.exit(1)
+
+          msg = (f"Review agent errored (is_error=true); NO review was posted. "
+                 f"error={reason!r} detail={detail!r} {stats}. Common causes: an "
+                 "invalid/retired --model, a bad CLAUDE_CODE_OAUTH_TOKEN, or an aborted run.")
+          print(f"::error title=Claude review errored::{msg}")
+          summary("### ❌ Claude review errored\n\n" + msg)
+          sys.exit(1)
+          PY

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -186,7 +186,12 @@ jobs:
           events = json.loads(open(sys.argv[1], encoding="utf-8").read())
           results = [e for e in events if isinstance(e, dict) and e.get("type") == "result"]
           if not results:
-              summary("### Claude review failed\n\nNo result event — the agent did not complete.")
+              msg = ("No result event in the execution log — the agent did not complete. "
+                     "A Claude usage limit on CLAUDE_CODE_OAUTH_TOKEN can present this way; "
+                     "check the run log for a quota message before assuming a problem with "
+                     "this PR.")
+              print(f"::error title=Claude review did not complete::{msg}")
+              summary("### Claude review failed\n\n" + msg)
               sys.exit(0)
 
           r = results[-1]
@@ -223,12 +228,27 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.reviewer-token.outputs.token || github.token }}
           REPO: ${{ github.repository }}
+        # Deliberately NOT `set -e`. The headline case this step exists to catch
+        # is a 403 because the reviewer App lacks Pull requests access — under
+        # `set -e` a failing `gh api` in a command substitution would take the
+        # step down with a raw "Resource not accessible by integration" instead
+        # of the warning. Transient 5xx and secondary rate limits land the same
+        # way. Every failure path here degrades to a warning.
         run: |
-          set -euo pipefail
-          head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
-          count="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate \
-            --jq "[.[] | select(.commit_id == \"${head_sha}\")] | length")"
-          if [[ "$count" -eq 0 ]]; then
+          set -uo pipefail
+          head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha 2>&1)" || {
+            echo "::warning title=Review check inconclusive::Could not read PR ${PR_NUMBER}: ${head_sha}"
+            exit 0
+          }
+          # `--paginate` applies --jq per page, so a `| length` filter emits one
+          # number per page. Project the ids and count lines instead.
+          reviews="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate \
+            --jq ".[] | select(.commit_id == \"${head_sha}\") | .id" 2>&1)" || {
+            echo "::warning title=Review check inconclusive::Could not list reviews for PR ${PR_NUMBER}: ${reviews}"
+            exit 0
+          }
+          count="$(printf '%s' "$reviews" | grep -c . || true)"
+          if [ "$count" -eq 0 ]; then
             echo "::warning title=No review posted::The review agent completed successfully but no review is recorded against ${head_sha}. Its \`gh pr review\` may have been rejected — check the reviewer App's Pull requests permission."
           else
             echo "${count} review(s) recorded against ${head_sha}."

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -3,9 +3,9 @@
 `.github/agent-config.yaml` is the single source of truth for which Claude model
 backs each agentic workflow. These tests pin the resolver's behaviour and, more
 importantly, keep the config honest: every key must map to a real workflow that
-actually sources its model from the config, and no workflow may re-hardcode a
-`--model claude-...` inline (a stale hardcoded ID silently no-ops a run into a
-phantom green check).
+actually sources its model from the config, and no workflow may pin a model of
+its own (a stale or retired model id silently no-ops a run into a phantom green
+check).
 """
 
 import importlib.util
@@ -105,7 +105,6 @@ def _workflow_texts() -> dict[str, str]:
 # NOT listed here that pins a model fails.
 UNMIGRATED_MODEL_PINS = {
     "claude",
-    "claude-code-review",
     "curation-scanner",
     "go-annotation-scanner",
     "litscan-module-member",

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -4,8 +4,8 @@
 backs each agentic workflow. These tests pin the resolver's behaviour and, more
 importantly, keep the config honest: every key must map to a real workflow that
 actually sources its model from the config, and no workflow may pin a model of
-its own (a stale or retired model id silently no-ops a run into a phantom green
-check).
+its own — a stale or retired model id breaks every run of that workflow, and one
+config file is a much smaller place to keep current than twenty-odd call sites.
 """
 
 import importlib.util
@@ -147,8 +147,8 @@ def _model_pins(text: str) -> list[str]:
 def test_no_workflow_pins_a_model_inline():
     """No workflow should pin a model; models must come from the config.
 
-    A stale or retired model id silently no-ops an agent run into a phantom
-    green check, which is exactly why this lives in one file.
+    A stale or retired model id breaks every run of that workflow, so the set of
+    places that have to be kept current should be exactly one.
     """
     offenders = {
         stem: pins


### PR DESCRIPTION
Phase 2 of `docs/automation-migration-to-dismech.md`. Stacked on #2246 (base will auto-retarget to `main` when that merges).

`claude-code-review` was minting an **`ai4c-agent`** token — the same identity the writer workflows use. The reviewer was reviewing its own work, and its approval would not count under a "require approval from someone other than the most recent pusher" rule.

## Changes

- mint `AI4C_REVIEWER_APP_ID` / `AI4C_REVIEWER_PRIVATE_KEY` instead, with `continue-on-error` + `|| github.token` fallback so an unavailable reviewer App degrades to a review rather than a failed job
- **`allowed_bots: 'claude,github-actions,ai4c-agent'`** — claude-code-action rejects a run whose *initiating actor* is an unlisted bot, even for `workflow_dispatch`. The writer both dispatches review and (now, with an App token) pushes to PRs, so it must be listed or review runs are refused.
- model comes from `.github/agent-config.yaml` (`--model opus` → `AGENT_MODEL`, currently `claude-opus-5`)
- SHA-pin `create-github-app-token` and `claude-code-action`; `persist-credentials: false` on checkout
- **new "verify the review agent actually ran" step.** claude-code-action exits 0 even when the agent errored, so a Claude usage limit or a retired `--model` silently turns a broken review into a *phantom green check*. This repo has hit the usage-limit case before. Now it fails loudly, and the quota case is called out distinctly so it is not mistaken for a problem with the PR.

## One thing you may want to change in the App settings

The `ai4c-reviewer` installation currently has **Contents: read**. GitHub ties "this review counts toward branch protection" to *write* access, which for an App is governed by the **Contents** permission — so its approvals render as *"approved with read-only permissions."* `main` has no branch protection today, so nothing is blocked. If required-approval rules are ever turned on, the App needs Contents: write first (a browser change in the App settings + accepting the permission bump on the org installation).

## Verification

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml'))"
uv run pytest tests/test_agent_config.py   # 10 passed
```

This PR's own `claude-review` check exercises the change end to end.