### PR TITLE
ci: manage agent cron cadence from one config

### DIFF
--- a/.github/cron-profiles.yaml
+++ b/.github/cron-profiles.yaml
@@ -1,0 +1,129 @@
+# Central cadence configuration for the scheduled agentic GitHub Actions.
+#
+# Instead of hand-editing the `cron:` lines in each workflow, pick a named
+# profile here and apply it with:
+#
+#     just cron-profile <name>          # rewrite workflows + commit
+#     just cron-profiles                # list profiles / show active
+#     just cron-profile-preview <name>  # diff only, no writes
+#
+# The applier (scripts/apply_cron_profile.py) rewrites ONLY the `on.schedule`
+# block in each managed workflow — everything else (inputs, jobs, comments
+# outside the schedule block) is left untouched. An empty workflow list removes
+# that workflow's schedule block while keeping manual `workflow_dispatch`.
+#
+# Conventions:
+#   * Each profile MUST define every managed workflow (the applier enforces this
+#     so a profile can't be half-configured).
+#   * Workflow keys are the file stem under .github/workflows/ (".yml" or
+#     ".yaml" is resolved automatically).
+#   * `comment:` is optional and rendered as a trailing inline comment.
+#
+# `medium` is the baseline and mirrors the cadence these workflows have been
+# running at, so applying it is behaviour-preserving (cosmetic normalisation
+# only). `slow` and `fast` dial the two high-frequency agents (pr-shepherd and
+# curation-scanner) down and up; the weekly scanners are deliberately
+# tier-invariant, because they are not the cost driver and their cadence is
+# tied to how fast their upstream sources actually move.
+#
+# `off` is the kill switch: every managed workflow gets an empty schedule list,
+# which makes the applier remove its `on.schedule` block. Manual
+# `workflow_dispatch` still works, so an agent can be triggered by hand while
+# the profile is `off`. We intentionally do NOT use impossible dates such as
+# Feb 30: GitHub can ignore invalid cron updates and leave the previous valid
+# schedule registered.
+#
+# Note: .github/workflows/main.yaml also has a weekly `schedule:` (the full
+# re-validation safety net). It is ordinary CI, not an agent, so it is not
+# managed here and `off` will not disable it.
+
+active: "medium"
+
+profiles:
+
+  slow:
+    description: Conservative cadence — minimise API/compute spend.
+    workflows:
+      pr-shepherd:
+        - cron: "37 */4 * * *"
+          comment: "every 4h"
+      curation-scanner:
+        - cron: "0 */12 * * *"
+          comment: "every 12h"
+      go-annotation-scanner:
+        - cron: "0 10 * * 6"
+          comment: "weekly, Saturday 10:00 UTC"
+      arba-issue-monitor:
+        - cron: "0 6 * * 6"
+          comment: "weekly, Saturday 06:00 UTC"
+      litscan-module-member:
+        - cron: "0 12 * * 6"
+          comment: "weekly, Saturday 12:00 UTC"
+      warm-reference-cache:
+        - cron: "0 4 * * 1"
+          comment: "Mondays 04:00 UTC, ahead of the weekly validate-all"
+      weekly-compliance:
+        - cron: "0 8 * * 5"
+          comment: "Fridays 08:00 UTC"
+
+  medium:
+    description: Baseline — the cadence these workflows already run at.
+    workflows:
+      pr-shepherd:
+        - cron: "37 1/1 * * *"
+          comment: "hourly, offset from the other agents"
+      curation-scanner:
+        - cron: "0 */8 * * *"
+          comment: "every 8h"
+      go-annotation-scanner:
+        - cron: "0 10 * * 6"
+          comment: "weekly, Saturday 10:00 UTC"
+      arba-issue-monitor:
+        - cron: "0 6 * * 6"
+          comment: "weekly, Saturday 06:00 UTC"
+      litscan-module-member:
+        - cron: "0 12 * * 6"
+          comment: "weekly, Saturday 12:00 UTC"
+      warm-reference-cache:
+        - cron: "0 4 * * 1"
+          comment: "Mondays 04:00 UTC, ahead of the weekly validate-all"
+      weekly-compliance:
+        - cron: "0 8 * * 5"
+          comment: "Fridays 08:00 UTC"
+
+  fast:
+    description: Push the two high-frequency agents to their hourly ceiling.
+    workflows:
+      pr-shepherd:
+        - cron: "37 1/1 * * *"
+          comment: "hourly, offset from the other agents"
+      curation-scanner:
+        - cron: "0 */2 * * *"
+          comment: "every 2h"
+      go-annotation-scanner:
+        - cron: "0 10 * * 6"
+          comment: "weekly, Saturday 10:00 UTC"
+      arba-issue-monitor:
+        - cron: "0 6 * * 6"
+          comment: "weekly, Saturday 06:00 UTC"
+      litscan-module-member:
+        - cron: "0 12 * * 6"
+          comment: "weekly, Saturday 12:00 UTC"
+      warm-reference-cache:
+        - cron: "0 4 * * 1"
+          comment: "Mondays 04:00 UTC, ahead of the weekly validate-all"
+      weekly-compliance:
+        - cron: "0 8 * * 5"
+          comment: "Fridays 08:00 UTC"
+
+  # Quoted: YAML 1.1 parses a bare `off` as the boolean false.
+  "off":
+    description: Kill switch — no schedules at all; workflow_dispatch still works.
+    workflows:
+      pr-shepherd: []
+      curation-scanner: []
+      go-annotation-scanner: []
+      arba-issue-monitor: []
+      litscan-module-member: []
+      warm-reference-cache: []
+      weekly-compliance: []

--- a/.github/workflows/arba-issue-monitor.yml
+++ b/.github/workflows/arba-issue-monitor.yml
@@ -2,8 +2,7 @@ name: ARBA Issue Monitor
 
 on:
   schedule:
-    # Run daily at 6 AM UTC (changed to 1/week for now)
-    - cron: '0 6 * * 6'
+    - cron: "0 6 * * 6"  # weekly, Saturday 06:00 UTC
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/curation-scanner.yml
+++ b/.github/workflows/curation-scanner.yml
@@ -2,7 +2,7 @@ name: Curation Scanner
 
 on:
   schedule:
-    - cron: "0 */8 * * *"
+    - cron: "0 */8 * * *"  # every 8h
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/go-annotation-scanner.yml
+++ b/.github/workflows/go-annotation-scanner.yml
@@ -2,8 +2,7 @@ name: GO Annotation Issue Scanner
 
 on:
   schedule:
-    # Run daily at 10 AM UTC (temporarily reduced)
-    - cron: '0 10 * * 6'
+    - cron: "0 10 * * 6"  # weekly, Saturday 10:00 UTC
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/litscan-module-member.yml
+++ b/.github/workflows/litscan-module-member.yml
@@ -2,8 +2,7 @@ name: LitScan Module-Member Scan
 
 on:
   schedule:
-    # Weekly Saturday scan. Dedup-by-PMID makes a wide re-scan window safe.
-    - cron: "0 12 * * 6"
+    - cron: "0 12 * * 6"  # weekly, Saturday 12:00 UTC
   workflow_dispatch:
     inputs:
       days:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,6 +63,8 @@ jobs:
               - '.github/actions/**'
               - '.github/scripts/**'
               - '.github/agent-config.yaml'
+              - '.github/cron-profiles.yaml'
+              - 'scripts/apply_cron_profile.py'
               - 'tests/js/**'
             genes:
               - 'genes/**/*-ai-review.yaml'
@@ -160,5 +162,6 @@ jobs:
       - name: Check agentic automation
         if: steps.changes.outputs.agents == 'true'
         run: |
-          uv run pytest tests/test_agent_config.py tests/test_agent_run_summary.py -q
+          uv run pytest tests/test_agent_config.py tests/test_agent_run_summary.py \
+            tests/test_apply_cron_profile.py -q
           just test-js

--- a/.github/workflows/pr-shepherd.yml
+++ b/.github/workflows/pr-shepherd.yml
@@ -2,8 +2,7 @@ name: PR Shepherd
 
 on:
   schedule:
-    # Run every N hours, offset from other workflows.
-    - cron: "37 1/1 * * *"
+    - cron: "37 1/1 * * *"  # hourly, offset from the other agents
   workflow_dispatch:
     inputs:
       max_prs:

--- a/.github/workflows/warm-reference-cache.yaml
+++ b/.github/workflows/warm-reference-cache.yaml
@@ -8,7 +8,7 @@ name: Warm reference cache
 
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: '0 4 * * 1'   # Mondays 04:00 UTC, ahead of the weekly validate-all
+    - cron: "0 4 * * 1"  # Mondays 04:00 UTC, ahead of the weekly validate-all
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/weekly-compliance.yaml
+++ b/.github/workflows/weekly-compliance.yaml
@@ -3,8 +3,7 @@ name: Weekly Compliance
 
 on:
   schedule:
-    # Runs every Friday at 8:00 AM UTC
-    - cron: '0 8 * * 5'
+    - cron: "0 8 * * 5"  # Fridays 08:00 UTC
   workflow_dispatch:
     inputs:
       num_files:

--- a/project.justfile
+++ b/project.justfile
@@ -2312,3 +2312,20 @@ gogpt-compare-all:
         done
     done
     echo "Total: compared $total genes"
+
+# ============== Scheduled-workflow cron profiles ==============
+
+# List the available cron cadence profiles and show the active one.
+cron-profiles:
+    uv run python scripts/apply_cron_profile.py --list
+
+# Show what a profile would change without writing anything.
+# Example: just cron-profile-preview fast
+cron-profile-preview name:
+    uv run python scripts/apply_cron_profile.py {{name}} --dry-run
+
+# Apply a cron cadence profile to the scheduled agent workflows and commit.
+# `just cron-profile off` is the kill switch: it removes every managed
+# `on.schedule` block, leaving workflow_dispatch intact.
+cron-profile name:
+    uv run python scripts/apply_cron_profile.py {{name}}

--- a/scripts/apply_cron_profile.py
+++ b/scripts/apply_cron_profile.py
@@ -37,7 +37,11 @@ DEFAULT_CONFIG = REPO_ROOT / ".github" / "cron-profiles.yaml"
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 
 SCHEDULE_RE = re.compile(r"^(?P<indent>\s*)schedule:\s*$")
-ON_RE = re.compile(r"^(?P<indent>\s*)on:\s*$")
+# `on:` may carry a trailing comment — several workflows here use
+# `on:  # yamllint disable-line rule:truthy` — and YAML also permits the
+# quoted forms "on": / 'on':. Requiring the line to END at the colon made the
+# insert path unreachable for those files, so `off` was a one-way switch.
+ON_RE = re.compile(r"^(?P<indent>\s*)[\"']?on[\"']?:\s*(?:#.*)?$")
 CRON_LINE_RE = re.compile(r"^\s*-\s*cron:\s*")
 COMMENT_LINE_RE = re.compile(r"^\s*#")
 
@@ -263,32 +267,40 @@ def main(argv: list[str] | None = None) -> int:
 
     workflows = config["profiles"][args.profile]["workflows"]
 
-    changed: list[Path] = []
+    # Compute every rewrite BEFORE writing anything. A workflow that cannot be
+    # rewritten must not leave the others half-applied with a stale `active:`.
+    pending: list[tuple[Path, str, str]] = []
     try:
         for stem, entries in workflows.items():
             path = resolve_workflow_file(stem)
             original = path.read_text()
             updated = rewrite_schedule(original, entries, wf_name=stem)
             if updated != original:
-                changed.append(path)
-                if args.dry_run:
-                    diff = difflib.unified_diff(
-                        original.splitlines(keepends=True),
-                        updated.splitlines(keepends=True),
-                        fromfile=f"a/{path.relative_to(REPO_ROOT)}",
-                        tofile=f"b/{path.relative_to(REPO_ROOT)}",
-                    )
-                    sys.stdout.writelines(diff)
-                else:
-                    path.write_text(updated)
+                pending.append((path, original, updated))
 
         config_text = args.config.read_text()
         new_config_text = set_active(config_text, args.profile)
-        config_changed = new_config_text != config_text
-        if config_changed and not args.dry_run:
-            args.config.write_text(new_config_text)
     except ConfigError as exc:
         parser.error(str(exc))
+
+    changed: list[Path] = [path for path, _, _ in pending]
+    config_changed = new_config_text != config_text
+
+    if args.dry_run:
+        for path, original, updated in pending:
+            sys.stdout.writelines(
+                difflib.unified_diff(
+                    original.splitlines(keepends=True),
+                    updated.splitlines(keepends=True),
+                    fromfile=f"a/{path.relative_to(REPO_ROOT)}",
+                    tofile=f"b/{path.relative_to(REPO_ROOT)}",
+                )
+            )
+    else:
+        for path, _, updated in pending:
+            path.write_text(updated)
+        if config_changed:
+            args.config.write_text(new_config_text)
 
     if args.dry_run:
         print(

--- a/scripts/apply_cron_profile.py
+++ b/scripts/apply_cron_profile.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Apply a named cron *profile* to the scheduled GitHub Actions workflows.
+
+Cron schedules in GitHub Actions are hard-coded inline in each workflow YAML
+with no native parameterisation. This script makes them switchable from a single
+source of truth (`.github/cron-profiles.yaml`): pick a profile, and every managed
+workflow's ``on.schedule`` cron block is rewritten to match.
+
+Only the ``schedule:`` block under ``on:`` is touched: profiles with cron entries
+replace or add that block, while profiles with an empty entry list remove it.
+Everything else (``workflow_dispatch`` inputs, ``jobs``, comments outside the
+schedule block) is left byte-for-byte intact. We deliberately do *not* round-trip
+the whole workflow through a YAML parser — GitHub's ``on:`` key is parsed as the
+YAML 1.1 boolean ``True``, which corrupts naive re-dumps — so the rewrite is a
+surgical, line-based edit.
+
+Usage:
+    python scripts/apply_cron_profile.py <profile>            # rewrite + commit
+    python scripts/apply_cron_profile.py <profile> --no-commit
+    python scripts/apply_cron_profile.py <profile> --dry-run  # show diff only
+    python scripts/apply_cron_profile.py --list               # profiles / active
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = REPO_ROOT / ".github" / "cron-profiles.yaml"
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+SCHEDULE_RE = re.compile(r"^(?P<indent>\s*)schedule:\s*$")
+ON_RE = re.compile(r"^(?P<indent>\s*)on:\s*$")
+CRON_LINE_RE = re.compile(r"^\s*-\s*cron:\s*")
+COMMENT_LINE_RE = re.compile(r"^\s*#")
+
+
+class ConfigError(RuntimeError):
+    """Raised when the profile config is malformed."""
+
+
+# --------------------------------------------------------------------------- #
+# Config loading / validation
+# --------------------------------------------------------------------------- #
+def load_config(path: Path) -> dict:
+    if not path.exists():
+        raise ConfigError(f"config not found: {path}")
+    data = yaml.safe_load(path.read_text()) or {}
+    profiles = data.get("profiles")
+    if not isinstance(profiles, dict) or not profiles:
+        raise ConfigError("config must define a non-empty `profiles:` mapping")
+
+    # Every profile must cover the same set of workflows so a profile can't be
+    # silently half-configured.
+    workflow_sets = {}
+    for name, profile in profiles.items():
+        wfs = (profile or {}).get("workflows")
+        if not isinstance(wfs, dict) or not wfs:
+            raise ConfigError(f"profile '{name}' has no `workflows:` mapping")
+        workflow_sets[name] = set(wfs)
+    reference_name, reference = next(iter(workflow_sets.items()))
+    for name, wfs in workflow_sets.items():
+        if wfs != reference:
+            missing = reference - wfs
+            extra = wfs - reference
+            detail = []
+            if missing:
+                detail.append(f"missing {sorted(missing)}")
+            if extra:
+                detail.append(f"unexpected {sorted(extra)}")
+            raise ConfigError(
+                f"profile '{name}' workflow set differs from '{reference_name}': "
+                + "; ".join(detail)
+            )
+
+    # Validate cron expressions up front.
+    for name, profile in profiles.items():
+        for wf, entries in profile["workflows"].items():
+            if not isinstance(entries, list):
+                raise ConfigError(f"{name}/{wf}: expected a list of cron entries")
+            for entry in entries:
+                expr = (entry or {}).get("cron")
+                if not isinstance(expr, str) or len(expr.split()) != 5:
+                    raise ConfigError(
+                        f"{name}/{wf}: invalid cron expression {expr!r} "
+                        "(must be 5 space-separated fields)"
+                    )
+    return data
+
+
+def resolve_workflow_file(stem: str) -> Path:
+    candidates = [WORKFLOW_DIR / f"{stem}.yml", WORKFLOW_DIR / f"{stem}.yaml"]
+    found = [c for c in candidates if c.exists()]
+    if not found:
+        raise ConfigError(f"no workflow file for '{stem}' (tried .yml/.yaml)")
+    if len(found) > 1:
+        raise ConfigError(
+            f"ambiguous workflow stem '{stem}': {[f.name for f in found]}"
+        )
+    return found[0]
+
+
+# --------------------------------------------------------------------------- #
+# Workflow rewriting
+# --------------------------------------------------------------------------- #
+def render_cron_lines(entries: list[dict], indent: str) -> list[str]:
+    lines = []
+    for entry in entries:
+        line = f'{indent}- cron: "{entry["cron"]}"'
+        comment = entry.get("comment")
+        if comment:
+            line += f"  # {comment}"
+        lines.append(line + "\n")
+    return lines
+
+
+def render_schedule_block(entries: list[dict], indent: str) -> list[str]:
+    """Render a complete ``schedule:`` block at *indent*."""
+    return [f"{indent}schedule:\n"] + render_cron_lines(entries, indent + "  ")
+
+
+def find_schedule_region(
+    lines: list[str], *, wf_name: str
+) -> tuple[int, int, int, str] | None:
+    """Return ``(schedule_idx, entries_start, entries_end, cron_indent)`` if present."""
+    sched_idx = next((i for i, ln in enumerate(lines) if SCHEDULE_RE.match(ln)), None)
+    if sched_idx is None:
+        return None
+
+    # The managed region runs from the line after `schedule:` while lines are
+    # either cron entries or comments; it stops at the first other line (a blank
+    # line or the next key such as `workflow_dispatch:`).
+    start = sched_idx + 1
+    end = start
+    saw_cron = False
+    while end < len(lines):
+        if CRON_LINE_RE.match(lines[end]):
+            saw_cron = True
+            end += 1
+        elif COMMENT_LINE_RE.match(lines[end]):
+            end += 1
+        else:
+            break
+    if not saw_cron:
+        raise ConfigError(
+            f"{wf_name}: `schedule:` block has no `- cron:` entries to replace"
+        )
+
+    # Preserve the existing cron-line indentation.
+    indent = "    "
+    for ln in lines[start:end]:
+        if CRON_LINE_RE.match(ln):
+            indent = ln[: len(ln) - len(ln.lstrip())]
+            break
+    return sched_idx, start, end, indent
+
+
+def rewrite_schedule(text: str, entries: list[dict], *, wf_name: str) -> str:
+    """Add, replace, or remove the first ``on.schedule`` block of *text*."""
+    lines = text.splitlines(keepends=True)
+    region = find_schedule_region(lines, wf_name=wf_name)
+
+    if not entries:
+        if region is None:
+            return text
+        sched_idx, _start, end, _indent = region
+        new_text = "".join(lines[:sched_idx] + lines[end:])
+    elif region is None:
+        on_idx = next((i for i, ln in enumerate(lines) if ON_RE.match(ln)), None)
+        if on_idx is None:
+            raise ConfigError(f"{wf_name}: no `on:` block found")
+
+        on_indent = ON_RE.match(lines[on_idx]).group("indent")  # type: ignore[union-attr]
+        sched_indent = on_indent + "  "
+        new_text = "".join(
+            lines[: on_idx + 1]
+            + render_schedule_block(entries, sched_indent)
+            + lines[on_idx + 1 :]
+        )
+    else:
+        _sched_idx, start, end, indent = region
+        new_text = "".join(
+            lines[:start] + render_cron_lines(entries, indent) + lines[end:]
+        )
+
+    # Sanity: the rewritten file must still parse as YAML. This is intentionally
+    # parse-only; we do not dump it back to YAML because YAML 1.1 treats `on` as
+    # a boolean key.
+    try:
+        yaml.safe_load(new_text)
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive
+        raise ConfigError(f"{wf_name}: rewrite produced invalid YAML: {exc}") from exc
+    return new_text
+
+
+def set_active(config_text: str, profile: str) -> str:
+    # Quote the value so profile names that YAML 1.1 would coerce to a boolean
+    # (e.g. `off`, `on`, `no`, `yes`) round-trip back as the string profile name.
+    new_text, n = re.subn(
+        r"^active:.*$", f'active: "{profile}"', config_text, count=1, flags=re.MULTILINE
+    )
+    if n == 0:
+        raise ConfigError("config has no top-level `active:` line to update")
+    return new_text
+
+
+# --------------------------------------------------------------------------- #
+# Git
+# --------------------------------------------------------------------------- #
+def git_commit(paths: list[Path], profile: str) -> None:
+    rel = [str(p.relative_to(REPO_ROOT)) for p in paths]
+    subprocess.run(["git", "-C", str(REPO_ROOT), "add", *rel], check=True)
+    msg = f"Apply '{profile}' cron profile to scheduled workflows"
+    subprocess.run(["git", "-C", str(REPO_ROOT), "commit", "-m", msg], check=True)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def cmd_list(config: dict) -> int:
+    active = config.get("active")
+    print(f"active profile: {active}\n")
+    for name, profile in config["profiles"].items():
+        marker = "*" if name == active else " "
+        desc = (profile or {}).get("description", "")
+        print(f" {marker} {name:<14} {desc}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profile", nargs="?", help="profile name to apply")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--list", action="store_true", help="list profiles and exit")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="show diffs, write nothing"
+    )
+    parser.add_argument(
+        "--no-commit", action="store_true", help="write files but do not commit"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_config(args.config)
+    except ConfigError as exc:
+        parser.error(str(exc))
+
+    if args.list or not args.profile:
+        return cmd_list(config)
+
+    if args.profile not in config["profiles"]:
+        parser.error(
+            f"unknown profile '{args.profile}'. Available: "
+            + ", ".join(config["profiles"])
+        )
+
+    workflows = config["profiles"][args.profile]["workflows"]
+
+    changed: list[Path] = []
+    try:
+        for stem, entries in workflows.items():
+            path = resolve_workflow_file(stem)
+            original = path.read_text()
+            updated = rewrite_schedule(original, entries, wf_name=stem)
+            if updated != original:
+                changed.append(path)
+                if args.dry_run:
+                    diff = difflib.unified_diff(
+                        original.splitlines(keepends=True),
+                        updated.splitlines(keepends=True),
+                        fromfile=f"a/{path.relative_to(REPO_ROOT)}",
+                        tofile=f"b/{path.relative_to(REPO_ROOT)}",
+                    )
+                    sys.stdout.writelines(diff)
+                else:
+                    path.write_text(updated)
+
+        config_text = args.config.read_text()
+        new_config_text = set_active(config_text, args.profile)
+        config_changed = new_config_text != config_text
+        if config_changed and not args.dry_run:
+            args.config.write_text(new_config_text)
+    except ConfigError as exc:
+        parser.error(str(exc))
+
+    if args.dry_run:
+        print(
+            f"\n[dry-run] profile '{args.profile}': "
+            f"{len(changed)} workflow file(s) would change."
+        )
+        return 0
+
+    if not changed and not config_changed:
+        print(f"Profile '{args.profile}' already applied — nothing to do.")
+        return 0
+
+    commit_paths = changed + ([args.config] if config_changed else [])
+    print(f"Applied profile '{args.profile}':")
+    for p in changed:
+        print(f"  rewrote {p.relative_to(REPO_ROOT)}")
+    if config_changed:
+        print(f"  set active: {args.profile} in {args.config.relative_to(REPO_ROOT)}")
+
+    if args.no_commit:
+        print(
+            "\n--no-commit: changes written to the working tree (unstaged) for your review."
+        )
+        return 0
+
+    git_commit(commit_paths, args.profile)
+    print("\nCommitted. Push with: git push -u origin <branch>")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_apply_cron_profile.py
+++ b/tests/test_apply_cron_profile.py
@@ -8,6 +8,7 @@ tests pin the three cases that matters: replace, remove, and re-insert.
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from scripts.apply_cron_profile import (
@@ -144,3 +145,69 @@ def test_main_ci_workflow_is_not_managed():
     for profile in config["profiles"].values():
         assert "main" not in profile["workflows"]
     assert "cron:" in (Path(".github/workflows/main.yaml")).read_text()
+
+
+def test_off_then_back_round_trips_every_managed_workflow():
+    """`off` must be reversible for every managed workflow, byte for byte.
+
+    The kill switch removes the `on.schedule` block; restoring a profile has to
+    take the *insert* path, which is only reachable if `on:` is recognised. It
+    was not for workflows written as `on:  # yamllint disable-line rule:truthy`
+    (warm-reference-cache, main, deploy-docs), so `off` was one-way for those —
+    and because writes happened inside the apply loop, a failure part-way left
+    the other workflows rewritten with a stale `active:`. The synthetic bare
+    `on:` in the insert test above cannot catch this; the committed files can.
+    """
+    config = load_config(DEFAULT_CONFIG)
+    active = str(config["active"])
+    for stem, entries in config["profiles"][active]["workflows"].items():
+        path = resolve_workflow_file(stem)
+        original = path.read_text()
+        disabled = rewrite_schedule(original, [], wf_name=stem)
+        assert "cron:" not in disabled, f"{path.name} still scheduled after off"
+        restored = rewrite_schedule(disabled, entries, wf_name=stem)
+        assert restored == original, (
+            f"{path.name} does not survive off -> {active}; the kill switch is "
+            f"one-way for it"
+        )
+
+
+def test_on_key_is_recognised_with_a_trailing_comment():
+    """The yamllint-pragma form is what broke the insert path."""
+    original = """name: Demo
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+"""
+    updated = rewrite_schedule(
+        original, [{"cron": "0 4 * * 1", "comment": "weekly"}], wf_name="demo"
+    )
+    assert '    - cron: "0 4 * * 1"  # weekly' in updated
+    assert "# yamllint disable-line rule:truthy" in updated
+
+
+def test_apply_is_atomic_when_one_workflow_cannot_be_rewritten(tmp_path, monkeypatch):
+    """A failure part-way must not leave other workflows rewritten."""
+    import scripts.apply_cron_profile as mod
+
+    config = load_config(DEFAULT_CONFIG)
+    active = str(config["active"])
+    stems = list(config["profiles"][active]["workflows"])
+    before = {s: resolve_workflow_file(s).read_text() for s in stems}
+
+    real = mod.rewrite_schedule
+
+    def explode(text, entries, *, wf_name):
+        if wf_name == stems[-1]:
+            raise mod.ConfigError("simulated failure")
+        # force a change so the earlier files would be written if not atomic
+        return real(text, [], wf_name=wf_name)
+
+    monkeypatch.setattr(mod, "rewrite_schedule", explode)
+    with pytest.raises(SystemExit):
+        mod.main([active])
+
+    for stem in stems:
+        assert resolve_workflow_file(stem).read_text() == before[stem], (
+            f"{stem} was modified despite a failure on {stems[-1]}"
+        )

--- a/tests/test_apply_cron_profile.py
+++ b/tests/test_apply_cron_profile.py
@@ -1,0 +1,146 @@
+"""Tests for the cron-cadence profile applier.
+
+The applier does a surgical, line-based rewrite of each managed workflow's
+``on.schedule`` block rather than round-tripping the YAML — GitHub's ``on:`` key
+parses as the YAML 1.1 boolean ``True``, which a naive re-dump corrupts. These
+tests pin the three cases that matters: replace, remove, and re-insert.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from scripts.apply_cron_profile import (
+    DEFAULT_CONFIG,
+    load_config,
+    resolve_workflow_file,
+    rewrite_schedule,
+)
+
+
+def test_rewrite_schedule_replaces_existing_schedule_entries():
+    original = """name: Demo
+
+on:
+  schedule:
+    - cron: "0 0 30 2 *"  # old
+  workflow_dispatch:
+    inputs:
+      note:
+        type: string
+"""
+
+    updated = rewrite_schedule(
+        original,
+        [
+            {"cron": "0 */4 * * 1-5", "comment": "weekday"},
+            {"cron": "0 */8 * * 0,6", "comment": "weekend"},
+        ],
+        wf_name="demo",
+    )
+
+    assert '    - cron: "0 */4 * * 1-5"  # weekday' in updated
+    assert '    - cron: "0 */8 * * 0,6"  # weekend' in updated
+    assert "workflow_dispatch:" in updated
+    assert "0 0 30 2 *" not in updated
+
+
+def test_rewrite_schedule_removes_schedule_block_for_empty_entries():
+    original = """name: Demo
+
+on:
+  schedule:
+    - cron: "37 * * * *"  # hourly
+  workflow_dispatch:
+    inputs:
+      note:
+        type: string
+"""
+
+    updated = rewrite_schedule(original, [], wf_name="demo")
+
+    assert "schedule:" not in updated
+    assert "cron:" not in updated
+    assert "workflow_dispatch:" in updated
+    assert "inputs:" in updated
+
+
+def test_rewrite_schedule_inserts_schedule_block_when_reenabling():
+    original = """name: Demo
+
+on:
+  workflow_dispatch:
+    inputs:
+      note:
+        type: string
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+"""
+
+    updated = rewrite_schedule(
+        original,
+        [{"cron": "37 * * * *", "comment": "hourly"}],
+        wf_name="demo",
+    )
+
+    assert (
+        """on:
+  schedule:
+    - cron: "37 * * * *"  # hourly
+  workflow_dispatch:
+"""
+        in updated
+    )
+    assert "jobs:" in updated
+
+
+def test_repo_config_is_valid_and_every_managed_workflow_exists():
+    """The committed profile config must load and name only real workflows."""
+    config = load_config(DEFAULT_CONFIG)
+    for profile in config["profiles"].values():
+        for stem in profile["workflows"]:
+            assert resolve_workflow_file(stem).exists()
+
+
+def test_active_profile_matches_the_committed_workflow_schedules():
+    """Applying the active profile must be a no-op.
+
+    If someone hand-edits a `cron:` line instead of going through a profile, the
+    committed workflows drift from the config and the next `just cron-profile`
+    silently reverts them. Catch that here instead.
+    """
+    config = load_config(DEFAULT_CONFIG)
+    active = str(config["active"])
+    for stem, entries in config["profiles"][active]["workflows"].items():
+        path = resolve_workflow_file(stem)
+        original = path.read_text()
+        assert rewrite_schedule(original, entries, wf_name=stem) == original, (
+            f"{path.name} has drifted from the '{active}' cron profile; "
+            f"run `just cron-profile {active}`"
+        )
+
+
+def test_off_profile_removes_every_schedule():
+    config = load_config(DEFAULT_CONFIG)
+    for stem, entries in config["profiles"]["off"]["workflows"].items():
+        assert entries == []
+        updated = rewrite_schedule(
+            resolve_workflow_file(stem).read_text(), entries, wf_name=stem
+        )
+        assert "cron:" not in updated
+        # ... and the workflow must still be valid YAML with a dispatch trigger.
+        parsed = yaml.safe_load(updated)
+        # `on:` parses as the YAML 1.1 boolean True.
+        triggers = parsed[True]
+        assert "workflow_dispatch" in triggers
+
+
+def test_main_ci_workflow_is_not_managed():
+    """main.yaml's weekly re-validation is CI, not an agent; `off` must not
+    disable it."""
+    config = load_config(DEFAULT_CONFIG)
+    for profile in config["profiles"].values():
+        assert "main" not in profile["workflows"]
+    assert "cron:" in (Path(".github/workflows/main.yaml")).read_text()


### PR DESCRIPTION
Phase 4 (cadence half). Stacked on #2260 → #2255 → #2253 → #2249 → #2247 → #2246.

GitHub cannot parameterise `schedule:` at run time, so changing cadence has meant hand-editing a cron line in each workflow. `.github/cron-profiles.yaml` + `scripts/apply_cron_profile.py` make it one switch:

```
just cron-profiles                # list profiles / show active
just cron-profile-preview fast    # diff only, no writes
just cron-profile slow            # rewrite + commit
```

## The kill switch is the point

`just cron-profile off` removes every managed `on.schedule` block, so the whole agent fleet stops in one commit — while `workflow_dispatch` still works for manual runs. Empty schedules rather than an impossible date like Feb 30: GitHub can ignore an invalid cron update and leave the previous valid schedule registered.

## `active: medium` is behaviour-preserving

It reproduces the cadence these workflows already run at. Every cron expression is byte-identical; only quoting and trailing comments are normalised:

```
- cron: '0 6 * * 6'          ->  - cron: "0 6 * * 6"  # weekly, Saturday 06:00 UTC
- cron: "37 1/1 * * *"       ->  - cron: "37 1/1 * * *"  # hourly, offset from the other agents
```

## Implementation note

The applier rewrites **only** the `on.schedule` block, line-based rather than round-tripping the YAML: GitHub's `on:` key parses as the YAML 1.1 boolean `True`, which a naive re-dump corrupts. Ported from dismech.

## Two tests worth calling out

- `main.yaml`'s weekly full re-validation is deliberately **not** managed — it is ordinary CI, not an agent, and `off` must not disable it. Pinned by a test.
- A drift test: if someone hand-edits a `cron:` line instead of going through a profile, the next `just cron-profile` would silently revert it. The test fails first, with the command to run.

## Verification

```
uv run python scripts/apply_cron_profile.py --list
uv run pytest tests/test_agent_config.py tests/test_apply_cron_profile.py -q   # 17 passed
uv run mypy tests/test_apply_cron_profile.py                                    # clean
python3 -c "import yaml, glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.y*ml')]"
```

`slow`/`fast` only move `pr-shepherd` and `curation-scanner`; the weekly scanners are tier-invariant because their cadence is tied to how fast their upstream sources move, not to our spend. Easy to change — it is one file now.