### PR TITLE
ci: finish the App-token migration; no PAT_FOR_PR reference remains

### DIFF
--- a/.github/actions/claude-issue-summarize-action/action.yml
+++ b/.github/actions/claude-issue-summarize-action/action.yml
@@ -19,11 +19,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout repository code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
     - name: Create prompt file
       shell: bash
       run: |

--- a/.github/actions/claude-issue-triage-action/action.yml
+++ b/.github/actions/claude-issue-triage-action/action.yml
@@ -19,11 +19,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout repository code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
     - name: Create prompt file
       shell: bash
       run: |

--- a/.github/agent-config.yaml
+++ b/.github/agent-config.yaml
@@ -68,3 +68,7 @@ workflows:
 
   pr-shepherd:
     model: claude-opus-5
+
+  # Weekly sweep that improves the lowest-scoring gene reviews.
+  weekly-compliance:
+    model: claude-opus-5

--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/claude-issue-summarize.yml
+++ b/.github/workflows/claude-issue-summarize.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Run Claude Issue summarize
         uses: ./.github/actions/claude-issue-summarize-action

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Run Claude Issue Triage
         uses: ./.github/actions/claude-issue-triage-action

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -116,14 +116,28 @@ jobs:
           #
           # `mcp_config:`, `model:` and `allowed_tools:` were dropped the same way
           # — none of them are v1 inputs. Everything now goes through claude_args,
-          # which is how v1 takes CLI flags.
+          # which is how v1 takes CLI flags. Both flags ACCUMULATE with tag mode's
+          # own values rather than replacing them, so the comment-update and CI
+          # MCP tools survive.
+          #
+          # The old file asked for `Bash(*),Edit,MultiEdit,Write`, but since the
+          # input was being discarded it never took effect — the agent has been
+          # running on tag mode's narrow set. Restoring that literally would grant
+          # arbitrary shell and blanket write for the first time, in the same PR
+          # that calls this workflow out as the incident shape, so it is scoped to
+          # what the gene-review protocol actually needs instead. Edit/Write are
+          # deliberately absent: tag mode runs `--permission-mode acceptEdits`,
+          # which already permits edits inside the workspace, and listing the
+          # tools would extend that to the whole runner.
           claude_args: |
             --model ${{ env.AGENT_MODEL }}
             --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}, "sequential-thinking": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]}}}'
-            --allowedTools "Bash,Edit,MultiEdit,Write,Read,Glob,Grep,WebSearch,WebFetch,mcp__ols__search_all_ontologies,mcp__ols__get_terms_from_ontology"
+            --allowedTools "Read,Glob,Grep,WebSearch,WebFetch,Bash(just:*),Bash(uv:*),Bash(uvx:*),Bash(gh:*),Bash(git:*),mcp__ols__search_all_ontologies,mcp__ols__get_terms_from_ontology,mcp__sequential-thinking__sequentialthinking"
 
       - name: Write step summary
-        if: always()
+        # Not `always()`: with cancel-in-progress a superseded run writes no
+        # execution log, and the summary would report that as breakage.
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/agent-run-summary
         with:
           execution-file: ${{ steps.claude.outputs.execution_file }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -103,72 +103,28 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.ai4c-token.outputs.token }}
-          allowed_bots: "ai4c-agent,claude,github-actions"
-          mcp_config: |
-            {
-              "mcpServers": {
-                "ols": {
-                  "command": "uvx",
-                  "args": [
-                    "ols-mcp"
-                  ]
-                },
-                "sequential-thinking": {
-                  "command": "npx",
-                  "args": [
-                    "-y",
-                    "@modelcontextprotocol/server-sequential-thinking"
-                  ]
-                }
-              }
-            }
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # Lets Claude read CI results on PRs.
           additional_permissions: |
             actions: read
-          
-          model: ${{ env.AGENT_MODEL }}
-          
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-          
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-          
-          # Optional: Allow Claude to run specific commands
-          allowed_tools: "Bash(*),FileEdit,Edit,MultiEdit,WebSearch,WebFetch,mcp__ols_mcp__search_all_ontologies,mcp__ols_mcp__get_terms_from_ontology"
-          
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          custom_instructions: |
-            REPO: ${{ github.repository }}
-            ISSUE NUMBER: ${{ github.event.issue.number }}
-            TITLE: ${{ github.event.issue.title }}
-            BODY: ${{ github.event.issue.body }}
-            AUTHOR: ${{ github.event.issue.user.login }}
 
-            First analyzer the user request. If it doesn't involve gene review, 
+          # No `prompt:` on purpose. This is the interactive "@claude" responder,
+          # and v1 switches to non-interactive automation mode as soon as a prompt
+          # is supplied. Repository conventions come from CLAUDE.md, which the
+          # agent reads; they used to be duplicated here in a `custom_instructions:`
+          # block that v1 does not accept and silently discarded.
+          #
+          # `mcp_config:`, `model:` and `allowed_tools:` were dropped the same way
+          # — none of them are v1 inputs. Everything now goes through claude_args,
+          # which is how v1 takes CLI flags.
+          claude_args: |
+            --model ${{ env.AGENT_MODEL }}
+            --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}, "sequential-thinking": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]}}}'
+            --allowedTools "Bash,Edit,MultiEdit,Write,Read,Glob,Grep,WebSearch,WebFetch,mcp__ols__search_all_ontologies,mcp__ols__get_terms_from_ontology"
 
-            If the user asks for a gene review, you must perform the following steps:
-              
-            When reviewing a gene, first check if the relevant files are in place. To create the uniprot and goa files, and a stub review,
-            run `just fetch-gene SPECIES GENE`. Never initiate these yourself. If a GENE-deep-research.md is NOT already present, you
-            should first do extensive literature search and make one, being sure to include citations for all statements.
-
-            ALWAYS do a `just validate SPECIES GENE` before finishing. You must fix BOTH ERRORs and WARNINGs.
-
-            Make sure you use the correct uniprot code for SPECIES (unless this is a common species: human, worm, fly, rat, mouse)
-            And use the uniprot gene symbol
-
-            Make sure your commit also includes:
-
-            - GENE-goa.tsv and GENE-uniprot.txt (if you created these with `just fetch-gene`)
-            - GENE-deep-research.md (if this was not previously present)
-            - New publications in `publications/`
-            - any bioinformatics analyses
-
-            Make a PR at the end
-          
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
-
+      - name: Write step summary
+        if: always()
+        uses: ./.github/actions/agent-run-summary
+        with:
+          execution-file: ${{ steps.claude.outputs.execution_file }}
+          title: "@claude Run"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -144,11 +144,13 @@ jobs:
           # exactly the RCE the action's vendored scripts/git-push.sh wrapper
           # exists to close (HackerOne #3556799). Tag mode already unions in
           # `git add`/`git commit`/`git rm` and that wrapper, so only read-only
-          # verbs were missing and only those are added.
+          # verbs were missing and only those are added. `git fetch` is NOT among
+          # them despite looking read-only: `git fetch 'ext::sh -c <cmd>'` runs
+          # <cmd> locally, since protocol.ext.allow defaults to `user`.
           claude_args: |
             --model ${{ env.AGENT_MODEL }}
             --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}, "sequential-thinking": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]}}}'
-            --allowedTools "Read,Glob,Grep,WebSearch,WebFetch,Bash(just:*),Bash(uv:*),Bash(uvx:*),Bash(gh:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git checkout:*),mcp__ols__search_all_ontologies,mcp__ols__get_terms_from_ontology,mcp__ols__get_ontology_info,mcp__sequential-thinking__sequentialthinking"
+            --allowedTools "Read,Glob,Grep,WebSearch,WebFetch,Bash(just:*),Bash(uv:*),Bash(uvx:*),Bash(gh:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),mcp__ols__search_all_ontologies,mcp__ols__get_terms_from_ontology,mcp__ols__get_ontology_info,mcp__sequential-thinking__sequentialthinking"
 
       - name: Write step summary
         # Not `always()`: with cancel-in-progress a superseded run writes no

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -123,16 +123,32 @@ jobs:
           # The old file asked for `Bash(*),Edit,MultiEdit,Write`, but since the
           # input was being discarded it never took effect — the agent has been
           # running on tag mode's narrow set. Restoring that literally would grant
-          # arbitrary shell and blanket write for the first time, in the same PR
-          # that calls this workflow out as the incident shape, so it is scoped to
-          # what the gene-review protocol actually needs instead. Edit/Write are
+          # blanket write for the first time, in the same commit that calls this
+          # workflow out as the incident shape, so it is scoped to what the
+          # gene-review protocol needs instead. Edit/MultiEdit/Write are
           # deliberately absent: tag mode runs `--permission-mode acceptEdits`,
           # which already permits edits inside the workspace, and listing the
           # tools would extend that to the whole runner.
+          #
+          # BE CLEAR ABOUT WHAT THIS LIST IS AND IS NOT. It is not a confinement
+          # boundary: `Bash(uv:*)` covers `uv run python -c '...'`, `Bash(uvx:*)`
+          # runs an arbitrary PyPI package, and `gh alias set --shell` is a shell
+          # escape. Arbitrary execution is ACCEPTED for this agent, because only
+          # OWNER/MEMBER/COLLABORATOR can trigger it (see the job `if:`) and it
+          # holds a token that expires with the job. What the list actually buys
+          # is workspace-scoped writes and the removal of `Bash(*)`.
+          #
+          # Git is the one exception worth spelling out, because it has a
+          # documented escape rather than an implied one: a `Bash(git:*)` prefix
+          # rule permits `git push --receive-pack='sh -c ...' ext::sh`, which is
+          # exactly the RCE the action's vendored scripts/git-push.sh wrapper
+          # exists to close (HackerOne #3556799). Tag mode already unions in
+          # `git add`/`git commit`/`git rm` and that wrapper, so only read-only
+          # verbs were missing and only those are added.
           claude_args: |
             --model ${{ env.AGENT_MODEL }}
             --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}, "sequential-thinking": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]}}}'
-            --allowedTools "Read,Glob,Grep,WebSearch,WebFetch,Bash(just:*),Bash(uv:*),Bash(uvx:*),Bash(gh:*),Bash(git:*),mcp__ols__search_all_ontologies,mcp__ols__get_terms_from_ontology,mcp__sequential-thinking__sequentialthinking"
+            --allowedTools "Read,Glob,Grep,WebSearch,WebFetch,Bash(just:*),Bash(uv:*),Bash(uvx:*),Bash(gh:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git checkout:*),mcp__ols__search_all_ontologies,mcp__ols__get_terms_from_ontology,mcp__ols__get_ontology_info,mcp__sequential-thinking__sequentialthinking"
 
       - name: Write step summary
         # Not `always()`: with cancel-in-progress a superseded run writes no

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,17 +47,40 @@ jobs:
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
       )
     runs-on: ubuntu-latest
+    # A GitHub App installation token expires 60 minutes after minting and does
+    # not refresh; stay inside that window.
+    timeout-minutes: 55
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
+      # Scopes the default GITHUB_TOKEN only; the agent works with the ai4c-agent
+      # App token below.
+      contents: read
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: Generate ai4c-agent token
+        id: ai4c-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          token: ${{ steps.ai4c-token.outputs.token }}
+          # This agent has Bash(*); do not leave a token in .git/config for it
+          # to read. git authenticates via the gh credential helper below.
+          persist-credentials: false
+
+      - name: Configure git identity and credential helper
+        env:
+          GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+          APP_SLUG: ${{ steps.ai4c-token.outputs.app-slug }}
+        run: |
+          APP_USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          gh auth setup-git
 
       - name: Resolve agent config
         uses: ./.github/actions/resolve-agent-config
@@ -73,10 +96,14 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
-        
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
+        env:
+          GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.ai4c-token.outputs.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.ai4c-token.outputs.token }}
+          allowed_bots: "ai4c-agent,claude,github-actions"
           mcp_config: |
             {
               "mcpServers": {

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -23,13 +23,20 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0  # otherwise, you will fail to push refs to dest repo
+          persist-credentials: false
 
       - name: Configure git for the bot
         # Gives the bot that commits to gh-pages a name & email address
-        # so that the commits have an author in the commit log.
+        # so that the commits have an author in the commit log. `mkdocs
+        # gh-deploy` shells out to `git push`, so it needs credentials: serve
+        # them from GH_TOKEN via the gh credential helper rather than leaving
+        # the token in .git/config.
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
+          gh auth setup-git
 
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
@@ -53,5 +60,9 @@ jobs:
         run: uv sync --dev --no-progress
 
       - name: Generate schema documentation
+        env:
+          # Consumed by the gh credential helper configured above when
+          # `mkdocs gh-deploy` pushes to gh-pages.
+          GH_TOKEN: ${{ github.token }}
         run: |
           uv run mkdocs gh-deploy

--- a/.github/workflows/generate-pages.yaml
+++ b/.github/workflows/generate-pages.yaml
@@ -34,14 +34,24 @@ jobs:
   generate-pages:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      # Scopes the default GITHUB_TOKEN only; the branch push and the PR are made
+      # with the ai4c-agent App token below.
+      contents: read
 
     steps:
+      - name: Generate ai4c-agent token
+        id: ai4c-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ steps.ai4c-token.outputs.token }}
+          persist-credentials: false
 
       # NOTE: The previous "Close stale regeneration PRs" step closed the
       # regeneration PR if it was older than one hour. Because the PR is created
@@ -158,11 +168,16 @@ jobs:
       - name: Create or update regeneration PR
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PAT_FOR_PR != '' && secrets.PAT_FOR_PR || github.token }}
+          GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+          APP_SLUG: ${{ steps.ai4c-token.outputs.app-slug }}
         shell: bash
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Commit as the ai4c-agent App bot and serve the short-lived token to git
+          # through the gh credential helper, instead of persisting it in .git/config.
+          APP_USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          gh auth setup-git
 
           BRANCH_NAME="${{ steps.pr-metadata.outputs.branch }}"
           git fetch origin "$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" || true

--- a/.github/workflows/generate-pages.yaml
+++ b/.github/workflows/generate-pages.yaml
@@ -33,24 +33,17 @@ concurrency:
 jobs:
   generate-pages:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       # Scopes the default GITHUB_TOKEN only; the branch push and the PR are made
       # with the ai4c-agent App token below.
       contents: read
 
     steps:
-      - name: Generate ai4c-agent token
-        id: ai4c-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
-          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ steps.ai4c-token.outputs.token }}
           persist-credentials: false
 
       # NOTE: The previous "Close stale regeneration PRs" step closed the
@@ -164,6 +157,22 @@ jobs:
             echo "project_count=$PROJECT_COUNT"
             echo "module_count=$MODULE_COUNT"
           } >> "$GITHUB_OUTPUT"
+
+      # Minted HERE, not at job start. An App installation token lives 60
+      # minutes and does not refresh, and this is the longest job in the repo —
+      # the last completed run took 58 minutes rendering ~1200 gene pages plus
+      # projects, modules and the browser app. A token minted at job start would
+      # expire during the render and 401 on the push below, discarding all of it.
+      # `timeout-minutes: 55` (what the agent workflows use) would be worse still:
+      # it would kill a run that legitimately needs the time. The render needs no
+      # credentials, so the token is minted immediately before the only step that
+      # does.
+      - name: Generate ai4c-agent token
+        id: ai4c-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
 
       - name: Create or update regeneration PR
         if: steps.check-changes.outputs.has_changes == 'true'

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -14,6 +14,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/warm-reference-cache.yaml
+++ b/.github/workflows/warm-reference-cache.yaml
@@ -18,24 +18,17 @@ concurrency:
 jobs:
   warm-reference-cache:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       # Scopes the default GITHUB_TOKEN only; the branch push and the PR are made
       # with the ai4c-agent App token below.
       contents: read
 
     steps:
-      - name: Generate ai4c-agent token
-        id: ai4c-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
-          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ steps.ai4c-token.outputs.token }}
           persist-credentials: false
 
       - name: Install uv
@@ -79,6 +72,16 @@ jobs:
             echo "changed=$CHANGED"
             echo "total=$TOTAL"
           } >> "$GITHUB_OUTPUT"
+
+      # Minted here rather than at job start, for the same reason as
+      # generate-pages: the cache warm needs no credentials, only the push does,
+      # and a token minted at job start burns its 60-minute life on the fetch.
+      - name: Generate ai4c-agent token
+        id: ai4c-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
 
       - name: Create or update warm-cache PR
         if: steps.check-changes.outputs.has_changes == 'true'

--- a/.github/workflows/warm-reference-cache.yaml
+++ b/.github/workflows/warm-reference-cache.yaml
@@ -19,14 +19,24 @@ jobs:
   warm-reference-cache:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      # Scopes the default GITHUB_TOKEN only; the branch push and the PR are made
+      # with the ai4c-agent App token below.
+      contents: read
 
     steps:
+      - name: Generate ai4c-agent token
+        id: ai4c-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ steps.ai4c-token.outputs.token }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -73,11 +83,16 @@ jobs:
       - name: Create or update warm-cache PR
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PAT_FOR_PR != '' && secrets.PAT_FOR_PR || github.token }}
+          GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+          APP_SLUG: ${{ steps.ai4c-token.outputs.app-slug }}
         shell: bash
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Commit as the ai4c-agent App bot and serve the short-lived token to git
+          # through the gh credential helper, instead of persisting it in .git/config.
+          APP_USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          gh auth setup-git
 
           BRANCH_NAME="${{ steps.metadata.outputs.branch }}"
           git fetch origin "$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" || true

--- a/.github/workflows/weekly-compliance.yaml
+++ b/.github/workflows/weekly-compliance.yaml
@@ -20,29 +20,52 @@ on:
         type: string
 
       model:
-        description: "Claude model to use"
-        default: claude-opus-4-7
-        type: choice
-        options:
-          - claude-sonnet-4-6
-          - claude-haiku-4-5-20251001
-          - claude-opus-4-7
+        description: "Optional model ID override (blank = use the configured default in agent-config.yaml)"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   compliance-fixes:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # A GitHub App installation token expires 60 minutes after minting and does
+    # not refresh; stay inside that window.
+    timeout-minutes: 55
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
+      # Scopes the default GITHUB_TOKEN only; the ai4c-agent App token below does
+      # the privileged work.
+      contents: read
 
     steps:
+      - name: Generate ai4c-agent token
+        id: ai4c-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ steps.ai4c-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Resolve agent config
+        uses: ./.github/actions/resolve-agent-config
+        with:
+          workflow: weekly-compliance
+          model-override: ${{ inputs.model }}
+
+      - name: Configure git identity and credential helper
+        env:
+          GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+          APP_SLUG: ${{ steps.ai4c-token.outputs.app-slug }}
+        run: |
+          APP_USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          gh auth setup-git
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -56,14 +79,23 @@ jobs:
           uv sync
 
       - name: Run Claude Compliance Fixes
-        uses: anthropics/claude-code-action@v1
+        id: compliance
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
+        env:
+          GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.ai4c-token.outputs.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Without a token this job reported success for weeks while producing no
+          # PRs at all: `gh pr create` failed silently and nothing captured it.
+          github_token: ${{ steps.ai4c-token.outputs.token }}
+          show_full_output: true
+          allowed_bots: "ai4c-agent,claude,github-actions"
 
           claude_args: |
             --dangerously-skip-permissions
             --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}}}'
-            --model ${{ inputs.model || 'claude-opus-4-7' }}
+            --model ${{ env.AGENT_MODEL }}
 
           prompt: |
             You are running as part of an automated CI workflow to improve the AI Gene Review knowledge base.
@@ -104,3 +136,18 @@ jobs:
             - Incremental fixes are fine — we will get to everything eventually
             - Follow `CLAUDE.md` conventions and the gene review schema
             - Be conservative with annotation `action` changes; only upgrade confidence when evidence is clear
+
+      - name: Write step summary
+        if: always()
+        env:
+          # Pass model output through the environment, never interpolate it into
+          # the shell script (attacker-influenceable -> command injection).
+          RESULT: ${{ steps.compliance.outputs.result }}
+        run: |
+          {
+            echo "## Weekly Compliance Run"
+            echo ""
+            echo '~~~~'
+            printf '%s\n' "$RESULT"
+            echo '~~~~'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/weekly-compliance.yaml
+++ b/.github/workflows/weekly-compliance.yaml
@@ -89,7 +89,6 @@ jobs:
           # Without a token this job reported success for weeks while producing no
           # PRs at all: `gh pr create` failed silently and nothing captured it.
           github_token: ${{ steps.ai4c-token.outputs.token }}
-          show_full_output: true
           allowed_bots: "ai4c-agent,claude,github-actions"
 
           claude_args: |
@@ -139,15 +138,7 @@ jobs:
 
       - name: Write step summary
         if: always()
-        env:
-          # Pass model output through the environment, never interpolate it into
-          # the shell script (attacker-influenceable -> command injection).
-          RESULT: ${{ steps.compliance.outputs.result }}
-        run: |
-          {
-            echo "## Weekly Compliance Run"
-            echo ""
-            echo '~~~~'
-            printf '%s\n' "$RESULT"
-            echo '~~~~'
-          } >> "$GITHUB_STEP_SUMMARY"
+        uses: ./.github/actions/agent-run-summary
+        with:
+          execution-file: ${{ steps.compliance.outputs.execution_file }}
+          title: "Weekly Compliance Run"

--- a/.github/workflows/weekly-compliance.yaml
+++ b/.github/workflows/weekly-compliance.yaml
@@ -137,7 +137,9 @@ jobs:
             - Be conservative with annotation `action` changes; only upgrade confidence when evidence is clear
 
       - name: Write step summary
-        if: always()
+        # Not `always()`: with cancel-in-progress a superseded run writes no
+        # execution log, and the summary would report that as breakage.
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/agent-run-summary
         with:
           execution-file: ${{ steps.compliance.outputs.execution_file }}

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -227,9 +227,16 @@ CLAUDE_ACTION_V1_OUTPUTS = {
 
 def _action_definition_files():
     """Every file that can invoke an action: workflows and composite actions."""
-    return sorted(WORKFLOW_DIR.glob("*.y*ml")) + sorted(
-        (REPO_ROOT / ".github" / "actions").rglob("action.y*ml")
-    )
+    # Everything under .github/ that can declare steps. Deliberately broad: a
+    # step file in an unexpected place (.github/copilot-setup-steps.yml) is
+    # exactly the kind of thing a narrower glob misses. Files with no steps —
+    # agent-config.yaml, cron-profiles.yaml, dependabot.yml — simply yield none.
+    return sorted((REPO_ROOT / ".github").rglob("*.y*ml"))
+
+
+def _definition_name(path: Path) -> str:
+    """A composite action is named by its directory, a workflow by its stem."""
+    return path.parent.name if path.stem == "action" else path.stem
 
 
 def _steps(doc: dict):
@@ -247,7 +254,7 @@ def _claude_action_steps():
             if ((step or {}).get("uses") or "").startswith(
                 "anthropics/claude-code-action@"
             ):
-                yield path.stem if path.name != "action.yml" else path.parent.name, step
+                yield _definition_name(path), step
 
 
 def test_no_workflow_passes_an_undeclared_input_to_claude_code_action():

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -225,15 +225,29 @@ CLAUDE_ACTION_V1_OUTPUTS = {
 }
 
 
+def _action_definition_files():
+    """Every file that can invoke an action: workflows and composite actions."""
+    return sorted(WORKFLOW_DIR.glob("*.y*ml")) + sorted(
+        (REPO_ROOT / ".github" / "actions").glob("*/action.yml")
+    )
+
+
+def _steps(doc: dict):
+    """Yield steps from a workflow (jobs.*.steps) or a composite action (runs.steps)."""
+    for job in (doc.get("jobs") or {}).values():
+        yield from (job or {}).get("steps") or []
+    yield from ((doc.get("runs") or {}).get("steps") or [])
+
+
 def _claude_action_steps():
-    """Yield (workflow stem, step mapping) for every claude-code-action step."""
-    for path in WORKFLOW_DIR.glob("*.y*ml"):
-        doc = yaml.safe_load(path.read_text())
-        for job in (doc.get("jobs") or {}).values():
-            for step in (job or {}).get("steps") or []:
-                uses = (step or {}).get("uses") or ""
-                if uses.startswith("anthropics/claude-code-action@"):
-                    yield path.stem, step
+    """Yield (file stem, step mapping) for every claude-code-action step."""
+    for path in _action_definition_files():
+        doc = yaml.safe_load(path.read_text()) or {}
+        for step in _steps(doc):
+            if ((step or {}).get("uses") or "").startswith(
+                "anthropics/claude-code-action@"
+            ):
+                yield path.stem if path.name != "action.yml" else path.parent.name, step
 
 
 def test_no_workflow_passes_an_undeclared_input_to_claude_code_action():
@@ -251,12 +265,11 @@ def test_no_workflow_passes_an_undeclared_input_to_claude_code_action():
 def test_no_workflow_reads_an_undeclared_claude_code_action_output():
     """`steps.<id>.outputs.result` does not exist; it renders as empty."""
     offenders = []
-    for path in WORKFLOW_DIR.glob("*.y*ml"):
-        doc = yaml.safe_load(path.read_text())
+    for path in _action_definition_files():
+        doc = yaml.safe_load(path.read_text()) or {}
         ids = {
             step.get("id")
-            for job in (doc.get("jobs") or {}).values()
-            for step in ((job or {}).get("steps") or [])
+            for step in _steps(doc)
             if (step or {}).get("uses", "").startswith("anthropics/claude-code-action@")
         }
         text = path.read_text()
@@ -296,7 +309,7 @@ def test_claude_action_pin_matches_the_recorded_sets():
     of quietly turning both tests into no-ops.
     """
     pins = set()
-    for path in WORKFLOW_DIR.glob("*.y*ml"):
+    for path in _action_definition_files():
         pins.update(
             re.findall(r"anthropics/claude-code-action@([0-9a-f]{40})", path.read_text())
         )
@@ -311,7 +324,7 @@ def test_claude_action_pin_matches_the_recorded_sets():
 def test_claude_code_action_is_always_sha_pinned():
     """A moved tag could swap in code that exfiltrates the App token."""
     floating = []
-    for path in WORKFLOW_DIR.glob("*.y*ml"):
+    for path in _action_definition_files():
         for ref in re.findall(r"anthropics/claude-code-action@(\S+)", path.read_text()):
             if not re.fullmatch(r"[0-9a-f]{40}", ref):
                 floating.append(f"{path.stem}: @{ref}")

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -186,8 +186,13 @@ def test_managed_workflows_use_the_resolver_action():
             )
 
 
-# Inputs declared by anthropics/claude-code-action at the SHA every workflow
-# pins (be7b93b, v1). Refresh with:
+# The SHA these input/output sets were read from. If a workflow bumps the pin,
+# the sets below may no longer describe the action —
+# test_claude_action_pin_matches_the_recorded_sets fails so the bump comes with
+# a refresh rather than silently invalidating both guards.
+CLAUDE_ACTION_PINNED_SHA = "be7b93b1907a4abad570368f3c74b6fe3807510b"
+
+# Inputs declared by anthropics/claude-code-action at that SHA. Refresh with:
 #   gh api "/repos/anthropics/claude-code-action/contents/action.yml?ref=<sha>" \
 #     --jq .content | base64 -d | python3 -c \
 #     "import sys,yaml;print(sorted(yaml.safe_load(sys.stdin)['inputs']))"
@@ -281,3 +286,33 @@ def test_every_claude_code_action_workflow_is_in_the_agent_config():
         "workflow(s) run claude-code-action but are not in agent-config.yaml, so "
         f"their model is not centrally configured: {sorted(using - managed)}"
     )
+
+
+def test_claude_action_pin_matches_the_recorded_sets():
+    """Every workflow must pin the SHA the input/output sets were read from.
+
+    The two guards above are only as good as their hardcoded vocabulary. Tying
+    them to the pin means bumping the action forces a deliberate refresh instead
+    of quietly turning both tests into no-ops.
+    """
+    pins = set()
+    for path in WORKFLOW_DIR.glob("*.y*ml"):
+        pins.update(
+            re.findall(r"anthropics/claude-code-action@([0-9a-f]{40})", path.read_text())
+        )
+    unexpected = pins - {CLAUDE_ACTION_PINNED_SHA}
+    assert not unexpected, (
+        "claude-code-action is pinned to a SHA the recorded input/output sets "
+        f"were not read from: {sorted(unexpected)}. Re-read them from that SHA "
+        "and update CLAUDE_ACTION_PINNED_SHA."
+    )
+
+
+def test_claude_code_action_is_always_sha_pinned():
+    """A moved tag could swap in code that exfiltrates the App token."""
+    floating = []
+    for path in WORKFLOW_DIR.glob("*.y*ml"):
+        for ref in re.findall(r"anthropics/claude-code-action@(\S+)", path.read_text()):
+            if not re.fullmatch(r"[0-9a-f]{40}", ref):
+                floating.append(f"{path.stem}: @{ref}")
+    assert not floating, "claude-code-action must be SHA-pinned:\n" + "\n".join(floating)

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -99,13 +99,11 @@ def _workflow_texts() -> dict[str, str]:
     return {path.stem: path.read_text() for path in WORKFLOW_DIR.glob("*.y*ml")}
 
 
-# Workflows not yet migrated onto the central config. Delete an entry when its
-# workflow starts resolving its model from .github/agent-config.yaml; the list
-# must only ever shrink, and the test fails if an entry becomes stale. Anything
-# NOT listed here that pins a model fails.
-UNMIGRATED_MODEL_PINS = {
-    "weekly-compliance",
-}
+# Escape hatch for a workflow not yet migrated onto the central config. Now
+# empty: every agentic workflow resolves its model from agent-config.yaml. An
+# entry here must correspond to a real pin (a stale entry fails the test), so
+# the list can only shrink.
+UNMIGRATED_MODEL_PINS: set[str] = set()
 
 # Model families, plus the bare aliases the CLI also accepts (`--model opus`).
 _MODEL_VALUE = (

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -184,3 +184,100 @@ def test_managed_workflows_use_the_resolver_action():
                 f"workflow '{stem}' is in agent-config.yaml but does not `uses:` "
                 f"the resolve-agent-config action"
             )
+
+
+# Inputs declared by anthropics/claude-code-action at the SHA every workflow
+# pins (be7b93b, v1). Refresh with:
+#   gh api "/repos/anthropics/claude-code-action/contents/action.yml?ref=<sha>" \
+#     --jq .content | base64 -d | python3 -c \
+#     "import sys,yaml;print(sorted(yaml.safe_load(sys.stdin)['inputs']))"
+# The v0 names `mode`, `direct_prompt`, `model`, `mcp_config`, `allowed_tools`
+# and `custom_instructions` are NOT here. GitHub only warns about an unexpected
+# input, so passing one silently drops it — arba-issue-monitor never delivered
+# its prompt and claude.yml never applied its model, MCP servers or tool
+# allowlist, both for months, both green the whole time.
+CLAUDE_ACTION_V1_INPUTS = {
+    "additional_permissions", "allowed_bots", "allowed_non_write_users",
+    "anthropic_api_key", "anthropic_federation_rule_id", "anthropic_oidc_audience",
+    "anthropic_organization_id", "anthropic_service_account_id",
+    "anthropic_workspace_id", "assignee_trigger", "base_branch", "bot_id",
+    "bot_name", "branch_name_template", "branch_prefix",
+    "classify_inline_comments", "claude_args", "claude_code_oauth_token",
+    "display_report", "exclude_comments_by_actor", "github_token",
+    "include_comments_by_actor", "include_fix_links", "label_trigger",
+    "path_to_bun_executable", "path_to_claude_code_executable",
+    "plugin_marketplaces", "plugins", "prompt", "settings", "show_full_output",
+    "ssh_signing_key", "track_progress", "trigger_phrase", "use_bedrock",
+    "use_commit_signing", "use_foundry", "use_sticky_comment", "use_vertex",
+}
+
+# Outputs it declares. Notably there is no `result`: workflows that wrote
+# `${{ steps.<id>.outputs.result }}` were emitting an empty string, which is why
+# run reports go through .github/actions/agent-run-summary instead.
+CLAUDE_ACTION_V1_OUTPUTS = {
+    "branch_name", "execution_file", "github_token", "session_id",
+    "structured_output",
+}
+
+
+def _claude_action_steps():
+    """Yield (workflow stem, step mapping) for every claude-code-action step."""
+    for path in WORKFLOW_DIR.glob("*.y*ml"):
+        doc = yaml.safe_load(path.read_text())
+        for job in (doc.get("jobs") or {}).values():
+            for step in (job or {}).get("steps") or []:
+                uses = (step or {}).get("uses") or ""
+                if uses.startswith("anthropics/claude-code-action@"):
+                    yield path.stem, step
+
+
+def test_no_workflow_passes_an_undeclared_input_to_claude_code_action():
+    offenders = []
+    for stem, step in _claude_action_steps():
+        for key in (step.get("with") or {}):
+            if key not in CLAUDE_ACTION_V1_INPUTS:
+                offenders.append(f"{stem}: with.{key}")
+    assert not offenders, (
+        "input(s) not declared by the pinned claude-code-action; GitHub only "
+        "warns, so these are silently dropped:\n" + "\n".join(offenders)
+    )
+
+
+def test_no_workflow_reads_an_undeclared_claude_code_action_output():
+    """`steps.<id>.outputs.result` does not exist; it renders as empty."""
+    offenders = []
+    for path in WORKFLOW_DIR.glob("*.y*ml"):
+        doc = yaml.safe_load(path.read_text())
+        ids = {
+            step.get("id")
+            for job in (doc.get("jobs") or {}).values()
+            for step in ((job or {}).get("steps") or [])
+            if (step or {}).get("uses", "").startswith("anthropics/claude-code-action@")
+        }
+        text = path.read_text()
+        for step_id in filter(None, ids):
+            for ref in re.findall(
+                rf"steps\.{re.escape(step_id)}\.outputs\.([A-Za-z_][A-Za-z0-9_]*)", text
+            ):
+                if ref not in CLAUDE_ACTION_V1_OUTPUTS:
+                    offenders.append(f"{path.stem}: steps.{step_id}.outputs.{ref}")
+    assert not offenders, (
+        "claude-code-action output(s) that do not exist (these expand to an "
+        "empty string):\n" + "\n".join(offenders)
+    )
+
+
+def test_every_claude_code_action_workflow_is_in_the_agent_config():
+    """The reverse of test_managed_workflows_use_the_resolver_action.
+
+    An empty pin-allowlist does not by itself mean every agent is centrally
+    modelled: a workflow that pins no model AND is absent from the config is
+    invisible to both other tests.
+    """
+    config = yaml.safe_load(CONFIG_PATH.read_text())
+    managed = set(config["workflows"])
+    using = {stem for stem, _ in _claude_action_steps()}
+    assert not (using - managed), (
+        "workflow(s) run claude-code-action but are not in agent-config.yaml, so "
+        f"their model is not centrally configured: {sorted(using - managed)}"
+    )

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -228,7 +228,7 @@ CLAUDE_ACTION_V1_OUTPUTS = {
 def _action_definition_files():
     """Every file that can invoke an action: workflows and composite actions."""
     return sorted(WORKFLOW_DIR.glob("*.y*ml")) + sorted(
-        (REPO_ROOT / ".github" / "actions").glob("*/action.yml")
+        (REPO_ROOT / ".github" / "actions").rglob("action.y*ml")
     )
 
 
@@ -294,7 +294,11 @@ def test_every_claude_code_action_workflow_is_in_the_agent_config():
     """
     config = yaml.safe_load(CONFIG_PATH.read_text())
     managed = set(config["workflows"])
-    using = {stem for stem, _ in _claude_action_steps()}
+    # Only workflows: agent-config keys are workflow stems, and
+    # test_every_config_workflow_file_exists requires a matching workflow file,
+    # so a composite action must not be demanded as a config key.
+    workflow_stems = {p.stem for p in WORKFLOW_DIR.glob("*.y*ml")}
+    using = {stem for stem, _ in _claude_action_steps()} & workflow_stems
     assert not (using - managed), (
         "workflow(s) run claude-code-action but are not in agent-config.yaml, so "
         f"their model is not centrally configured: {sorted(using - managed)}"
@@ -329,3 +333,30 @@ def test_claude_code_action_is_always_sha_pinned():
             if not re.fullmatch(r"[0-9a-f]{40}", ref):
                 floating.append(f"{path.stem}: @{ref}")
     assert not floating, "claude-code-action must be SHA-pinned:\n" + "\n".join(floating)
+
+
+def test_every_checkout_is_non_persisting():
+    """No `actions/checkout` anywhere under .github/ may leave a token on disk.
+
+    `actions/checkout` writes an HTTP Basic `extraheader` into `.git/config`
+    unless told not to, which is the exact path by which the PAT was read out of
+    a runner and disclosed. A per-FILE grep is not enough — it passes a file
+    with two checkouts where only one is flagged, and it misses composite
+    actions entirely, which is how a second token-persisting checkout survived
+    inside claude-issue-{summarize,triage}-action.
+    """
+    offenders = []
+    for path in _action_definition_files():
+        doc = yaml.safe_load(path.read_text()) or {}
+        for i, step in enumerate(_steps(doc)):
+            uses = (step or {}).get("uses") or ""
+            if not uses.startswith("actions/checkout@"):
+                continue
+            with_ = (step or {}).get("with") or {}
+            if with_.get("persist-credentials") not in (False, "false"):
+                name = (step or {}).get("name") or f"step {i}"
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {name}")
+    assert not offenders, (
+        "checkout(s) that persist credentials into .git/config:\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
Last of the auth migration. Stacked on #2255 → #2253 → #2249 → #2247 → #2246.

## The three remaining `PAT_FOR_PR` workflows

`weekly-compliance`, `warm-reference-cache` and `generate-pages` move to the ai4c-agent App token, with `persist-credentials: false` and `gh auth setup-git`.

**`weekly-compliance` had the false-green shape** that cost dismech ~11 days: **no `github_token` at all**, so its `gh pr create` would fail silently while the job reported success and produced no PRs. It now gets a real token *and* output capture, so a silent failure is visible. Its model also comes from `agent-config.yaml` — which **empties `UNMIGRATED_MODEL_PINS`**: every agentic workflow now resolves its model centrally.

## `claude.yml` was the last write-capable agent on a persisted default token

It has `Bash(*)` and `contents: write`, and its checkout wrote the token into `.git/config` — precisely the incident shape (a Bash-enabled agent that can `cat .git/config`). Now on the App token with a non-persisting checkout.

## The rest

No agent attached, so not the incident vector, but no reason to leave a token on disk either:

- `claude-issue-summarize`, `claude-issue-triage`, `pypi-publish` never push → just stop persisting.
- `deploy-docs` **does** push (`mkdocs gh-deploy` shells out to `git push`), so it gets the agent treatment: `gh auth setup-git` serving `GH_TOKEN` at push time instead of a token in `.git/config`.

## Verification (the guide's final checklist, run locally)

```
$ grep -rn "secrets.PAT_FOR_PR" .github/
(empty)

$ grep -rL "persist-credentials: false" $(grep -rl "actions/checkout" .github/workflows/)
(empty)

$ grep -rnE "\-\-model .*claude-(opus|sonnet|haiku)-" .github/workflows/
(empty)

$ uv run pytest tests/test_agent_config.py -q   # 10 passed
$ just test-js                                   # 14 pass
$ python3 -c "import yaml, glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.y*ml')]"
```

**The `PAT_FOR_PR` secret can be deleted once this stack is merged** — that's the last step, and I'll flag it separately rather than doing it silently.