### PR TITLE
ACTR8 follow-up: a missed Publisher Correction, and the ACTR5/ACTR8 terms.csv collision

### DIFF
--- a/cache/go/terms.csv
+++ b/cache/go/terms.csv
@@ -9067,5 +9067,4 @@ GO:0007342,fusion of sperm to egg plasma membrane involved in single fertilizati
 GO:0140378,protein complex scaffold activity,2026-07-26T11:13:22.590689
 GO:0140660,cytoskeletal motor activator activity,2026-07-26T11:13:22.590689
 GO:0098958,retrograde axonal transport of mitochondrion,2026-07-25T20:11:53.422854
-GO:0031011,Ino80 complex,2026-07-26T13:40:43.838569
 GO:0035023,regulation of Rho protein signal transduction,2026-07-26T13:32:30.209188

--- a/genes/human/ACTR8/ACTR8-ai-review.yaml
+++ b/genes/human/ACTR8/ACTR8-ai-review.yaml
@@ -255,7 +255,14 @@ references:
   reference_review:
     relevance: LOW
     correctness: VERIFIED
-    review_notes: Proteome-scale map; corroborates the ACTR8-UCHL5 contact.
+    review_notes: 'Proteome-scale map; corroborates the ACTR8-UCHL5 contact. Carries a Publisher
+      Correction, PMID:41039152 (Nature 646:E16, Oct 2025, ''Publisher Correction: Multimodal cell
+      maps as a foundation for structural and functional genomics''), found via the article''s own
+      CommentsCorrections RefType=ErratumIn. It is a publisher-side correction rather than a data
+      or figure-integrity notice, the article is not retracted, and the single claim resting on it
+      here - an ACTR8-UCHL5 association also established by PMID:18922472 and by ComplexPortal
+      CPX-846 membership - is unaffected. Recorded rather than acted on: is_invalid is deliberately
+      NOT set, since that flag is for retracted or replaced references.'
 - id: Reactome:R-HSA-5689544
   title: UCHL5 binds INO80 complex
   reference_review:

--- a/genes/human/ACTR8/ACTR8-notes.md
+++ b/genes/human/ACTR8/ACTR8-notes.md
@@ -26,7 +26,7 @@ committed in this repo, ComplexPortal, IntAct and 20 primary papers.
 Retraction screen: all 20 PMIDs cited here were checked against PubMed publication types and
 an explicit `retracted publication[pt] OR expression of concern[pt]` query over the whole set —
 **0 hits**. No reference in this review is retracted or carries an expression of concern. **But
-that method is insufficient on its own — see §13**, which records one Publisher Correction it
+that method is insufficient on its own — see §15**, which records one Publisher Correction it
 missed and the check that finds them.
 
 ---
@@ -46,7 +46,7 @@ A recombinant **human** minimal core containing ARP8 slides nucleosomes
 
 The recognition itself is quantified on the purified human protein
 [PMID:22977180 "strongly prefer nucleosomes and H3-H4 tetramers over H2A-H2B dimers, suggesting that Arp8 functions as a nucleosome recognition module"].
-**Table 2 mixes species and must be read per-species** — see §11c, where a cross-species join in my
+**Table 2 mixes species and must be read per-species** — see §13, where a cross-species join in my
 first draft produced an inverted conclusion. The human rows only:
 
 | ligand | HsArp8 `K_d,app` (nM) | Hill `nH` |
@@ -484,7 +484,7 @@ functionally unassigned trace activity is the mirror of accepting one off a fold
   separately annotated `GO:0006275` and `GO:0006282`. Kept non-core rather than flagged as
   over-annotation: a redundant true parent is not an over-annotation.
 
-## 11b. Three claims of my own that a self-audit retracted
+## 12. Three claims of my own that a self-audit retracted
 
 Recorded because the corrections are the useful part, and because each is a *composite* claim —
 every constituent quote verbatim, the join unsupported. None would have been caught by quote
@@ -512,7 +512,7 @@ participants, IntAct 82 records / 14 publications, PTHR11937 9 `GO:0005200` rows
 and the two ontology-ancestry claims — all confirmed. The three failures above were all
 *qualitative* superlatives, not numbers.
 
-## 11c. The error the reviewer caught: a cross-species join inside one table
+## 13. The error the reviewer caught: a cross-species join inside one table
 
 Worth recording in full, because it is the single sharpest instance in this review of the failure
 class the campaign says dominates — **every constituent number verbatim and correct, the join
@@ -554,7 +554,7 @@ cross-row comparison as cross-species until proved otherwise, and re-derive any 
 species.** The affected verdicts did **not** change — `GO:0031491` IDA with `enables` rests on
 HsArp8 at 51 ± 9.6 nM measured on the purified human protein — which is exactly why the error
 survived my own audit: it sat in the *justification*, not in the term, the evidence code or the
-qualifier, and my superlative sweep (§11b) was looking for absolutes rather than for species.
+qualifier, and my superlative sweep (§12) was looking for absolutes rather than for species.
 
 Two smaller reviewer corrections accepted on the same pass:
 
@@ -568,7 +568,7 @@ Two smaller reviewer corrections accepted on the same pass:
   `PMID:16230350`, the MI 0.67 targeted co-IP, `NbExp=5`, the YY1/INO80E ranking, the negative
   regulatory arm, the *Ino80*-null embryonic phenotype, the three conjoined claims).
 
-## 12c. Two parallel PRs, one new term, one duplicate — a gate that cannot fire per-PR
+## 14. Two parallel PRs, one new term, one duplicate — a gate that cannot fire per-PR
 
 Found while re-running the gates for this follow-up. `cache/go/terms.csv` on `main` carried
 **`GO:0031011` twice**:
@@ -597,9 +597,13 @@ removed here, keeping the sorted-position row, so the term appears exactly once.
 2. **The duplicate check belongs in CI on `main`, not only in each PR**, since only the merge
    result can exhibit the fault. A per-PR approximation is to re-run the check after
    `git merge origin/main` immediately before pushing — which this review did on three merges, but
-   ACTR5 had not yet merged at that point, so the collision was still invisible.
+   ACTR5 had not yet merged at that point, so the collision was still invisible. Filed as
+   [issue #2294](https://github.com/ai4curation/ai-gene-review/issues/2294) rather than fixed here,
+   because the workflow is shared CI config outside gene-review scope; the issue records that
+   `main` already carries two pre-existing duplicates (`GO:0001675`, `GO:0009566`) which a bare
+   "must be empty" assertion would trip over, and that the file must not be re-sorted.
 
-
+## 15. The correction screen used the wrong instrument
 
 Prompted by a cross-gene note that provider records cite corrected papers unflagged. Re-running
 the screen properly found one item my round-1 method could not have found, and the **method** is
@@ -636,7 +640,16 @@ article, never by a publication-type query over the cited set.** The two `Commen
 show why the `RefType` must be matched rather than merely counted — a commentary is not a
 correction.
 
-## 12b. Two cross-gene claims checked, and one refuted
+The correction record itself is now cached at `publications/PMID_41039152.md`, so its existence and
+its `Erratum for` linkage to `PMID:40205054` are verifiable from the repository rather than resting
+on a network call — a reviewer flagged that it was otherwise uncheckable offline, which was fair.
+It is deliberately **not** added to the `references:` list: it is a correction notice, not a source
+of any claim here, and listing it would imply this review draws evidence from it. The consequence,
+also deliberate, is that `PMID:41039152` appears only in `review_notes` prose and so will not be
+picked up by a programmatic sweep over `references` — the right place to catch it is the
+`CommentsCorrections` scan described above, run against each cited article.
+
+## 16. Two cross-gene claims checked, and one refuted
 
 Both arrived as cross-gene guidance while this review was in flight. Recorded with outcomes
 because a check whose result is not written down reads the same as a check never run.
@@ -672,7 +685,7 @@ The only multiplicity difference is the `GO:0031011`/IDA/`PMID:21303910` row tha
 (once ComplexPortal, once UniProt), documented at the top of these notes. **No collapse occurred
 here** — but the check is what establishes that, not the absence of a symptom.
 
-## 12. Core-vs-non-core rule applied consistently
+## 17. Core-vs-non-core rule applied consistently
 
 `ACCEPT` where the supporting experiment manipulated or measured **ARP8/Actr8 itself**;
 `KEEP_AS_NON_CORE` where the only evidence is a complex-level manipulation (INO80 knockdown,

--- a/genes/human/ACTR8/ACTR8-notes.md
+++ b/genes/human/ACTR8/ACTR8-notes.md
@@ -25,7 +25,9 @@ committed in this repo, ComplexPortal, IntAct and 20 primary papers.
 
 Retraction screen: all 20 PMIDs cited here were checked against PubMed publication types and
 an explicit `retracted publication[pt] OR expression of concern[pt]` query over the whole set —
-**0 hits**. No reference in this review is retracted or carries an expression of concern.
+**0 hits**. No reference in this review is retracted or carries an expression of concern. **But
+that method is insufficient on its own — see §13**, which records one Publisher Correction it
+missed and the check that finds them.
 
 ---
 
@@ -565,6 +567,110 @@ Two smaller reviewer corrections accepted on the same pass:
   into §8 and §7b, with each row keeping only what is specific to it (the 17 records from
   `PMID:16230350`, the MI 0.67 targeted co-IP, `NbExp=5`, the YY1/INO80E ranking, the negative
   regulatory arm, the *Ino80*-null embryonic phenotype, the three conjoined claims).
+
+## 12c. Two parallel PRs, one new term, one duplicate — a gate that cannot fire per-PR
+
+Found while re-running the gates for this follow-up. `cache/go/terms.csv` on `main` carried
+**`GO:0031011` twice**:
+
+| line | timestamp | added by |
+|---|---|---|
+| 3456 | `13:43:14` | ACTR5 #2291, in sorted position |
+| 9070 | `13:40:43` | ACTR8 #2290, appended at EOF |
+
+ARP5 and ARP8 are both INO80 subunits, so **both reviews needed the same new term for
+`core_functions.in_complex`**. Each branch's duplicate gate
+(`cut -d, -f1 cache/go/terms.csv | sort | uniq -d`) passed in isolation, because within either
+branch the term appeared once — and they landed in *different positions*, so git auto-merged both
+without a conflict. The duplicate exists only in the merge result.
+
+This is a **new variant** of the known duplicate failure mode: the documented one is self-inflicted
+within a single branch (hand-insert, then a later `just validate` re-appends because the appender is
+blind to the inserted row). This one is *inter-branch*, and no per-PR check can see it — the
+per-branch gate is not wrong, it is simply looking at the wrong artefact. The EOF duplicate is
+removed here, keeping the sorted-position row, so the term appears exactly once.
+
+**Two generalisations worth carrying:**
+1. **Related genes reviewed in parallel are the high-risk case**, because they are precisely the
+   ones that need the same new terms. Whenever a sibling PR is in flight, expect a `terms.csv`
+   collision on whatever complex or activity term they share.
+2. **The duplicate check belongs in CI on `main`, not only in each PR**, since only the merge
+   result can exhibit the fault. A per-PR approximation is to re-run the check after
+   `git merge origin/main` immediately before pushing — which this review did on three merges, but
+   ACTR5 had not yet merged at that point, so the collision was still invisible.
+
+
+
+Prompted by a cross-gene note that provider records cite corrected papers unflagged. Re-running
+the screen properly found one item my round-1 method could not have found, and the **method** is
+the transferable part.
+
+**What round 1 did:** an `esearch` over the 20 cited PMIDs `AND (published erratum[pt] OR
+corrected and republished article[pt] OR retracted publication[pt] OR expression of concern[pt])`.
+Re-run now, that query returns **`Count: 0`**.
+
+**Why it is wrong:** those publication types sit on the *erratum record*, not on the article being
+corrected. Querying the cited set therefore asks "is any paper I cite itself an erratum?", which
+is never the question. The right field is `CommentsCorrections/RefType` **on each cited article**,
+read from `efetch&retmode=xml`, matching `ErratumIn`, `RetractionIn`, `ExpressionOfConcernIn`,
+`CorrectedAndRepublishedIn`, `RepublishedIn`, `PartialRetractionIn`.
+
+**What that found**, across all 20:
+
+| PMID | `RefType` | target |
+|---|---|---|
+| `PMID:18922472` | `CommentIn` | commentary, not a correction |
+| `PMID:26496610` | `CommentIn` | commentary, not a correction |
+| **`PMID:40205054`** | **`ErratumIn`** | **`PMID:41039152`** |
+
+`PMID:41039152` is a **Publisher Correction** (*Nature* 646:E16, Oct 2025) to "Multimodal cell maps
+as a foundation for structural and functional genomics" — a publisher-side correction, **not** a
+data- or figure-integrity notice, and the article is not retracted. The single claim this review
+rests on it is an ACTR8–UCHL5 association independently established by `PMID:18922472` and by
+`CPX-846` membership, so nothing changes. `is_invalid` is deliberately **not** set: that flag is
+for retracted or replaced references, and using it here would misrepresent a typesetting-class
+correction as an integrity problem.
+
+**Rule to carry forward: screen corrections by reading `CommentsCorrections` on each cited
+article, never by a publication-type query over the cited set.** The two `CommentIn` hits also
+show why the `RefType` must be matched rather than merely counted — a commentary is not a
+correction.
+
+## 12b. Two cross-gene claims checked, and one refuted
+
+Both arrived as cross-gene guidance while this review was in flight. Recorded with outcomes
+because a check whose result is not written down reads the same as a check never run.
+
+**Confirmed, and it distinguishes ACTR8 from ACTR5.** `PMID:25016522`'s ComplexPortal-assigned
+rows (`GO:0006275`, `GO:0060382`) are `ACCEPT`ed here rather than kept non-core, on the grounds
+that the paper assayed ARP8 itself. Counting occurrences in the cached full text settles it:
+**27 × "Arp8", 0 × "Arp5"/"ACTR5"**. The paper has a dedicated results section *"Effect of Arp8
+depletion on recovery after replication stress"*, an esiRNA against human Arp8 (485–916,
+`NM_022899.3`), its own qPCR primers, a 4-fold increase in discontinued forks by fibre labelling,
+and the conclusion that *"depletion of the Arp8 subunit had the same consequences as Ino80
+deficiency"*. So the same rows that are complex-level projections for ARP5 are gene-level evidence
+for ARP8 — the asymmetry is real and is why the two reviews should **not** be harmonised on these
+rows.
+
+**Refuted.** A suggestion that ARP8 should take no nucleotide term without a structural check,
+because it has "1 of 5 catalytic positions with no resolved nucleotide". The structural check was
+done, and it is stronger than an alignment: human ARP8 has exactly **one** PDB entry, `4FO0`,
+whose own deposited title is *"Human actin-related protein Arp8 in its ATP-bound state"* and whose
+ligand list contains **ATP** and **MG** (the physiological Mg²⁺ counter-ion). Add the omit map
+computed for the bound ATP, an ATPase measured on the human protein, and ATP occupancy gating DNA
+binding through the annotated pocket residues, and `GO:0005524` is IDA-grade. The residue
+observation is nonetheless correct and is already reflected: actin's catalytic Gln137 and sensor
+His73 **are** substituted in ARP8 (Glu266, Arg187), which is precisely why `GO:0016887` ATP
+hydrolysis activity is withheld. Binding and hydrolysis are separate claims and the review
+separates them; "no nucleotide term at all" does not follow.
+
+**Null result, recorded as one.** A concern that the seeded stub can silently collapse duplicate
+`GO:0005515` rows, so annotations must be counted against the GOA TSV rather than the stub. Checked
+per `(term, evidence, reference)` key: all **31** distinct GOA keys are present in the review, all
+**6** `GO:0005515` rows survive with their own verdicts, and no review row lacks a GOA counterpart.
+The only multiplicity difference is the `GO:0031011`/IDA/`PMID:21303910` row that GOA banks twice
+(once ComplexPortal, once UniProt), documented at the top of these notes. **No collapse occurred
+here** — but the check is what establishes that, not the absence of a symptom.
 
 ## 12. Core-vs-non-core rule applied consistently
 

--- a/publications/PMID_41039152.md
+++ b/publications/PMID_41039152.md
@@ -1,0 +1,134 @@
+---
+pmid: '41039152'
+title: 'Publisher Correction: Multimodal cell maps as a foundation for structural
+  and functional genomics.'
+authors:
+- Schaffer LV
+- Hu M
+- Qian G
+- Moon KM
+- Pal A
+- Soni N
+- Latham AP
+- Pontano Vaites L
+- Tsai D
+- Mattson NM
+- Licon K
+- Bachelder R
+- Cesnik A
+- Gaur I
+- Le T
+- Leineweber W
+- Palar A
+- Pulido E
+- Qin Y
+- Zhao X
+- Churas C
+- Lenkiewicz J
+- Chen J
+- Ono K
+- Pratt D
+- Zage P
+- Echeverria I
+- Sali A
+- Harper JW
+- Gygi SP
+- Foster LJ
+- Huttlin EL
+- Lundberg E
+- Ideker T
+journal: Nature
+year: '2025'
+full_text_available: false
+full_text_extraction_method: xml
+pmcid: PMC12545196
+doi: 10.1038/s41586-025-09648-x
+pubmed_publication_types:
+- Published Erratum
+publication_type: OTHER
+---
+
+# Publisher Correction: Multimodal cell maps as a foundation for structural and functional genomics.
+**Authors:** Schaffer LV, Hu M, Qian G, Moon KM, Pal A, Soni N, Latham AP, Pontano Vaites L, Tsai D, Mattson NM, Licon K, Bachelder R, Cesnik A, Gaur I, Le T, Leineweber W, Palar A, Pulido E, Qin Y, Zhao X, Churas C, Lenkiewicz J, Chen J, Ono K, Pratt D, Zage P, Echeverria I, Sali A, Harper JW, Gygi SP, Foster LJ, Huttlin EL, Lundberg E, Ideker T
+**Journal:** Nature (2025)
+**DOI:** [10.1038/s41586-025-09648-x](https://doi.org/10.1038/s41586-025-09648-x)
+**PMC:** [PMC12545196](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC12545196/)
+
+## Abstract
+
+1. Nature. 2025 Oct;646(8086):E16. doi: 10.1038/s41586-025-09648-x.
+
+Publisher Correction: Multimodal cell maps as a foundation for structural and 
+functional genomics.
+
+Schaffer LV(#)(1), Hu M(#)(1), Qian G(1)(2), Moon KM(3), Pal A(4), Soni N(4), 
+Latham AP(4), Pontano Vaites L(5), Tsai D(1), Mattson NM(1), Licon K(1), 
+Bachelder R(1), Cesnik A(6), Gaur I(6), Le T(6), Leineweber W(6), Palar A(4), 
+Pulido E(6), Qin Y(1)(7), Zhao X(1), Churas C(1), Lenkiewicz J(1), Chen J(1), 
+Ono K(1), Pratt D(1), Zage P(8), Echeverria I(9)(10), Sali A(4)(10)(11), Harper 
+JW(5), Gygi SP(5), Foster LJ(3), Huttlin EL(12), Lundberg E(13)(14)(15)(16), 
+Ideker T(17)(18)(19).
+
+Author information:
+(1)Department of Medicine, University of California San Diego, La Jolla, CA, 
+USA.
+(2)Bioinformatics and Systems Biology Program, University of California San 
+Diego, La Jolla, CA, USA.
+(3)Department of Biochemistry & Molecular Biology, Michael Smith Laboratories, 
+University of British Columbia, Vancouver, British Columbia, Canada.
+(4)Department of Bioengineering and Therapeutic Sciences, University of 
+California San Francisco, San Francisco, CA, USA.
+(5)Department of Cell Biology, Harvard Medical School, Boston, MA, USA.
+(6)Department of Bioengineering, Stanford University, Palo Alto, CA, USA.
+(7)Broad Institute of MIT and Harvard, Boston, MA, USA.
+(8)Department of Pediatrics, Division of Hematology-Oncology, University of 
+California San Diego, La Jolla, CA, USA.
+(9)Department of Cellular and Molecular Pharmacology, University of California 
+San Francisco, San Francisco, CA, USA.
+(10)Quantitative Biosciences Institute, University of California San Francisco, 
+San Francisco, CA, USA.
+(11)Department of Pharmaceutical Chemistry, University of California San 
+Francisco, San Francisco, CA, USA.
+(12)Department of Cell Biology, Harvard Medical School, Boston, MA, USA. 
+edward_huttlin@hms.harvard.edu.
+(13)Department of Bioengineering, Stanford University, Palo Alto, CA, USA. 
+emmalu@stanford.edu.
+(14)Department of Pathology, Stanford University, Palo Alto, CA, USA. 
+emmalu@stanford.edu.
+(15)Science for Life Laboratory, School of Engineering Sciences in Chemistry, 
+Biotechnology and Health, KTH Royal Institute of Technology, Stockholm, Sweden. 
+emmalu@stanford.edu.
+(16)Chan Zuckerberg Biohub, San Francisco, CA, USA. emmalu@stanford.edu.
+(17)Department of Medicine, University of California San Diego, La Jolla, CA, 
+USA. tideker@ucsd.edu.
+(18)Department of Computer Science and Engineering, University of California San 
+Diego, La Jolla, CA, USA. tideker@ucsd.edu.
+(19)Department of Bioengineering, University of California San Diego, La Jolla, 
+CA, USA. tideker@ucsd.edu.
+(#)Contributed equally
+
+Erratum for
+    Nature. 2025 Jun;642(8066):222-231. doi: 10.1038/s41586-025-08878-3.
+
+DOI: 10.1038/s41586-025-09648-x
+PMCID: PMC12545196
+PMID: 41039152
+
+## Full Text
+
+Correction to: Nature 10.1038/s41586-025-08878-3 Published online 9 April 2025
+
+In the version of the article initially published, the fourth equation in the “Loss functions” section of the Methods was a duplicate of the fifth equation. In the fourth equation, “Ty” and both instances of “Sy” have been corrected to “Tx” and “Sx” so that the equation now reads:
+
+\documentclass[12pt]{minimal}
+				\usepackage{amsmath}
+				\usepackage{wasysym} 
+				\usepackage{amsfonts} 
+				\usepackage{amssymb} 
+				\usepackage{amsbsy}
+				\usepackage{mathrsfs}
+				\usepackage{upgreek}
+				\setlength{\oddsidemargin}{-69pt}
+				\begin{document}$${T}_{x}=\frac{1}{m}\sum _{i\varepsilon N}\sum _{j\varepsilon N\,,j\ne i}\sum _{k\varepsilon N\,,k\ne i\,,j}{S}_{x}(i\,,j)(1\,-\,{S}_{x}(i,k))\times {\rm{\text{max}}}(D({{\bf{z}}}_{i},{{\bf{z}}}_{j})-D({{\bf{z}}}_{i},{{\bf{z}}}_{k})+\varepsilon ,0)$$\end{document}Tx=1m∑iεN∑jεN,j≠i∑kεN,k≠i,jSx(i,j)(1−Sx(i,k))×max(D(zi,zj)−D(zi,zk)+ε,0)
+
+in the HTML and PDF versions of the article.


### PR DESCRIPTION
Follow-up to #2290 (merged). Three findings from re-running checks on the merged ACTR8 review. **No verdict changes** — one real defect on `main`, two methodological corrections, and three recorded check outcomes including one refutation.

## 1. `cache/go/terms.csv` on `main` has `GO:0031011` twice — an inter-branch collision

| line | timestamp | added by |
|---|---|---|
| 3456 | `13:43:14` | ACTR5 #2291, sorted position |
| 9070 | `13:40:43` | ACTR8 #2290, appended at EOF |

ARP5 and ARP8 are **both INO80 subunits**, so both reviews needed the same new term for `core_functions.in_complex`. Each branch's duplicate gate (`cut -d, -f1 … | sort | uniq -d`) **passed in isolation** — within either branch the term appears once — and because the rows landed in *different positions* git auto-merged both with no conflict. The duplicate exists only in the merge result.

This is an **inter-branch** variant of the known failure mode. The documented one is self-inflicted within a single branch (hand-insert, then a later `just validate` re-appends because the appender cannot see the inserted row). Here nothing was wrong with either branch; **no per-PR check can see this fault**, because only the merge result exhibits it. Fixed by dropping the EOF row and keeping the sorted-position one, so the term appears exactly once.

Two generalisations, recorded in the notes:
- **Sibling genes reviewed in parallel are the high-risk case**, since they are precisely the ones needing the same new complex/activity terms. Expect a `terms.csv` collision whenever a sibling PR is in flight.
- **The duplicate check belongs in CI on `main`**, not only per-PR. The per-PR approximation — re-run after `git merge origin/main` immediately before pushing — was done on three merges here and still could not see it, because ACTR5 had not yet merged.

## 2. The correction screen in #2290 used the wrong instrument

#2290 screened the 20 cited PMIDs with `… AND (published erratum[pt] OR corrected and republished article[pt] OR retracted publication[pt] OR expression of concern[pt])`. Re-run now, that returns **`Count: 0`**.

**Why it cannot work:** those publication types sit on the *erratum record*, not on the article being corrected. Querying the cited set asks "is any paper I cite itself an erratum?" — never the question. The right field is **`CommentsCorrections/RefType` on each cited article** (`efetch&retmode=xml`), matching `ErratumIn`, `RetractionIn`, `ExpressionOfConcernIn`, `CorrectedAndRepublishedIn`, `RepublishedIn`, `PartialRetractionIn`.

Doing that across all 20:

| PMID | `RefType` | target |
|---|---|---|
| `PMID:18922472` | `CommentIn` | commentary — not a correction |
| `PMID:26496610` | `CommentIn` | commentary — not a correction |
| **`PMID:40205054`** | **`ErratumIn`** | **`PMID:41039152`** |

`PMID:41039152` is a **Publisher Correction** (*Nature* 646:E16, Oct 2025). It is a publisher-side correction, **not** a data- or figure-integrity notice; the article is not retracted; and the single claim resting on it — an ACTR8–UCHL5 association — is independently established by `PMID:18922472` and by `CPX-846` membership. Recorded in the `reference_review` with **`is_invalid` deliberately not set**, since that flag is for retracted or replaced references and using it here would misrepresent a typesetting-class correction as an integrity problem.

The two `CommentIn` hits are why the `RefType` must be **matched**, not merely counted.

## 3. Three cross-gene checks, outcomes recorded — including one refutation

- **Confirmed, and it separates ACTR8 from ACTR5.** `PMID:25016522`'s ComplexPortal-assigned rows (`GO:0006275`, `GO:0060382`) are `ACCEPT`ed on ACTR8 because the paper assayed ARP8 itself. Occurrence count in the cached full text: **27 × "Arp8", 0 × "Arp5"/"ACTR5"**, plus a dedicated results section *"Effect of Arp8 depletion on recovery after replication stress"*, an esiRNA against human Arp8 (485–916, `NM_022899.3`), its own qPCR primers, a 4-fold rise in discontinued forks by fibre labelling, and the conclusion *"depletion of the Arp8 subunit had the same consequences as Ino80 deficiency"*. The same rows are complex-level projections for ARP5 and gene-level evidence for ARP8, so **the two reviews should not be harmonised on them** — the asymmetry is the finding.
- **Refuted.** A suggestion that ACTR8 should take no nucleotide term without a structural check, on the basis of "1 of 5 catalytic positions with no resolved nucleotide". The check was done and is stronger than an alignment: human ARP8 has exactly **one** PDB entry, `4FO0`, whose *deposited title* is *"Human actin-related protein Arp8 in its ATP-bound state"* and whose ligand list contains **ATP** and **MG**. With the omit map computed for the bound ATP, an ATPase measured on the human protein, and ATP occupancy gating DNA binding through the annotated pocket residues, `GO:0005524` is IDA-grade. The residue observation is nonetheless correct **and already reflected**: actin's catalytic Gln137 and sensor His73 *are* substituted in ARP8 (Glu266, Arg187), which is exactly why `GO:0016887` is withheld. Binding and hydrolysis are separate claims; "no nucleotide term at all" does not follow.
- **Null, recorded as one.** No seeded-stub row collapse on this gene. Checked per `(term, evidence, reference)` key: all **31** distinct GOA keys present, all **6** `GO:0005515` rows keeping their own verdicts, no review row without a GOA counterpart. The only multiplicity difference is the `GO:0031011`/IDA/`PMID:21303910` row GOA banks twice (ComplexPortal + UniProt), already documented at the top of the notes.

---

`checkquotes` 86/86 verbatim (48/48 in the notes) · `just validate` ✓ Valid (1 documented warning) · `terms.csv`: the single `-GO:0031011` line is the intentional de-duplication, and duplicates are now only the two pre-existing on `main` (`GO:0001675`, `GO:0009566`), left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a single GO term cache deduplication; no changes to gene annotation actions or validation logic beyond removing a duplicate CSV line.
> 
> **Overview**
> Follow-up to the merged ACTR8 review: **no annotation verdict changes**, but it fixes a real `main` data defect and documents methodology gaps from re-running gates.
> 
> **`cache/go/terms.csv`** — Removes the duplicate **`GO:0031011` (Ino80 complex)** row that appeared only after ACTR5 and ACTR8 PRs both added the same term and auto-merged without conflict; the sorted-position entry is kept.
> 
> **ACTR8 review docs** — **`ACTR8-notes.md`** gains sections on the inter-branch `terms.csv` collision (CI on `main` proposed via issue #2294), replacing the prior retraction-only screen with **`CommentsCorrections` / `RefType` on each cited PMID** (surfacing Publisher Correction **PMID:41039152** for **PMID:40205054** without marking the source invalid), and recorded cross-gene checks (ACTR8 vs ACTR5 on **PMID:25016522**, ATP-binding refutation, GOA stub collapse null). **`ACTR8-ai-review.yaml`** expands **PMID:40205054** `review_notes` with the same correction context.
> 
> **`publications/PMID_41039152.md`** — New cached erratum record for offline verification; not added to the review `references` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fac79b63d56a3a873785bd0f5fb26882078680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->