### PR TITLE
ABI3BP follow-up: apply the three review nits that missed the #2250 auto-merge

### DIFF
--- a/genes/human/ABI3BP/ABI3BP-ai-review.yaml
+++ b/genes/human/ABI3BP/ABI3BP-ai-review.yaml
@@ -7,9 +7,9 @@ taxon:
   label: Homo sapiens
 description: >-
   ABI3BP (also called TARSH, target of Nesh-SH3) is a large secreted glycoprotein that is
-  deposited into the extracellular matrix, where it acts on cells rather than on the fabric of
-  the matrix. The 1068-residue precursor carries an N-terminal signal peptide, two fibronectin
-  type-III domains near either end, a family-specific C-terminal domain shared with FNDC1, and
+  deposited into the extracellular matrix, where its characterised action is on cells rather than
+  on the mechanical fabric of the matrix. The 1068-residue precursor carries an N-terminal signal
+  peptide, two fibronectin type-III domains near either end, a family-specific C-terminal domain shared with FNDC1, and
   a very large intrinsically disordered central region that is dense in proline-rich SH3-binding
   motifs and is the site of extensive alternative splicing. It has no catalytic domain. Its
   characterised receptor is integrin beta-1: matrix-deposited ABI3BP binds integrin beta-1 and
@@ -871,10 +871,11 @@ core_functions:
 proposed_new_terms:
 - proposed_name: matricellular protein activity
   proposed_definition: >-
-    The activity of a secreted protein that resides in the extracellular matrix and acts on cells
-    by engaging cell-surface receptors so as to modulate their signalling, adhesion or
-    differentiation state, without contributing appreciably to the mechanical integrity of the
-    matrix.
+    The activity of a secreted protein that resides in the extracellular matrix and acts on cells by
+    engaging cell-surface receptors, thereby modulating their signalling, adhesion, proliferation or
+    differentiation state. The defining feature is the cell-instructive action on a receptor; whether
+    a protein with this activity also contributes to the mechanical integrity of the matrix is a
+    separate question, and this term neither asserts nor excludes it.
   proposed_parent:
     id: GO:0048018
     label: receptor ligand activity
@@ -955,9 +956,12 @@ suggested_questions:
     negative regulation of mesenchymal stem cell proliferation (GO:1902461), positive regulation of
     integrin activation (GO:0033625), negative regulation of the ERK1/ERK2 cascade (GO:0070373),
     positive regulation of osteoblast differentiation (GO:0045669), positive regulation of fat cell
-    differentiation (GO:0045600) and positive regulation of cardiac muscle cell differentiation
-    (GO:2000727). Because the mechanism is mouse-based, all are ISS on the human gene with mouse
-    Abi3bp (MGI:MGI:2444583) as supporting entity.
+    differentiation (GO:0045600), positive regulation of cardiac muscle cell differentiation
+    (GO:2000727) and negative regulation of dendrite morphogenesis (GO:0050774). Because every
+    perturbation experiment is mouse-based, all are ISS on the human gene with mouse Abi3bp
+    (MGI:MGI:2444583) as supporting entity. Note that GO:0050774 comes from a different axis of the
+    biology with no identified receptor, which is why it is the one proposed process kept out of
+    core_functions.
 
     A curator taking these up should note the term-definition trap documented on the GO:0045669
     row: the apparently ideal lineage-agnostic terms GO:2000738 and GO:2000741 both target

--- a/genes/human/ABI3BP/ABI3BP-notes.md
+++ b/genes/human/ABI3BP/ABI3BP-notes.md
@@ -303,6 +303,14 @@ signalling, not adhesion of the cell to the matrix. Plain `GO:0005178` is the ho
   shows is only that Abi3bp is not a growth-factor-like ERK *agonist*. The proposal now rests on the
   ontology gap alone, which is where its weight always was, with the tethering question moved to
   `suggested_questions`.
+
+  **The proposed *definition* had the same flaw and was fixed in a second pass.** It originally read
+  "…without contributing appreciably to the mechanical integrity of the matrix" — an unmeasurable
+  negative, and one that this review's own position ("never tested") means ABI3BP cannot be shown to
+  satisfy. Proposing a term whose defining clause the motivating example cannot be demonstrated to
+  meet would have been self-defeating in front of a GO editor. Reworded positively: the defining
+  feature is the cell-instructive action on a receptor, and the term now explicitly neither asserts
+  nor excludes a structural contribution.
 - Senescence, antiviral and blood-brain-barrier roles left unannotated and moved into
   `suggested_questions` / `suggested_experiments`. The senescence literature contradicts itself
   (§4) and no term should be asserted until that is resolved. Note the contrast with the neuronal


### PR DESCRIPTION
# ABI3BP follow-up: the three 🔵 nits from #2250

Follow-up to #2250, which **auto-merged at `8949c1bc4` about a minute before this commit landed**, so the three non-blocking 🔵 items from @ai4c-agent's approving review never reached `main`. Verified against `origin/main` rather than assumed — before this PR, main still contained the old unmeasurable-negative definition (1 match), still lacked `GO:0050774` in the process enumeration (0 matches), and still carried the unhedged `description` clause (1 match).

No annotation actions, terms, evidence codes or quotes change. 22 insertions, 10 deletions across the review YAML and the notes.

### 1. The proposed term's definition discriminated on an unmeasurable negative

This was the one worth not deferring, because it was inconsistent with the PR's *own* argument. The definition required:

> …without contributing appreciably to the mechanical integrity of the matrix

while the three `MARK_AS_OVER_ANNOTATED` rows argue that for ABI3BP a structural contribution "has never been *excluded* — it has never been *tested*". The motivating example therefore could not be shown to satisfy the defining clause of the term it motivates, which a GO editor would find immediately.

Reworded positively, with the ambiguity stated rather than hidden:

> …acts on cells by engaging cell-surface receptors, thereby modulating their signalling, adhesion, proliferation or differentiation state. The defining feature is the cell-instructive action on a receptor; whether a protein with this activity also contributes to the mechanical integrity of the matrix is a separate question, and this term neither asserts nor excludes it.

This also stops the term excluding matricellular proteins that genuinely have both a structural and a signalling role, which the old wording did for no good reason.

### 2. `GO:0050774` was missing from the biological-process enumeration

The `suggested_questions` entry listing the proposed BP terms still named six, from before the dendrite row was added. Now names all of them, plus why `GO:0050774` is the one proposed process deliberately kept out of `core_functions` (different axis of the biology, no identified receptor), so the list no longer implies all eight rows sit on the same footing.

### 3. Unhedged `description` clause

"acts on cells rather than on the fabric of the matrix" → "its characterised action is on cells rather than on the mechanical fabric of the matrix". *Characterised* is the load-bearing word: a statement about what has been measured, not a claim about what is impossible.

### Verification

- Each edit applied by a script that **asserts its anchor is present and unique before replacing, then re-greps afterwards**, so a missed occurrence fails loudly rather than silently no-op'ing; diff inspected at claim level (`git diff -U0 | grep '^[-+][^-+]'`) rather than trusting that a changed line means a changed claim; YAML re-parsed to confirm 18 annotations / 10 questions intact.
- `checkquotes.py` — **100 quotes, 0 problems**
- `just validate human ABI3BP` — **✓ Valid, zero warnings**
- `git diff origin/main HEAD -- cache/go/terms.csv | grep '^-GO:'` — **empty**; this branch makes no `terms.csv` change at all, since #2250 already landed the four new terms.
- Branched fresh off current `origin/main` (post-#2250), so no stale-cache or shared-cache conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
