### PR TITLE
Document that the AADACL4 register-cut assertion is one-directional

### DIFF
--- a/genes/human/AADACL4/AADACL4-bioinformatics/analyze_catalytic_machinery.py
+++ b/genes/human/AADACL4/AADACL4-bioinformatics/analyze_catalytic_machinery.py
@@ -129,6 +129,16 @@ PANEL: dict[str, tuple[str, str]] = {
 # rather than tuned silently, and the margin assertion below is what keeps it
 # honest - an earlier attempt at 31.0 aborted the run because NlhH was only 0.7
 # points away.
+#
+# Note what the assertion does NOT cover. It is one-directional: it is fatal only
+# when a member lands *inside* the margin. A future release that moved a genuine
+# AADAC-family member cleanly below the threshold (or a distant node member above
+# it) passes the assertion and instead flips `register_cut_matches_family` to
+# False, which is reported in RESULTS.md but does not stop the run. That is
+# deliberate - the numeric cut has to be free to disagree with the hand-assigned
+# roles, since that disagreement is the whole point of cross-checking one against
+# the other - but it means a reader must look at that flag rather than assume the
+# assertion has already vouched for the partition.
 REGISTER_IDENTITY_THRESHOLD = 31.3
 REGISTER_MIN_GAP = 0.75
 


### PR DESCRIPTION
Closes the one residual 🔵 from the follow-up review on #2263 (AADACL4), which was correct.

The straddle assertion in `analyze_catalytic_machinery.py` is **one-directional**: it aborts only
when a panel member lands *inside* `REGISTER_MIN_GAP` of the identity threshold. A future UniProt
release that moved a genuine AADAC-family member cleanly *below* the cut — or a distant node member
above it — passes the assertion and instead flips `register_cut_matches_family` to `False`, which
`RESULTS.md` reports but which does not stop the run.

That asymmetry is deliberate: the numeric cut has to be free to disagree with the hand-assigned
roles, because that disagreement is precisely what makes the cross-check meaningful rather than
circular. But it was not written down, so a later reader could reasonably assume the assertion had
already vouched for the partition. It is now stated in the comment beside the constants, including
what a reader has to check instead.

**Comment-only change.** A fresh `uv run python analyze_catalytic_machinery.py` reproduces both
`RESULTS.md` and `results.json` byte-for-byte (verified by `diff`), and `just validate human AADACL4`
is ✓ Valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
