### PR TITLE
cache: drop the duplicate GO:0043159 row introduced in #2268

### DIFF
--- a/cache/go/terms.csv
+++ b/cache/go/terms.csv
@@ -9058,4 +9058,3 @@ GO:0032013,negative regulation of ARF protein signal transduction,2026-07-25T18:
 GO:0140312,cargo adaptor activity,2026-07-25T18:16:04.586533
 GO:0002079,inner acrosomal membrane,2026-07-25T19:52:28.426975
 GO:0007342,fusion of sperm to egg plasma membrane involved in single fertilization,2026-07-25T19:52:28.383999
-GO:0043159,acrosomal matrix,2026-07-25T19:52:28.313681


### PR DESCRIPTION
Housekeeping for a defect I introduced in #2268.

`cache/go/terms.csv` had exactly **one** duplicated curie across its 9060 rows, and it was mine:

```
line 4879: GO:0043159,acrosomal matrix,2026-07-25T19:36:28.950556   <- sorted position, kept
line 9061: GO:0043159,acrosomal matrix,2026-07-25T19:52:28.313681   <- appended at EOF, removed
```

### How it happened

While reviewing ACRBP I hit the known dropped-rows problem: my branch's `terms.csv` had lost 7 rows
relative to `origin/main`. I fixed it the documented way — `git checkout origin/main -- cache/go/terms.csv`
then re-inserted only my six new terms at their sorted positions, deliberately **not** re-sorting the
file (main is not globally sorted, and re-sorting manufactures spurious deletions). A `just validate`
run sixteen minutes later appended `GO:0043159` again at EOF, evidently not matching my hand-inserted
row, leaving two copies.

### The fix

Removes the appended copy and keeps the one in sorted position, which restores both uniqueness and
the file's local sort order. Verified programmatically:

- no duplicated curie remains anywhere in the file (9059 rows, 9059 distinct)
- the diff is the single deleted line, nothing else
- **stable under re-validation**: three consecutive `just validate human ACRBP` runs leave the file at
  one `GO:0043159` row and the working tree clean, so the append does not recur once the duplicate is
  gone

### Note for the reviewer on the terms.csv gate

The campaign gate `git diff origin/main HEAD -- cache/go/terms.csv | grep '^-GO:'` is **expected to be
non-empty on this branch** — the single deleted line it reports is the entire intended change, not the
accidental-deletion bug the gate normally guards against. Gates run in the prescribed order
(checkquotes → validate → terms.csv diff last):

- `checkquotes.py`: 63 quotes, 0 problems
- `just validate human ACRBP`: ✓ Valid, no warnings
- `terms.csv` diff: one deletion, zero additions, as intended

No gene review content is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
