### PR TITLE
fix: agent-run-summary failed to load, breaking 7 workflows

### DIFF
--- a/.github/actions/agent-run-summary/action.yml
+++ b/.github/actions/agent-run-summary/action.yml
@@ -5,9 +5,15 @@ description: >
 
   claude-code-action v1 has NO `result` output — its outputs are execution_file,
   branch_name, github_token, session_id and structured_output. Every workflow
-  here previously wrote `${{ steps.<id>.outputs.result }}`, which is empty, so
-  the run reports were empty fenced blocks. This action reads the last `result`
-  event out of `execution_file` instead.
+  here previously read a `steps.<id>.outputs.result` expression, which is empty,
+  so the run reports were empty fenced blocks. This action reads the last
+  `result` event out of `execution_file` instead.
+
+  Do not write a literal GitHub expression in this description. `description:`
+  is template-evaluated when the manifest loads, so an illustrative
+  "dollar-brace steps dot ..." is parsed as a real expression, `steps` is not a
+  valid manifest context, and the whole action fails to load with
+  "Unrecognized named-value: 'steps'".
 
 inputs:
   execution-file:

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -367,3 +367,37 @@ def test_every_checkout_is_non_persisting():
         "checkout(s) that persist credentials into .git/config:\n"
         + "\n".join(offenders)
     )
+
+
+def test_no_action_manifest_field_contains_a_github_expression():
+    """`action.yml` manifest fields are template-evaluated when the action loads.
+
+    A GitHub expression outside `runs:` — even an illustrative one inside a
+    `description:` — is parsed for real. `steps` is not a valid manifest context,
+    so the action fails to load with "Unrecognized named-value: 'steps'" and
+    every workflow that uses it hard-fails. This is exactly how
+    agent-run-summary shipped broken: the prose explaining the bug it fixes
+    contained the expression it was warning about, which took down the summary
+    step in seven workflows at once.
+
+    Expressions inside `runs.steps` are fine — those are evaluated at run time
+    with a real context — so only the manifest-level fields are checked.
+    """
+    offenders = []
+    for path in (REPO_ROOT / ".github" / "actions").rglob("action.y*ml"):
+        doc = yaml.safe_load(path.read_text()) or {}
+        fields = {
+            "name": doc.get("name"),
+            "description": doc.get("description"),
+        }
+        for section in ("inputs", "outputs"):
+            for key, spec in (doc.get(section) or {}).items():
+                for sub in ("description", "default"):
+                    fields[f"{section}.{key}.{sub}"] = (spec or {}).get(sub)
+        for field, value in fields.items():
+            if isinstance(value, str) and "${{" in value:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {field}")
+    assert not offenders, (
+        "GitHub expression in an action manifest field; it is evaluated at load "
+        "time and will break the action:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
**Hotfix — this is red on `main` right now.** Caught by review on #2241, verified independently.

## What broke

`.github/actions/agent-run-summary/action.yml` does not load:

```
action.yml (Line: 2, Col: 14): Unrecognized named-value: 'steps'.
  Located at position 1 within expression: steps.<id>.outputs.result
Failed to load .../agent-run-summary/action.yml
```

`description:` is **template-evaluated when an action manifest loads**. My description contained the literal expression it was warning about, as documentation prose — so it was parsed as a real expression, `steps` is not a valid manifest context, and the action failed to load outright. The shell body underneath was correct and never ran.

The comment explaining the bug *was* the bug.

## Blast radius

Every workflow using it hard-fails at `Write step summary`: `arba-issue-monitor`, `claude`, `curation-scanner`, `go-annotation-scanner`, `litscan-module-member`, `pr-shepherd`, `weekly-compliance`.

`pr-shepherd` is the canary — the only one whose cron has fired since #2253. Run [30193662761](https://github.com/ai4curation/ai-gene-review/actions/runs/30193662761) on main: token, checkout, resolver and agent all green, summary step red.

**And it's a regression, not just an incomplete fix.** Before #2253 that step *succeeded* while writing the empty fence #2253 set out to fix. After, the report is still missing **and** the job goes red. Strictly worse than what it replaced.

## The fix

The prose now *describes* the expression instead of containing one, and says why so the next person doesn't reintroduce it.

## The guard

`test_no_action_manifest_field_contains_a_github_expression` checks every manifest-level field — `name`, `description`, and every input/output `description`/`default` — across `.github/actions/**/action.y*ml`. Expressions under `runs.steps` are deliberately untouched; those are evaluated at run time with a real context.

Verified to fail against a probe manifest:
```
caught: .github/actions/probe-desc/action.yml: description
```

An audit of the other manifests found no second instance.

## Why nothing caught it

This is a second occupant of a blind spot the migration doc already names for `.github/actions/claude-code-action`: **nothing in the repo parsed action manifests at all.** The pinned-SHA, input-vocabulary and central-model guards only inspect `anthropics/claude-code-action` *call sites*. YAML-parses in CI confirm the file is valid YAML — which it is; it's the GitHub-expression layer above YAML that rejects it. This test closes that gap for manifests.