### PR TITLE
chore: stop the repo re-creating the dragon-ai-agent account and its PAT

### DIFF
--- a/.github/actions/claude-issue-summarize-action/action.yml
+++ b/.github/actions/claude-issue-summarize-action/action.yml
@@ -42,7 +42,7 @@ runs:
             - If there are links in the issue to websites, database entities, etc, then look these up.
             - If there are links or references to papers, then looks these up and summarize (don't guess content - if you can't access the paper, then say "I can't access the paper")
             - Try using artl-mcp to get paper fulltext.
-            - If you want a more powerful AI agent to take on this one and make a PR, use this magic phrase: `@dragon-ai-agent please <INSTRUCTIONS>`
+            - If you want a more powerful AI agent to take on this one and make a PR, use this magic phrase: `@ai4c-agent please <INSTRUCTIONS>`
 
         2. Next, use the GitHub tools to get context about the issue:
            - You have access to these github tools:

--- a/ai.just
+++ b/ai.just
@@ -38,7 +38,6 @@ gh-add-secrets:
   }
 
   # Set each secret if the corresponding env var exists
-  set_secret_if_exists "PAT_FOR_PR"
   set_secret_if_exists "ANTHROPIC_API_KEY"
   set_secret_if_exists "OPENAI_API_KEY"
   set_secret_if_exists "CBORG_API_KEY"
@@ -47,6 +46,4 @@ gh-add-secrets:
   set_secret_if_exists "FUTUREHOUSE_API_KEY"
   set_secret_if_exists "EDISON_API_KEY"
 
-gh-invite-dragon-ai:
-  gh api repos/:owner/:repo/collaborators/dragon-ai-agent --method PUT --field permission=write > /dev/null
 

--- a/justfile
+++ b/justfile
@@ -177,15 +177,15 @@ _ai-instructions: goosehints copilot-instructions
 gh-add-topics:
   gh repo edit --add-topic "ai-gene-review,monarchinitiative,linkml"
 
+# PAT_FOR_PR is deliberately absent: the agentic workflows authenticate with
+# short-lived ai4c-agent / ai4c-reviewer GitHub App tokens, and the PAT this
+# recipe used to install was the credential exposed in the dragon-ai-agent
+# incident. Do not reintroduce it.
 gh-add-secrets:
-  gh secret set PAT_FOR_PR --body "$PAT_FOR_PR"
   gh secret set ANTHROPIC_API_KEY --body "$ANTHROPIC_API_KEY"
   gh secret set OPENAI_API_KEY --body "$OPENAI_API_KEY"
   gh secret set CBORG_API_KEY --body "$CBORG_API_KEY"
   gh secret set CLAUDE_CODE_OATH_TOKEN --body "$CLAUDE_CODE_OATH_TOKEN"
-
-gh-invite-the-dragon:
-  gh api repos/monarch-initiative/ai-gene-review/collaborators/dragon-ai-agent -X PUT -f permission=push
 
 # ============== Include project-specific recipes ==============
 


### PR DESCRIPTION
Raised in review of #2241. The *workflows* are off `dragon-ai-agent`; the *repository* was not.

## What the repo was still doing

- **`justfile:gh-invite-the-dragon`** and **`ai.just:gh-invite-dragon-ai`** each `PUT` `dragon-ai-agent` back as a collaborator with push/write. Deleted.
- **`gh-add-secrets`** (justfile) and `ai.just`'s secret loop each re-install **`PAT_FOR_PR`** — the exact credential exposed in the incident. A single `just gh-add-secrets` would have undone the migration. Removed, with a comment explaining why so it doesn't get helpfully restored.
- The **issue summarizer advertises the mention keyword to every new issue** and was still telling people to use `@dragon-ai-agent please`. Now `@ai4c-agent please`.

## One correction to the finding

The review inferred *live access* from the collaborator list. Checking directly:

```
GET /repos/.../collaborators?affiliation=direct  ->  cmungall, caufieldjh, dragon-ai-agent
GET /users/dragon-ai-agent                       ->  404 Not Found
```

**The account no longer exists.** What remains is a dangling direct-collaborator entry for a deleted user — it grants nothing, and these recipes could no longer recreate it even if run. So this is hygiene and footgun-removal, not a live exposure. The stale entry itself is a one-click removal in repo settings; I've left that to @cmungall rather than mutating repo permissions unasked.

## What stays

`@dragon-ai-agent please …` remains a valid mention keyword. It's a text match with no account behind it, kept so older issue threads and muscle memory still work, and the trust gate classifies it as an agent trigger accordingly.