### PR TITLE
AADACL2 follow-up: take the five review suggestions from #2266

### DIFF
--- a/genes/human/AADACL2/AADACL2-ai-review.yaml
+++ b/genes/human/AADACL2/AADACL2-ai-review.yaml
@@ -56,11 +56,14 @@ existing_annotations:
       - map all three of their catalytic residues onto exactly those positions. Those eight include the 51.6 percent
       identical human AADAC and three independently characterised mycobacterial carboxylesterases.'
     action: MODIFY
-    reason: The term is correct but sits two levels above what the evidence licenses. GO:0017171 serine hydrolase
+    reason: 'The term is correct but sits two levels above what the evidence licenses. GO:0017171 serine hydrolase
       activity is defined as catalysis using a serine nucleophile activated by an acid/base proton relay, which
-      is precisely the conserved Ser-Asp-His triad and oxyanion hole documented on this protein and corroborated
-      by alignment to characterised relatives. The right fix is at the tree level - place GO:0017171 at the AADAC-family
-      node PTN009058713, which would correct AADACL2, AADACL3 and AADACL4 together.
+      is precisely the conserved Ser-Asp-His triad and oxyanion hole documented on this protein. Broken down by
+      position, the nucleophile evidence is stronger than the aggregate: all 15 active-site-annotated sources align
+      their own catalytic serine onto AADACL2 position 189 and 14 of the 15 carry a serine there, while the acid
+      (341) and base (371) are corroborated by 8 of 15 because they sit in the C-terminal half where global alignment
+      loses register below 26.5 percent identity. The right fix is at the tree level - place GO:0017171 at the AADAC-family
+      node PTN009058713, which would correct AADACL2, AADACL3 and AADACL4 together.'
     proposed_replacement_terms:
     - id: GO:0017171
       label: serine hydrolase activity
@@ -70,6 +73,8 @@ existing_annotations:
         own annotated triad
     - reference_id: file:human/AADACL2/AADACL2-bioinformatics/RESULTS.md
       supporting_text: The placement is the wrong way round with respect to what actually transfers.
+    - reference_id: file:human/AADACL2/AADACL2-bioinformatics/RESULTS.md
+      supporting_text: Every one of the fifteen sources places its own catalytic serine on AADACL2 position 189
     - reference_id: file:human/AADACL2/AADACL2-uniprot.txt
       supporting_text: FT   ACT_SITE        189
     - reference_id: file:human/AADACL2/AADACL2-uniprot.txt
@@ -220,9 +225,10 @@ existing_annotations:
     action: UNDECIDED
     reason: The sole basis is a predicted signal-peptide cleavage site whose -1 residue is one signal peptidase
       I does not use, and the same segment is a validated uncleaved membrane anchor in the closest characterised
-      paralog. GOA simultaneously carries the mutually exclusive GO:0016020 membrane for this protein. Accepting
-      extracellular region would settle by fiat a topology question that no experiment has addressed; removing it
-      would equally assert the alternative. The contradiction, not a winner, is what this record currently supports.
+      paralog. GOA simultaneously carries GO:0016020 membrane for this protein. The two terms are not disjoint in
+      GO - a shed ectodomain can legitimately be in both - but here they are two incompatible readings of one hydrophobic
+      helix, and only one of them can describe the mature protein. Accepting extracellular region would settle by
+      fiat a topology question that no experiment has addressed; removing it would equally assert the alternative.
     supported_by:
     - reference_id: file:human/AADACL2/AADACL2-uniprot.txt
       supporting_text: 'CC   -!- SUBCELLULAR LOCATION: Secreted.'
@@ -250,8 +256,8 @@ existing_annotations:
     reason: Kept open for the same reason as the PAINT row. The family-majority topology is a real argument for
       membrane anchoring, and the sequence measurements do not exclude it - AADACL2's N-terminal hydrophobic core
       scores higher than AADAC's validated anchor, and the predicted cleavage site is atypical. But nothing specific
-      to AADACL2 supports it either, and the annotation coexists with its own contradiction in the same record.
-      This should be resolved experimentally, not by choosing which pipeline to trust.
+      to AADACL2 supports it either, and the same record carries the alternative reading of the same helix. This
+      should be resolved experimentally, not by choosing which pipeline to trust.
     supported_by:
     - reference_id: file:human/AADACL2/AADACL2-bioinformatics/RESULTS.md
       supporting_text: Of the 14 reviewed members, AADACL2 is the only one whose N-terminal hydrophobic segment
@@ -275,9 +281,13 @@ existing_annotations:
       the alignment result that the seven closest WITH/FROM sources, plus Mycobacterium tuberculosis LipN, place
       their own catalytic residues on exactly those three positions.'
     action: MODIFY
-    reason: Correct but under-informative for AADACL2. The domain signature cannot distinguish an active serine
-      hydrolase from a fold-retaining pseudoenzyme, whereas this protein's annotated active sites and their conservation
+    reason: 'Correct but under-informative for AADACL2. The domain signature cannot distinguish an active serine
+      hydrolase from a fold-retaining pseudoenzyme, whereas this protein''s annotated active sites and their conservation
       across characterised relatives do, and they support the mechanism term GO:0017171 serine hydrolase activity.
+      To be explicit about where the fix belongs: the IPR013094-to-GO:0016787 mapping itself should not change,
+      because most proteins matching a bare alpha/beta-hydrolase-3 domain warrant nothing more specific. The correction
+      is a protein-level annotation on AADACL2, made from its own residue-level evidence, that supersedes the signature-level
+      default.'
     proposed_replacement_terms:
     - id: GO:0017171
       label: serine hydrolase activity
@@ -307,10 +317,14 @@ existing_annotations:
       name-giving activity is hydrolysis of the amide bond of arylacetamide xenobiotics, so the bond type AADACL2
       prefers is an open question rather than a settled one.'
     action: ACCEPT
-    reason: A family-specific signature, not a fold signature, supporting the activity that every characterised
+    reason: 'A family-specific signature, not a fold signature, supporting the activity that every characterised
       member of the family possesses, in a protein whose catalytic triad and oxyanion hole are intact and in register
-      with those members. This is the best available statement of the presumed core function and should be retained,
+      with those members. It is the most informative activity statement currently on the record and should be retained,
       with the understanding that it is prediction-grade and that the substrate and precise bond type are undetermined.
+      Note that core_functions records the mechanism term GO:0017171 rather than this one: GO:0052689 says more
+      about the reaction, but it is inferred from family membership, whereas the serine-hydrolase mechanism is evidenced
+      on this protein''s own residues - and it is also the statement that survives if AADACL2 turns out to prefer
+      amide over ester bonds, as its closest characterised relative AADAC does.'
     supported_by:
     - reference_id: file:human/AADACL2/AADACL2-uniprot.txt
       supporting_text: DR   PIRSF; PIRSF037251; Arylacetamide_deacetylase; 1.
@@ -326,10 +340,13 @@ core_functions:
 - description: 'AADACL2 is expected to act as a serine hydrolase of the GDXG (hormone-sensitive-lipase-like) alpha/beta-hydrolase
     clan, using the Ser189-Asp341-His371 triad and the HGG oxyanion-hole loop at 111-113 to attack a carbonyl-containing
     substrate, most probably a carboxylic ester by analogy with every characterised member of the AADAC family.
-    The mechanism term is what the evidence licenses; the substrate is unknown, no activity has been measured, and
-    no biological process can be assigned. No location is recorded here deliberately: the protein is in the secretory
-    pathway, but whether it is released or retained by an uncleaved type-II anchor is unresolved, so committing
-    to either extracellular region or membrane would overstate what is known.'
+    The mechanism term is recorded here in preference to the more specific GO:0052689 carboxylic ester hydrolase
+    activity, which is retained on the record but is inferred from family membership: the serine-hydrolase mechanism
+    is the part evidenced on this protein''s own residues, and it is also the part that survives if AADACL2 turns
+    out to prefer amide bonds as its closest characterised relative AADAC does. The substrate is unknown, no activity
+    has been measured, and no biological process can be assigned. No location is recorded here deliberately: the
+    protein is in the secretory pathway, but whether it is released or retained by an uncleaved type-II anchor is
+    unresolved, so committing to either extracellular region or membrane would overstate what is known.'
   molecular_function:
     id: GO:0017171
     label: serine hydrolase activity
@@ -389,9 +406,10 @@ knowledge_gaps:
   dark_aspect: CC_DARK
   status: OPEN
   significance: The two possibilities imply different biology - a soluble enzyme acting in the extracellular space
-    or stratum corneum, against a membrane-tethered enzyme acting on lipids of the secretory pathway - and they
-    cannot both be annotated. The curation-side half of the gap is that GOA currently carries both, from three separate
-    pipelines, without any flag that they are mutually exclusive.
+    or stratum corneum, against a membrane-tethered enzyme acting on lipids of the secretory pathway. GO does not
+    forbid a protein from carrying both terms, but these two are alternative readings of a single hydrophobic helix,
+    so only one can describe the mature protein. The curation-side half of the gap is that GOA currently carries
+    both, from three separate pipelines, with nothing recording that they are alternatives rather than complements.
   resolution: A protease-protection or medium-versus-membrane fractionation experiment on tagged AADACL2 in a keratinocyte
     line, plus N-terminal sequencing of the mature protein, would settle it and license exactly one of the two existing
     annotations.
@@ -611,6 +629,15 @@ references:
     correctness: VERIFIED
     review_notes: The MGC paper, cited by UniProt as the source of the placental cDNA and of the Ala186Ser variant
       (dbSNP rs1972977). Correctly cited; no functional content.
+- id: PMID:16641997
+  title: The DNA sequence, annotation and analysis of human chromosome 3.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: The chromosome 3 sequencing paper, cited by UniProt as the genomic source for AADACL2. Listed
+      so that the record is self-contained in stating that all three of the UniProt RN references for this gene
+      are large-scale sequencing efforts with no functional content.
 - id: file:human/AADACL2/AADACL2-deep-research-affinage.md
   title: Affinage mechanistic annotation for AADACL2 (human)
   findings:

--- a/genes/human/AADACL2/AADACL2-bioinformatics/RESULTS.md
+++ b/genes/human/AADACL2/AADACL2-bioinformatics/RESULTS.md
@@ -52,6 +52,22 @@ lies at 26.5% identity or below, which is where this global alignment loses regi
 C-terminal half (for Afmid and Aes the source His has no aligned partner at all). The failures
 are therefore alignment artefacts, not evidence of residue loss.
 
+Broken down by position, the aggregate understates the nucleophile badly:
+
+| AADACL2 position | residue | sources aligning here | with the identical residue |
+|---|---|---|---|
+| 189 | Ser | **15 / 15** | **14 / 15** |
+| 341 | Asp | 8 / 15 | 8 / 15 |
+| 371 | His | 8 / 15 | 8 / 15 |
+
+**Every one of the fifteen sources places its own catalytic serine on AADACL2 position 189**,
+and fourteen of them carry a serine there. The single exception is soybean HIDH, whose own
+annotated nucleophile is a threonine — and HIDH is the one source in the set that is not a
+hydrolase at all but a dehydratase, so the substitution is informative rather than noise. The
+8/15 triad-complete figure is driven entirely by the acid and the base, which sit in the
+C-terminal half where register is lost below 26.5% identity. The nucleophile elbow, the most
+conserved element of the fold, never loses register.
+
 So this is not a case of a family name propagating onto a fold-only relic: the nucleophile,
 the acid, the base and the oxyanion loop are all present and all in register with three
 independently characterised bacterial carboxylesterases and with the 51.6%-identical human

--- a/genes/human/AADACL2/AADACL2-bioinformatics/audit_aadacl2_record.py
+++ b/genes/human/AADACL2/AADACL2-bioinformatics/audit_aadacl2_record.py
@@ -293,6 +293,33 @@ def q1_catalytic_machinery(target_rec: dict, protein_sources: list[dict]) -> dic
                 and all(m["same_residue"] and m["lands_on_annotated_target_site"] for m in mapped),
             }
         )
+    # Per-residue breakdown. The aggregate "triad complete" count understates the
+    # nucleophile evidence: the serine elbow is the most conserved part of the fold and
+    # never loses alignment register, while the acid and base sit in the C-terminal half
+    # where a global alignment drifts at low identity. Report the three positions
+    # separately so the aggregate cannot be mistaken for a statement about the serine.
+    by_residue = {}
+    with_sites = [s for s in per_source if s["annotated_active_sites"]]
+    for rank, position in enumerate(own_act):
+        landed, identical = 0, 0
+        for s in with_sites:
+            hit = next(
+                (m for m in s["mapped_active_sites"] if m["target_position"] == position), None
+            )
+            if hit is None and rank < len(s["mapped_active_sites"]):
+                hit = s["mapped_active_sites"][rank] if s["mapped_active_sites"][rank]["target_position"] == position else None
+            if hit is None:
+                continue
+            landed += 1
+            if hit["same_residue"]:
+                identical += 1
+        by_residue[str(position)] = {
+            "target_residue": target_seq[position - 1],
+            "sources_landing_here": landed,
+            "sources_with_identical_residue": identical,
+            "n_sources_considered": len(with_sites),
+        }
+
     return {
         "target_length": len(target_seq),
         "target_annotated_active_sites": own_act,
@@ -300,6 +327,10 @@ def q1_catalytic_machinery(target_rec: dict, protein_sources: list[dict]) -> dic
         "target_annotated_motifs": own_motif,
         "gdxg_nucleophile_elbow_matches": gdxg,
         "prosite_gdxg_serine_signature": "PS01174" in json.dumps(target_rec.get("uniProtKBCrossReferences", [])),
+        "per_target_active_site": by_residue,
+        "n_sources_corroborating_full_triad": sum(
+            1 for s in with_sites if s["corroborates_target_triad"]
+        ),
         "per_source": per_source,
     }
 
@@ -535,6 +566,13 @@ def main() -> None:
           f"= {''.join(q1['target_active_site_residues'])}")
     print(f"  GDXG nucleophile-elbow matches: {q1['gdxg_nucleophile_elbow_matches']}")
     print(f"  PROSITE PS01174 (GDXG lipase Ser) on the record: {q1['prosite_gdxg_serine_signature']}")
+    for pos, v in q1["per_target_active_site"].items():
+        print(f"  position {pos} ({v['target_residue']}): {v['sources_landing_here']}"
+              f"/{v['n_sources_considered']} sources align here, "
+              f"{v['sources_with_identical_residue']} with the same residue")
+    print(f"  sources corroborating the complete triad: "
+          f"{q1['n_sources_corroborating_full_triad']}/"
+          f"{len([s for s in q1['per_source'] if s['annotated_active_sites']])}")
     for s in q1["per_source"]:
         if not s["annotated_active_sites"]:
             continue

--- a/genes/human/AADACL2/AADACL2-bioinformatics/results.json
+++ b/genes/human/AADACL2/AADACL2-bioinformatics/results.json
@@ -129,6 +129,27 @@
       }
     ],
     "prosite_gdxg_serine_signature": true,
+    "per_target_active_site": {
+      "189": {
+        "target_residue": "S",
+        "sources_landing_here": 15,
+        "sources_with_identical_residue": 14,
+        "n_sources_considered": 15
+      },
+      "341": {
+        "target_residue": "D",
+        "sources_landing_here": 8,
+        "sources_with_identical_residue": 8,
+        "n_sources_considered": 15
+      },
+      "371": {
+        "target_residue": "H",
+        "sources_landing_here": 8,
+        "sources_with_identical_residue": 8,
+        "n_sources_considered": 15
+      }
+    },
+    "n_sources_corroborating_full_triad": 8,
     "per_source": [
       {
         "accession": "Q9FX94",

--- a/genes/human/AADACL2/AADACL2-notes.md
+++ b/genes/human/AADACL2/AADACL2-notes.md
@@ -7,7 +7,8 @@ protein level`, Pharos `Tdark`. Reviewed 2026-07-25 for the PAINT + affinage cam
 
 Seven GOA rows, **no experimental evidence of any kind**: 2 IBA (PANTHER) and 5 IEA
 (InterPro ×2, ARBA ×2, UniProt SubCell ×1). Three rows are activities at three levels of
-generality; three are locations, two of which are mutually exclusive.
+generality; three are locations, two of which are incompatible readings of the same
+N-terminal helix.
 
 | term | evidence | source |
 |---|---|---|
@@ -135,6 +136,32 @@ The UniProt record carries two DrugBank cross-references, `DB07814 Gibberellic a
 `DB07815 Gibberellin A4`. The plant gibberellin receptor GID1 is a derivative of this same
 GDXG/HSL-like carboxylesterase clan, so these are almost certainly structure-similarity
 mappings rather than any claim about human ligands. Not used for anything in the review.
+
+## Round-1 review follow-ups (PR #2266, approved with five non-blocking suggestions)
+
+All five were taken:
+
+1. The aggregate 8/15 triad figure understated the nucleophile. `results.json` already had the
+   per-position data: **all 15 sources align their own catalytic serine onto position 189, and
+   14 of 15 carry a Ser there** (the exception is soybean HIDH, whose own nucleophile is Thr —
+   and HIDH is the one source that is a dehydratase, not a hydrolase). The 8/15 figure is
+   driven entirely by the acid and base drifting out of register below 26.5% identity. Added as
+   a table in `RESULTS.md` section 1, computed by the script (`per_target_active_site`), and
+   surfaced in the `GO:0017171` MODIFY reason.
+2. The `GO:0052689` ACCEPT reason called that term "the best available statement of the core
+   function" while `core_functions` uses `GO:0017171`. Reconciled: `GO:0052689` is the most
+   informative *activity* statement on the record, but it is inferred from family membership,
+   whereas the serine-hydrolase mechanism is evidenced on this protein's own residues and is
+   also what survives if AADACL2 prefers amide over ester bonds, as AADAC does.
+3. "Mutually exclusive" overstated GO semantics — `GO:0005576` and `GO:0016020` are not
+   disjoint (a shed ectodomain can be in both). Narrowed everywhere to what is actually
+   claimed: two incompatible readings of one hydrophobic helix, only one of which can describe
+   the mature protein.
+4. The InterPro2GO `GO:0016787` MODIFY now says where the fix lands — the
+   IPR013094→GO:0016787 mapping should *not* change, since a bare alpha/beta-hydrolase-3 match
+   warrants nothing more; the correction is a protein-level annotation on AADACL2.
+5. Added `PMID:16641997` (chromosome 3 sequencing, UniProt `RN[2]`) to `references:` so the
+   "all three UniProt references are large-scale sequencing" claim is self-contained.
 
 ## Actions taken
 

--- a/publications/PMID_16641997.md
+++ b/publications/PMID_16641997.md
@@ -1,0 +1,177 @@
+---
+pmid: '16641997'
+title: The DNA sequence, annotation and analysis of human chromosome 3.
+authors:
+- Muzny DM
+- Scherer SE
+- Kaul R
+- Wang J
+- Yu J
+- Sudbrak R
+- Buhay CJ
+- Chen R
+- Cree A
+- Ding Y
+- Dugan-Rocha S
+- Gill R
+- Gunaratne P
+- Harris RA
+- Hawes AC
+- Hernandez J
+- Hodgson AV
+- Hume J
+- Jackson A
+- Khan ZM
+- Kovar-Smith C
+- Lewis LR
+- Lozado RJ
+- Metzker ML
+- Milosavljevic A
+- Miner GR
+- Morgan MB
+- Nazareth LV
+- Scott G
+- Sodergren E
+- Song XZ
+- Steffen D
+- Wei S
+- Wheeler DA
+- Wright MW
+- Worley KC
+- Yuan Y
+- Zhang Z
+- Adams CQ
+- Ansari-Lari MA
+- Ayele M
+- Brown MJ
+- Chen G
+- Chen Z
+- Clendenning J
+- Clerc-Blankenburg KP
+- Chen R
+- Chen Z
+- Davis C
+- Delgado O
+- Dinh HH
+- Dong W
+- Draper H
+- Ernst S
+- Fu G
+- Gonzalez-Garay ML
+- Garcia DK
+- Gillett W
+- Gu J
+- Hao B
+- Haugen E
+- Havlak P
+- He X
+- Hennig S
+- Hu S
+- Huang W
+- Jackson LR
+- Jacob LS
+- Kelly SH
+- Kube M
+- Levy R
+- Li Z
+- Liu B
+- Liu J
+- Liu W
+- Lu J
+- Maheshwari M
+- Nguyen BV
+- Okwuonu GO
+- Palmeiri A
+- Pasternak S
+- Perez LM
+- Phelps KA
+- Plopper FJ
+- Qiang B
+- Raymond C
+- Rodriguez R
+- Saenphimmachak C
+- Santibanez J
+- Shen H
+- Shen Y
+- Subramanian S
+- Tabor PE
+- Verduzco D
+- Waldron L
+- Wang J
+- Wang J
+- Wang Q
+- Williams GA
+- Wong GK
+- Yao Z
+- Zhang J
+- Zhang X
+- Zhao G
+- Zhou J
+- Zhou Y
+- Nelson D
+- Lehrach H
+- Reinhardt R
+- Naylor SL
+- Yang H
+- Olson M
+- Weinstock G
+- Gibbs RA
+journal: Nature
+year: '2006'
+full_text_available: false
+doi: 10.1038/nature04728
+pubmed_publication_types:
+- Journal Article
+- Research Support, N.I.H., Extramural
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# The DNA sequence, annotation and analysis of human chromosome 3.
+**Authors:** Muzny DM, Scherer SE, Kaul R, Wang J, Yu J, Sudbrak R, Buhay CJ, Chen R, Cree A, Ding Y, Dugan-Rocha S, Gill R, Gunaratne P, Harris RA, Hawes AC, Hernandez J, Hodgson AV, Hume J, Jackson A, Khan ZM, Kovar-Smith C, Lewis LR, Lozado RJ, Metzker ML, Milosavljevic A, Miner GR, Morgan MB, Nazareth LV, Scott G, Sodergren E, Song XZ, Steffen D, Wei S, Wheeler DA, Wright MW, Worley KC, Yuan Y, Zhang Z, Adams CQ, Ansari-Lari MA, Ayele M, Brown MJ, Chen G, Chen Z, Clendenning J, Clerc-Blankenburg KP, Chen R, Chen Z, Davis C, Delgado O, Dinh HH, Dong W, Draper H, Ernst S, Fu G, Gonzalez-Garay ML, Garcia DK, Gillett W, Gu J, Hao B, Haugen E, Havlak P, He X, Hennig S, Hu S, Huang W, Jackson LR, Jacob LS, Kelly SH, Kube M, Levy R, Li Z, Liu B, Liu J, Liu W, Lu J, Maheshwari M, Nguyen BV, Okwuonu GO, Palmeiri A, Pasternak S, Perez LM, Phelps KA, Plopper FJ, Qiang B, Raymond C, Rodriguez R, Saenphimmachak C, Santibanez J, Shen H, Shen Y, Subramanian S, Tabor PE, Verduzco D, Waldron L, Wang J, Wang J, Wang Q, Williams GA, Wong GK, Yao Z, Zhang J, Zhang X, Zhao G, Zhou J, Zhou Y, Nelson D, Lehrach H, Reinhardt R, Naylor SL, Yang H, Olson M, Weinstock G, Gibbs RA
+**Journal:** Nature (2006)
+**DOI:** [10.1038/nature04728](https://doi.org/10.1038/nature04728)
+
+## Abstract
+
+1. Nature. 2006 Apr 27;440(7088):1194-8. doi: 10.1038/nature04728.
+
+The DNA sequence, annotation and analysis of human chromosome 3.
+
+Muzny DM(1), Scherer SE, Kaul R, Wang J, Yu J, Sudbrak R, Buhay CJ, Chen R, Cree 
+A, Ding Y, Dugan-Rocha S, Gill R, Gunaratne P, Harris RA, Hawes AC, Hernandez J, 
+Hodgson AV, Hume J, Jackson A, Khan ZM, Kovar-Smith C, Lewis LR, Lozado RJ, 
+Metzker ML, Milosavljevic A, Miner GR, Morgan MB, Nazareth LV, Scott G, 
+Sodergren E, Song XZ, Steffen D, Wei S, Wheeler DA, Wright MW, Worley KC, Yuan 
+Y, Zhang Z, Adams CQ, Ansari-Lari MA, Ayele M, Brown MJ, Chen G, Chen Z, 
+Clendenning J, Clerc-Blankenburg KP, Chen R, Chen Z, Davis C, Delgado O, Dinh 
+HH, Dong W, Draper H, Ernst S, Fu G, Gonzalez-Garay ML, Garcia DK, Gillett W, Gu 
+J, Hao B, Haugen E, Havlak P, He X, Hennig S, Hu S, Huang W, Jackson LR, Jacob 
+LS, Kelly SH, Kube M, Levy R, Li Z, Liu B, Liu J, Liu W, Lu J, Maheshwari M, 
+Nguyen BV, Okwuonu GO, Palmeiri A, Pasternak S, Perez LM, Phelps KA, Plopper FJ, 
+Qiang B, Raymond C, Rodriguez R, Saenphimmachak C, Santibanez J, Shen H, Shen Y, 
+Subramanian S, Tabor PE, Verduzco D, Waldron L, Wang J, Wang J, Wang Q, Williams 
+GA, Wong GK, Yao Z, Zhang J, Zhang X, Zhao G, Zhou J, Zhou Y, Nelson D, Lehrach 
+H, Reinhardt R, Naylor SL, Yang H, Olson M, Weinstock G, Gibbs RA.
+
+Author information:
+(1)Human Genome Sequencing Center, Baylor College of Medicine, One Baylor Plaza, 
+Houston, Texas 77030, USA.
+
+After the completion of a draft human genome sequence, the International Human 
+Genome Sequencing Consortium has proceeded to finish and annotate each of the 24 
+chromosomes comprising the human genome. Here we describe the sequencing and 
+analysis of human chromosome 3, one of the largest human chromosomes. Chromosome 
+3 comprises just four contigs, one of which currently represents the longest 
+unbroken stretch of finished DNA sequence known so far. The chromosome is 
+remarkable in having the lowest rate of segmental duplication in the genome. It 
+also includes a chemokine receptor gene cluster as well as numerous loci 
+involved in multiple human cancers such as the gene encoding FHIT, which 
+contains the most common constitutive fragile site in the genome, FRA3B. Using 
+genomic sequence from chimpanzee and rhesus macaque, we were able to 
+characterize the breakpoints defining a large pericentric inversion that 
+occurred some time after the split of Homininae from Ponginae, and propose an 
+evolutionary history of the inversion.
+
+DOI: 10.1038/nature04728
+PMID: 16641997 [Indexed for MEDLINE]


### PR DESCRIPTION
## AADACL2 follow-up: the five non-blocking suggestions from #2266

#2266 was approved and merged before this delta landed on the branch, so it comes as its own PR. All five suggestions from the round-1 review are taken; nothing declined.

**1. The aggregate understated the nucleophile evidence.** `results.json` already had the per-position data, so the script now reports it explicitly (`q1_catalytic_machinery.per_target_active_site`) rather than my reading it off by hand:

| AADACL2 position | residue | sources aligning here | with the identical residue |
|---|---|---|---|
| 189 | Ser | **15 / 15** | **14 / 15** |
| 341 | Asp | 8 / 15 | 8 / 15 |
| 371 | His | 8 / 15 | 8 / 15 |

One detail worth adding to the reviewer's framing: the 15th source, the one without a Ser at 189, is soybean HIDH, whose own annotated nucleophile is Thr164 — and HIDH is the single source in the set that is not a hydrolase but a 2-hydroxyisoflavanone **dehydratase**. The one substitution is the one case where the chemistry differs, which makes it evidence rather than noise. Added as a table in `RESULTS.md` section 1 and surfaced in the `GO:0017171` MODIFY reason, with a new `supported_by` quote.

**2. Two "best statement" claims that could not both be true.** The `GO:0052689` ACCEPT reason called that term the best statement of the core function while `core_functions` uses `GO:0017171`. Reconciled on substance rather than by softening: `GO:0052689` is the most informative *activity* statement on the record, but it is inferred from family membership; `GO:0017171` is the part evidenced on this protein's own residues **and** the part that survives if AADACL2 prefers amide bonds — which is not hypothetical, since AADAC's name-giving activity is amide hydrolysis of arylacetamides. That asymmetry is now the stated reason `core_functions` records the mechanism term.

**3. "Mutually exclusive" overstated GO semantics.** Correct — the two terms are not disjoint, and the ER lumen is topologically continuous with the extracellular space. Narrowed in all four places (the `GO:0005576` reason, the `GO:0016020` IEA reason, knowledge gap 2's significance, and the notes) to what the evidence supports: two incompatible readings of one hydrophobic helix, only one of which can describe the mature protein. That GO does not forbid both terms is now said explicitly, so the claim is about this protein rather than about the ontology.

**4. Where the InterPro2GO fix lands.** The `IPR013094` → `GO:0016787` mapping should *not* change — most proteins matching a bare alpha/beta-hydrolase-3 domain warrant nothing more specific, and remapping the signature would break it for everything else that carries it. The correction is a protein-level annotation on AADACL2 from its own residue-level evidence, superseding the signature-level default. Now stated in the reason so the MODIFY cannot be read as a signature remapping request.

**5. `PMID:16641997`** (chromosome 3 sequencing, UniProt `RN[2]`) fetched, cached and added to `references:` with `relevance: LOW`, so the "all three UniProt `RN` references are large-scale sequencing with no functional content" claim is checkable inside the YAML rather than only in the notes.

### Verification on this branch

- `just validate human AADACL2` → `✓ Valid`, no warnings
- `checkquotes` → 46/46 verbatim, including the two new quotes
- `results.json` re-runs **byte-identical** after the script change (`diff` clean), so the new `RESULTS.md` table is derived, not hand-maintained
- `git diff origin/main HEAD -- cache/go/terms.csv | grep '^-GO:'` → 0

No actions changed: still 3 MODIFY, 3 UNDECIDED, 1 ACCEPT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
