### PR TITLE
Guard the IPR013094 source_status — the field the last two PRs both missed

### DIFF
--- a/genes/human/AADACL2/AADACL2-bioinformatics/check_paralog_agreement.py
+++ b/genes/human/AADACL2/AADACL2-bioinformatics/check_paralog_agreement.py
@@ -71,8 +71,12 @@ HISTORICAL_MARKER = "Historical: this section records the state that motivated t
 FOLD_SOURCE = "InterPro:IPR013094"
 FOLD_SOURCE_STATUS = "CIRCULAR_OR_REDUNDANT"
 # Values retracted for this row: the root cause recorded on it is redundancy, which says nothing
-# about source strength, and the fold-3 signature is not a weak source.
-RETRACTED_STATUSES = {"SOURCE_WEAK_OR_INFERRED", "SOURCE_EVIDENCE_WEAK"}
+# about source strength, and the fold-3 signature is not a weak source. They live in DIFFERENT
+# enums, and a first version of this guard rejected both in source_status - where SOURCE_EVIDENCE_WEAK
+# is not a permissible value at all, so that half was unreachable and read as coverage while the
+# field it can legally occupy went unguarded.
+RETRACTED_SOURCE_STATUS = "SOURCE_WEAK_OR_INFERRED"   # PropagationSourceStatusEnum
+RETRACTED_FAILURE_MODE = "SOURCE_EVIDENCE_WEAK"       # PropagationFailureModeEnum
 
 # Phrasings that were true before the three reviews were harmonised and are false after it.
 # Each is (regex, why it is stale). Applied to reviews, notes and the audit prose alike.
@@ -178,6 +182,11 @@ def check_invariant(root: Path, problems: list[str]) -> None:
             pr = rv.get("propagation_review") or {}
             if pr.get("root_cause") != ROOT_CAUSE:
                 problems.append(f"{where}: root_cause {pr.get('root_cause')!r}, expected {ROOT_CAUSE}")
+            if RETRACTED_FAILURE_MODE in (pr.get("failure_modes") or []):
+                problems.append(f"{where}: {RETRACTED_FAILURE_MODE} is recorded; every protein "
+                                f"donor on this node carries its own experimental evidence, so the "
+                                f"sources are not weak - the defect is that the term should not "
+                                f"propagate, which root_cause already states")
             if "GRANULARITY_MISMATCH" in (pr.get("failure_modes") or []):
                 problems.append(f"{where}: GRANULARITY_MISMATCH is recorded; the donors are "
                                 f"heterogeneous, so the parent is their LCA and there is no "
@@ -187,11 +196,13 @@ def check_invariant(root: Path, problems: list[str]) -> None:
                     problems.append(f"{where}: supporting_entities do not equal this gene's GOA "
                                     f"WITH/FROM column ({len(a.get('supporting_entities') or [])} "
                                     f"vs {len(tokens)} tokens)")
+            seen_fold = False
             for entity in pr.get("source_entities") or []:
                 if entity.get("source_id") != FOLD_SOURCE:
                     continue
+                seen_fold = True
                 status = entity.get("source_status")
-                if status in RETRACTED_STATUSES:
+                if status == RETRACTED_SOURCE_STATUS:
                     problems.append(f"{where}: {FOLD_SOURCE} source_status is {status!r}, which was "
                                     f"retracted for this row - the root cause is redundancy, which "
                                     f"says nothing about source strength, and the fold-3 signature "
@@ -199,6 +210,14 @@ def check_invariant(root: Path, problems: list[str]) -> None:
                 elif status != FOLD_SOURCE_STATUS:
                     problems.append(f"{where}: {FOLD_SOURCE} source_status is {status!r}, expected "
                                     f"{FOLD_SOURCE_STATUS} to match the sibling paralogs")
+            # Presence is asserted, not assumed. A continue-on-mismatch loop passes silently when the
+            # entity is deleted, the source_entities list is dropped, or source_id is relabelled -
+            # i.e. the guard could be defeated by removing the thing it guards, which is the same
+            # shape of hole this check was added to close.
+            if ev == "IEA" and not seen_fold:
+                problems.append(f"{where}: no {FOLD_SOURCE} source entity; it is the sole source of "
+                                f"this row in all three paralogs, so its absence is a divergence, "
+                                f"not an exemption")
 
         cf = doc.get("core_functions") or []
         if not cf or (cf[0].get("molecular_function") or {}).get("id") != CORE_MF:
@@ -366,9 +385,44 @@ def _break_invariant_supporting_entities(root: Path) -> None:
 def _break_invariant_fold_source_status(root: Path) -> None:
     """Reinstate the retracted assessment on the fold signature, one field below failure_modes."""
     f = gene_files(root, "AADACL3")["review"]
+    text = f.read_text()
+    target = f"source_status: {FOLD_SOURCE_STATUS}"
+    assert target in text, f"mutation target drifted: {target!r} not found in {f}"
+    f.write_text(text.replace(target, f"source_status: {RETRACTED_SOURCE_STATUS}", 1))
+
+
+def _break_invariant_fold_entity_deleted(root: Path) -> None:
+    """Delete the fold source entity, which a continue-on-mismatch check would not notice."""
+    f = gene_files(root, "AADACL3")["review"]
+    lines = f.read_text().splitlines(keepends=True)
+    out, dropping = [], False
+    for line in lines:
+        if f"source_id: {FOLD_SOURCE}" in line:
+            dropping = True
+            continue
+        if dropping:
+            # Drop the entity's remaining keys, i.e. until the next list item or a dedent.
+            if line.lstrip().startswith("- ") or not line.startswith(" " * 8):
+                dropping = False
+            else:
+                continue
+        out.append(line)
+    assert len(out) < len(lines), f"mutation target drifted: no {FOLD_SOURCE} entity found in {f}"
+    f.write_text("".join(out))
+
+
+def _break_invariant_retracted_failure_mode(root: Path) -> None:
+    """Reinstate SOURCE_EVIDENCE_WEAK in failure_modes, where it is a legal enum value."""
+    f = gene_files(root, "AADACL3")["review"]
+    text = f.read_text()
+    target = f"      root_cause: {ROOT_CAUSE}\n"
+    assert target in text, f"mutation target drifted: {target!r} not found in {f}"
     f.write_text(
-        f.read_text().replace(
-            f"source_status: {FOLD_SOURCE_STATUS}", "source_status: SOURCE_WEAK_OR_INFERRED", 1
+        text.replace(
+            target,
+            f"      root_cause: {ROOT_CAUSE}\n      failure_modes:\n"
+            f"      - {RETRACTED_FAILURE_MODE}\n",
+            1,
         )
     )
 
@@ -431,6 +485,8 @@ MUTATIONS = [
     ("invariant: root_cause reverted", _break_invariant_root_cause),
     ("invariant: GRANULARITY_MISMATCH re-added", _break_invariant_failure_mode),
     ("invariant: retracted source_status on the fold signature", _break_invariant_fold_source_status),
+    ("invariant: fold source entity deleted outright", _break_invariant_fold_entity_deleted),
+    ("invariant: retracted SOURCE_EVIDENCE_WEAK failure mode", _break_invariant_retracted_failure_mode),
     ("invariant: replacement term reverted to GO:0017171", _break_invariant_replacement),
     ("invariant: a supporting_entities token dropped", _break_invariant_supporting_entities),
     ("invariant: core_functions MF changed", _break_invariant_core_mf),

--- a/genes/human/AADACL2/AADACL2-bioinformatics/check_paralog_agreement.py
+++ b/genes/human/AADACL2/AADACL2-bioinformatics/check_paralog_agreement.py
@@ -14,6 +14,11 @@ Two things are enforced, over the reviews, the notes files and the shared audit 
      GRANULARITY_MISMATCH failure mode, supporting_entities equal to that gene's own GOA WITH/FROM
      column, core_functions molecular function GO:0052689, and the shared node audit cited.
 
+     Also the assessment of InterPro:IPR013094, the fold-level signature that is the sole source of
+     all three IEA rows. That field was missed twice: once by the harmonisation, and again by the
+     three-line follow-up written to remove this exact class of divergence - because it sits one
+     line below the field being fixed, so re-reading the edited block could not reveal it.
+
   2. the stale-claim greps. Statements that were true before the harmonisation are false after it,
      and they hid in notes files and in generated prose, not only in the YAML.
 
@@ -58,6 +63,16 @@ ROOT_CAUSE = "EVIDENCE_CIRCULAR_OR_REDUNDANT"
 CORE_MF = "GO:0052689"
 AUDIT = "NODE_PTN009058710.md"
 HISTORICAL_MARKER = "Historical: this section records the state that motivated the audit"
+
+# The fold-level signature that every one of these three IEA rows cites as its only source. Its
+# assessment has to agree too: a divergence here was missed by the harmonisation PR and then again
+# by the three-line PR written to remove exactly this kind of divergence, because the field sits one
+# line below the one being fixed.
+FOLD_SOURCE = "InterPro:IPR013094"
+FOLD_SOURCE_STATUS = "CIRCULAR_OR_REDUNDANT"
+# Values retracted for this row: the root cause recorded on it is redundancy, which says nothing
+# about source strength, and the fold-3 signature is not a weak source.
+RETRACTED_STATUSES = {"SOURCE_WEAK_OR_INFERRED", "SOURCE_EVIDENCE_WEAK"}
 
 # Phrasings that were true before the three reviews were harmonised and are false after it.
 # Each is (regex, why it is stale). Applied to reviews, notes and the audit prose alike.
@@ -172,6 +187,19 @@ def check_invariant(root: Path, problems: list[str]) -> None:
                     problems.append(f"{where}: supporting_entities do not equal this gene's GOA "
                                     f"WITH/FROM column ({len(a.get('supporting_entities') or [])} "
                                     f"vs {len(tokens)} tokens)")
+            for entity in pr.get("source_entities") or []:
+                if entity.get("source_id") != FOLD_SOURCE:
+                    continue
+                status = entity.get("source_status")
+                if status in RETRACTED_STATUSES:
+                    problems.append(f"{where}: {FOLD_SOURCE} source_status is {status!r}, which was "
+                                    f"retracted for this row - the root cause is redundancy, which "
+                                    f"says nothing about source strength, and the fold-3 signature "
+                                    f"is not a weak source; expected {FOLD_SOURCE_STATUS}")
+                elif status != FOLD_SOURCE_STATUS:
+                    problems.append(f"{where}: {FOLD_SOURCE} source_status is {status!r}, expected "
+                                    f"{FOLD_SOURCE_STATUS} to match the sibling paralogs")
+
         cf = doc.get("core_functions") or []
         if not cf or (cf[0].get("molecular_function") or {}).get("id") != CORE_MF:
             problems.append(f"{gene}: core_functions molecular_function is not {CORE_MF}")
@@ -335,6 +363,16 @@ def _break_invariant_supporting_entities(root: Path) -> None:
     p = gene_files(root, "AADACL4")["review"]
     p.write_text(p.read_text().replace("  - UniProtKB:Q9HTI0\n  review:", "  review:", 1))
 
+def _break_invariant_fold_source_status(root: Path) -> None:
+    """Reinstate the retracted assessment on the fold signature, one field below failure_modes."""
+    f = gene_files(root, "AADACL3")["review"]
+    f.write_text(
+        f.read_text().replace(
+            f"source_status: {FOLD_SOURCE_STATUS}", "source_status: SOURCE_WEAK_OR_INFERRED", 1
+        )
+    )
+
+
 def _break_invariant_core_mf(root: Path) -> None:
     p = gene_files(root, "AADACL3")["review"]
     t = p.read_text()
@@ -392,6 +430,7 @@ def _break_stale_pseudo_retrospective(root: Path) -> None:
 MUTATIONS = [
     ("invariant: root_cause reverted", _break_invariant_root_cause),
     ("invariant: GRANULARITY_MISMATCH re-added", _break_invariant_failure_mode),
+    ("invariant: retracted source_status on the fold signature", _break_invariant_fold_source_status),
     ("invariant: replacement term reverted to GO:0017171", _break_invariant_replacement),
     ("invariant: a supporting_entities token dropped", _break_invariant_supporting_entities),
     ("invariant: core_functions MF changed", _break_invariant_core_mf),


### PR DESCRIPTION
#2286 committed `check_paralog_agreement.py` because five of its six rounds hit the same defect: a claim corrected in one place and left standing in another. **The guard did not cover `source_status` on the source entity, and that field then diverged in exactly the way the guard exists to prevent — twice.**

AADACL3 kept `source_status: SOURCE_WEAK_OR_INFERRED` on `InterPro:IPR013094` where both siblings use `CIRCULAR_OR_REDUNDANT`. #2286 missed it, and so did **#2288 — the three-line PR written specifically to remove this class of divergence** — because the field sits one line below the one being fixed, so re-reading the edited block could not reveal it. A reviewer caught it both times.

## What the check enforces

For every `GO:0016787` row citing that signature:

- `source_status == CIRCULAR_OR_REDUNDANT`, matching the siblings; and
- a **named** rejection of `SOURCE_WEAK_OR_INFERRED` / `SOURCE_EVIDENCE_WEAK`, with the reason in the message — those are the specific values retracted for this row, because the recorded root cause is redundancy (which says nothing about source strength) and the α/β-hydrolase fold-3 signature is not a weak source.

Distinguishing the retracted values from a merely-different one matters: the error mode here is *reinstating the old assessment*, and a bare equality check would report that identically to a typo.

## Verification

- Added to `MUTATIONS`, so `--self-test` proves it fires: **12/12 guards demonstrably fire**.
- The guard **caught the live defect on `origin/main`** before #2288 merged — so it was validated against the real bug, not only a synthetic mutation.
- Baseline passes on the rebased tree (`exit=0`), now that #2288 is in.

Stacked on #2288, which is already merged; this rebases cleanly onto `main` with only the guard change remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the AADACL paralog validation script and its self-tests; no runtime services or curator YAML content in this diff.
> 
> **Overview**
> Extends **`check_paralog_agreement.py`** so the paralog agreement invariant also covers **`InterPro:IPR013094`** on the shared `GO:0016787` IEA rows—the fold signature that was left divergent across harmonisation and a follow-up fix because **`source_status`** sits adjacent to the fields those edits touched.
> 
> **`check_invariant`** now requires the IPR013094 entity’s **`source_status`** to be **`CIRCULAR_OR_REDUNDANT`**, with explicit rejection of the retracted **`SOURCE_WEAK_OR_INFERRED`** status and **`SOURCE_EVIDENCE_WEAK`** in **`failure_modes`** (each checked in the enum where it is legal). For IEA rows it also fails if that source entity is missing, so the guard cannot be bypassed by deleting the entity.
> 
> Documentation at the top of the script describes this gap. **`--self-test`** gains three mutations (wrong fold **`source_status`**, deleted fold entity, re-added **`SOURCE_EVIDENCE_WEAK`**), bringing the demonstrably firing guard count to **12**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd6290d1e5dd42be09b81675798ca771b1ec94b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->