### PR TITLE
Affinage deep-research files are verbatim provider records, not curated

### DIFF
--- a/genes/human/A1BG/A1BG-deep-research-affinage.md
+++ b/genes/human/A1BG/A1BG-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 100.0
 n_discoveries: 6
 citation_count: 6
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for A1BG (human)
@@ -22,9 +23,7 @@ note: >-
 
 A1BG is a secreted immunoglobulin-like domain plasma glycoprotein that functions through protein–protein interactions to regulate the activity and stability of partner proteins across diverse physiological contexts [PMID:39433128, PMID:40560034]. Its third of five repeated immunoglobulin-like domains binds CAP-superfamily proteins such as CRISP2 in a magnesium-dependent manner, and this interaction inhibits CRISP2 sterol-binding in vitro and abolishes its sterol export function in yeast [PMID:39433128]. In a distinct context, adipocyte-secreted A1BG binds and stabilizes NAMPT, raising NAD+ production to enhance PARP1/ATM-mediated DNA repair and thereby drive cisplatin resistance in osteosarcoma [PMID:40560034]. A1BG also has a sex-specific cardiac role: cardiomyocyte-specific deletion causes dilated cardiomyopathy with disrupted intercalated disc architecture and altered glucose-6-phosphate and acetyl-CoA metabolism in female but not male mice, consistent with sex-specific cardiac interactomes [PMID:40270023]. Beyond these interaction-based roles, the broader signaling and regulatory logic linking A1BG's partners across tissues has not been characterized in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0098772 molecular function regulator activity
 - **localization:** GO:0005576 extracellular region

--- a/genes/human/A1BG/A1BG-notes.md
+++ b/genes/human/A1BG/A1BG-notes.md
@@ -121,8 +121,8 @@ non-core.
 
 ## Affinage assessment
 
-The affinage report passed its trust gates (`gates_passed: True`, accession P04217 matching
-the local UniProt record) and its narrative — secreted Ig-domain plasma protein acting through
+The affinage report passed its trust gates at fetch time (accession P04217 matching the local
+UniProt record, no non-human organism token; it carries no `self_evaluation_pairwise` score) and its narrative — secreted Ig-domain plasma protein acting through
 protein–protein interactions with CRISP2 and NAMPT — agrees with the primary literature. Its
 own `mechanism_profile` grounding (`GO:0098772 molecular function regulator activity`,
 `GO:0005576 extracellular region`) is correct but coarse; `GO:0140311` was chosen instead as

--- a/genes/human/A2ML1/A2ML1-ai-review.yaml
+++ b/genes/human/A2ML1/A2ML1-ai-review.yaml
@@ -444,7 +444,8 @@ references:
     correctness: LOW_QUALITY
     review_notes: >-
       Trust gate TRIPPED - affinage's own head-to-head self-evaluation scored this record
-      pairwise = loss against the curated UniProt reference (gates_passed false), so it was
+      pairwise = loss against the curated UniProt reference (recorded in the record's own
+      self_evaluation_pairwise frontmatter field), so it was
       treated with extra scepticism and every claim used was re-verified against the cited
       PMIDs and UniProt. The narrative did hold up on the core biology and it usefully
       reports both sides of the contested Noonan-syndrome association. Marked LOW_QUALITY

--- a/genes/human/A2ML1/A2ML1-deep-research-affinage.md
+++ b/genes/human/A2ML1/A2ML1-deep-research-affinage.md
@@ -8,27 +8,22 @@ self_evaluation_pairwise: loss
 faith_pct: 100.0
 n_discoveries: 8
 citation_count: 8
-gates_passed: False
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for A2ML1 (human)
-
-> ⚠️ **CAUTION — trust gate(s) tripped; review before using:**
->
-> - Affinage's own head-to-head self-evaluation scored this record `pairwise = loss` (not `win`) vs the curated UniProt reference — treat the narrative with extra scepticism.
 
 ## Current model (mechanistic narrative)
 
 A2ML1 is a secreted broad-spectrum protease inhibitor of the alpha-2-macroglobulin family expressed in stratified epithelia and other tissues, where it was first identified as the p170 autoantigen recognized by paraneoplastic pemphigus autoantibodies [PMID:20805888]. Loss-of-function variants in A2ML1 confer susceptibility to otitis media: rare and damaging variants cosegregate with disease in human pedigrees and otitis-prone children [PMID:26121085], variant carriers show reduced A2ML1 expression [PMID:31009165], and A2ml1-knockout mice develop spontaneous middle ear disease with tympanic membrane perforation and effusion accompanied by upregulation of desmoplakin (Dsp), implicating dysregulated keratinocyte/epithelial integrity as the disease mechanism [PMID:38759260]. In pancreatic cancer, A2ML1 is overexpressed and promotes progression and epithelial-mesenchymal transition by downregulating LZTR1 and activating the KRAS/MAPK pathway [PMID:40615919]. Heterozygous germline A2ML1 variants were associated with a Noonan-syndrome-like phenotype in a zebrafish model [PMID:24939586], but a systematic segregation analysis across RASopathy families found these variants inherited from unaffected parents alongside alternative disease-causing aberrations, not supporting a causal role in Noonan syndrome [PMID:33082526].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0098772 molecular function regulator activity
 - **localization:** GO:0005576 extracellular region

--- a/genes/human/A2ML1/A2ML1-notes.md
+++ b/genes/human/A2ML1/A2ML1-notes.md
@@ -8,7 +8,7 @@ literature.
 
 The affinage record for A2ML1 **failed its trust gate**: affinage's own head-to-head
 self-evaluation scored it `pairwise = loss` against the curated UniProt reference
-(`gates_passed: False`). Everything taken from it was therefore re-verified against the
+(recorded in the record's own `self_evaluation_pairwise` frontmatter field). Everything taken from it was therefore re-verified against the
 cited PMIDs before use. In the event the narrative held up well — its core claim
 (secreted broad-spectrum alpha-2-macroglobulin-family protease inhibitor of stratified
 epithelia) matches UniProt and PMID:16298998 exactly. Where it is weakest is exactly where

--- a/genes/human/AADACL2/AADACL2-ai-review.yaml
+++ b/genes/human/AADACL2/AADACL2-ai-review.yaml
@@ -798,7 +798,8 @@ references:
   reference_review:
     relevance: LOW
     correctness: VERIFIED
-    review_notes: 'The record reports gates_passed True with zero discoveries and zero citations. An empty provider
+    review_notes: 'The record is empty - zero discoveries, zero citations, and no self_evaluation_pairwise
+      score, so the tool''s trust gates had nothing to catch. An empty provider
       record is not by itself evidence that literature is absent, so the claim was verified separately: PubMed returns
       six AADACL2 hits, none of them a functional characterisation, and the three UniProt RN references are all
       large-scale sequencing papers. The independent confirmation is PMID:35736449, which states in prose that the

--- a/genes/human/AADACL2/AADACL2-deep-research-affinage.md
+++ b/genes/human/AADACL2/AADACL2-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 
 n_discoveries: 0
 citation_count: 0
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for AADACL2 (human)
@@ -22,9 +23,7 @@ note: >-
 
 No mechanistic discoveries found in literature.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** *(none)*
 - **localization:** *(none)*

--- a/genes/human/AADACL2/AADACL2-notes.md
+++ b/genes/human/AADACL2/AADACL2-notes.md
@@ -23,7 +23,8 @@ N-terminal helix.
 ## Literature: genuinely absent for function, present for genetics
 
 PubMed returns 6 hits for `AADACL2`; none characterises the protein. The affinage record came
-back empty (`n_discoveries: 0`, `citation_count: 0`, `gates_passed: True`), and in this case
+back empty (`n_discoveries: 0`, `citation_count: 0`, no `self_evaluation_pairwise` score), and
+in this case
 the emptiness is corroborated rather than taken on trust — the only literature statement
 about AADACL2's function is that there isn't one:
 

--- a/genes/human/AADACL3/AADACL3-deep-research-affinage.md
+++ b/genes/human/AADACL3/AADACL3-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 
 n_discoveries: 0
 citation_count: 0
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for AADACL3 (human)
@@ -22,9 +23,7 @@ note: >-
 
 No mechanistic discoveries found in literature.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** *(none)*
 - **localization:** *(none)*

--- a/genes/human/AADACL3/AADACL3-notes.md
+++ b/genes/human/AADACL3/AADACL3-notes.md
@@ -51,8 +51,8 @@ analysis below.
 
 ## Literature: checked, and genuinely absent
 
-Affinage returned an empty record (`n_discoveries: 0`, `citation_count: 0`,
-`gates_passed: True`). Per the campaign rules an empty provider record is not
+Affinage returned an empty record (`n_discoveries: 0`, `citation_count: 0`, and no
+`self_evaluation_pairwise` score). Per the campaign rules an empty provider record is not
 evidence that literature is absent, so PubMed was searched directly. Seven
 records mention AADACL3, and not one assays the protein or its activity: two
 livestock body-weight association studies (Chinese Holstein cows, Chinese

--- a/genes/human/AADACL4/AADACL4-deep-research-affinage.md
+++ b/genes/human/AADACL4/AADACL4-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 
 n_discoveries: 0
 citation_count: 0
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for AADACL4 (human)
@@ -22,9 +23,7 @@ note: >-
 
 No mechanistic discoveries found in literature.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** *(none)*
 - **localization:** *(none)*

--- a/genes/human/AADACL4/AADACL4-notes.md
+++ b/genes/human/AADACL4/AADACL4-notes.md
@@ -37,8 +37,8 @@ have not, to our knowledge, been described for AADAC or the related enzymes AADA
 AADACL4."]. The `AADACL1` in that sentence is NCEH1/KIAA1363, so the review is naming the
 AADAC/NCEH1 clade AADACL4 belongs to.
 
-The affinage deep-research record is empty (`n_discoveries: 0`, `citation_count: 0`,
-though `gates_passed: True`). Following the campaign rule that an empty affinage record is
+The affinage deep-research record is empty (`n_discoveries: 0`, `citation_count: 0`, and no
+`self_evaluation_pairwise` score — the trust gates were clear only for want of anything to gate). Following the campaign rule that an empty affinage record is
 not evidence that literature is absent, I checked independently:
 
 - UniProt cites exactly one reference for this entry, the chromosome 1 sequencing paper

--- a/genes/human/AAGAB/AAGAB-deep-research-affinage.md
+++ b/genes/human/AAGAB/AAGAB-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 12
 citation_count: 10
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for AAGAB (human)
@@ -22,9 +23,7 @@ note: >-
 
 AAGAB (p34) is an assembly chaperone for heterotetrameric clathrin adaptor protein complexes, nucleating the formation of AP1, AP2, and AP4 that drive clathrin-mediated membrane trafficking [PMID:31353312, PMID:34494650, PMID:35976721]. It uses two functionally distinct modules: an N-terminal type I pseudoGTPase domain (catalytically inactive) that engages and stabilizes the small σ subunits of AP1 and AP2 through an interface distinct from conventional GTPase contacts, and a C-terminal dimerization domain that recognizes the γ subunit of AP1 and the α subunit of AP2 using a shared surface; AAGAB exists as a homodimer that transitions to monomer upon binding adaptor subunits [PMID:36598941]. By guiding the sequential, ordered association of adaptor subunits and stabilizing partially assembled intermediates, AAGAB prevents the degradation that otherwise destroys unassembled subunits [PMID:31353312, PMID:34494650]. For AP2, AAGAB initiates assembly by forming an AAGAB:α:σ2 complex that is then handed off to CCDC32, which completes tetramer assembly before release [PMID:39145939]. Loss of AAGAB collapses adaptor assembly, broadly remodeling surface protein homeostasis, impairing endocytic recycling of growth factor receptors such as EGFR, and causing accumulation of the AP4 cargo ATG9A at the trans-Golgi network [PMID:23064416, PMID:34494650, PMID:35976721]. Nonsense and CTD-truncating mutations in AAGAB destabilize the protein and abolish chaperone function, causing punctate palmoplantar keratoderma (PPKP1) [PMID:23000146, PMID:36598941]. AAGAB additionally supports clathrin-mediated synaptic vesicle recycling and neurotransmitter release in neurons [PMID:38253235], and in hypoxic-ischemic injury models acts upstream of the E3 ligase NEDD4-1 to control ubiquitination of PTEN and SHIP2 [PMID:33712741, PMID:41412220].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140096 catalytic activity, acting on a protein, GO:0044183 protein folding chaperone, GO:0098772 molecular function regulator activity
 - **localization:** GO:0005829 cytosol, GO:0005794 Golgi apparatus

--- a/genes/human/AAMDC/AAMDC-deep-research-affinage.md
+++ b/genes/human/AAMDC/AAMDC-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 4
 citation_count: 2
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for AAMDC (human)
@@ -22,9 +23,7 @@ note: >-
 
 AAMDC is an oncogenic signaling regulator amplified in estrogen receptor-positive breast cancer that drives estrogen-independent tumor growth by activating the PI3K-AKT-mTOR axis [PMID:33772001]. Downstream of this signaling, AAMDC controls the translational upregulation of ATF4 and MYC and the transcriptional output of AAMDC-dependent promoters, and ectopic AAMDC expression is sufficient to activate AKT [PMID:33772001]. Through these effectors AAMDC reprograms cellular metabolism, governing the expression of enzymes in the one-carbon folate, methionine, and lipid metabolism pathways [PMID:33772001]. AAMDC physically interacts with the Rab GTPase-activating protein RabGAP1L and colocalizes with RabGAP1L and Rab7a at endolysosomes, forming an assembly platform that links it to the endolysosomal compartment [PMID:33772001]. Beyond these findings, the biochemical activity of AAMDC itself and the structural basis of its signaling and RabGAP1L interaction have not been characterized in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** *(none)*
 - **localization:** GO:0005764 lysosome, GO:0005768 endosome

--- a/genes/human/AAMP/AAMP-deep-research-affinage.md
+++ b/genes/human/AAMP/AAMP-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 10
 citation_count: 10
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for AAMP (human)
@@ -22,9 +23,7 @@ note: >-
 
 AAMP is a WD40- and immunoglobulin-domain-containing protein, distributed both intracellularly and at the cell surface, that governs cell migration, angiogenesis, and innate immune signaling primarily by acting as a positive regulator of Rho-family GTPases and the actin cytoskeleton [PMID:8683944, PMID:26350504, PMID:39404373]. Its amino-terminal positively charged region binds heparin with high affinity and mediates heparin-sensitive, glycosaminoglycan-dependent cell binding and clustering, and anti-AAMP antibody blocks endothelial tube formation [PMID:8683944, PMID:18634104]. In vascular endothelial cells AAMP is recruited by VEGF to membrane protrusions and is required for VEGF-induced tube formation, aortic ring sprouting, actin stress fiber formation, and gel contraction through RhoA/Rho-kinase signaling [PMID:26350504]. Mechanistically, AAMP binds RhoA directly and protects it from SMURF2-mediated ubiquitination and degradation, thereby raising active RhoA levels [PMID:34901393], regulates the stability and activity of both RhoA and RhoB and colocalizes with F-actin and cortactin at membrane ruffles where it constrains endothelial barrier function [PMID:39404373], and binds CDC42 to promote its activation by impeding the ARHGAP1–CDC42 interaction [PMID:33279622]; collectively these activities drive cancer cell adhesion, growth, and invasion [PMID:23564791, PMID:33279622, PMID:34901393]. Independently of its cytoskeletal role, AAMP interacts via its WD40 domains with the NLR protein Nod2 and modulates Nod1/Nod2-driven NF-κB activation [PMID:19535145], and binds the co-stimulatory protein B7-H3 to influence T-cell proliferation [PMID:35919070].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0098772 molecular function regulator activity, GO:0008092 cytoskeletal protein binding, GO:0060090 molecular adaptor activity, GO:0008289 lipid binding
 - **localization:** GO:0005829 cytosol, GO:0005886 plasma membrane, GO:0005576 extracellular region, GO:0005856 cytoskeleton

--- a/genes/human/AAR2/AAR2-deep-research-affinage.md
+++ b/genes/human/AAR2/AAR2-deep-research-affinage.md
@@ -8,27 +8,22 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 10
 citation_count: 10
-gates_passed: False
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for AAR2 (human)
-
-> ⚠️ **CAUTION — trust gate(s) tripped; review before using:**
->
-> - Possible symbol collision: the narrative's opening names a non-human context ("yeast") despite a human record — verify the narrative describes human AAR2 and not a same-symbol protein (cf. the ADA case).
 
 ## Current model (mechanistic narrative)
 
 AAR2 (yeast Aar2p / human C20ORF4) is an assembly factor for the U5 small nuclear ribonucleoprotein (snRNP) that controls the timing of spliceosome maturation, first identified through its requirement for pre-mRNA splicing in yeast [PMID:1922071]. It is a component of a cytoplasmic precursor U5 snRNP containing Prp8, Snu114, U5 snRNA, and Sm proteins, but is excluded from the tri-snRNP and assembled spliceosome, and its loss impairs snRNP recycling across rounds of splicing [PMID:11720285, PMID:16945917]. Mechanistically, Aar2 binds the RNase H domain of Prp8 and, by extending its C terminus to dock the Jab1/MPN domain onto a composite Aar2-RNase H platform, sterically occludes the binding sites for the Brr2/SNRNP200 helicase while also occupying the RNase H RNA-binding surface to block U4/U6 di-snRNA loading, thereby preventing premature spliceosome activation [PMID:21764848, PMID:23442228]. Crystal structures of the Aar2-Prp8 assembly establish that Aar2 and Brr2 are mutually exclusive binders of Prp8, so that upon nuclear import Brr2 displaces Aar2 to generate the mature, catalytically competent U5 snRNP [PMID:23442228, PMID:23727230]. This handoff is governed by phosphorylation: a phospho-mimetic substitution (S253E in yeast) lowers Aar2 affinity for Prp8 and shifts the equilibrium toward Brr2-Prp8 and U4/U6 binding, and CK2α1 and SGK2 are candidate kinases that abrogate the AAR2-PRPF8 interaction in human cells [PMID:21764848, PMID:23442228, PMID:35225431]. Human AAR2 is a conserved ortholog that binds the PRPF8 RNase H domain, but its structure reveals a distinct interaction in which AAR2 locks PRPF8 RH in a conformation compatible only with the first transesterification step, indicating a regulatory role beyond simple placeholder activity for SNRNP200 [PMID:26527271, PMID:36322420].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0098772 molecular function regulator activity, GO:0060090 molecular adaptor activity
 - **localization:** GO:0005829 cytosol, GO:0005634 nucleus

--- a/genes/human/AARD/AARD-deep-research-affinage.md
+++ b/genes/human/AARD/AARD-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 100.0
 n_discoveries: 2
 citation_count: 2
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for AARD (human)
@@ -22,9 +23,7 @@ note: >-
 
 AARD is a Sertoli cell-specific protein that functions as a transcriptional target of androgen signaling during testis development [PMID:17486547, PMID:27959439]. Its expression is restricted to Sertoli cells, where it is upregulated during mouse testis differentiation coincident with early testis cord formation [PMID:17486547]. Ligand-bound androgen receptor (AR) directly activates Aard transcription by binding an androgen-responsive element in its promoter; accordingly, AARD protein is lost in Sertoli cell-selective AR knockout mice and induced by testosterone in primary Sertoli cells [PMID:27959439]. Beyond its position downstream of AR signaling in the Sertoli cell, no molecular activity, interaction partners, or cellular function for AARD have been characterized in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** *(none)*
 - **localization:** *(none)*

--- a/genes/human/AASDH/AASDH-deep-research-affinage.md
+++ b/genes/human/AASDH/AASDH-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 2
 citation_count: 1
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for AASDH (human)
@@ -22,9 +23,7 @@ note: >-
 
 AASDH (ACSF4-U26) is a β-alanine-activating enzyme that catalyzes an ATP-dependent reaction forming a covalent acyl-enzyme thioester intermediate with β-alanine, with near-absolute substrate specificity for β-alanine among the standard amino acids and a KM of ~5 µM [PMID:24467666]. Catalysis depends on a phosphopantetheine cofactor: a point mutant lacking the phosphopantetheine attachment site fails to form the thioester bond [PMID:24467666]. The β-alanine transfer activity resides in the adenylation domain, since deletion of the C-terminal PQQDH-related domain does not abolish transfer onto thiol acceptors; the physiological function of this C-terminal domain has not been characterized in the available corpus [PMID:24467666]. Beyond this in vitro activation and transfer chemistry, no downstream pathway or in vivo role for AASDH has been established in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140657 ATP-dependent activity, GO:0016874 ligase activity
 - **localization:** *(none)*

--- a/genes/human/ABCB10/ABCB10-deep-research-affinage.md
+++ b/genes/human/ABCB10/ABCB10-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 22
 citation_count: 22
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ABCB10 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ABCB10 is a homodimeric ABC transporter of the inner mitochondrial membrane that exports the tetrapyrrole biliverdin from the matrix to the cytosol, coupling mitochondrial redox and iron metabolism to cellular fate decisions in erythroid, hepatic, cardiac, immune, and stem cell lineages [PMID:34011630, PMID:22240895]. Structurally it adopts an exporter fold with matrix-facing nucleotide-binding domains, captured crystallographically in an open-inwards conformation both in the apo and nucleotide-bound states, with a transmembrane portal assisting substrate entry [PMID:23716676]; it is delivered to the inner membrane by an unusually long 105-residue presequence and assembles into homodimers and higher oligomers [PMID:15215243]. Its ATPase cycle is the functional core: catalytic Walker A/B and C-loop residues are required for ATP binding and hydrolysis [PMID:26053025], conserved transmembrane arginines R232/R295 mediate biliverdin-induced ATPase stimulation and conformational switching [PMID:41229075], and activity is tuned by cardiolipin, which binds preferentially and cooperatively [PMID:37807693], and by glutathione redox status acting partly through glutathionylation at Cys547 [PMID:26053025]. Functionally, ABCB10 ATPase activity is essential for hemoglobinization independent of any block at the ferrochelatase or ALA-export steps, and it shapes the heme biosynthetic transcriptional program via Bach1 [PMID:28808058]; biliverdin/bilirubin export rather than direct ALA or dALA transport is the established substrate axis [PMID:34011630, PMID:28808058, PMID:33253225]. ABCB10 physically organizes mitochondrial iron-heme machinery, stabilizing mitoferrin-1 to enhance iron import [PMID:19805291] and forming a complex with ferrochelatase bridged to ABCB7 near the nucleotide-binding domains [PMID:20427704, PMID:30765471]. Loss of ABCB10 causes mitochondrial and lysosomal iron accumulation, elevated ROS, and lethal failure of erythropoiesis [PMID:22240895, PMID:38655715, PMID:38493949], while its bilirubin product acts as the maladaptive effector limiting hepatic glucose handling and beta-cell insulin secretion through PTP1B and H2O2 signaling [PMID:34011630, PMID:34823065]; it additionally supports CD4+ T cell metabolic reprogramming and memory formation [PMID:34893527] and the mitochondrial unfolded protein response [PMID:28315685, PMID:30802639].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140657 ATP-dependent activity, GO:0005215 transporter activity, GO:0008289 lipid binding, GO:0140313 molecular sequestering activity
 - **localization:** GO:0005739 mitochondrion

--- a/genes/human/ABCB10/ABCB10-notes.md
+++ b/genes/human/ABCB10/ABCB10-notes.md
@@ -68,7 +68,8 @@ membership is captured; what the bare binding rows add is the specific partner i
 
 ## Provider assessment
 
-The best affinage record of the campaign so far: `gates_passed: True`, `pairwise: win`, and the
+The best affinage record of the campaign so far: `self_evaluation_pairwise: win` with clear
+trust gates, and the
 narrative correctly foregrounds the substrate switch — *"biliverdin/bilirubin export rather than
 direct ALA or dALA transport is the established substrate axis"*. It also assembles the
 cardiolipin dependence, the glutathionylation at Cys547, the R232/R295 ATPase-stimulation

--- a/genes/human/ABHD14A/ABHD14A-deep-research-affinage.md
+++ b/genes/human/ABHD14A/ABHD14A-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 100.0
 n_discoveries: 5
 citation_count: 4
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ABHD14A (human)
@@ -22,9 +23,7 @@ note: >-
 
 ABHD14A is a metabolic serine hydrolase of the α/β-hydrolase superfamily, closely related at the sequence level to ABHD14B, from which it is distinguished by defined sequence determinants [PMID:37974539]. A soluble N-terminally truncated form is an active enzyme that preferentially hydrolyzes short-chain esters, and its p-nitrophenyl-acetate hydrolysis is enhanced by CoA, consistent with a ping-pong type acetyltransferase mechanism analogous to ABHD14B [PMID:bio_10.1101_2025.11.28.691245]. Heterologously expressed full-length protein localizes to the Golgi apparatus, while endogenous protein is undetectable across immortalized cell lines and adult mouse tissues despite transcriptomic predictions [PMID:bio_10.1101_2025.11.28.691245]. At the transcriptional level, ABHD14A (Dorz1) is positively regulated by the zinc-finger transcription factor Zic1 in cerebellar granule neuron precursors [PMID:14667578]. Beyond these findings, the physiological substrates and in vivo role of ABHD14A have not been characterized in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0016787 hydrolase activity, GO:0016740 transferase activity
 - **localization:** GO:0005794 Golgi apparatus

--- a/genes/human/ABHD18/ABHD18-deep-research-affinage.md
+++ b/genes/human/ABHD18/ABHD18-deep-research-affinage.md
@@ -8,27 +8,22 @@ self_evaluation_pairwise:
 faith_pct: 100.0
 n_discoveries: 5
 citation_count: 2
-gates_passed: False
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ABHD18 (human)
-
-> ⚠️ **CAUTION — trust gate(s) tripped; review before using:**
->
-> - Possible symbol collision: the narrative's opening names a non-human context ("yeast") despite a human record — verify the narrative describes human ABHD18 and not a same-symbol protein (cf. the ADA case).
 
 ## Current model (mechanistic narrative)
 
 ABHD18 is a conserved α/β-hydrolase that acts as the cardiolipin (CL) lipase in the CL remodelling pathway, functionally homologous to yeast Cld1 [PMID:40903572, PMID:40378955]. It deacylates CL to generate monolysocardiolipin (MLCL) in vitro, and its inactivation in cells and mice shifts the lipidome toward nascent CL [PMID:40903572]. Rather than removing a single acyl chain, ABHD18 carries out stepwise hydrolysis, further deacylating CL to dilyso-CL and beyond, with CL species bearing more than five double bonds being resistant to its activity [PMID:40378955]. In the context of TAZ deficiency (Barth syndrome), inactivation of ABHD18—genetically or with a selective covalent small-molecule inhibitor—suppresses pathological MLCL accumulation and rescues mitochondrial dysfunction and organismal morbidity/mortality across TAZ-mutant cells, mice, human patient fibroblasts, and zebrafish embryos, establishing ABHD18 as a genetic suppressor of TAZ loss-of-function and a druggable node in CL metabolism [PMID:40903572, PMID:40378955].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0016787 hydrolase activity, GO:0016740 transferase activity
 - **localization:** *(none)*

--- a/genes/human/ABHD8/ABHD8-ai-review.yaml
+++ b/genes/human/ABHD8/ABHD8-ai-review.yaml
@@ -628,9 +628,9 @@ references:
   reference_review:
     relevance: MEDIUM
     correctness: LOW_QUALITY
-    review_notes: 'Affinage record with gates_passed: False (its own pairwise self-evaluation scored ''tie'',
-      not ''win'', against curated UniProt), so it is used here only for the one thing a corpus-level
-      synthesis is good evidence for: the negative that no catalytic activity or substrate has been characterised.
+    review_notes: 'Affinage record whose own self_evaluation_pairwise scored ''tie'', not ''win'',
+      against curated UniProt, tripping the tool''s trust gate, so it is used here only for the one
+      thing a corpus-level synthesis is good evidence for: the negative that no catalytic activity or substrate has been characterised.
       Every mechanistic claim in this review is cited to PMID:39225180 or to the UniProt record instead,
       deliberately - not to this narrative.'
 - id: file:human/ABHD8/ABHD8-bioinformatics/RESULTS.md

--- a/genes/human/ABHD8/ABHD8-deep-research-affinage.md
+++ b/genes/human/ABHD8/ABHD8-deep-research-affinage.md
@@ -8,27 +8,22 @@ self_evaluation_pairwise: tie
 faith_pct: 100.0
 n_discoveries: 3
 citation_count: 2
-gates_passed: False
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ABHD8 (human)
-
-> ⚠️ **CAUTION — trust gate(s) tripped; review before using:**
->
-> - Affinage's own head-to-head self-evaluation scored this record `pairwise = tie` (not `win`) vs the curated UniProt reference — treat the narrative with extra scepticism.
 
 ## Current model (mechanistic narrative)
 
 ABHD8 is an α/β-hydrolase domain-containing protein that functions as a negative regulator of NLRP3 inflammasome activation by controlling NLRP3 protein turnover [PMID:39225180]. ABHD8 interacts physically with NLRP3 and acts as a scaffold that recruits the palmitoyltransferase ZDHHC12 to NLRP3, promoting NLRP3 palmitoylation and its subsequent degradation through the chaperone-mediated autophagy (CMA) pathway; loss of ABHD8 stabilizes NLRP3 and enhances inflammasome activation, whereas overexpression dampens LPS- and alum-triggered activation in vivo [PMID:39225180]. This regulatory axis is a target of viral subversion, as the SARS-CoV-2 nucleocapsid protein disrupts the ABHD8–NLRP3 association, elevating NLRP3 levels and driving excessive inflammasome activation [PMID:39225180]. ABHD8 expression is itself controlled at the 19p13.1 locus, where risk SNPs physically contact the ABHD8 promoter and risk alleles increase its transactivation [PMID:27601076]. Beyond these findings, the catalytic activity of the α/β-hydrolase domain and its direct enzymatic substrates have not been characterized in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0060090 molecular adaptor activity
 - **localization:** *(none)*

--- a/genes/human/ABI3BP/ABI3BP-ai-review.yaml
+++ b/genes/human/ABI3BP/ABI3BP-ai-review.yaml
@@ -1661,8 +1661,8 @@ references:
     correctness: VERIFIED
     review_notes: >-
       Precomputed LLM-generated research, not a curated annotation, and treated as a preliminary
-      source throughout. Its frontmatter reports gates_passed True with 100% self-assessed faith,
-      and all 12 citations are numeric PMIDs - there are no bioRxiv DOIs sitting in a PMID-shaped
+      source throughout. Its frontmatter reports 100% self-assessed faith and carries no
+      self_evaluation_pairwise score, and all 12 citations are numeric PMIDs - there are no bioRxiv DOIs sitting in a PMID-shaped
       field, which is the failure mode to check for. Every finding it lists was checked against the
       cited PMID and the substantive ones were independently quoted from those papers instead.
 

--- a/genes/human/ABI3BP/ABI3BP-deep-research-affinage.md
+++ b/genes/human/ABI3BP/ABI3BP-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 100.0
 n_discoveries: 12
 citation_count: 12
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ABI3BP (human)
@@ -22,9 +23,7 @@ note: >-
 
 ABI3BP is a secreted extracellular matrix protein that acts as a brake on stem and progenitor cell proliferation while licensing their differentiation [PMID:23666637, PMID:25296984]. Mechanistically, ABI3BP deposited in the matrix binds integrin-β1 and drives Src association with paxillin, stabilizing focal adhesions and stress fibers; loss of ABI3BP releases this brake, increasing proliferation through cyclin-D1, ERK1/2, and Src to promote S-phase entry, and severely impairing osteogenic and adipogenic differentiation of mesenchymal stem cells [PMID:23666637]. In cardiac progenitor cells the same integrin-β1 axis signals through PKC-ζ and Akt to drive cardiomyocyte differentiation, such that genetic ablation expands the progenitor pool but worsens recovery after myocardial infarction [PMID:25296984]. ABI3BP couples this anti-proliferative role to cellular senescence: its loss inhibits proliferation and induces p53/p21-dependent growth arrest with multicentrosome formation in fibroblasts [PMID:19338757], and conversely its downregulation suppresses senescence through the Nrf2 antioxidant pathway in vascular smooth muscle cells [PMID:40889718] and through Klotho-dependent control of ferroptosis in renal tubular cells [PMID:38812032]. ABI3BP expression is epigenetically silenced by EZH2-mediated H3K27 methylation directed by the lncRNA MALAT1 [PMID:31174563]. The protein also maintains F-actin organization and type-I interferon (IRF3/TBK1) signaling against RNA virus replication [PMID:38384000], shapes mitral cell dendritic refinement in the olfactory bulb as a secreted factor [PMID:19302145], and is proteolytically cleaved by thrombin at Arg337, with recombinant ABI3BP protecting the blood-brain barrier after ischemia-reperfusion injury via PI3K/Akt survival signaling [PMID:41839242].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0098631 cell adhesion mediator activity, GO:0098772 molecular function regulator activity
 - **localization:** GO:0031012 extracellular matrix, GO:0005576 extracellular region

--- a/genes/human/ABR/ABR-ai-review.yaml
+++ b/genes/human/ABR/ABR-ai-review.yaml
@@ -231,7 +231,7 @@ references:
   title: Affinage mechanistic annotation for ABR (human)
   findings:
   - statement: >-
-      Provider record reports gates_passed: True, faith_pct 100.0, 15 citations, all numeric PubMed
+      Provider record reports self_evaluation_pairwise win, faith_pct 100.0, 15 citations, all numeric PubMed
       ids (no bioRxiv DOIs in PMID-shaped fields). Its corpus-level conclusion that ABR acts in
       vivo predominantly as a negative regulator of Rac matches the primary literature.
   - statement: >-

--- a/genes/human/ABR/ABR-deep-research-affinage.md
+++ b/genes/human/ABR/ABR-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 15
 citation_count: 15
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ABR (human)
@@ -22,9 +23,7 @@ note: >-
 
 ABR is a dual-function regulator of Rho-family GTPase signaling that carries both a Dbl-homology guanine-nucleotide exchange factor (GEF) domain and a C-terminal GTPase-activating protein (GAP) domain within a single polypeptide [PMID:8349582, PMID:7479768]. Biochemical reconstitution established that its GEF domain stimulates GTP loading of CDC42, RhoA, Rac1, and Rac2 (rank order CDC42 > RhoA > Rac1 = Rac2) while its GAP domain selectively inactivates Rac1, Rac2, and CDC42 but not RhoA or Ras, with each domain binding substrate non-competitively [PMID:7479768]. In vivo, ABR acts predominantly as a negative regulator of Rac: it is redundant with its paralog BCR, and combined loss in mice elevates active Rac1 and downstream p38 MAPK signaling, producing cerebellar developmental defects in glia [PMID:11684658], dysregulated macrophage morphology, motility, and phagocytosis with sustained Rac activation [PMID:17116687], excessive neutrophil ROS and protease output [PMID:19703997], and pulmonary vascular remodeling under hypoxia [PMID:23152932]. ABR enforces spatial control of GTPase activity: in single-cell wound repair it is recruited to the active-Rho zone through binding GTP-bound Rho, where it locally amplifies Rho via its GEF domain and restricts Cdc42 via its GAP domain to keep the two activity zones segregated [PMID:21295482], and it transiently translocates to the plasma membrane and phagosomes upon CSF-1 stimulation [PMID:17116687]. At excitatory synapses ABR binds the scaffold PSD-95 and constrains basal Rac1 activity to support long-term potentiation maintenance and memory [PMID:20962234], and in CD4+ T cells it deactivates Rac to limit chemotaxis and allergic airway responses [PMID:24058174]. ABR additionally supports phagocytosis in trabecular meshwork cells via an integrin/RAC1 pathway [PMID:31516309], osteoclast differentiation and bone resorption through interaction with PARG and Rho GTPases [PMID:37507586], mitotic fidelity and centrosome dynamics in human embryonic stem cells [PMID:28579391], and hyperglycaemia-driven RhoA activation and actin organization in feto-placental endothelium [PMID:38776074]. ABR is also the host target of the bacterial effector EspH, which binds the ABR GAP domain to hijack Rac1 and Cdc42 signaling [PMID:36219160].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140096 catalytic activity, acting on a protein, GO:0098772 molecular function regulator activity, GO:0060089 molecular transducer activity
 - **localization:** GO:0005886 plasma membrane, GO:0031410 cytoplasmic vesicle, GO:0005815 microtubule organizing center

--- a/genes/human/ABR/ABR-notes.md
+++ b/genes/human/ABR/ABR-notes.md
@@ -407,7 +407,8 @@ Three of these were found by the PR reviewer, and all three were real.
 
 ## Provider record (affinage)
 
-`gates_passed: True`, `faith_pct: 100.0`, 15 citations, all numeric PubMed ids (no bioRxiv
+`self_evaluation_pairwise: win` with clear trust gates, `faith_pct: 100.0`, 15 citations, all
+numeric PubMed ids (no bioRxiv
 DOIs in PMID-shaped fields). Its corpus-level conclusion matches the primary literature and
 is cited once, for that corpus-level direction only. **It does not cite Amin et al. 2016
 (PMID:27481945)** — the paper that reconciles the substrate conflict and that Reactome relies

--- a/genes/human/ABRA/ABRA-ai-review.yaml
+++ b/genes/human/ABRA/ABRA-ai-review.yaml
@@ -936,8 +936,8 @@ references:
     relevance: MEDIUM
     correctness: VERIFIED
     review_notes: 'External precomputed LLM research, treated as a preliminary source; every claim used
-      was re-checked against the cited PMIDs. gates_passed is True and no bioRxiv DOI appears in a PMID-shaped
-      field. One over-attribution was found and is recorded against PMID:20940261: the record credits
+      was re-checked against the cited PMIDs. Its self_evaluation_pairwise is win and no bioRxiv DOI appears
+      in a PMID-shaped field. One over-attribution was found and is recorded against PMID:20940261: the record credits
       ABRA with the Costars-domain actin/motility phenotype, which belongs to the domain-only protein
       ABRACL. Its own mechanism_profile is coarse as expected - GO:0140110 transcription regulator activity
       would be an error for a protein that never touches DNA - and none of its GO ids were imported.'

--- a/genes/human/ABRA/ABRA-deep-research-affinage.md
+++ b/genes/human/ABRA/ABRA-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 12
 citation_count: 12
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ABRA (human)
@@ -22,9 +23,7 @@ note: >-
 
 ABRA (STARS) is a striated-muscle-enriched actin-binding protein that couples sarcomeric actin dynamics to the transcriptional program governing muscle growth and adaptation [PMID:11983702]. It localizes to the sarcomeric Z disc/I-band, binds actin filaments, and activates Rho-GTPase signaling, which in turn drives nuclear translocation of the MRTF-A/MRTF-B co-activators to stimulate SRF-dependent transcription of muscle structural and growth genes [PMID:11983702, PMID:17415416]. Its actin-cytoskeleton-regulating activity is conserved through the C-terminal Costars domain, whose function in actin organization and motility is preserved across species [PMID:20940261]. The STARS→RhoA→MRTF→SRF axis operates as a feed-forward autoregulatory loop, since SRF binds the STARS proximal promoter and ABRA is itself required for cardiac development, with loss of zebrafish STARS causing severe cardiac dysfunction rescuable by SRF [PMID:22815879]. Beyond the heart, ABRA mediates fluid-shear-stress-induced arteriogenesis through NO-dependent Rho signaling in vascular smooth muscle [PMID:19778941] and tracks coordinately with skeletal muscle hypertrophy and atrophy [PMID:19255118]. ABRA transcription is induced by MEF2 and by PGC-1α/ERRα, repressed by GATA4, and its protein is suppressed post-transcriptionally by miR-628-5p with aging [PMID:17415416, PMID:21486805, PMID:22431517, PMID:27739650]. Its physical partners include the actin-binding ABLIM-2 and ABLIM-3 proteins, which synergistically enhance STARS-dependent SRF activation [PMID:17194709].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0008092 cytoskeletal protein binding, GO:0098772 molecular function regulator activity, GO:0140110 transcription regulator activity
 - **localization:** GO:0005856 cytoskeleton, GO:0005829 cytosol

--- a/genes/human/ABRA/ABRA-notes.md
+++ b/genes/human/ABRA/ABRA-notes.md
@@ -101,7 +101,8 @@ for the mouse record too.
 
 ## 5. Caveats on the affinage record
 
-`gates_passed: True`, all 12 citations are real numeric PMIDs, and the mechanistic narrative
+`self_evaluation_pairwise: win` with clear trust gates, all 12 citations are real numeric PMIDs,
+and the mechanistic narrative
 is accurate. One over-attribution:
 
 > "Its actin-cytoskeleton-regulating activity is conserved through the C-terminal Costars

--- a/genes/human/ABRACL/ABRACL-deep-research-affinage.md
+++ b/genes/human/ABRACL/ABRACL-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 100.0
 n_discoveries: 8
 citation_count: 8
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ABRACL (human)
@@ -22,9 +23,7 @@ note: >-
 
 ABRACL is a small winged helix-like protein that regulates actin cytoskeletal dynamics and cell motility, a role conserved from the Dictyostelium ortholog Costars, whose loss produces aberrant F-actin distribution and excessive pseudopod formation that human ABRACL rescues [PMID:20940261]. Structurally it adopts a three-helix, four-stranded antiparallel β-sheet winged helix-like fold that lacks DNA-binding activity and presents a conserved hydrophobic groove implicated in protein–protein interaction [PMID:21082705]. Mechanistically, ABRACL binds cofilin and inhibits cofilin-stimulated F-actin depolymerization, shifting the F/G-actin balance toward polymerized actin at the leading edge to drive cell migration [PMID:33670794]. This actin-promoting activity underlies a recurrent pro-tumorigenic role: ABRACL knockdown suppresses proliferation, migration, and invasion across esophageal, breast, gastric, and glioma cancer models [PMID:33728339, PMID:35341461, PMID:39286126, PMID:39376051], with its expression transcriptionally activated by MYBL2 and CBX4 [PMID:35341461, PMID:39376051] and post-transcriptionally repressed by miR-145-5p [PMID:33728339]. In neural progenitor cells ABRACL localizes to the nucleus and inhibits neuronal differentiation, indicating a context-dependent role distinct from its cytoplasmic actin function [PMID:26537243].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0008092 cytoskeletal protein binding, GO:0098772 molecular function regulator activity
 - **localization:** GO:0005856 cytoskeleton, GO:0005634 nucleus

--- a/genes/human/ACAN/ACAN-deep-research-affinage.md
+++ b/genes/human/ACAN/ACAN-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 80.0
 n_discoveries: 16
 citation_count: 14
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACAN (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACAN encodes aggrecan, a large extracellular matrix proteoglycan that anchors into cartilage matrix and into CNS perineuronal nets (PNNs) through its N-terminal G1 region, whose immunoglobulin domain and tandem Link modules form a single structural unit that clamps a hyaluronan decasaccharide within a continuous binding groove; mutation of this glycosaminoglycan-binding site abolishes hyaluronan binding yet only partially reduces PNN incorporation, showing that hyaluronan binding contributes to but is not strictly required for PNN integration. At the C-terminus, integrity of the G3 domain C-type lectin repeat is required for efficient aggrecan secretion and for binding to cartilage matrix ligands, and missense variants there reduce both [PMID:35338222]. ACAN transcription in chondrocytes is driven by SOX9 cooperating with the SOX trio, a step gated upstream by TET1-mediated 5hmC deposition at chondrocyte-specific SOX9 sites that licenses SOX9 occupancy [PMID:33134768] and by SIRT1 deacetylation of SOX9, which promotes its importin-β-dependent nuclear entry and binding to a -10 kb ACAN enhancer [PMID:26910618]; SHOX2 contributes by physically partnering with SOX5/SOX6 to transactivate ACAN regulatory elements [PMID:24421874], and the locus carries at least eleven evolutionarily conserved, partly SOX9-independent enhancers [PMID:22820679]. ACAN output is further tuned post-transcriptionally by miR-140 acting through RALA and translationally by the mTOR/4E-BP1/eIF4E axis coupled to Smad signaling [PMID:24063364, PMID:32485037]. Loss-of-function mutations — nonsense/frameshift and aberrant-splicing alleles triggering nonsense-mediated decay, and locus-disrupting rearrangements — produce ACAN haploinsufficiency that causes chondrodysplasia and proportionate short stature [PMID:17952705, PMID:38782218, PMID:29302920]. In the CNS, aggrecan-containing PNNs serve cell-type-specific roles: deletion from CA2 pyramidal neurons impairs social memory and reversal learning while deletion from PV interneurons impairs contextual fear memory, and HDAC2 in PV+ cells sustains Acan expression to gate PNN aggregation and fear-memory extinction [PMID:37131076].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0005198 structural molecule activity, GO:0008289 lipid binding
 - **localization:** GO:0031012 extracellular matrix, GO:0005576 extracellular region

--- a/genes/human/ACAP1/ACAP1-ai-review.yaml
+++ b/genes/human/ACAP1/ACAP1-ai-review.yaml
@@ -1418,7 +1418,7 @@ references:
     relevance: MEDIUM
     correctness: UNVERIFIED
     review_notes: >-
-      Machine-fetched Affinage record; gates_passed is True and all ten citations are genuine numeric
+      Machine-fetched Affinage record; its self_evaluation_pairwise is win and all ten citations are genuine numeric
       PMIDs, with no bioRxiv DOIs in PMID-shaped fields. Its narrative is broadly accurate and it
       correctly surfaced the two papers this review had not otherwise reached, PMID:36917255
       (Rab10-ACAP1-ARF6 cascade on the M4 muscarinic receptor) and PMID:37505213 (ACAP1 bridging

--- a/genes/human/ACAP1/ACAP1-deep-research-affinage.md
+++ b/genes/human/ACAP1/ACAP1-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 10
 citation_count: 10
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACAP1 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACAP1 is an ARF6 GTPase-activating protein that operates as a coat component of the endocytic recycling pathway, sorting cargo from endosomes back to the plasma membrane to control processes such as cell migration and glucose homeostasis [PMID:17664335]. It assembles into a novel ARF6-regulated clathrin coat complex that drives stimulation-dependent recycling of integrin beta1 and insulin-stimulated recycling of Glut4 [PMID:17664335], and it localizes to a tubular recycling endosome distinct from the ARAP2/APPL1-positive compartment, with the two ARF6 GAPs exerting opposing effects on integrin internalization and focal adhesions [PMID:25225293]. Cargo engagement is switch-regulated: Akt phosphorylation of ACAP1 relieves a localized autoinhibition to enhance binding of a defined recycling sorting signal in the integrin beta1 cytoplasmic tail, coupling recycling to upstream signaling [PMID:16256741, PMID:22645133]. Its membrane-deforming activity arises from an unconventional division of labor between adjacent domains, in which the PH domain mediates membrane binding and curvature generation while the BAR domain mediates clustering of ACAP1 molecules into a lattice that deforms the membrane [PMID:25284369]. Beyond integrin and Glut4 trafficking, ACAP1 acts in a Rab10-ACAP1-Arf6 cascade that inactivates Arf6 to arrest the M4 muscarinic acetylcholine receptor in early endosomes [PMID:36917255], and it scaffolds a PTPN9-FGFR2 complex to facilitate FGFR2 dephosphorylation, a function requiring its PH and Arf-GAP domains [PMID:37505213].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0098772 molecular function regulator activity, GO:0008289 lipid binding, GO:0060090 molecular adaptor activity, GO:0005198 structural molecule activity
 - **localization:** GO:0005768 endosome, GO:0031410 cytoplasmic vesicle

--- a/genes/human/ACAP2/ACAP2-ai-review.yaml
+++ b/genes/human/ACAP2/ACAP2-ai-review.yaml
@@ -1140,7 +1140,7 @@ references:
   reference_review:
     relevance: MEDIUM
     correctness: LOW_QUALITY
-    review_notes: 'Machine-fetched Affinage record; gates_passed True, faith 100%. Its value here was
+    review_notes: 'Machine-fetched Affinage record; self_evaluation_pairwise win, faith 100%. Its value here was
       the reference list rather than the prose. It surfaced PMID:22045739, PMID:22344257,
       PMID:24600047, PMID:25694427, PMID:25853217, PMID:16806385 and PMID:40251363, four of which
       materially shaped this review, and none of which is cited by any GOA row. The prose is unreliable

--- a/genes/human/ACAP2/ACAP2-deep-research-affinage.md
+++ b/genes/human/ACAP2/ACAP2-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 7
 citation_count: 7
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACAP2 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACAP2 (centaurin-β2) is an ARF6 GTPase-activating protein that operates as a downstream effector of GTP-bound Rab35 to locally inactivate Arf6 and thereby couple membrane trafficking to actin-dependent cellular remodeling [PMID:22344257, PMID:22045739]. Rab35 accumulates at Arf6-positive endosomes and the phagocytic cup and recruits ACAP2 in a GTP-Rab35-dependent manner, and ACAP2's Arf6-GAP activity at these sites drives NGF-induced neurite outgrowth and FcγR-mediated phagosome formation [PMID:22344257, PMID:22045739]. This Rab35–ACAP2–Arf6 axis is also deployed as a negative regulator of oligodendrocyte differentiation and myelination, where ACAP2 opposes the Arf6-GEF cytohesin-2 [PMID:24600047]. The direct Rab35–ACAP2 interaction is highly specific, requiring Thr-76/Thr-81 in the Rab35 switch II region and Asn-610/Asn-691 within the minimal Rab35-binding domain of ACAP2, and binding-deficient mutants of either protein fail to support neurite outgrowth [PMID:25694427]. Independent of its GAP function, ACAP2 (the human homolog of C. elegans CNT-1) carries a phosphoinositide-binding-dependent pro-apoptotic activity, as its knockdown blocks 5-fluorouracil-induced apoptosis [PMID:25853217]. ACAP2 protein levels are set by ubiquitin-mediated proteasomal degradation through the E3 ligase RNF126 [PMID:40251363].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140096 catalytic activity, acting on a protein, GO:0098772 molecular function regulator activity, GO:0008289 lipid binding
 - **localization:** GO:0005768 endosome, GO:0005886 plasma membrane

--- a/genes/human/ACAP3/ACAP3-ai-review.yaml
+++ b/genes/human/ACAP3/ACAP3-ai-review.yaml
@@ -1480,7 +1480,7 @@ references:
     relevance: MEDIUM
     correctness: VERIFIED
     review_notes: >-
-      gates_passed True, five numeric PMIDs, no bioRxiv DOIs in PMID fields. Its narrative is
+      self_evaluation_pairwise win, five numeric PMIDs, no bioRxiv DOIs in PMID fields. Its narrative is
       accurate against the four functional papers and it surfaced PMID:41520057 and
       PMID:39098591, which the UniProt reference list does not contain. Its own GO grounding
       is coarse (GO:0098772, no localisation) and was not used, and no sentence from it is

--- a/genes/human/ACAP3/ACAP3-deep-research-affinage.md
+++ b/genes/human/ACAP3/ACAP3-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 5
 citation_count: 5
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACAP3 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACAP3 is a GTPase-activating protein (GAP) selective for the small GTPase Arf6 that governs cell morphological dynamics in both neural development and epithelial cancers [PMID:27330119]. In neurons, ACAP3 drives neurite outgrowth by cycling Arf6 between its GTP- and GDP-bound states; loss of ACAP3 raises GTP-bound Arf6 and abolishes outgrowth, a defect rescued by wild-type but not GAP-inactive ACAP3 [PMID:27330119], and the same GAP-dependent activity is required for cortical neuronal migration in vivo [PMID:28919417]. In cancer cells, ACAP3 acts as a tumour suppressor: in lung adenocarcinoma it inhibits EGFR signalling by impairing EGFR recycling and accelerating lysosome-mediated EGFR degradation in a GAP-activity-dependent manner, suppressing proliferation [PMID:41520057], and in papillary thyroid carcinoma it suppresses viability, migration, and invasion while promoting apoptosis through modulation of AKT and p53 signalling [PMID:39098591]. ACAP3 expression is held down epigenetically, via Myc-driven DNA hypermethylation and deacetylation in lung adenocarcinoma [PMID:41520057] and via HDAC2 in papillary thyroid carcinoma [PMID:39098591].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0098772 molecular function regulator activity
 - **localization:** *(none)*

--- a/genes/human/ACAP3/ACAP3-notes.md
+++ b/genes/human/ACAP3/ACAP3-notes.md
@@ -273,7 +273,8 @@ the check was run — `GO:0005886` documented 4 of 7 donors, `GO:0005096` 3 of 6
 
 ## 9. Affinage record
 
-`ACAP3-deep-research-affinage.md` has `gates_passed: True`, five numeric PMIDs, no
+`ACAP3-deep-research-affinage.md` has `self_evaluation_pairwise: win` and clear trust gates,
+five numeric PMIDs, no
 bioRxiv-DOI-in-a-PMID-field entries. Its narrative is accurate on the four functional
 papers and was useful for finding PMID:41520057 and PMID:39098591, which the UniProt
 reference list does not contain. Its own GO grounding is coarse (`GO:0098772 molecular

--- a/genes/human/ACBD3/ACBD3-deep-research-affinage.md
+++ b/genes/human/ACBD3/ACBD3-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 34
 citation_count: 34
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACBD3 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACBD3 (GCP60/PAP7) is a peripheral Golgi-membrane scaffolding protein that organizes lipid-modifying and signaling machinery on Golgi/TGN membranes and at ER–Golgi contact sites [PMID:11590181, PMID:27009356]. Its central scaffolding output is the direct recruitment of the lipid kinase PI4KB to membranes through its GOLD domain, an interaction defined structurally by NMR that both anchors PI4KB to the Golgi and stimulates its enzymatic activity to maintain Golgi PI4P homeostasis [PMID:27009356, PMID:27989622]. ACBD3 is itself targeted to the Golgi by a two-step mechanism: the Sec1/Munc-18 protein SCFD1 with the SNARE SEC22B acts upstream of an MWT374-376 motif that binds the golgins giantin and golgin-45 [PMID:38134218, PMID:11590181, PMID:28777890]. Beyond PI4KB, ACBD3 acts as an A-kinase anchoring protein, binding PKA regulatory subunits (RIα and RII via the GOLD domain) to position PKA at the Golgi and at mitochondria, where it couples cholesterol transport to hormone-stimulated steroidogenesis and where it controls cargo-triggered PKA activation governing KDEL-receptor retrograde trafficking [PMID:11731621, PMID:12943713, PMID:37044218, PMID:34493279]. ACBD3 is required for Golgi stack integrity and for FAPP2-mediated glucosylceramide transport and ER-to-Golgi ceramide/sphingolipid flux, with knockout producing enlarged, unstacked Golgi and altered sphingolipid pools [PMID:29750412, PMID:34298889]. The same membrane-coupling activity is extensively exploited by pathogens: picornavirus 3A proteins clamp ACBD3 onto replication-organelle membranes to recruit and activate PI4KB for viral PI4P synthesis, and the OSBP–VAP cholesterol-transport machinery is co-opted through ACBD3 as well [PMID:22124328, PMID:22258260, PMID:27989622, PMID:28065508, PMID:31381608, PMID:29367253]. ACBD3 also concentrates ligand-activated STING at ER–Golgi contact sites to drive ER export and type-I interferon responses [PMID:36543137], partners with Numb during mitotic Golgi fragmentation to influence asymmetric neural cell-fate specification [PMID:17418793], and modulates apoptotic signaling through a redox-sensitive Cys-463 interaction with a caspase-generated golgin-160 fragment [PMID:17711851]. Salmonella effectors SseF/SseG bind ACBD3 to position Salmonella-containing vacuoles at the Golgi [PMID:27406559], underscoring ACBD3 as a recurrently hijacked membrane-organizing hub.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0060090 molecular adaptor activity, GO:0098772 molecular function regulator activity, GO:0008289 lipid binding
 - **localization:** GO:0005794 Golgi apparatus, GO:0005783 endoplasmic reticulum, GO:0005829 cytosol, GO:0005739 mitochondrion

--- a/genes/human/ACP7/ACP7-deep-research-affinage.md
+++ b/genes/human/ACP7/ACP7-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 
 n_discoveries: 0
 citation_count: 0
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACP7 (human)
@@ -22,9 +23,7 @@ note: >-
 
 No mechanistic discoveries found in literature.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** *(none)*
 - **localization:** *(none)*

--- a/genes/human/ACRBP/ACRBP-ai-review.yaml
+++ b/genes/human/ACRBP/ACRBP-ai-review.yaml
@@ -1289,7 +1289,7 @@ references:
     relevance: MEDIUM
     correctness: VERIFIED
     review_notes: >-
-      Machine-generated preliminary source with gates_passed true and all twelve citations
+      Machine-generated preliminary source with self_evaluation_pairwise win and all twelve citations
       resolving to numeric PubMed identifiers; its dated findings were checked against the primary
       abstracts and none was found to misstate them, and its own confidence grading correctly
       separates the reproductive literature from the low-confidence cancer-cell knockdown work.

--- a/genes/human/ACRBP/ACRBP-deep-research-affinage.md
+++ b/genes/human/ACRBP/ACRBP-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 12
 citation_count: 12
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACRBP (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACRBP (SP32/OY-TES-1/CT23) is an acrosomal matrix protein that controls the packaging and timed activation of the sperm protease proacrosin during spermiogenesis and fertilization [PMID:8144514, PMID:27303034]. It was first purified as a proacrosin-binding protein that selectively recognizes the 55-/53-/49-kDa proacrosin and acrosin-intermediate forms and accelerates proacrosin autoactivation at basic pH in vitro, acting through both amino- and carboxyl-terminal sequences of proacrosin [PMID:8144514]. In mouse, alternative splicing generates two functionally distinct isoforms that bind separate domains of the proacrosin C-terminus: ACRBP-V5 drives formation and configuration of the large acrosomal granule during early spermiogenesis, while the processed ACRBP-C retains proacrosin in an inactive state and accelerates its autoactivation upon acrosomal exocytosis [PMID:23426433, PMID:27303034]. Genetic ablation of both isoforms causes acrosome malformation, fragmented acrosomes, and severe subfertility, with ACRBP-V5 transgenic rescue restoring acrosomal granule formation; the subfertility reflects an incomplete acrosome reaction rather than impaired sperm migration [PMID:27303034, PMID:30606959]. Maturation of ACRBP from precursor to mature form depends on the proprotein convertase PCSK4, and ACRBP undergoes tyrosine phosphorylation during capacitation, with surface ACRBP contributing to sperm–zona pellucida binding and priming of the acrosome reaction [PMID:22357636, PMID:15955892, PMID:34086710]. A separate body of low-confidence work links ACRBP/OY-TES-1/CT23 knockdown to proliferation, migration, and apoptosis phenotypes in mesenchymal stem cells and hepatocellular carcinoma lines, but this somatic role has not been mechanistically resolved in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0098772 molecular function regulator activity, GO:0140313 molecular sequestering activity
 - **localization:** GO:0031410 cytoplasmic vesicle, GO:0005886 plasma membrane

--- a/genes/human/ACRBP/ACRBP-notes.md
+++ b/genes/human/ACRBP/ACRBP-notes.md
@@ -263,7 +263,8 @@ handled as an over-annotation for other genes in this repository (AAAS, ACADS, A
 
 ## Process notes
 
-- `gates_passed: True` on the affinage record; all 12 citations are numeric PMIDs. Its narrative
+- `self_evaluation_pairwise: win` and clear trust gates on the affinage record; all 12 citations
+  are numeric PMIDs. Its narrative
   is accurate on the mechanism, and its own GO grounding (`GO:0098772`, `GO:0140313`,
   `GO:0031410`, `GO:0005886`) was not imported: `GO:0005886 plasma membrane` rests only on the
   boar antibody-accessibility experiment, and `GO:0140313 molecular sequestering activity` frames

--- a/genes/human/ACRV1/ACRV1-ai-review.yaml
+++ b/genes/human/ACRV1/ACRV1-ai-review.yaml
@@ -1255,7 +1255,7 @@ references:
   reference_review:
     relevance: MEDIUM
     correctness: VERIFIED
-    review_notes: 'Machine-fetched affinage record; gates_passed True, faith_pct 100, and all thirteen citations
+    review_notes: 'Machine-fetched affinage record; no self_evaluation_pairwise score, faith_pct 100, and all thirteen citations
       are genuine numeric PMIDs, which is why it was usable as a lead-generator. Every claim taken from it was re-verified
       against the cited paper, and two needed correction: it presents the human hemizona and bovine secondary-binding
       results as a flat contradiction, and it repeats the 1990 no-homology conclusion without noting the Ly-6/uPAR

--- a/genes/human/ACRV1/ACRV1-deep-research-affinage.md
+++ b/genes/human/ACRV1/ACRV1-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 100.0
 n_discoveries: 13
 citation_count: 13
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACRV1 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACRV1 (SP-10) is a testis-specific intra-acrosomal protein expressed in round spermatids that functions in the terminal steps of sperm–egg interaction [PMID:2310816, PMID:10529272]. It encodes a hydrophilic protein with an N-terminal signal peptide and an internal block of three amino-acid repeat types, with no homology to other characterized sequences, and is expressed as alternatively spliced mRNAs [PMID:1693291]. SP-10 is synthesized as a ~45 kDa precursor that is proteolytically processed by trypsin-like (acrosin-type) and other intra-acrosomal endoproteases into a heterogeneous family of 18–32 kDa peptides, with maturation beginning in the testis and continuing in the proximal epididymis [PMID:1637938, PMID:7888499]. Rather than being an integral membrane protein, it is a peripheral acrosomal protein tethered to the acrosomal membranes through a chaotrope-sensitive, detergent-resistant anchor [PMID:1591355]. During the acrosome reaction it redistributes to the inner acrosomal membrane of the equatorial segment, where it mediates sperm–oolemma binding in a beta-1 integrin-independent manner without participating in sperm–zona binding [PMID:2310816, PMID:10775167]. Transcription is controlled by a TATA-less 294-bp proximal promoter sufficient for round spermatid-specific expression [PMID:10529272]; TDP-43 binds GTGTGT motifs within this promoter to repress transcription and pause RNA polymerase II in spermatocytes through its RNA-binding RRM1 domain, while NF45/NF90 act through a Pu-box (AGAAAA) element to upregulate promoter activity [PMID:21252238, PMID:17942973]. The same promoter region functions as a CpG-free vertebrate insulator in somatic cells, where TDP-43-dependent tethering to the nuclear matrix blocks enhancer–promoter communication [PMID:14512027, PMID:17932037]. In ovarian cancer cells, ectopic ACRV1 acts together with ZNF280A and CUX2 to activate PI3K/AKT signaling and glycolysis [PMID:41338461].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0098631 cell adhesion mediator activity
 - **localization:** GO:0031410 cytoplasmic vesicle, GO:0005886 plasma membrane

--- a/genes/human/ACRV1/ACRV1-notes.md
+++ b/genes/human/ACRV1/ACRV1-notes.md
@@ -263,7 +263,8 @@ inference about what the full text might contain.
 
 - `just fetch-gene human ACRV1` — 10 GOA rows, 6 seeded (the five IPI rows collapse to one
   in the stub; expanded back to one entry per GOA row, in GOA order).
-- `affinage_deep_research.py human ACRV1 --write` — `gates_passed: True`, `faith_pct: 100`,
+- `affinage_deep_research.py human ACRV1 --write` — trust gates clear at fetch time (no
+  `self_evaluation_pairwise` score), `faith_pct: 100`,
   13 citations, all numeric PMIDs. Two claims in its narrative needed correction against
   the sources rather than being taken on trust: it presents the sperm–zona results as a
   flat contradiction, and it repeats the 1990 "no homology" conclusion without noting the

--- a/genes/human/ACTL7A/ACTL7A-deep-research-affinage.md
+++ b/genes/human/ACTL7A/ACTL7A-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 83.33333333333333
 n_discoveries: 14
 citation_count: 14
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACTL7A (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACTL7A is a testis-enriched actin-like protein essential for acrosome biogenesis and sperm head shaping during spermiogenesis [PMID:36734600]. It localizes dynamically to the nucleus and subacrosomal space of developing spermatids and later to postacrosomal regions, where it drives formation of subacrosomal filamentous actin and anchors the acrosome to the nucleus via the acroplaxome; its loss abolishes subacrosomal F-actin, causes abnormal acrosomal granule migration, and produces peeling, detached acrosomes [PMID:36734600]. ACTL7A operates within a perinuclear theca cytoskeletal network, co-immunoprecipitating with the zona-pellucida-binding protein ZPBP and being stabilized by FNDC8, whose depletion destabilizes ACTL7A and disrupts head morphogenesis [PMID:35921706, PMID:41169243]. Disruption of the acrosome-acroplaxome-manchette complex upon ACTL7A loss yields small-headed sperm, accompanied by dysregulation of the PI3K/AKT/mTOR/autophagy axis and PDLIM1 accumulation that impairs manchette development [PMID:37667331]. A central downstream consequence of ACTL7A dysfunction is mislocalization, reduced expression, or co-discharge of the sperm-borne oocyte activation factor PLCζ (PLCZ1), which abolishes oocyte calcium oscillations and causes total fertilization failure [PMID:32923619, PMID:35863052]. Loss-of-function and missense mutations in ACTL7A cause male infertility through acrosomal and perinuclear theca ultrastructural defects and oocyte activation deficiency, a phenotype rescuable by artificial oocyte activation [PMID:32923619, PMID:34727571].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0008092 cytoskeletal protein binding, GO:0005198 structural molecule activity
 - **localization:** GO:0005634 nucleus, GO:0005856 cytoskeleton

--- a/genes/human/ACTL7A/ACTL7A-notes.md
+++ b/genes/human/ACTL7A/ACTL7A-notes.md
@@ -430,7 +430,7 @@ justify ortholog transfer to the human gene, not direct-assay codes on it.
 
 ## 10. Affinage deep-research record
 
-`gates_passed: True`, faith 83.3%, 14 citations. The narrative is broadly accurate and its PLCζ
+`self_evaluation_pairwise: win` (trust gates clear at fetch time), faith 83.3%, 14 citations. The narrative is broadly accurate and its PLCζ
 framing is confirmed against the primary papers. Two cautions applied here:
 
 - One citation, `PMID:bio_10.1101_2025.03.27.645694`, is a **bioRxiv DOI in a PMID-shaped field**,

--- a/genes/human/ACTL7B/ACTL7B-ai-review.yaml
+++ b/genes/human/ACTL7B/ACTL7B-ai-review.yaml
@@ -312,7 +312,7 @@ references:
     relevance: MEDIUM
     correctness: LOW_QUALITY
     review_notes: >-
-      gates_passed was True and the narrative correctly surfaced PMID:36617158 and
+      The record carries no self_evaluation_pairwise score; its narrative correctly surfaced PMID:36617158 and
       PMID:38464253, but the record missed PMID:37800308 entirely - the Development 2023
       Actl7b-null paper that supplies the only informative molecular partner - which was
       found instead by a direct PubMed search of the gene symbol. Its own GO grounding

--- a/genes/human/ACTL7B/ACTL7B-deep-research-affinage.md
+++ b/genes/human/ACTL7B/ACTL7B-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 100.0
 n_discoveries: 5
 citation_count: 5
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACTL7B (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACTL7B is a testis-enriched actin-related protein required for spermiogenesis and male fertility [PMID:36617158]. The intronless human gene on chromosome 9q31 arose by retroposition of a spliced actin-progenitor mRNA and encodes a 415-amino-acid actin-like protein expressed predominantly in testis [PMID:10373328]. Its germ-cell-restricted expression is controlled at two levels: repressive CpG methylation within the ORF CpG island silences the promoter in somatic cells, while demethylation accompanies expression in spermatogenic cells [PMID:12907721], and a bidirectional intergenic regulatory region together with CREMτ acting on CRE-like promoter motifs drives haploid germ-cell-specific transcription [PMID:12704725]. During spermiogenesis ACTL7B localizes to the developing acrosome, the early spermatid nucleus, and the flagellum connecting region, and its loss in mice produces severe oligoteratozoospermia with multiple morphological abnormalities of the flagellum and sperm head [PMID:36617158]. Beyond this established role, ACTL7B's intranuclear function and its candidate involvement in chromatin regulation through HDAC1/HDAC3 and nucleosome remodeler complexes have not been biochemically characterized in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0008092 cytoskeletal protein binding
 - **localization:** GO:0005634 nucleus, GO:0031410 cytoplasmic vesicle

--- a/genes/human/ACTL7B/ACTL7B-notes.md
+++ b/genes/human/ACTL7B/ACTL7B-notes.md
@@ -29,7 +29,7 @@ lesser extent, in the prostate." whereas "ACTL7A is expressed in a wide variety 
 ## 2. What is actually known about function (all of it from mouse)
 
 Two independent `Actl7b`-null mouse lines were published in 2023 and agree. Only one of them
-is in the affinage record (`ACTL7B-deep-research-affinage.md`, `gates_passed: True`); the
+is in the affinage record (`ACTL7B-deep-research-affinage.md`, trust gates clear at fetch time); the
 other, PMID:37800308, was found by a plain PubMed search of the gene symbol and turns out to
 carry the only informative molecular partner ACTL7B has. Affinage's own GO grounding for this
 gene proposes `GO:0008092 cytoskeletal protein binding` as the molecular activity, which no

--- a/genes/human/ACTL8/ACTL8-ai-review.yaml
+++ b/genes/human/ACTL8/ACTL8-ai-review.yaml
@@ -1468,8 +1468,8 @@ references:
   findings:
   - statement: >-
       Machine-generated literature summary that surfaced the entire tumour-biology literature for
-      ACTL8, none of which is represented in GOA. Its self-evaluation reports gates_passed True with
-      a faithfulness score of 85.7 per cent, and all eight of its citations are numeric PMIDs.
+      ACTL8, none of which is represented in GOA. Its self-evaluation reports a faithfulness score of
+      85.7 per cent and no pairwise score, and all eight of its citations are numeric PMIDs.
   - statement: >-
       Used only as a lead. Every claim taken from it was re-read against the cached PMID, and no
       mechanistic assertion is sourced from its prose. Doing that check is what revealed that one of

--- a/genes/human/ACTL8/ACTL8-deep-research-affinage.md
+++ b/genes/human/ACTL8/ACTL8-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 85.71428571428571
 n_discoveries: 8
 citation_count: 8
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACTL8 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACTL8 (CT57) is a cancer-testis antigen that functions as an oncogenic driver across multiple epithelial cancers, where it promotes proliferation, migration, invasion, and cell cycle progression while restraining apoptosis [PMID:33883901, PMID:31962007]. Loss-of-function studies in triple-negative breast cancer, gastric cancer, oral squamous cell carcinoma, lung adenocarcinoma, and endometrial cancer consistently show that ACTL8 silencing suppresses tumor cell growth and motility, an effect reproduced in nude-mouse xenografts [PMID:33883901, PMID:35051678, PMID:31962007, PMID:32125225]. Mechanistically, ACTL8 acts upstream of PI3K/AKT/mTOR signaling: knockdown reduces pathway phosphorylation and pharmacological pathway modulators reverse or mimic the ACTL8 phenotype in both breast and gastric cancer models [PMID:33883901, PMID:39322809]. ACTL8 sustains a cell-cycle and proliferation transcriptional program, supporting expression of FOXM1, STMN1, PLK1, BIRC5, CDK1, cyclin B2, cyclin E1, and c-Myc, while its loss derepresses p21 and shifts EMT markers toward an epithelial state [PMID:35051678, PMID:35116946, PMID:32125225]. ACTL8 additionally drives MYC-dependent glutamine metabolism through SLC1A5 and GLS1, maintaining redox homeostasis; MYC re-expression rescues the metabolic phenotype but not p-AKT, placing ACTL8 above both axes [PMID:41621692]. The small molecule Momordin Ic binds ACTL8 directly and destabilizes it via ubiquitin-proteasome degradation, establishing ACTL8 as a druggable target [PMID:41621692]. ACTL8 protein is detected in the cytoplasm of tumor cells [PMID:41129177].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** *(none)*
 - **localization:** GO:0005829 cytosol

--- a/genes/human/ACTL8/ACTL8-notes.md
+++ b/genes/human/ACTL8/ACTL8-notes.md
@@ -29,7 +29,7 @@ An `AltName: Full=Cancer/testis antigen 57; Short=CT57` reflects its identificat
 CT-antigen survey PMID:15905330.
 
 **The affinage record was not empty and must not be treated as if it were.** It returned
-`gates_passed: True`, 8 citations, and a coherent oncology narrative. Checking UniProt's own
+clear trust gates at fetch time, 8 citations, and a coherent oncology narrative. Checking UniProt's own
 `RN`/`RX` list independently confirms only sequencing papers plus PMID:15905330 — so the
 tumour-biology literature reaches this review *only* through affinage, and every claim taken from
 it was re-read against the cached PMID.
@@ -285,7 +285,8 @@ ACCEPT and is now `KEEP_AS_NON_CORE`, which is what its own reason had said all 
 
 - Worktree `/private/tmp/wt-ACTL8`, branch `paint/ACTL8`.
 - `just fetch-gene human ACTL8` → 16 GOA rows, 6 seeded references.
-- affinage: `gates_passed: True`, faith 85.7%, 8 citations, all numeric PMIDs (no bioRxiv-shaped
+- affinage: trust gates clear at fetch time (no `self_evaluation_pairwise` score), faith 85.7%,
+  8 citations, all numeric PMIDs (no bioRxiv-shaped
   ids). Every claim used was re-verified against the cached PMID; the retraction of PMID:32125225
   was found this way and is not flagged by affinage.
 - `just fetch-gene-pmids` + 9 extra `just fetch-pmid` calls.

--- a/genes/human/ACTR10/ACTR10-ai-review.yaml
+++ b/genes/human/ACTR10/ACTR10-ai-review.yaml
@@ -321,7 +321,7 @@ references:
     relevance: MEDIUM
     correctness: VERIFIED
     review_notes: >-
-      Machine-generated deep research, gates_passed true, three numeric PMID citations
+      Machine-generated deep research, self_evaluation_pairwise win, three numeric PMID citations
       all of which were fetched and read in full text here. Its narrative summary of
       the zebrafish work is accurate and is cited only at that summary level, alongside
       the primary quotations. Its own GO grounding (GO:0060090 molecular adaptor

--- a/genes/human/ACTR10/ACTR10-deep-research-affinage.md
+++ b/genes/human/ACTR10/ACTR10-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 4
 citation_count: 3
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACTR10 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACTR10 (Arp11), the pointed-end subunit of the dynactin complex, mediates the physical attachment of dynactin-bound cargo to the dynein retrograde motor in neurons [PMID:28414272]. It is specifically required for coupling mitochondria to dynactin and thereby for dynein-driven retrograde mitochondrial transport in axons; an Actr10 construct lacking its dynactin-binding domain still binds mitochondria, indicating that Actr10 functions as the mitochondria-anchoring element rather than merely a structural dynactin subunit [PMID:28414272]. This retrograde transport activity is essential for homeostatic mitochondrial distribution: its loss causes aged organelles to accumulate at axon terminals while cell body mitochondria are depleted [PMID:33376159]. Beyond mitochondria, Actr10 is required for proper distribution of Mbp mRNA in oligodendrocytes, where Mbp mRNA granules associate with the dynein/dynactin motor complex, extending its role to motor-driven mRNA transport [PMID:29073112]. Genetic interaction places Actr10-dependent retrograde mitochondrial movement in a pathway with the fission GTPase Drp1 [PMID:28414272].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0060090 molecular adaptor activity
 - **localization:** GO:0005856 cytoskeleton, GO:0005739 mitochondrion

--- a/genes/human/ACTR10/ACTR10-notes.md
+++ b/genes/human/ACTR10/ACTR10-notes.md
@@ -306,7 +306,8 @@ subunit-specific activity) and
 
 ## 9. Provenance / process
 
-- affinage deep research ran with `gates_passed: True`, 3 numeric PMID citations, all
+- affinage deep research ran with `self_evaluation_pairwise: win` and clear trust gates,
+  3 numeric PMID citations, all
   three of which were fetched and read in full text. Its narrative is accurate on the
   zebrafish work; its "Affinage mechanism profile" grounding (`GO:0060090 molecular
   adaptor activity`, `GO:0005739 mitochondrion`) was not imported.

--- a/genes/human/ACTR1A/ACTR1A-ai-review.yaml
+++ b/genes/human/ACTR1A/ACTR1A-ai-review.yaml
@@ -336,7 +336,7 @@ references:
     reference_review:
       relevance: LOW
       correctness: VERIFIED
-      review_notes: 'gates_passed: True, two citations, both real numeric PMIDs (31221720, 41142317),
+      review_notes: 'self_evaluation_pairwise: win, two citations, both real numeric PMIDs (31221720, 41142317),
         no bioRxiv DOIs in the PMID field. Recorded here for provenance but deliberately not used to support
         any annotation: its narrative covers only a candidate TLR2 signalling role and an in-vitro SETD3
         methylation event, both of which this review declines to annotate, and its own mechanism profile

--- a/genes/human/ACTR1A/ACTR1A-deep-research-affinage.md
+++ b/genes/human/ACTR1A/ACTR1A-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 2
 citation_count: 2
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACTR1A (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACTR1A (alpha-centractin) is a subunit of the dynactin complex that additionally participates in innate immune signaling and is subject to post-translational regulation [PMID:31221720, PMID:41142317]. ACTR1A physically associates with TLR2 and is required for TLR2-mediated pro-inflammatory cytokine induction, since its knockdown reduces cytokine output downstream of the receptor [PMID:31221720]. ACTR1A is also an in vitro substrate of the SETD3 protein histidine methyltransferase, which methylates recombinant ACTR1A and contacts it in cells, extending SETD3's substrate repertoire beyond beta-actin to this dynactin subunit [PMID:41142317]. Beyond these findings, the structural basis of these interactions, the in-cell methylation site, and the link between ACTR1A modification and dynactin function have not been characterized in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** *(none)*
 - **localization:** *(none)*

--- a/genes/human/ACTR1A/ACTR1A-notes.md
+++ b/genes/human/ACTR1A/ACTR1A-notes.md
@@ -403,7 +403,8 @@ should go to ACTR1A and not to ACTR10.
 ## Process log
 
 - `just fetch-gene human ACTR1A` -> 43 GOA rows, 3 PMIDs newly cached.
-- affinage record: `gates_passed: True`, 2 citations (both numeric PMIDs:
+- affinage record: `self_evaluation_pairwise: win`, trust gates clear, 2 citations (both
+  numeric PMIDs:
   31221720, 41142317), no bioRxiv-DOI-in-PMID-field entries. Its narrative is
   confined to TLR2 and SETD3 and says nothing about dynactin architecture, so
   the structural content of this review comes from UniProt, the primary

--- a/genes/human/ACTR1B/ACTR1B-ai-review.yaml
+++ b/genes/human/ACTR1B/ACTR1B-ai-review.yaml
@@ -302,7 +302,7 @@ references:
   reference_review:
     relevance: MEDIUM
     correctness: VERIFIED
-    review_notes: 'Machine-fetched affinage record, gates_passed: True. Treated as a lead, not as evidence.
+    review_notes: 'Machine-fetched affinage record, self_evaluation_pairwise: win. Treated as a lead, not as evidence.
       Its central claim -- beta-centractin as a stoichiometric minor subunit of the cytosolic 20S dynactin
       complex with no free pool, at roughly 1:15 against alpha-centractin -- was re-verified verbatim
       against PMID:7696711 before use, which states the ratio the other way round (15:1 alpha:beta) for

--- a/genes/human/ACTR1B/ACTR1B-deep-research-affinage.md
+++ b/genes/human/ACTR1B/ACTR1B-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 
 n_discoveries: 3
 citation_count: 4
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACTR1B (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACTR1B (beta-centractin) is an actin-related protein that functions as a stoichiometric minor subunit of the cytosolic 20S dynactin complex [PMID:7696711]. It partitions predominantly to the cytosolic fraction with no detectable free pool, residing within dynactin at a fixed ratio of approximately 1:15 relative to alpha-centractin, which establishes its identity as a constitutive structural component of this complex rather than an independently acting protein [PMID:7696711]. Beyond its membership in dynactin, ACTR1B abundance is modulated in a cell-type-specific manner: it is differentially altered in human platelets upon glycoprotein VI activation [PMID:20107233] and down-regulated in dendritic cells pulsed with high-metastatic-potential hepatocellular carcinoma lysates, where its reduction tracks with diminished CD86 expression and impaired allostimulatory capacity [PMID:17619203, PMID:17925177]. No direct functional dissection of ACTR1B's role within dynactin or in these cellular contexts has been characterized in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0005198 structural molecule activity
 - **localization:** GO:0005829 cytosol

--- a/genes/human/ACTR1B/ACTR1B-notes.md
+++ b/genes/human/ACTR1B/ACTR1B-notes.md
@@ -486,7 +486,7 @@ cytoskeleton.
 
 ## 11. Things the affinage record got right, and its limits
 
-`gates_passed: True`. Its central claim — ACTR1B as a stoichiometric minor
+`self_evaluation_pairwise: win`, trust gates clear. Its central claim — ACTR1B as a stoichiometric minor
 subunit of 20S dynactin at ~1:15 versus alpha, with no free pool, from
 PMID:7696711 — checks out verbatim against the abstract (§1); the direction of
 the ratio is quoted the other way round in the source (15:1 alpha:beta) but the

--- a/genes/human/ACTR5/ACTR5-ai-review.yaml
+++ b/genes/human/ACTR5/ACTR5-ai-review.yaml
@@ -268,7 +268,7 @@ references:
   reference_review:
     relevance: LOW
     correctness: LOW_QUALITY
-    review_notes: 'The machine-fetched affinage record (gates_passed: True, 2 citations, 3 dated findings).
+    review_notes: 'The machine-fetched affinage record (self_evaluation_pairwise: win, 2 citations, 3 dated findings).
       Its narrative is faithful to PMID:36563143 for the HCC/CDKN2A phenotype, which is why that one sentence
       is cited here, but its corpus coverage is narrow: it found 2 papers where UniProt lists 12 primary
       references, and it missed the entire structural literature on this gene - both human INO80-nucleosome

--- a/genes/human/ACTR5/ACTR5-deep-research-affinage.md
+++ b/genes/human/ACTR5/ACTR5-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 3
 citation_count: 2
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACTR5 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACTR5 is a component of the INO80 chromatin remodeling complex that functions as a dependency for hepatocellular carcinoma proliferation [PMID:36563143]. Its loss-of-function activates CDKN2A expression and ablates CDK/E2F-driven cell cycle signaling, thereby attenuating tumor growth [PMID:36563143]. ACTR5 acts together with its partner IES6 through a mechanism distinct from the canonical INO80 complex, since high-density CRISPR tiling profiles of ACTR5 and IES6 diverge from those of other INO80 subunits [PMID:36563143]. Beyond this chromatin-associated cell cycle role, no further biochemical mechanism (substrate specificity, recruitment, or structural basis of CDKN2A repression) has been characterized in the available corpus.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** *(none)*
 - **localization:** *(none)*

--- a/genes/human/ACTR5/ACTR5-notes.md
+++ b/genes/human/ACTR5/ACTR5-notes.md
@@ -455,7 +455,7 @@ Two committed scripts, both tested by deliberate mutation rather than by reading
 * `just fetch-gene human ACTR5`; `just fetch-gene-pmids human ACTR5`;
   `just fetch-pmid` for 26306040, 16618800, 39676660, 41775336, 36563143,
   40386946.
-* Affinage record: `gates_passed: True`, 2 citations, 3 findings. Both cited
+* Affinage record: `self_evaluation_pairwise: win`, trust gates clear, 2 citations, 3 findings. Both cited
   PMIDs are real PubMed records (no `PMID:bio_*` preprint ids). Neither is
   retracted; PMID:36563143 has the 2025 erratum described in §10, which the
   provider does not flag. PMID:40386946 (a childhood-lupus trio-WES study whose

--- a/genes/human/ACTR8/ACTR8-ai-review.yaml
+++ b/genes/human/ACTR8/ACTR8-ai-review.yaml
@@ -279,9 +279,9 @@ references:
     relevance: NONE
     correctness: LOW_QUALITY
     review_notes: 'Recorded so the provider gap is machine-readable, and cited by nothing in this review.
-      The record is empty - n_discoveries 0, citation_count 0, no findings table, no citations - with
-      gates_passed True only because there is nothing to gate. That is a provider gap, not a literature
-      gap: the UniProt RN list alone carries 13 references, including a 2.6 A crystal structure whose
+      The record is empty - n_discoveries 0, citation_count 0, no findings table, no citations, and no
+      self_evaluation_pairwise score - so the trust gates were clear only because there was nothing
+      to gate. That is a provider gap, not a literature gap: the UniProt RN list alone carries 13 references, including a 2.6 A crystal structure whose
       RP line reads FUNCTION, SUBUNIT, AND ATP-BINDING SITES, and this review rests on 20 primary papers.
       The file is deliberately not used as a supporting_text anywhere, because a provider''s silence
       is weaker evidence than a provider''s assertion, and the campaign has already been burned once

--- a/genes/human/ACTR8/ACTR8-deep-research-affinage.md
+++ b/genes/human/ACTR8/ACTR8-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 
 n_discoveries: 0
 citation_count: 0
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACTR8 (human)
@@ -22,9 +23,7 @@ note: >-
 
 No mechanistic discoveries found in literature.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** *(none)*
 - **localization:** *(none)*

--- a/genes/human/ACTR8/ACTR8-notes.md
+++ b/genes/human/ACTR8/ACTR8-notes.md
@@ -13,7 +13,8 @@ UniProt; the seeder de-duplicates it).
 ## 1. Provider record: empty, and that is a provider gap, not a literature gap
 
 The affinage record has `n_discoveries: 0`, `citation_count: 0`, no findings table and no
-citations, with `gates_passed: True` (vacuously — there is nothing to gate). Per the campaign
+citations, and no `self_evaluation_pairwise` score; the trust gates were clear only vacuously —
+there is nothing to gate. Per the campaign
 rule, an empty provider record is **not** evidence that literature is absent, and here it is
 demonstrably wrong: the UniProt `RN` list alone carries 13 references including a 2.6 Å crystal
 structure paper with `FUNCTION, SUBUNIT, AND ATP-BINDING SITES` in its `RP` line

--- a/genes/human/ATXN3/ATXN3-deep-research-affinage.md
+++ b/genes/human/ATXN3/ATXN3-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 24
 citation_count: 24
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ATXN3 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ATXN3 is a Josephin-family deubiquitinating enzyme that maintains protein homeostasis through the ubiquitin-proteasome system, with knockout animals accumulating ubiquitinated proteins in vivo [PMID:17764659]. It removes ubiquitin from a broad range of substrates to control their stability, including HDAC3 during antiviral interferon-I signaling [PMID:29802126], the transcription factors KLF4 [PMID:31563563], YAP via Josephin-domain engagement of the YAP WW domain with K48-linkage specificity [PMID:37349820], and JunB/IRF1/STAT3/HIF-2α to drive PD-L1 expression in tumor cells [PMID:38038129]. Beyond catalysis, ATXN3 operates in genome maintenance as a component of a transcription-coupled DNA repair complex with RNA polymerase II, PNKP and CBP, where its activity protects CBP from ubiquitin-mediated degradation and supports global transcription and error-free double-strand break repair [PMID:30994454, PMID:32205441]. It also functions through a catalytic-independent activity to organize chromatin, controlling HDAC3 subcellular localization and chromatin recruitment, with loss producing abnormal nuclear morphology, altered replication timing and epigenetic marks [PMID:36971114, PMID:30231063]. Nuclear entry of ATXN3 is gated by CK2/GSK3 phosphorylation of serine 29 within the Josephin domain [PMID:20347968], and the protein is processed by calpains and caspases to generate C-terminal fragments [PMID:23100324, PMID:19783548]. ATXN3 also participates in ER-associated retrotranslocation, deubiquitinating type II iodothyronine deiodinase as it is extracted via the p97 ATPase [PMID:24196352]. Polyglutamine expansion causes the SCA3/MJD spinocerebellar ataxia through multiple toxic mechanisms: nuclear inclusion formation that sequesters the proteasome [PMID:10072437], physical inactivation of PNKP leading to persistent DNA damage and ATM-mediated apoptotic signaling [PMID:25590633], cell-autonomous impairment of oligodendrocyte maturation [PMID:35042771], potassium channel dysfunction [PMID:16765348], and toxicity arising from -1 ribosomal frameshifting at the expanded CAG repeat rather than the polyQ tract alone [PMID:16087686, PMID:22337953].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140096 catalytic activity, acting on a protein, GO:0016787 hydrolase activity
 - **localization:** GO:0005634 nucleus, GO:0005829 cytosol, GO:0005730 nucleolus

--- a/genes/human/BRCA1/BRCA1-deep-research-affinage.md
+++ b/genes/human/BRCA1/BRCA1-deep-research-affinage.md
@@ -8,27 +8,22 @@ self_evaluation_pairwise: tie
 faith_pct: 100.0
 n_discoveries: 22
 citation_count: 22
-gates_passed: False
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for BRCA1 (human)
-
-> ⚠️ **CAUTION — trust gate(s) tripped; review before using:**
->
-> - Affinage's own head-to-head self-evaluation scored this record `pairwise = tie` (not `win`) vs the curated UniProt reference — treat the narrative with extra scepticism.
 
 ## Current model (mechanistic narrative)
 
 BRCA1 is a multifunctional nuclear tumor suppressor that safeguards genome integrity by promoting error-free homologous recombination (HR) repair of DNA double-strand breaks and limiting mutagenic nonhomologous repair [PMID:10549283]. It executes HR through two genetically separable activities: a coiled-coil-dependent function that counteracts the 53BP1-RIF1-Shieldin axis to license DNA end resection, and a Δ11-region/PALB2-dependent function that loads RAD51 onto resected DNA, with RNF168 acting redundantly with BRCA1 in the PALB2-loading step [PMID:30704900, PMID:32359443]. BRCA1 functions as a RING-domain heterodimer with BARD1; cryo-EM of the BRCA1-BARD1–nucleosome complex shows BARD1 ankyrin and BRCT domains reading nucleosomal histones, DNA, and the DSB-specific H2A K13/K15 monoubiquitin mark while the RING domains position an E2 enzyme for C-terminal H2A ubiquitylation that opposes 53BP1 [PMID:34321665]. Recruitment to ionizing-radiation-induced foci requires cooperation of the BRCA1 RING and BRCT domains and co-localization with MDC1, with cancer mutations abolishing targeting [PMID:15569676], and BRCA1 retention at breaks is organized by the RAP80/Abraxas(CCDC98)/MERIT40-containing BRCA1-A complex, which controls foci formation and the G2/M checkpoint [PMID:17643121, PMID:19261748]. Heterodimer assembly and DNA-damage localization are tuned by SIRT2-mediated deacetylation of the BARD1 RING interface, while BAP1 antagonizes the BRCA1/BARD1 ligase through both catalytic and non-catalytic mechanisms [PMID:33789098, PMID:19117993]. As an E3 ubiquitin ligase BRCA1/BARD1 modifies substrates including topoisomerase IIα, regulating DNA decatenation and chromosome segregation [PMID:15965487], and estrogen receptor-α, repressing its transcriptional activity [PMID:19887647]. BRCA1 activity is integrated into genotoxic stress signaling through ATR phosphorylation of multiple residues including Ser1423 at stalled replication forks [PMID:11114888] and through p53/CRM1-dependent nuclear export after DNA damage [PMID:15087457]. Beyond repair, BRCA1 maintains centromere stability by resolving R-loops at α-satellite repeats to preserve CENP-A loading [PMID:34599155], supports XIST RNA concentration and chromatin structure on the inactive X chromosome [PMID:12419249], and acts as a transcriptional regulator—autorepressing its own promoter via a BRCA1/E2F1/Rb complex dissolved by genotoxic stress [PMID:20068145] and controlling target genes such as SIRT1 and the ferroptosis regulators VDAC3 and GPX4 [PMID:18851829, PMID:38552003].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0016874 ligase activity, GO:0140096 catalytic activity, acting on a protein, GO:0140110 transcription regulator activity, GO:0003677 DNA binding, GO:0140098 catalytic activity, acting on RNA
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome, GO:0005654 nucleoplasm

--- a/genes/human/BRCA2/BRCA2-deep-research-affinage.md
+++ b/genes/human/BRCA2/BRCA2-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 27
 citation_count: 27
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for BRCA2 (human)
@@ -22,9 +23,7 @@ note: >-
 
 BRCA2 is a central mediator of homologous recombination (HR) that loads and stabilizes the RAD51 recombinase on resected DNA to drive error-free repair of double-strand breaks, with loss of function producing chromosomal instability, checkpoint defects, and crosslinker hypersensitivity [PMID:9660919, PMID:11756561]. A large C-terminal domain binds single-stranded DNA through three OB folds (with an HTH motif implicated in dsDNA binding) and stimulates RAD51-mediated recombination in vitro [PMID:12228710]. Full-length BRCA2 binds RAD51 and selectively assembles it onto ssDNA over dsDNA, displaces RPA, and stabilizes the resulting filament by blocking RAD51 ATP hydrolysis [PMID:20729832]; at the molecular level it accelerates RAD51 nucleation on RPA-coated ssDNA to rates approaching those on naked ssDNA, overcoming the kinetic barrier RPA imposes [PMID:36976771]. The eight BRC repeats engage RAD51 non-equivalently to control filament assembly versus disruption [PMID:15937124], while the C-terminal TR2 motif braces adjacent RAD51 protomers across the filament interface via an acidic-patch contact [PMID:37919288]. BRCA2 is brought to damage sites through the BRCA1–PALB2 axis, which places BRCA1 upstream of BRCA2 in HR [PMID:19268590], and through FANCD2/Fanconi-pathway interactions that promote its chromatin loading [PMID:15199141, PMID:12915460]. Beyond canonical HR, BRCA2 protects reversed replication forks from MRE11-, PTIP-, and RAD52-mediated nucleolytic degradation by assembling stable RAD51 filaments on regressed arms [PMID:29038466], and it limits DNA:RNA hybrid (R-loop) accumulation at breaks and at G/C-rich chromatin by recruiting RNase H2 in S/G2 phase [PMID:30560944, PMID:35715464]. Its activity is governed by phosphoregulation and proteostasis: ATM/ATR phosphorylation recruits PP2A-B56 to promote RAD51 filament formation [PMID:34593815], a PLK1-T207 phosphorylation event builds a PP2A–BUBR1 complex required for mitotic chromosome alignment [PMID:32286328], DSS1 and ssDNA control BRCA2 oligomeric state [PMID:32609828], and reactive metabolites such as formaldehyde and methylglyoxal trigger its proteasomal degradation to cause transient functional haploinsufficiency and mutagenesis [PMID:28575672, PMID:38608703]. BRCA2 additionally functions as a meiotic recombination mediator, stimulating DMC1 strand exchange through DMC1-preferring BRC repeats and acting within meiosis-specific complexes [PMID:26976601, PMID:31242413, PMID:32609828].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0003677 DNA binding, GO:0140096 catalytic activity, acting on a protein, GO:0060090 molecular adaptor activity, GO:0098772 molecular function regulator activity
 - **localization:** GO:0005634 nucleus, GO:0005694 chromosome, GO:0000228 nuclear chromosome

--- a/genes/human/BRIP1/BRIP1-deep-research-affinage.md
+++ b/genes/human/BRIP1/BRIP1-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 38
 citation_count: 40
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for BRIP1 (human)
@@ -22,9 +23,7 @@ note: >-
 
 BRIP1 (BACH1/FANCJ) is a 5′-to-3′ DEAH-box ATP-dependent DNA helicase that maintains genome stability during DNA replication and repair, and its loss defines Fanconi anemia complementation group J [PMID:16153896, PMID:16116423, PMID:16116424, PMID:16116421]. Catalytic activity depends on an N-terminal iron–sulfur cluster coordinated by three conserved cysteines—mutated in Fanconi anemia and cancer—and on Q-motif (Q25)-dependent dimerization, with the dimer showing enhanced ATPase, helicase, and DNA-binding activity [PMID:16973432, PMID:22582397, PMID:32542039]. The enzyme unwinds duplex DNA, dissociates G-quadruplex (G4) structures, disrupts triplex DNA and protein–DNA complexes, and inhibits RAD51 strand exchange, contacting both translocating and non-translocating strands during unwinding [PMID:18426915, PMID:18978354, PMID:19150983, PMID:17145708]. A central physiological role is resolving G4 obstacles during replication: FANCJ counteracts fork stalling at G4 structures—a function it performs in cell-free Xenopus extracts independently of the canonical FA pathway—and engages G4s through a dedicated AKKQ recognition motif that also mediates MLH1 binding, while a PIP-like region recruits REV1 to assemble a G4 repair complex [PMID:23530069, PMID:25193968, PMID:27342280, PMID:31861576]. FANCJ operates in interstrand crosslink repair downstream of FANCD2 monoubiquitination, where its helicase activity and direct MLH1 (MutLα) interaction—rather than its BRCA1 interaction—are required to correct ICL sensitivity [PMID:16116421, PMID:17581638]. FANCJ directly binds and stabilizes FANCD2/FANCI and is reciprocally required for FANCD2 chromatin loading and focus formation [PMID:25070891, PMID:26336824, PMID:20676667]. In homologous recombination, CDK-dependent S990 phosphorylation drives both BRCA1 interaction and K1249 acetylation, the latter recruiting CtIP to promote DNA end resection [PMID:32251466, PMID:22792074]. FANCJ couples to checkpoint and replication-stress responses via phospho-Thr1133-dependent binding to the TopBP1 BRCT7/8 domains, supporting ATR signaling and RPA chromatin loading, and cooperates with RPA on damaged and G4 substrates [PMID:20159562, PMID:21127055, PMID:17596542]. Genetically, FANCJ helicase function suppresses spontaneous and replication-stress-induced microsatellite instability independently of FANCD2, with Fancj-null mice predisposed to lymphoma [PMID:26637282, PMID:27179029]. Beyond replication and repair, FANCJ unfolds protein adducts in DNA–protein crosslink repair to enable SPRTN cleavage and translesion synthesis [PMID:36608669], and contributes to S-phase PARP1 activity through its MLH1 interaction, explaining its requirement for PARP inhibitor efficacy in BRCA1-deficient cells [PMID:38521768].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140657 ATP-dependent activity, GO:0140097 catalytic activity, acting on DNA, GO:0003677 DNA binding, GO:0016787 hydrolase activity, GO:0060090 molecular adaptor activity
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome

--- a/genes/human/ERCC4/ERCC4-deep-research-affinage.md
+++ b/genes/human/ERCC4/ERCC4-deep-research-affinage.md
@@ -8,27 +8,22 @@ self_evaluation_pairwise: tie
 faith_pct: 100.0
 n_discoveries: 40
 citation_count: 41
-gates_passed: False
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ERCC4 (human)
-
-> ⚠️ **CAUTION — trust gate(s) tripped; review before using:**
->
-> - Affinage's own head-to-head self-evaluation scored this record `pairwise = tie` (not `win`) vs the curated UniProt reference — treat the narrative with extra scepticism.
 
 ## Current model (mechanistic narrative)
 
 ERCC4 (XPF) is the catalytic subunit of a structure-specific endonuclease that operates as an obligate heterodimer with ERCC1 to incise DNA at single-strand/double-strand junctions across multiple genome-maintenance pathways [PMID:8253090, PMID:8253091, PMID:7559382, PMID:9525876]. The purified heterodimer cleaves bubble, splayed-arm, and flap substrates on the 5' side of ss/ds junctions, requiring divalent cations and a minimal stretch of unpaired nucleotides [PMID:9525876], with the nuclease active site mapping to XPF residues 670–740 where point mutations abolish catalysis without affecting DNA binding [PMID:11953324]. Structural work resolves the basis for substrate engagement: ERCC1 and XPF contribute non-equivalent (HhH)₂ and central domains that bind ssDNA and dsDNA asymmetrically [PMID:16076955, PMID:22483113], and cryo-EM shows the DNA-free complex adopts an auto-inhibited conformation that masks the active site until junction engagement couples the ERCC1 (HhH)₂ to the nuclease domains [PMID:32111838]. In nucleotide excision repair, the complex is recruited through direct ERCC1–XPA interaction to execute the 5' incision [PMID:8197175, PMID:17948053], and its participation is distributive, with damage-induced transient immobilization at lesions [PMID:10320375]. Beyond NER, XPF-ERCC1 carries out interstrand crosslink unhooking downstream of FANCD2 ubiquitylation and SLX4 recruitment, with RPA activating incision at replication-fork ICL structures and SNM1A loading from the resulting nicks [PMID:19805513, PMID:24726325, PMID:28607004, PMID:28292785], and it functions in double-strand break end-joining and single-strand annealing [PMID:18541667, PMID:17962301]. The complex additionally maintains telomeres [PMID:18812185], processes R-loops in association with XAB2 [PMID:34039990], drives ALT telomere synthesis via TERRA R-loops [PMID:36184605], and supports CTCF/cohesin-dependent chromatin looping for transcriptional regulation and imprinted-gene silencing independent of repair, a role requiring its catalytic activity [PMID:22771116, PMID:28368372]. Heterodimerization governs the complex's integrity and compartmentalization: XPF stability requires ERCC1 [PMID:20418188], nuclear import of ERCC1 requires XPF [PMID:28130555], and USP45-mediated deubiquitylation of ERCC1 promotes recruitment to damage sites [PMID:25538220]. Biallelic ERCC4 mutations cause Fanconi anemia, and the spectrum of XP, XFE progeroid, and FA phenotypes reflects mutations that separably impair NER, ICL repair, or proper localization [PMID:20221251, PMID:23623386, PMID:30165384].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140097 catalytic activity, acting on DNA, GO:0016787 hydrolase activity, GO:0003677 DNA binding, GO:0003723 RNA binding
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome

--- a/genes/human/FANCA/FANCA-deep-research-affinage.md
+++ b/genes/human/FANCA/FANCA-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 29
 citation_count: 29
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for FANCA (human)
@@ -22,9 +23,7 @@ note: >-
 
 FANCA is a large nuclear protein that serves as a scaffold organizer of the Fanconi anemia (FA) core complex, the assembly required for activating the FA/BRCA interstrand crosslink (ICL) repair pathway [PMID:9789045, PMID:21273304]. Through an N-terminal arginine-rich motif (residues 18–29, with Arg1/Arg2/Leu8 critical) FANCA binds FANCG, and the two proteins reciprocally stabilize each other and promote nuclear accumulation of the complex [PMID:10567393, PMID:11050007, PMID:32002546]; cryo-EM defines a C-terminal arc-shaped HEAT-repeat solenoid that forms a pseudo-symmetric dimer and engages FANCG at both N- and C-terminal interfaces, with disease mutations at these contacts blocking nuclear import and pathway function [PMID:32002546]. FANCA additionally complexes with FANCC and FANCF, and its nuclear localization is necessary and sufficient for correcting mitomycin C hypersensitivity in FA-A cells, distinct from FANCC's separable cytoplasmic role [PMID:9398857, PMID:9746759, PMID:11063725]. FAAP20 directly binds and stabilizes FANCA, and its loss reduces FANCD2 monoubiquitination and reproduces FA phenotypes, placing FANCA upstream of the central ICL-repair switch [PMID:22396592]. Patient-derived missense and truncation mutations cause FA by preventing nuclear relocation and pathway activation rather than by graded loss of an intrinsic activity, accounting for the absence of genotype–phenotype correlation [PMID:21273304]. FANCA is regulated by DNA-damage-induced ATR phosphorylation on Ser1449 and by NEK2 phosphorylation on Thr351 at centrosomes [PMID:19109555, PMID:23806870]. Beyond core-complex scaffolding, purified FANCA possesses intrinsic nucleic acid binding (RNA > ssDNA > dsDNA) via its C-terminal domain and directly catalyzes single-strand annealing and strand exchange comparable to RAD52, acting in the single-strand-annealing branch of double-strand break repair independently of the canonical FA pathway, with FANCG stimulating these activities [PMID:22194614, PMID:30057198]. FANCA also localizes to centrosomes and pericentriolar material during mitosis, where it maintains centrosomal integrity, spindle assembly, and spindle-assembly-checkpoint function [PMID:23806870, PMID:26366677]. It engages additional partners — BRCA1, the SWI/SNF subunit BRG1, alpha-spectrin II, and mu-calpain — linking it to chromatin and to a spectrin scaffold that recruits FANCA to crosslink sites [PMID:10551855, PMID:11726552, PMID:12354784, PMID:20518497].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0003677 DNA binding, GO:0003723 RNA binding, GO:0140097 catalytic activity, acting on DNA, GO:0060090 molecular adaptor activity, GO:0005198 structural molecule activity
 - **localization:** GO:0005634 nucleus, GO:0005829 cytosol, GO:0005815 microtubule organizing center

--- a/genes/human/FANCB/FANCB-deep-research-affinage.md
+++ b/genes/human/FANCB/FANCB-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise:
 faith_pct: 100.0
 n_discoveries: 8
 citation_count: 8
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for FANCB (human)
@@ -22,9 +23,7 @@ note: >-
 
 FANCB (originally identified as FAAP95) is an X-linked component of the Fanconi anemia (FA) core complex that acts upstream to promote FANCD2 monoubiquitination during the repair of DNA interstrand crosslinks (ICLs) [PMID:15611632, PMID:21458466]. Loss of FANCB abolishes MMC- and crosslink-induced FANCD2 foci formation and reduces RAD51 foci, sister chromatid exchange, and gene targeting, producing crosslinker hypersensitivity and chromosomal instability, while a parallel MUS81-dependent route handles replication-fork repair independently of FANCB [PMID:17903171, PMID:21458466]. Biochemical reconstitution establishes that FANCB protein is indispensable for FANCD2 monoubiquitination, and the degree of residual monoubiquitination conferred by FANCB missense variants correlates with clinical severity [PMID:32106311]. Beyond canonical ICL repair, FANCB has dedicated germline and stem-cell roles: during male meiosis it localizes to the sex chromosomes in an MDC1/γH2AX-dependent manner, is required for meiotic FANCD2 localization, and shapes sex-chromosome H3K9 methylation (decreasing H3K9me2 and increasing H3K9me3 upon loss), with FANCB-mutant mice showing primordial germ cell defects and spermatogonial failure [PMID:26123487]; it also maintains hematopoietic stem cell quiescence and repopulating capacity [PMID:26658157]. Truncating loss-of-function FANCB mutations cause X-linked VACTERL-hydrocephalus syndrome in hemizygous males, with carrier females showing skewed X-inactivation [PMID:21910217].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140096 catalytic activity, acting on a protein
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome

--- a/genes/human/FANCC/FANCC-deep-research-affinage.md
+++ b/genes/human/FANCC/FANCC-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 34
 citation_count: 34
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for FANCC (human)
@@ -22,9 +23,7 @@ note: >-
 
 FANCC encodes a ~60-kDa protein with dual roles in genome maintenance and cytoprotection, originally defined as a Fanconi anemia gene required for cellular resistance to DNA interstrand cross-linking agents [PMID:8499901, PMID:7517562]. As part of a nuclear FA core complex, FANCC assembles with FANCA, FANCG, FANCF, and FANCE in a series of interdependent interactions: FANCA-FANCC binding [PMID:9398857], FANCG-bridged complex formation [PMID:10373536], FANCF incorporation [PMID:11063725], and FANCE-mediated linkage of FANCC to the substrate FANCD2 [PMID:16127171]; phosphorylation-dependent nuclear accumulation of this complex defines a common pathway disrupted across multiple FA complementation groups [PMID:9789045]. This assembly is required for FANCD2 monoubiquitination, and its loss abrogates that modification, elevates spontaneous chromosomal breakage, and confers selective sensitivity to cross-linking agents [PMID:16762635]. Downstream, FANCC promotes homologous recombination and error-prone repair of abasic sites, suppresses sister chromatid exchange, and acts in concert with BLM helicase to maintain genome stability [PMID:15327776, PMID:15616572], operating in parallel pathways with BRCA2 and HELQ [PMID:16687415, PMID:24005041]. Independently of the core complex, cytoplasmic FANCC exerts anti-apoptotic functions essential for hematopoietic progenitor survival [PMID:8621788, PMID:8977247]: it binds Hsp70 to form a ternary complex that inhibits the pro-apoptotic kinase PKR [PMID:11500375, PMID:12397061], binds non-phosphorylated STAT1 to facilitate its docking and activation at the IFN-gamma receptor [PMID:10848598], and attenuates NADPH cytochrome P450 reductase activity [PMID:9787138]. Patient-derived mutant FANCC (L554P) loses both core-complex (FANCA, cdc2) and signaling (STAT1) interactions [PMID:9398857, PMID:9242535, PMID:10848598].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0060090 molecular adaptor activity, GO:0098772 molecular function regulator activity, GO:0003677 DNA binding
 - **localization:** GO:0005829 cytosol, GO:0005634 nucleus

--- a/genes/human/FANCD2/FANCD2-deep-research-affinage.md
+++ b/genes/human/FANCD2/FANCD2-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 60
 citation_count: 60
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for FANCD2 (human)
@@ -22,9 +23,7 @@ note: >-
 
 FANCD2 is the central effector of the Fanconi anemia (FA) DNA repair pathway, originally identified by positional cloning as the FA-D2 gene product whose reintroduction complements mitomycin C sensitivity in patient cells [PMID:11239453]. Its activation is governed by a regulated cycle of post-translational modification: ATR/ATM kinases phosphorylate FANCD2 (T691, S717) and its partner FANCI, priming the complex [PMID:16943440, PMID:36050501], after which the FA core complex — minimally the FANCB-FANCL-FAAP100 module using UBE2T as E2 — monoubiquitinates FANCD2 on K561 during S phase and in response to DNA damage [PMID:12239151, PMID:24905007, PMID:31873223]. This modification drives translocation from soluble nucleoplasm to chromatin, where FANCD2 forms damage-induced foci with BRCA1 and RAD51 [PMID:12239151, PMID:15454491]. FANCD2 functions as an obligate heterodimer with its paralog FANCI, and DNA engagement by the ID2 complex is required for efficient monoubiquitination [PMID:17412408, PMID:22287633, PMID:24623813]. Structural studies establish that the unmodified ID2 complex is recruited to DNA and that monoubiquitination triggers a conformational closure into a sliding clamp that encircles dsDNA, with ubiquitin acting as a molecular pin at the I-D interface; the clamp diffuses on duplex DNA and stalls at ssDNA-dsDNA junctions found at stalled replication forks [PMID:21764741, PMID:32066963, PMID:32510829, PMID:39085614]. Activated FANCD2 coordinates interstitial crosslink repair by recruiting the XPF-ERCC1/SLX4 nucleases for unhooking incisions, FAN1 and CtIP for end processing and resection, and by stabilizing RAD51 filaments and mediating strand exchange while protecting DNA ends from DNA2, MRE11, and EXO1 nucleases [PMID:20603015, PMID:24726325, PMID:24794430, PMID:24794434, PMID:27694619, PMID:37526271]. The cycle is reversed by USP1-UAF1, which deubiquitinates K561 in a DNA- and FANCI-contact-dependent manner requiring a FANCD2-specific sequence in the USP1 N-terminus [PMID:18082605, PMID:31253762, PMID:33795880]. Beyond crosslink repair, FANCD2 — including its non-ubiquitinated form — restrains replication fork progression at common fragile sites and in BRCA1/2-deficient cells where its loss is synthetic lethal, suppresses R-loop accumulation by recruiting RNA-processing factors and collaborating with SRSF1 for mRNA export, activates TAp63 transcription to suppress skin carcinogenesis, and localizes to mitochondria where it supports homeostasis through ATAD3 and TUFM [PMID:23806336, PMID:26797144, PMID:27768874, PMID:27264184, PMID:28378742, PMID:30431240, PMID:38165804].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0003677 DNA binding, GO:0003723 RNA binding, GO:0031386 protein tag activity, GO:0140096 catalytic activity, acting on a protein, GO:0060090 molecular adaptor activity, GO:0140110 transcription regulator activity
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome, GO:0005654 nucleoplasm, GO:0005739 mitochondrion

--- a/genes/human/FANCE/FANCE-deep-research-affinage.md
+++ b/genes/human/FANCE/FANCE-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 10
 citation_count: 10
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for FANCE (human)
@@ -22,9 +23,7 @@ note: >-
 
 FANCE is a nuclear subunit of the Fanconi anemia (FA) core complex that functions as a molecular bridge coupling the core complex to its downstream substrate, the FANCD2-FANCI heterodimer [PMID:12093742, PMID:16127171]. It binds FANCC directly and, through a distinct region, contacts FANCD2, thereby recruiting the substrate for monoubiquitination; FANCE is required for nuclear accumulation of FANCC, formation of the FANCA-FANCC complex, FANCD2 monoubiquitination, and FANCD2 nuclear foci assembly [PMID:12093742, PMID:12239156, PMID:16513431]. The FANCC-binding and FANCD2-binding surfaces are separable, and the extreme C-terminal residue phenylalanine 522 is the critical determinant of the FANCD2/FANCI interaction required for substrate monoubiquitination and DNA cross-link repair [PMID:16513431, PMID:24451376]. Structurally FANCE adopts a repeated helical (HEAT-like) fold, and disease-associated mutations map to this domain and disrupt the FANCE-FANCD2 interaction [PMID:17308347]. Beyond its scaffolding role, FANCE is directly phosphorylated by Chk1 at threonine 346 and serine 374 upon DNA damage, an event dispensable for FANCD2 monoubiquitination but required for cross-link repair, defining a separable monoubiquitination-independent function [PMID:17296736]. The FANCC-FANCE-FANCF subcomplex is evolutionarily conserved and additionally acts to suppress meiotic crossovers [PMID:36652992].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0060090 molecular adaptor activity, GO:0140096 catalytic activity, acting on a protein
 - **localization:** GO:0005634 nucleus

--- a/genes/human/FANCF/FANCF-deep-research-affinage.md
+++ b/genes/human/FANCF/FANCF-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 9
 citation_count: 9
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for FANCF (human)
@@ -22,9 +23,7 @@ note: >-
 
 FANCF is a nuclear adaptor protein essential for assembly of the Fanconi anemia (FA) core complex, which drives monoubiquitination of FANCD2 to enable repair of DNA interstrand cross-links [PMID:11063725, PMID:21915857]. It functions as a flexible bridging subunit: its C-terminus binds FANCG to nucleate assembly of other FA proteins, while its N-terminus stabilizes FANCA/FANCG contacts and is required to recruit the FANCC/FANCE subcomplex [PMID:15262960]. The C-terminal domain adopts a Cand1-like helical repeat fold whose two surface loops are critical both for interaction with other core complex components and for FANCD2 monoubiquitination and cellular resistance to mitomycin C [PMID:17082180]. Loss of FANCF abolishes FANCD2 monoubiquitination and produces G2 arrest, chromosomal aberrations, sensitivity to cross-linking agents, and, in mice, defective gametogenesis and ovarian tumors, establishing its non-redundant role in the FA/BRCA pathway in vivo [PMID:21915857]. The FANCC-FANCE-FANCF subcomplex is evolutionarily conserved to plants, where it additionally acts as an anti-crossover factor during meiotic recombination [PMID:36652992]. FANCF expression is transcriptionally activated by ICSBP/IRF8 during myeloid differentiation [PMID:19801548] and is suppressed by p53-driven miR-30c, such that p53 loss in cancer cells upregulates FANCF and confers chemoresistance [PMID:31511498]; silencing FANCF inactivates the FA/BRCA pathway and sensitizes breast and ovarian cancer cells to chemotherapeutic agents through p38/JNK MAPK signaling [PMID:22952942, PMID:23440494].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0060090 molecular adaptor activity
 - **localization:** GO:0005634 nucleus

--- a/genes/human/FANCG/FANCG-deep-research-affinage.md
+++ b/genes/human/FANCG/FANCG-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 30
 citation_count: 30
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for FANCG (human)
@@ -22,9 +23,7 @@ note: >-
 
 FANCG (identical to XRCC9) is a tetratricopeptide-repeat (TPR) scaffold protein of the Fanconi anemia (FA) DNA-repair pathway, originally identified by its ability to complement the mitomycin C-, cisplatin-, and crosslink-hypersensitive phenotype and chromosomal instability of FA-G cells [PMID:9806548, PMID:9256465]. Within the FA nuclear core complex, FANCG directly binds FANCA through an arginine-rich motif at the FANCA N-terminus and its own C-terminal/TPR contact surfaces, mutually stabilizing the two proteins, promoting nuclear import of the complex, and additionally recruiting FANCC via its C-terminus [PMID:10373536, PMID:10567393, PMID:11050007, PMID:10961856]; cryo-EM of the FANCA-FANCG complex shows FANCG making independent contacts with the FANCA N-terminal region and C-terminal HEAT solenoid, both required for FANCA nuclear localization [PMID:32002546]. Its TPR motifs (notably TPR1, 2, 5, 6) constitute the protein-protein interaction scaffold needed for assembly of both the core complex and downstream complexes [PMID:14697762, PMID:20450923]. The assembled core complex is required for damage-induced monoubiquitination of FANCD2, the central activating event of the pathway [PMID:11751423, PMID:11719385]. Independently of core-complex function, FANCG nucleates a discrete D1-D2-G-X3 complex with BRCA2/FANCD1, FANCD2, and the RAD51 paralog XRCC3, an assembly that depends on phosphorylation of FANCG at Ser7 and supports homologous-recombination repair of interstrand crosslinks [PMID:12915460, PMID:16621732, PMID:18212739], consistent with FANCG being required for efficient HR repair of double-strand breaks [PMID:12861027]. FANCG is further phosphorylated at Ser383/Ser387 by Cdc2 during mitosis [PMID:15367677] and modified by K63-linked polyubiquitin chains that recruit the Rap80-BRCA1 complex for HR repair while being dispensable for FANCD2 monoubiquitination [PMID:25132264], and it links the pathway to the ERCC1-XPF endonuclease that performs ICL unhooking through its TPR motifs [PMID:20518486]. A mitochondrial pool of FANCG, separable from its nuclear repair function, protects against oxidative stress and supports FANCJ helicase iron-sulfur integrity via frataxin [PMID:32989015].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0060090 molecular adaptor activity, GO:0005198 structural molecule activity
 - **localization:** GO:0005634 nucleus, GO:0005829 cytosol, GO:0005739 mitochondrion

--- a/genes/human/FANCI/FANCI-deep-research-affinage.md
+++ b/genes/human/FANCI/FANCI-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 43
 citation_count: 43
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for FANCI (human)
@@ -22,9 +23,7 @@ note: >-
 
 FANCI is a central effector of the Fanconi anemia DNA interstrand crosslink (ICL) repair pathway, functioning as the obligate partner of FANCD2 in a heterodimeric (ID2) clamp that recognizes and processes damaged replication forks [PMID:17412408, PMID:17460694]. The complex acts as a sliding clamp that diffuses on dsDNA and stalls specifically at single-strand/double-strand junctions characteristic of stalled forks, then encircles the DNA through a closed conformation [PMID:39085614, PMID:32066963]. Activation proceeds through ordered post-translational regulation: ATR phosphorylates conserved S/TQ motifs (notably S556, S559, S565), priming the complex by destabilizing its open state, stabilizing DNA and FANCD2 association, and protecting the eventual ubiquitin marks from USP1:UAF1 [PMID:18931676, PMID:32117957, PMID:36050501], and PP2A dephosphorylates an inhibitory FANCD2 cluster to license chromatin loading [PMID:39535917]. The UBE2T-FANCL E2-E3 pair then monoubiquitinates FANCD2 (K561) and FANCI (K523), a reaction strongly stimulated by FANCI's DNA binding and required for clamping the heterodimer on dsDNA [PMID:19111657, PMID:19589784, PMID:22287633, PMID:32167469]; FANCI's own ubiquitin reciprocally protects FANCD2's ubiquitin from USP1-UAF1 deubiquitination and enables re-ubiquitination, establishing an interdependent ubiquitin lock [PMID:32510829, PMID:36385258]. The activated clamp recruits the downstream nuclease FAN1 and directly stabilizes RAD51-DNA filaments to protect fork ends [PMID:20671156, PMID:27694619]. Beyond canonical repair, FANCI carries out FANCD2-independent functions: it restrains dormant origin firing under replication stress [PMID:25843623], localizes to the nucleolus to support pre-rRNA transcription and large-subunit processing in its deubiquitinated state [PMID:30692263], stimulates homologous recombination D-loop formation and is essential for meiosis and spermatogenesis [PMID:31219578, PMID:34373449], and can switch from FANCD2 partnering to PIDD1 binding to drive caspase-2/PIDDosome-dependent apoptosis when ICL repair fails [PMID:34256011]. Patient-derived mutations affecting the C-terminal NLS/EDGE region and the Tower domain disrupt these activities, linking FANCI to the Fanconi anemia phenotype [PMID:20971953, PMID:27405460].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0003677 DNA binding, GO:0003723 RNA binding, GO:0140096 catalytic activity, acting on a protein, GO:0060090 molecular adaptor activity, GO:0098772 molecular function regulator activity
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome, GO:0005730 nucleolus

--- a/genes/human/FANCL/FANCL-deep-research-affinage.md
+++ b/genes/human/FANCL/FANCL-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 22
 citation_count: 22
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for FANCL (human)
@@ -22,9 +23,7 @@ note: >-
 
 FANCL is the catalytic RING-type E3 ubiquitin ligase subunit of the Fanconi anemia core complex, partnering with the E2 enzyme UBE2T to monoubiquitinate FANCD2 and FANCI and thereby drive homologous-recombination repair of DNA interstrand crosslinks [PMID:19111657, PMID:17352736]. Its crystal structure resolves a tripartite architecture in which the central DRWD/URD domain binds the FANCD2/FANCI substrate dimer while the C-terminal RING domain mediates E2 recruitment, and an extensive electrostatic/hydrophobic RING–UBE2T interface confers selective recruitment of UBE2T over other E2 enzymes [PMID:20154706, PMID:24389026]. Reconstitution shows FANCL and UBE2T are sufficient to monoubiquitinate FANCD2, with FANCI both stimulating the reaction and restricting modification to the correct lysine (K561 on FANCD2; K523 on FANCI) [PMID:19111657, PMID:19589784]; the N-terminal ELF domain additionally binds free ubiquitin via the Ile44 patch to promote efficient damage-induced FANCD2 monoubiquitination in cells [PMID:26149689]. FANCL-dependent monoubiquitination is required for FANCD2 chromatin and nuclear-matrix association and for HR repair of induced chromosomal breaks, an epistatic relationship conserved from Drosophila to vertebrates [PMID:14712086, PMID:17352736, PMID:16860002]. A catalytic-cysteine knock-in mouse establishes that loss of RING E3 ligase activity alone reproduces all major Fanconi anemia phenotypes, and FANCL variants causing protein destabilization or cytoplasmic mislocalization underlie premature ovarian insufficiency [PMID:41259745, PMID:32048394]. Beyond DNA repair, FANCL extends K11-linked non-proteolytic ubiquitin chains on β-catenin to enhance Wnt target transcription in hematopoietic stem/progenitor cells [PMID:22653977], supports Parkin-mediated mitophagy through a ubiquitin ligase-independent mitochondrial function [PMID:35644338], and is required for primordial germ cell proliferation and oocyte survival through meiosis [PMID:12417526, PMID:20661450].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0016874 ligase activity, GO:0140096 catalytic activity, acting on a protein, GO:0031386 protein tag activity
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome, GO:0005739 mitochondrion

--- a/genes/human/FANCM/FANCM-deep-research-affinage.md
+++ b/genes/human/FANCM/FANCM-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 41
 citation_count: 41
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for FANCM (human)
@@ -22,9 +23,7 @@ note: >-
 
 FANCM is an ATP-dependent DNA translocase and branch-point migrase that recognizes branched DNA intermediates—Holliday junctions, replication forks, and D-loops—and remodels them to preserve genome stability during replication stress [PMID:18206976, PMID:18285517]. Through its N-terminal translocase domain it catalyzes bidirectional branch migration and replication fork reversal in an ATPase-dependent manner [PMID:18206976, PMID:18843105], with the Hel2i subdomain coupling specific branched-DNA engagement to catalytic migration [PMID:39189453, PMID:40447800]. Beyond its enzymatic activity, FANCM serves as a chromatin-targeting scaffold that loads the Fanconi anemia core complex onto chromatin in a cell-cycle-dependent manner and is required for normal FANCD2 monoubiquitination [PMID:18174376, PMID:17289582]; it bridges the FA and Bloom syndrome dissolvasome pathways through two conserved motifs—MM1 binding the core complex via FANCF and MM2 binding RMI1/topoisomerase IIIα—with loss of bridging elevating sister chromatid exchange [PMID:20064461, PMID:22392978]. FANCM functions in a stable heterodimeric module with the histone-fold proteins MHF1-MHF2, which stimulate its DNA binding and fork-remodeling activity and switch its DNA-binding preference toward branched DNA [PMID:20347428, PMID:20347429, PMID:24699063], and it partners with FAAP24, whose DNA-binding (HhH)2 domain targets the complex to chromatin [PMID:17289582, PMID:24003026]. Functionally distinct activities are separable: the translocase activity is dispensable for FA pathway activation but required for replication fork stability, ICL traverse, ATR/CHK1 checkpoint signaling, and recovery of stalled forks [PMID:18285517, PMID:18995830, PMID:22279085, PMID:24207054], and FANCM facilitates ATR checkpoint activation by promoting RPA and TopBP1 chromatin retention [PMID:20670894, PMID:20057355]. FANCM is regulated by ATR-dependent phosphorylation at S1045 and by Plk1/β-TRCP-driven mitotic degradation that releases the core complex from chromatin [PMID:23698467, PMID:19270156]. At ALT telomeres, its translocase activity and BTR-complex interaction suppress TERRA R-loops and BLM-driven break-induced telomere synthesis, rendering FANCM-BTR disruption selectively toxic to ALT cancer cells [PMID:31138795, PMID:31138797], and FANCM loss is synthetic-lethal with BRCA1 hypomorphs and with SMARCAL1 [PMID:33882298, PMID:39510066]. The ortholog studies establish a conserved role in limiting recombination outcomes by dissociating D-loops, including meiotic crossover control [PMID:18851838, PMID:32386601].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140657 ATP-dependent activity, GO:0003677 DNA binding, GO:0140097 catalytic activity, acting on DNA, GO:0060090 molecular adaptor activity, GO:0098772 molecular function regulator activity
 - **localization:** GO:0005694 chromosome, GO:0005634 nucleus

--- a/genes/human/MAD2L2/MAD2L2-deep-research-affinage.md
+++ b/genes/human/MAD2L2/MAD2L2-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 47
 citation_count: 47
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for MAD2L2 (human)
@@ -22,9 +23,7 @@ note: >-
 
 MAD2L2 (REV7/MAD2B/FANCV) is a HORMA-domain adaptor that uses a multivalent 'safety-belt' surface to bind structurally diverse partners and thereby coordinates DNA damage tolerance, double-strand break (DSB) repair pathway choice, and mitotic cell-cycle control [PMID:20164194, PMID:28887307, PMID:31484720]. In translesion synthesis, REV7 is the non-catalytic subunit of DNA polymerase zeta, binding the catalytic subunit REV3L through two short sequence motifs and recruiting REV1 via a distinct interface, with REV7 dimerization tethered by the two REV3 motifs being required for assembly of a functional REV1/pol zeta complex [PMID:20164194, PMID:22859296, PMID:25567983, PMID:30111544]; this activity underlies damage-induced mutagenesis and resistance to UV and crosslinking agents [PMID:3897794, PMID:25567983], and a point mutation (C70R) that severs the REV7–REV3 interaction abolishes damage tolerance and causes germ-cell loss and infertility [PMID:24356953]. REV7 is the central subunit of the shieldin complex (with SHLD1, SHLD2/FAM35A, SHLD3), which is recruited to DSBs and telomeres through the H4K20me2–53BP1–RIF1 axis and inhibits 5' end resection to enforce NHEJ over homologous recombination; its loss restores resection in BRCA1-deficient cells and causes PARP-inhibitor resistance [PMID:25799992, PMID:25799990, PMID:30046110, PMID:30154076, PMID:29160738]. Shieldin assembly depends on SHLD2-driven REV7 dimerization and on REV7's C-terminal wrapping around SHLD3, and is reversed by TRIP13-catalyzed closed-to-open conformational switching together with p31comet, which also disassembles the REV7–REV3 complex; competing seatbelt ligands such as CHAMP1 likewise tune this balance [PMID:31796627, PMID:31915374, PMID:33051298, PMID:34521823, PMID:36044844]. Independently of shieldin, REV7 protects and restarts stalled replication forks in a REV3L/REV1-dependent manner by limiting MRE11 resection [PMID:36075897]. In mitotic control, MAD2L2 inhibits both CDH1-APC and CDC20-APC by binding the activators rather than the core APC [PMID:11459826, PMID:11459825], and biallelic inactivating REV7 mutations cause Fanconi anemia (REV7 = FANCV) [PMID:27500492].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0060090 molecular adaptor activity, GO:0098772 molecular function regulator activity, GO:0003677 DNA binding
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome

--- a/genes/human/PALB2/PALB2-deep-research-affinage.md
+++ b/genes/human/PALB2/PALB2-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 35
 citation_count: 35
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for PALB2 (human)
@@ -22,9 +23,7 @@ note: >-
 
 PALB2 (Partner and Localizer of BRCA2) is the central scaffold of homologous recombination (HR) repair of DNA double-strand breaks, physically bridging BRCA1 and BRCA2 so that the recombinase machinery can be assembled at sites of damage [PMID:19268590, PMID:19584259]. Through its N-terminal coiled-coil it binds BRCA1 (residues L21/L24/L35) and through its C-terminus it binds BRCA2, thereby relaying BRCA1-mediated recruitment to BRCA2-RAD51 organization and strand invasion [PMID:17287723, PMID:19584259]; structurally the coiled-coil forms an antiparallel leucine-zipper that exists as a homodimer or as a BRCA1 heterodimer, and the switch from PALB2 homodimer to PALB2-BRCA1 heterodimer acts as the regulatory gate that activates HR [PMID:22941656, PMID:30289697]. PALB2 recruitment to breaks proceeds through an ubiquitin signaling cascade (MDC1, RNF8, RAP80, Abraxas upstream of BRCA1, and RNF168-generated ubiquitylated H2A read by BARD1-BRCA1), with the BRCA1-PALB2 heterodimer rather than the homodimer mediating RAD51 loading [PMID:23038782, PMID:28240985, PMID:34408138]. PALB2 carries intrinsic chromatin- and DNA-binding activities: a chromatin-association motif (ChAM) that engages the nucleosome acidic patch—an interaction antagonized by 53BP1 in BRCA1-deficient cells—and an N-terminal DNA-binding domain that stimulates RAD51 and possesses RAD51-independent strand-exchange activity [PMID:22193777, PMID:31017574, PMID:32041954]. Steady-state localization to actively transcribed genes occurs via MRG15 recognition of SETD2-deposited H3K36me3, protecting these regions during replication, and PALB2 is additionally recruited to stalled forks by phosphorylated RPA and sustains DNA polymerase η-dependent synthesis at blocked forks [PMID:28673974, PMID:25113031, PMID:24485656]. ATM/ATR-dependent phosphorylation of N-terminal S/Q sites is required for proper RAD51 foci formation and HR, and PALB2 also contributes to the G2/M checkpoint independently of CHK1/CHK2 [PMID:27113759, PMID:26420486, PMID:30337689]. Beyond DNA repair, PALB2 binds KEAP1 through a shared ETGE motif to promote NRF2-mediated antioxidant responses [PMID:22331464]. Patient-derived and systematic variant analyses establish that disruption of the BRCA1-PALB2 or BRCA2-PALB2 interactions, or destabilization of the WD40 domain, abolishes HR and confers sensitivity to platinum and PARP inhibitors, and mouse models disrupting these interactions produce Fanconi anemia-like and tumor-prone phenotypes [PMID:28319063, PMID:25016020, PMID:32732220, PMID:31636395, PMID:31757951].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0060090 molecular adaptor activity, GO:0003677 DNA binding, GO:0140097 catalytic activity, acting on DNA, GO:0042393 histone binding, GO:0003723 RNA binding, GO:0098772 molecular function regulator activity
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome, GO:0005654 nucleoplasm

--- a/genes/human/RAD51/RAD51-deep-research-affinage.md
+++ b/genes/human/RAD51/RAD51-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 45
 citation_count: 45
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for RAD51 (human)
@@ -22,9 +23,7 @@ note: >-
 
 RAD51 is the central eukaryotic recombinase that assembles as an ATP-dependent nucleoprotein filament on single-stranded DNA and catalyzes homology search and DNA strand exchange, the core reaction of homologous recombination [PMID:9012806]. Filament assembly on RPA-coated ssDNA is rate-limited by nucleation, which BRCA2 overcomes by chaperoning a preassembled RAD51 nucleus onto ssDNA, displacing RPA and stabilizing the filament against ATP hydrolysis [PMID:20729832, PMID:36976771]; a C-terminal BRCA2 TR2 motif braces adjacent protomers across the filament interface, while the BRC repeats engage distinct RAD51 surfaces [PMID:37919288, PMID:15937124]. The filament's recombinase activity is intrinsically coupled to ATP hydrolysis and to an inter-subunit ATP cap that tunes turnover versus strand-exchange efficiency [PMID:9012806, PMID:22275364], and Loop2 residues impose strict mismatch intolerance that distinguishes RAD51 from its meiotic counterpart DMC1 [PMID:34871438]. A broad network of mediators governs the filament: RAD52 targets RAD51 to RPA-ssDNA and channels lesions between strand invasion and annealing [PMID:9450760, PMID:9450758, PMID:18337252], Rad54 stimulates homologous pairing and branch migration and drives ATPase-dependent filament turnover from duplex DNA [PMID:9590697, PMID:17567608, PMID:18617519], the RAD51 paralogs assemble into complexes that remodel and stabilize presynaptic filaments [PMID:10749867, PMID:26186187, PMID:23810717], and HOP2-MND1 and FANCD2/FANCI further stimulate or stabilize the filament [PMID:24943459, PMID:27694619, PMID:37526271]. Filament abundance at replication forks is set antagonistically by RADX, which competes for ssDNA, stimulates RAD51 ATPase, and destabilizes filaments in opposition to BRCA2 [PMID:30021152, PMID:33453169, PMID:32621611]. Chromatin loading is controlled by post-translational modification, including TOPBP1/PLK1-dependent Ser14 phosphorylation, Mec1-dependent phosphorylation of the yeast enzyme, and TOPORS-dependent SUMOylation [PMID:26811421, PMID:21738226, PMID:35061896]. Beyond canonical double-strand break repair and break-induced replication [PMID:14993274], RAD51 protects stalled and nascent replication forks—catalyzing fork reversal while bypassing the bound CMG helicase, shielding abasic sites and nascent strands from MRE11/DNA2/EXO1 nucleases, and suppressing transcription-replication conflicts [PMID:37104614, PMID:39178838, PMID:37526271, PMID:36002000]; in its absence, MRE11-driven degradation of unprotected nascent DNA releases cytosolic fragments that activate STING-mediated innate immunity [PMID:28334891]. RAD51 also promotes mitotic DNA synthesis and centromere integrity [PMID:34508092, PMID:36702125] and forms TERRA R-loops at telomeres [PMID:33057192].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0003677 DNA binding, GO:0140657 ATP-dependent activity, GO:0140097 catalytic activity, acting on DNA, GO:0003723 RNA binding
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome

--- a/genes/human/RAD51C/RAD51C-deep-research-affinage.md
+++ b/genes/human/RAD51C/RAD51C-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 42
 citation_count: 42
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for RAD51C (human)
@@ -22,9 +23,7 @@ note: >-
 
 RAD51C is a central RAD51 paralog that organizes homologous recombination (HR) by serving as the shared, catalytic hub of two distinct paralog complexes—BCDX2 (RAD51B–RAD51C–RAD51D–XRCC2) and CX3 (RAD51C–XRCC3)—and is required for assembly of both [PMID:11744692, PMID:11842113, PMID:11912211]. RAD51C contributes ssDNA-binding, DNA-stimulated ATPase, and homologous-pairing/strand-annealing activities to these complexes, and acts as a recombination mediator that relieves RPA inhibition to promote RAD51 loading [PMID:11331762, PMID:11751636, PMID:15141025]. Cryo-EM and X-ray structures show that within BCDX2 the RAD51C–RAD51D–XRCC2 module mimics three RAD51 protomers to nucleate and extend RAD51 filaments on ssDNA in a manner dependent on the coupled ATPase activities of RAD51B and RAD51C, while CX3 binds ATP like RAD51 and contributes a polymerization/5′-capping motif governing replication fork protection, restart, and reversal [PMID:37344587, PMID:37488098]. Functionally, RAD51C is required for DNA-damage-induced RAD51 focus formation, Holliday-junction branch migration and resolution, and BRCA2-independent nuclear import of RAD51, and it also acts upstream in damage signaling by enabling ATM/NBS1/RPA-dependent recruitment and CHK2-dependent checkpoint activation [PMID:12000837, PMID:14716019, PMID:19451272, PMID:19783859]. Beyond canonical HR it joins a PALB2–BRCA2 complex, localizes to mitochondrial nucleoids with XRCC3 to support mtDNA maintenance, and stimulates ALKBH3-mediated demethylation repair [PMID:24141787, PMID:29158291, PMID:31642493]. RAD51C is a tumor suppressor: biallelic mutation causes a Fanconi anemia–like disorder (FANCO) and monoallelic loss-of-function confers breast and ovarian cancer susceptibility with PARP-inhibitor sensitivity, while reversion mutations and loss of promoter methylation drive PARPi resistance [PMID:20400963, PMID:28588062, PMID:34321239].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0003677 DNA binding, GO:0140657 ATP-dependent activity, GO:0140097 catalytic activity, acting on DNA, GO:0098772 molecular function regulator activity, GO:0060090 molecular adaptor activity
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome, GO:0005739 mitochondrion, GO:0005829 cytosol, GO:0005815 microtubule organizing center

--- a/genes/human/RFWD3/RFWD3-deep-research-affinage.md
+++ b/genes/human/RFWD3/RFWD3-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 17
 citation_count: 17
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for RFWD3 (human)
@@ -22,9 +23,7 @@ note: >-
 
 RFWD3 is a RING-finger/WD40 E3 ubiquitin ligase that governs the resolution and restart of stalled and damaged DNA replication forks by remodeling the protein composition of single-stranded DNA at sites of replication stress [PMID:26474068, PMID:33321094]. It is recruited to damaged chromatin and stalled forks through a direct interaction between its C-terminal coiled-coil/WD40 region and the RPA2 subunit of RPA, an interaction required for ATR-dependent Chk1 activation and for localization to interstrand crosslink (ICL)-stalled forks [PMID:21558276, PMID:21504906, PMID:28575657]. At ongoing forks RFWD3 also associates with PCNA via a PIP motif, an interaction that stabilizes the ligase and supports normal fork progression [PMID:30530694]. RFWD3 catalyzes multi-site polyubiquitination of the RPA complex and of RAD51, modifications that depend on ATR/ATM phosphorylation of RFWD3 and drive VCP/p97-mediated extraction of these factors from DNA, enabling late-phase homologous recombination, fork restart, and ICL repair [PMID:26474068, PMID:28575658]. By promoting PCNA ubiquitination, RFWD3 licenses translesion synthesis and recruits the DNA translocase ZRANB3 to catalyze fork reversal [PMID:33321094, PMID:37036693]. Biallelic RFWD3 mutations that disrupt RPA binding and chromatin recruitment cause Fanconi anemia complementation group W, with affected cells showing defective HR, ICL hypersensitivity, and chromosomal breakage [PMID:28575657, PMID:28691929]. Beyond the replication-stress core, RFWD3 cooperates with Mdm2 to stabilize p53 in the late DNA-damage response [PMID:20173098], and is itself controlled by UHRF1-mediated ubiquitination in a negative-feedback circuit with RAD51 [PMID:40940676].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0016874 ligase activity, GO:0140096 catalytic activity, acting on a protein
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome

--- a/genes/human/SLX4/SLX4-deep-research-affinage.md
+++ b/genes/human/SLX4/SLX4-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 57
 citation_count: 57
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for SLX4 (human)
@@ -22,9 +23,7 @@ note: >-
 
 SLX4 (BTBD12/FANCP) is a multidomain scaffold that assembles and activates a modular toolkit of structure-specific endonucleases—XPF-ERCC1, MUS81-EME1, and SLX1—to process branched DNA intermediates arising during replication, recombination, and interstrand crosslink (ICL) repair [PMID:19596235, PMID:19595721]. Through direct contacts it stimulates each partner nuclease and directs substrate specificity: the SLX1-SLX4 module is a Holliday junction resolvase and 5'-flap endonuclease [PMID:19596236, PMID:12832395], the N-terminal SLX4-XPF-ERCC1 interaction enhances XPF-ERCC1 activity up to 100-fold and executes the unhooking incisions of replication-coupled ICL repair [PMID:24726326, PMID:24726325], and CDK1-driven phosphorylation of the MUS81-binding region folds an SAP domain that recruits MUS81-EME1 into a stable SLX-MUS holoenzyme providing efficient HJ resolution at G2/M [PMID:24076221, PMID:36288699]. Structural work shows SLX4 activates SLX1 by displacing its autoinhibitory homodimer and that the SLX4 SAP domain positions 5'-flap substrates for accurate cleavage [PMID:25753413, PMID:34181713]. SLX4 itself dimerizes via its BTB domain, an event required for foci formation and telomeric localization [PMID:27131364]. Damage-site recruitment is multi-modal: the UBZ1 domain reads K63-linked polyubiquitin deposited by RNF168 and ubiquitylated FANCD2 at ICLs [PMID:24794496, PMID:21464321, PMID:34706224], while SUMO-interacting motifs (cooperating with PARylation) target SLX4 to resected/laser damage, fragile sites, PML bodies, and ALT telomeres [PMID:25533185, PMID:25722289]. At telomeres SLX4 docks on the shelterin subunit TRF2 via an HxLxP motif to deliver its nucleases and regulate telomere length and fragility [PMID:24012755, PMID:23994477], and it drives recombination-based ALT telomere processing in opposition to the BLM-TOP3A-RMI dissolution pathway [PMID:28877996]. SLX4 additionally functions as a SUMO E3 ligase that SUMOylates itself and XPF [PMID:25533188], forms SUMO/dimerization-driven nuclear condensates that compartmentalize the SUMO-RNF4 pathway and promote topoisomerase-1 DPC extraction [PMID:37059091], interacts with the helicase RTEL1 to prevent replication-transcription conflicts [PMID:32398829], and binds MSH2 through a SHIP box to suppress MutSα-dependent mismatch repair [PMID:35166826]. SLX4 protein levels are buffered by RNF4-mediated ubiquitin-dependent degradation counterbalanced by USP7 within PML nuclear bodies, preventing unscheduled nuclease activity [PMID:41002028]. Biallelic SLX4 mutations cause Fanconi anemia subtype FA-P, and its essential ICL-repair function maps to the N-terminal XPF-ERCC1-binding region [PMID:21240275, PMID:21240277, PMID:21240276].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140097 catalytic activity, acting on DNA, GO:0060090 molecular adaptor activity, GO:0016740 transferase activity, GO:0003677 DNA binding, GO:0098772 molecular function regulator activity
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome, GO:0005654 nucleoplasm

--- a/genes/human/UBE2T/UBE2T-deep-research-affinage.md
+++ b/genes/human/UBE2T/UBE2T-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 35
 citation_count: 37
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for UBE2T (human)
@@ -22,9 +23,7 @@ note: >-
 
 UBE2T is the dedicated E2 ubiquitin-conjugating enzyme of the Fanconi anemia (FA) DNA interstrand crosslink repair pathway, pairing with the E3 ligase FANCL to catalyze monoubiquitination of FANCD2 and FANCI on chromatin [PMID:16916645, PMID:19111657]. In vitro reconstitution established that FANCD2 monoubiquitination minimally requires UBE2T plus the FANCL RWD-like domain, with FANCI both stimulating the reaction and restricting it to the physiological substrate lysine K561, while FANCI itself is monoubiquitinated at K523 [PMID:19111657, PMID:19589784]. A crystal structure of the FANCL RING–UBE2T complex defined an extensive electrostatic and hydrophobic interface beyond the generic E2–E3 contact that determines selective recognition of UBE2T over other E2 enzymes [PMID:24389026]. This activity is governed by DNA damage-induced recruitment of UBE2T and FANCD2 to chromatin to form an active E2/E3 holoenzyme rather than by stable assembly of the core complex, and is negatively autoregulated by FANCL-stimulated UBE2T automonoubiquitination [PMID:16916645, PMID:17938197]. Biallelic loss-of-function mutations in UBE2T cause Fanconi anemia (FA-T subtype): patient cells lack FANCD2/FANCI monoubiquitination, fail to form FANCD2 foci, and are hypersensitive to crosslinkers, defects complemented by wild-type UBE2T [PMID:26119737, PMID:26046368, PMID:26085575]. Beyond crosslink repair, UBE2T contributes to nucleotide excision repair and to the resolution of R-loops and transcription-replication conflicts to maintain genome stability [PMID:22615860, PMID:36928776]. UBE2T protein abundance is controlled post-translationally by CaMKII-δ9-mediated phosphorylation-dependent degradation and by NEDD4L-directed proteasomal turnover [PMID:31481791, PMID:34838005]. In cancer, UBE2T acts as an oncogenic ubiquitin conjugator that ubiquitinates diverse substrates—including p53, RACK1, Akt, RPL6, CDC42, FOXO1, and CBX6—frequently through K48- or K63-linked chains and often independently of or in cooperation with various E3 ligases, thereby activating Wnt/β-catenin, PI3K/AKT, and related signaling outputs [PMID:33323973, PMID:35169125, PMID:36156329, PMID:39915000, PMID:39716485].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140096 catalytic activity, acting on a protein, GO:0016740 transferase activity
 - **localization:** GO:0005634 nucleus, GO:0000228 nuclear chromosome

--- a/genes/human/XRCC2/XRCC2-deep-research-affinage.md
+++ b/genes/human/XRCC2/XRCC2-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 29
 citation_count: 29
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for XRCC2 (human)
@@ -22,9 +23,7 @@ note: >-
 
 XRCC2 is a RecA/RAD51-family recombination-repair protein that is essential for homologous recombination (HR) repair of DNA double-strand breaks and for genome stability, with its loss causing >100-fold reduction in HR while leaving non-homologous end joining intact [PMID:9628903, PMID:9660962, PMID:10517641]. It functions as a stable subunit of the multimeric RAD51 paralog complexes: it forms a direct, ATPase-active complex with RAD51D [PMID:10871607] and is a component of the BCDX2 heterotetramer (RAD51B-RAD51C-RAD51D-XRCC2) that preferentially binds branched DNA and catalyzes strand annealing [PMID:15141025]. Cryo-EM resolves how these complexes act on RAD51 filaments: within BCDX2 the RAD51C-RAD51D-XRCC2 module mimics three RAD51 protomers to stimulate ATP-hydrolysis-dependent filament nucleation and extension on ssDNA, whereas the XRCC3-containing complex (XRCC3-RAD51C-RAD51D-XRCC2) caps 5' filament termini to promote homologous pairing [PMID:37344587, PMID:41196948]. Mechanistically, XRCC2 is required for damage-induced RAD51 focus formation and chromatin loading without itself requiring ATP binding, distinguishing its role from the ATP-dependent activity of XRCC3 [PMID:11301337, PMID:12488590, PMID:19470754]. Beyond canonical HR, XRCC2 acts late in the Fanconi anemia pathway downstream of FANCD2 monoubiquitination (designated FANCU) [PMID:27208205], restrains replication fork progression during dNTP imbalance through ATR-mediated phosphorylation at Ser247 [PMID:30566856], and is essential for mammalian meiotic recombination [PMID:30042186]. Biallelic XRCC2 mutation causes a Fanconi anemia phenotype [PMID:27208205], and a homozygous p.Leu14Pro mutation causes meiotic arrest and infertility in humans [PMID:30042186]. At the organismal level, Xrcc2 loss produces p53-dependent apoptosis of post-mitotic neurons and embryonic lethality [PMID:11118202, PMID:17116431].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0003677 DNA binding, GO:0140657 ATP-dependent activity, GO:0098772 molecular function regulator activity, GO:0140096 catalytic activity, acting on a protein
 - **localization:** GO:0005634 nucleus, GO:0005694 chromosome

--- a/projects/AFFINAGE_EVALUATION.md
+++ b/projects/AFFINAGE_EVALUATION.md
@@ -249,8 +249,10 @@ and measure **net curation value** — not exact-GO overlap.
 - Several times Affinage's own cited evidence **reinforced** an AIGR non-core/over-annotation
   call (FANCC redox mutants; RAD51C is-not-an-endonuclease; XRCC2 is-not-a-damage-sensor; SLX4
   nuclease-dead), the opposite of redundancy.
-- The two `tie`/CAUTION records (ERCC4, BRCA1) were correctly flagged, but against the **GO
-  layer** (a spurious RNA-catalytic term on BRCA1), not the prose, which was factually sound.
+- The two `pairwise = tie` records (ERCC4, BRCA1) were correctly gate-flagged (the
+  `self_evaluation_pairwise` frontmatter field plus the tool's stderr trust-gate warning,
+  recorded in each review's `reference_review`), but the weakness was in the **GO layer**
+  (a spurious RNA-catalytic term on BRCA1), not the prose, which was factually sound.
 
 **Takeaway:** used as this project endorses — narrative-as-input, GO-layer-ignored — Affinage
 delivered measurable, conservative value on the very pathway where it should have been most

--- a/projects/AFFINAGE_EVALUATION/README.md
+++ b/projects/AFFINAGE_EVALUATION/README.md
@@ -38,19 +38,32 @@ python affinage_deep_research.py human GPX4 --write    # -> genes/human/GPX4/GPX
 ```
 
 It is deliberately scoped to the **only** use the [evaluation](results/narrative-vs-go.md)
-endorses — a *free precomputed first pass for the human backlog* — and enforces the two
-required gates:
+endorses — a *free precomputed first pass for the human backlog*.
+
+**The emitted file is a VERBATIM external-provider record — no AIGR interpretation.**
+A `-deep-research-*.md` file reproduces exactly what the provider returned (like a
+falcon/perplexity report): Affinage's mechanistic narrative, its own `mechanism_profile`
+GO/Reactome grounding, the dated discoveries, and the citations. The file carries **no
+CAUTION banners, no "these GO terms are coarse, do not import them" advice, and no trust
+adjudication** — mixing AIGR's own opinion into the file would launder it into something
+that looks like the provider said it. Curatorial judgment of the record — relevance,
+correctness, whether to import its GO grounding, and the trust gates below — is the
+reviewer's, and belongs in the gene review's `references[].reference_review`
+(`relevance` / `correctness` / `review_notes`) and `findings`, **not** in the source file.
+
+The tool still helps the reviewer form that judgment via two checks, printed to **stderr**
+(never written into the file):
 
 1. **Human only.** Refuses any other species (Affinage is human-only).
-2. **Trust gates surfaced, never hidden.** It writes Affinage's own `evaluation.pairwise`
+2. **Trust gates (stderr reminder).** It surfaces Affinage's own `evaluation.pairwise`
    self-signal, compares the record's UniProt accession to the local `<GENE>-uniprot.txt`,
-   and scans the narrative's opening for a non-human organism token; any tripped gate
-   becomes a ⚠️ CAUTION banner at the top of the file (see the ADA symbol-collision case).
+   and scans the narrative's opening for a non-human organism token (the ADA symbol-collision
+   case). A tripped gate prints a ⚠️ warning telling you to record it in the review's
+   `reference_review` — it does not touch the file.
 
-The emitted file records the raw `mechanism_profile` GO ids **only for reference**, with an
-explicit note *not* to import them directly (the evaluation showed that layer is coarse and
-can contradict the narrative). It is external, LLM-generated preliminary research — treat it
-like a falcon/perplexity report, not a curated annotation.
+Only factual provenance (source URL, run date, accession, and Affinage's own self-evaluation
+numbers) is recorded in the file frontmatter. It is external, LLM-generated preliminary
+research — treat it like a falcon/perplexity report, not a curated annotation.
 
 ## Caveats
 

--- a/projects/AFFINAGE_EVALUATION/README.md
+++ b/projects/AFFINAGE_EVALUATION/README.md
@@ -35,15 +35,20 @@ file, so no pipeline change is needed to "wire in" Affinage — this tool just w
 ```bash
 python affinage_deep_research.py human GPX4            # print to stdout
 python affinage_deep_research.py human GPX4 --write    # -> genes/human/GPX4/GPX4-deep-research-affinage.md
+python affinage_deep_research.py human ADA   --write   # refused: wrong-protein gate trips (--force to override)
 ```
 
 It is deliberately scoped to the **only** use the [evaluation](results/narrative-vs-go.md)
 endorses — a *free precomputed first pass for the human backlog*.
 
-**The emitted file is a VERBATIM external-provider record — no AIGR interpretation.**
-A `-deep-research-*.md` file reproduces exactly what the provider returned (like a
-falcon/perplexity report): Affinage's mechanistic narrative, its own `mechanism_profile`
-GO/Reactome grounding, the dated discoveries, and the citations. The file carries **no
+**The emitted file is a faithful, unedited rendering of the external-provider record — no
+AIGR interpretation.** A `-deep-research-*.md` file reproduces what the provider returned
+(like a falcon/perplexity report): Affinage's mechanistic narrative, its own
+`mechanism_profile` GO/Reactome grounding, the dated discoveries, and the citations. (A few
+emitted fields are mechanical derivations of that content rather than provider fields —
+`citation_count` and the `## Citations` list union the discovery PMIDs with the `PMID:NNN`
+tokens in the narrative, and `n_discoveries` is a count — but nothing is edited or
+adjudicated.) The file carries **no
 CAUTION banners, no "these GO terms are coarse, do not import them" advice, and no trust
 adjudication** — mixing AIGR's own opinion into the file would launder it into something
 that looks like the provider said it. Curatorial judgment of the record — relevance,
@@ -60,6 +65,13 @@ The tool still helps the reviewer form that judgment via two checks, printed to 
    and scans the narrative's opening for a non-human organism token (the ADA symbol-collision
    case). A tripped gate prints a ⚠️ warning telling you to record it in the review's
    `reference_review` — it does not touch the file.
+3. **Blocking write gate.** Since the file itself carries no warning, the two *wrong-protein*
+   gates (accession mismatch, non-human organism token) also **refuse the write** when the
+   destination is inside `genes/` — a record describing a different protein must not land in
+   a gene folder, where a later review of that gene would ingest it. Exit is non-zero and
+   nothing is written unless `--force` is passed (or `--out` targets a path outside `genes/`).
+   The soft `pairwise` gate only warns; it is already in the frontmatter as
+   `self_evaluation_pairwise`.
 
 Only factual provenance (source URL, run date, accession, and Affinage's own self-evaluation
 numbers) is recorded in the file frontmatter. It is external, LLM-generated preliminary

--- a/projects/AFFINAGE_EVALUATION/affinage_deep_research.py
+++ b/projects/AFFINAGE_EVALUATION/affinage_deep_research.py
@@ -8,24 +8,33 @@ Affinage needs no pipeline change: this tool fetches the record and writes
 ``<GENE>-deep-research-affinage.md`` in the same shape as the other providers.
 
 This is the ONLY Affinage integration the evaluation endorses — a *free precomputed
-first pass for the human backlog* (see ../results/narrative-vs-go.md). It is gated by
-the two cheap checks that evaluation identified:
+first pass for the human backlog* (see ../results/narrative-vs-go.md).
 
-  1. HUMAN ONLY. Affinage covers only human; the tool refuses any other species.
-  2. Entity-collision / trust gates. It surfaces Affinage's own ``evaluation.pairwise``
-     self-signal (win/tie/loss) and compares the record's UniProt accession to the
-     local ``<GENE>-uniprot.txt`` (and scans the narrative's opening for a non-human
-     organism token) — the ADA-style symbol-collision failure. Any tripped gate is
-     written as a prominent ⚠️ CAUTION banner at the top of the file, never hidden.
+DESIGN PRINCIPLE — the file is a VERBATIM external-provider record, nothing more.
+A ``<GENE>-deep-research-*.md`` file reproduces exactly what the external provider
+returned (like a falcon/perplexity report): the mechanistic narrative, Affinage's own
+GO/Reactome ``mechanism_profile`` grounding, the dated discoveries, and the citations.
+It carries **no AIGR interpretation** — no CAUTION banners, no "these GO terms are
+coarse, do not import them" advice, no adjudication of trust. That curatorial judgment
+is the reviewer's, and it belongs in the gene review's
+``references[].reference_review`` (relevance / correctness / review_notes) and
+``findings`` — NOT in this source file. Mixing the two would launder AIGR's own
+opinion into something that looks like the provider said it.
 
-The file is genuinely Affinage-sourced (not authored here); provenance — source URL,
-Affinage run date, and the gate results — is recorded in the frontmatter so a curator
-treats it as external preliminary research, exactly like a falcon/perplexity report.
+The tool still HELPS the curator form that judgment: it is HUMAN ONLY (Affinage
+covers only human, so any other species is refused), and it runs two cheap trust
+checks — Affinage's own ``evaluation.pairwise`` self-signal (win/tie/loss), and an
+accession/organism cross-check against the local ``<GENE>-uniprot.txt`` for the
+ADA-style symbol-collision failure. Those gate results are printed to **stderr** as a
+reminder to record them in the review's ``reference_review``; they are deliberately
+kept OUT of the written file so the file stays a faithful provider record. Only
+factual provenance (source URL, run date, accession, Affinage's own self-eval numbers)
+is recorded in the frontmatter.
 
 Usage:
     python affinage_deep_research.py human GPX4                 # print to stdout
     python affinage_deep_research.py human GPX4 --write         # -> genes/human/GPX4/GPX4-deep-research-affinage.md
-    python affinage_deep_research.py human ADA                  # gate trips -> CAUTION banner
+    python affinage_deep_research.py human ADA                  # gate trips -> stderr warning (file stays verbatim)
 """
 from __future__ import annotations
 
@@ -68,7 +77,13 @@ def local_accession(species: str, gene: str) -> str | None:
 
 
 def run_gates(gene: str, data: dict, expected_acc: str | None) -> list[str]:
-    """Return a list of human-readable CAUTION strings (empty = all clear)."""
+    """Compute trust-gate warnings for the OPERATOR (printed to stderr, never written
+    into the file). Returns a list of human-readable strings (empty = all clear).
+
+    These are AIGR's judgment of the record, not Affinage's output — so they are
+    surfaced to the reviewer as a prompt to record the assessment in the gene review's
+    references[].reference_review, and are deliberately kept out of the verbatim file.
+    """
     cautions: list[str] = []
     up = (data.get("prefetch_data") or {}).get("uniprot") or {}
     aff_acc = up.get("accession")
@@ -97,13 +112,20 @@ def run_gates(gene: str, data: dict, expected_acc: str | None) -> list[str]:
 
 
 def render(species: str, gene: str, data: dict, expected_acc: str | None) -> str:
+    """Render the Affinage record VERBATIM as a deep-research source file.
+
+    This is a faithful reproduction of what Affinage returned — provider metadata,
+    the mechanistic narrative, Affinage's own GO/Reactome grounding, dated findings,
+    and citations. It carries no AIGR interpretation by design (see module docstring):
+    trust-gate judgment is surfaced separately (stderr) and recorded by the reviewer in
+    the gene review's ``references[].reference_review``, not here.
+    """
     tl = data.get("timeline") or {}
     nar = data.get("narrative") or {}
     up = (data.get("prefetch_data") or {}).get("uniprot") or {}
     ev = data.get("evaluation") or {}
     mp = nar.get("mechanism_profile") or {}
     disc = tl.get("discoveries") or []
-    cautions = run_gates(gene, data, expected_acc)
 
     all_pmids = sorted({p for d in disc for p in (d.get("pmids") or [])}
                        | set(re.findall(r"PMID:(\d+)", nar.get("mechanistic_narrative", "") or "")))
@@ -119,39 +141,29 @@ def render(species: str, gene: str, data: dict, expected_acc: str | None) -> str
     L.append(f"faith_pct: {ev.get('faith_pct', '')}")
     L.append(f"n_discoveries: {len(disc)}")
     L.append(f"citation_count: {len(all_pmids)}")
-    L.append(f"gates_passed: {not cautions}")
     L.append("note: >-")
-    L.append("  Machine-fetched from the Affinage API (Cheeseman Lab). This is external")
-    L.append("  precomputed research to be treated as a preliminary source, NOT a curated")
-    L.append("  annotation. Affinage is human-only and LLM-generated; verify claims against")
-    L.append("  the cited PMIDs before use.")
+    L.append("  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),")
+    L.append("  reproduced as-is as an external deep-research source (like a")
+    L.append("  falcon/perplexity report). It is Affinage-authored, LLM-generated, and")
+    L.append("  human-only. Curatorial assessment of this record — relevance, correctness,")
+    L.append("  trust gates, whether to import its GO grounding — is the reviewer's and")
+    L.append("  belongs in the gene review's references[].reference_review, not in this file.")
     L.append("---")
     L.append("")
     L.append(f"# Affinage mechanistic annotation for {gene} ({species})")
     L.append("")
-
-    if cautions:
-        L.append("> ⚠️ **CAUTION — trust gate(s) tripped; review before using:**")
-        for c in cautions:
-            L.append(f">")
-            L.append(f"> - {c}")
-        L.append("")
 
     L.append("## Current model (mechanistic narrative)")
     L.append("")
     L.append(nar.get("mechanistic_narrative") or tl.get("current_model") or "*(none provided)*")
     L.append("")
 
-    # mechanism profile (Affinage's own GO/Reactome grounding — recorded, not trusted)
+    # mechanism profile: Affinage's own GO/Reactome grounding, reproduced verbatim
     def terms(key, prefix=None):
         out = [f"{e.get('term_id')} {e.get('term_label')}" for e in (mp.get(key) or [])
                if prefix is None or str(e.get("term_id", "")).startswith(prefix)]
         return ", ".join(out) if out else "*(none)*"
-    L.append("## Affinage mechanism profile (its own GO/Reactome grounding)")
-    L.append("")
-    L.append("_Recorded for reference. The AIGR evaluation found this grounding is coarse "
-             "(collapses to general parents) and can contradict the narrative — do not import "
-             "these GO ids directly; re-ground from the narrative + PMIDs._")
+    L.append("## Affinage mechanism profile (Affinage's own GO/Reactome grounding)")
     L.append("")
     L.append(f"- **molecular_activity:** {terms('molecular_activity')}")
     L.append(f"- **localization:** {terms('localization')}")
@@ -202,6 +214,19 @@ def main() -> None:
 
     expected = args.accession or local_accession(args.species, args.gene)
     doc = render(args.species, args.gene, data, expected)
+
+    # Trust gates are a reminder to the reviewer, printed to stderr — never written into
+    # the verbatim provider file. Record the resulting judgment in the gene review's
+    # references[].reference_review (relevance / correctness / review_notes).
+    cautions = run_gates(args.gene, data, expected)
+    if cautions:
+        print(f"⚠️  {args.gene}: trust gate(s) tripped — record this in the review's "
+              f"reference_review, NOT in the deep-research file:", file=sys.stderr)
+        for c in cautions:
+            print(f"    - {c}", file=sys.stderr)
+    else:
+        print(f"✓  {args.gene}: trust gates clear "
+              f"(still record your own reference_review in the review).", file=sys.stderr)
 
     if args.out:
         Path(args.out).write_text(doc)

--- a/projects/AFFINAGE_EVALUATION/affinage_deep_research.py
+++ b/projects/AFFINAGE_EVALUATION/affinage_deep_research.py
@@ -10,15 +10,18 @@ Affinage needs no pipeline change: this tool fetches the record and writes
 This is the ONLY Affinage integration the evaluation endorses — a *free precomputed
 first pass for the human backlog* (see ../results/narrative-vs-go.md).
 
-DESIGN PRINCIPLE — the file is a VERBATIM external-provider record, nothing more.
-A ``<GENE>-deep-research-*.md`` file reproduces exactly what the external provider
+DESIGN PRINCIPLE — the file is a faithful, unedited rendering of the provider record,
+nothing more. A ``<GENE>-deep-research-*.md`` file reproduces what the external provider
 returned (like a falcon/perplexity report): the mechanistic narrative, Affinage's own
 GO/Reactome ``mechanism_profile`` grounding, the dated discoveries, and the citations.
-It carries **no AIGR interpretation** — no CAUTION banners, no "these GO terms are
-coarse, do not import them" advice, no adjudication of trust. That curatorial judgment
-is the reviewer's, and it belongs in the gene review's
-``references[].reference_review`` (relevance / correctness / review_notes) and
-``findings`` — NOT in this source file. Mixing the two would launder AIGR's own
+(A few emitted fields are mechanical derivations of that content rather than provider
+fields — ``citation_count`` and the ``## Citations`` list are the union of the discovery
+PMIDs and the ``PMID:NNN`` tokens in the narrative, and ``n_discoveries`` is a count —
+but nothing is edited, summarised or adjudicated.) It carries **no AIGR interpretation**
+— no CAUTION banners, no "these GO terms are coarse, do not import them" advice, no
+adjudication of trust. That curatorial judgment is the reviewer's, and it belongs in the
+gene review's ``references[].reference_review`` (relevance / correctness / review_notes)
+and ``findings`` — NOT in this source file. Mixing the two would launder AIGR's own
 opinion into something that looks like the provider said it.
 
 The tool still HELPS the curator form that judgment: it is HUMAN ONLY (Affinage
@@ -31,10 +34,18 @@ kept OUT of the written file so the file stays a faithful provider record. Only
 factual provenance (source URL, run date, accession, Affinage's own self-eval numbers)
 is recorded in the frontmatter.
 
+Because the written file no longer carries an in-file warning, the safety check lives in
+the TOOL instead: the two *wrong-protein* gates (accession mismatch, non-human organism
+token) are **blocking** — writing such a record into the live ``genes/`` tree is refused
+with a non-zero exit unless ``--force`` is passed — since a file in a gene folder is
+ingested by a later review of that gene. The soft ``pairwise`` signal never blocks; it is
+already in the frontmatter as ``self_evaluation_pairwise``.
+
 Usage:
     python affinage_deep_research.py human GPX4                 # print to stdout
     python affinage_deep_research.py human GPX4 --write         # -> genes/human/GPX4/GPX4-deep-research-affinage.md
-    python affinage_deep_research.py human ADA                  # gate trips -> stderr warning (file stays verbatim)
+    python affinage_deep_research.py human ADA --write          # blocking gate -> refuses to write (use --force)
+    python affinage_deep_research.py human ADA                  # stdout is never gated; warning goes to stderr
 """
 from __future__ import annotations
 
@@ -76,15 +87,30 @@ def local_accession(species: str, gene: str) -> str | None:
     return m.group(1) if m else None
 
 
-def run_gates(gene: str, data: dict, expected_acc: str | None) -> list[str]:
+def _in_gene_tree(dest: Path) -> bool:
+    """True if ``dest`` lands inside the live ``genes/`` tree (where a later review of that
+    gene would ingest it), as opposed to a scratch/results path."""
+    try:
+        dest.resolve().relative_to(REPO / "genes")
+    except ValueError:
+        return False
+    return True
+
+
+def run_gates(gene: str, data: dict, expected_acc: str | None) -> list[tuple[bool, str]]:
     """Compute trust-gate warnings for the OPERATOR (printed to stderr, never written
-    into the file). Returns a list of human-readable strings (empty = all clear).
+    into the file). Returns ``(blocking, message)`` pairs (empty = all clear).
+
+    ``blocking`` marks the two *wrong-protein* gates (accession mismatch, non-human
+    organism token): a record that describes a different protein must not land in a gene
+    folder, where a later review would ingest it. The ``pairwise`` self-signal is a soft
+    signal already present in the frontmatter, so it never blocks.
 
     These are AIGR's judgment of the record, not Affinage's output — so they are
     surfaced to the reviewer as a prompt to record the assessment in the gene review's
-    references[].reference_review, and are deliberately kept out of the verbatim file.
+    references[].reference_review, and are deliberately kept out of the provider file.
     """
-    cautions: list[str] = []
+    cautions: list[tuple[bool, str]] = []
     up = (data.get("prefetch_data") or {}).get("uniprot") or {}
     aff_acc = up.get("accession")
     ev = data.get("evaluation") or {}
@@ -93,32 +119,32 @@ def run_gates(gene: str, data: dict, expected_acc: str | None) -> list[str]:
     model = (data.get("timeline") or {}).get("current_model", "") or ""
 
     if pairwise and pairwise != "win":
-        cautions.append(
+        cautions.append((False,
             f"Affinage's own head-to-head self-evaluation scored this record "
             f"`pairwise = {pairwise}` (not `win`) vs the curated UniProt reference — "
-            f"treat the narrative with extra scepticism.")
+            f"treat the narrative with extra scepticism."))
     if expected_acc and aff_acc and expected_acc != aff_acc:
-        cautions.append(
+        cautions.append((True,
             f"Accession mismatch: local review uses `{expected_acc}` but the Affinage "
-            f"record's prefetch UniProt accession is `{aff_acc}`.")
+            f"record's prefetch UniProt accession is `{aff_acc}`."))
     opening = (model[:220] + " " + narr[:220]).lower()
     hit = next((t for t in NONHUMAN_TOKENS if t in opening), None)
     if hit:
-        cautions.append(
+        cautions.append((True,
             f"Possible symbol collision: the narrative's opening names a non-human "
             f"context (\"{hit}\") despite a human record — verify the narrative "
-            f"describes human {gene} and not a same-symbol protein (cf. the ADA case).")
+            f"describes human {gene} and not a same-symbol protein (cf. the ADA case)."))
     return cautions
 
 
-def render(species: str, gene: str, data: dict, expected_acc: str | None) -> str:
-    """Render the Affinage record VERBATIM as a deep-research source file.
+def render(species: str, gene: str, data: dict) -> str:
+    """Render the Affinage record as a deep-research source file.
 
-    This is a faithful reproduction of what Affinage returned — provider metadata,
+    This is a faithful, unedited rendering of what Affinage returned — provider metadata,
     the mechanistic narrative, Affinage's own GO/Reactome grounding, dated findings,
-    and citations. It carries no AIGR interpretation by design (see module docstring):
-    trust-gate judgment is surfaced separately (stderr) and recorded by the reviewer in
-    the gene review's ``references[].reference_review``, not here.
+    and citations. It does no trust work and carries no AIGR interpretation by design
+    (see module docstring): trust-gate judgment is surfaced separately (stderr) and
+    recorded by the reviewer in the gene review's ``references[].reference_review``.
     """
     tl = data.get("timeline") or {}
     nar = data.get("narrative") or {}
@@ -199,6 +225,10 @@ def main() -> None:
     ap.add_argument("--write", action="store_true",
                     help="Write to genes/<species>/<GENE>/<GENE>-deep-research-affinage.md")
     ap.add_argument("--out", help="Explicit output path (overrides --write location)")
+    ap.add_argument("--force", action="store_true",
+                    help="Write even if a blocking trust gate (accession mismatch / non-human "
+                         "organism token) trips. Use only when you have verified the record "
+                         "really does describe this gene.")
     args = ap.parse_args()
 
     if args.species.lower() != "human":
@@ -213,31 +243,46 @@ def main() -> None:
         sys.exit(f"❌ no Affinage record content for {args.gene}")
 
     expected = args.accession or local_accession(args.species, args.gene)
-    doc = render(args.species, args.gene, data, expected)
+    doc = render(args.species, args.gene, data)
 
     # Trust gates are a reminder to the reviewer, printed to stderr — never written into
-    # the verbatim provider file. Record the resulting judgment in the gene review's
+    # the provider file. Record the resulting judgment in the gene review's
     # references[].reference_review (relevance / correctness / review_notes).
     cautions = run_gates(args.gene, data, expected)
     if cautions:
         print(f"⚠️  {args.gene}: trust gate(s) tripped — record this in the review's "
               f"reference_review, NOT in the deep-research file:", file=sys.stderr)
-        for c in cautions:
-            print(f"    - {c}", file=sys.stderr)
+        for blocking, c in cautions:
+            print(f"    - {'[BLOCKING] ' if blocking else ''}{c}", file=sys.stderr)
     else:
         print(f"✓  {args.gene}: trust gates clear "
               f"(still record your own reference_review in the review).", file=sys.stderr)
 
     if args.out:
-        Path(args.out).write_text(doc)
-        print(f"wrote {args.out}")
+        dest = Path(args.out)
     elif args.write:
         dest = REPO / "genes" / args.species / args.gene / f"{args.gene}-deep-research-affinage.md"
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(doc)
-        print(f"wrote {dest}")
     else:
         print(doc)
+        return
+
+    # The written file carries no in-file warning, so the wrong-protein gates are enforced
+    # here instead: a record describing a different protein must not land in a gene folder,
+    # where a later review of that gene would ingest it as a source.
+    blocking = [c for is_blocking, c in cautions if is_blocking]
+    if blocking and _in_gene_tree(dest) and not args.force:
+        sys.exit(
+            f"❌ refusing to write {dest}: {len(blocking)} blocking trust gate(s) tripped "
+            f"(see stderr above). This record may describe a different protein, and a file in "
+            f"a gene folder is ingested by a later review of that gene. Verify the record "
+            f"first; pass --force to write anyway, or --out <path> to keep it outside genes/."
+        )
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(doc)
+    if blocking:
+        print(f"⚠️  wrote {dest} despite {len(blocking)} blocking gate(s) (--force)", file=sys.stderr)
+    print(f"wrote {dest}")
 
 
 if __name__ == "__main__":

--- a/projects/AFFINAGE_EVALUATION/results/backlog-slice.md
+++ b/projects/AFFINAGE_EVALUATION/results/backlog-slice.md
@@ -10,8 +10,10 @@ already ingests — so no pipeline change is needed to "wire in" Affinage.
 live `genes/human/` tree. Two reasons: (1) the repo PR template asks not to commit
 `*-deep-research-*.md`; (2) more importantly, a file in a gene folder is *ingested by a
 future review of that gene* — and some Affinage records describe the **wrong protein**
-(symbol collisions, see below), so an in-tree file would feed wrong-gene biology into a
-later review despite its CAUTION banner. The committed examples therefore live here under
+(symbol collisions, see below). Because the file is a **verbatim** provider record with no
+in-file warning (the trust gates are stderr-only, and their judgment is recorded in the
+review's `reference_review`, not the file), an in-tree file would silently feed wrong-gene
+biology into a later review. The committed examples therefore live here under
 `results/example-<GENE>-deep-research-affinage.md` (5 genes), mirroring the existing
 `example-GPX4` demo. Use `--write` locally when you actually intend a file to seed a
 specific gene's review.
@@ -47,10 +49,12 @@ that a naive import would have silently accepted:
 - **ADA** — the organism-token gate + `pairwise = loss` flagged the multi-entity chimera
   (see the [project page](../AFFINAGE_EVALUATION.md) §3).
 
-Every example file is clearly marked as **external, LLM-generated preliminary research**
-(not a curated annotation), records the mechanism-profile GO ids **for reference only**
-(with a "do not import directly" note), and surfaces any tripped gate as a ⚠️ CAUTION
-banner at the top.
+Every example file is a **verbatim** Affinage record — clearly marked in its frontmatter as
+**external, LLM-generated preliminary research** (not a curated annotation) and reproducing
+Affinage's own mechanism-profile GO ids as-is. It carries **no AIGR interpretation**: the
+trust gates print to **stderr** (see the ADA/ACAT1 runs above), and the reviewer records the
+resulting judgment — including whether to import the GO grounding — in the gene review's
+`references[].reference_review`, never in the source file.
 
 ## Reproduce / extend
 

--- a/projects/AFFINAGE_EVALUATION/results/backlog-slice.md
+++ b/projects/AFFINAGE_EVALUATION/results/backlog-slice.md
@@ -6,17 +6,25 @@ file — 794 such genes at time of writing). Running the tool with `--write` wri
 `genes/human/<GENE>/<GENE>-deep-research-affinage.md`, which the AIGR review workflow
 already ingests — so no pipeline change is needed to "wire in" Affinage.
 
-**Where the committed examples live.** We do **not** commit the generated files into the
-live `genes/human/` tree. Two reasons: (1) the repo PR template asks not to commit
-`*-deep-research-*.md`; (2) more importantly, a file in a gene folder is *ingested by a
-future review of that gene* — and some Affinage records describe the **wrong protein**
-(symbol collisions, see below). Because the file is a **verbatim** provider record with no
-in-file warning (the trust gates are stderr-only, and their judgment is recorded in the
-review's `reference_review`, not the file), an in-tree file would silently feed wrong-gene
-biology into a later review. The committed examples therefore live here under
-`results/example-<GENE>-deep-research-affinage.md` (5 genes), mirroring the existing
-`example-GPX4` demo. Use `--write` locally when you actually intend a file to seed a
-specific gene's review.
+**Where the committed examples live, and what gates an in-tree write.** The 5 demo genes
+of this slice are committed *here*, under `results/example-<GENE>-deep-research-affinage.md`,
+mirroring the existing `example-GPX4` demo — they illustrate the tool's output (including
+the two collision cases) without seeding any gene's review. That is separate from the
+backlog campaign, which *does* write into the live tree: there are 58
+`genes/human/*/*-deep-research-affinage.md` files committed at time of writing, one per
+gene actually being reviewed.
+
+The care needed is because a file in a gene folder is *ingested by a future review of that
+gene* — and some Affinage records describe the **wrong protein** (symbol collisions, see
+below). The file itself carries no in-file warning: it is a faithful provider record, and
+the trust-gate judgment belongs in the review's `reference_review`, not in the source file.
+So the safety check lives in the **tool** instead — `--write`/`--out` into `genes/` is
+**refused** (non-zero exit) when a wrong-protein gate trips (accession mismatch or a
+non-human organism token in the narrative opening), unless `--force` is passed. The soft
+`pairwise` signal only warns; it is already in the frontmatter as
+`self_evaluation_pairwise`. Use `--write` when you actually intend a file to seed a
+specific gene's review, and record your assessment of the record in that review's
+`references[].reference_review`.
 
 ## The 10-gene slice (gates make the case)
 
@@ -49,7 +57,8 @@ that a naive import would have silently accepted:
 - **ADA** — the organism-token gate + `pairwise = loss` flagged the multi-entity chimera
   (see the [project page](../AFFINAGE_EVALUATION.md) §3).
 
-Every example file is a **verbatim** Affinage record — clearly marked in its frontmatter as
+Every example file is a **faithful, unedited rendering** of the Affinage record — clearly
+marked in its frontmatter as
 **external, LLM-generated preliminary research** (not a curated annotation) and reproducing
 Affinage's own mechanism-profile GO ids as-is. It carries **no AIGR interpretation**: the
 trust gates print to **stderr** (see the ADA/ACAT1 runs above), and the reviewer records the

--- a/projects/AFFINAGE_EVALUATION/results/example-ABCA1-deep-research-affinage.md
+++ b/projects/AFFINAGE_EVALUATION/results/example-ABCA1-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 32
 citation_count: 34
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ABCA1 (human)
@@ -22,9 +23,7 @@ note: >-
 
 ABCA1 is an ATP-hydrolyzing integral membrane transporter that drives the rate-limiting first step of reverse cholesterol transport, exporting cellular cholesterol and phospholipids to lipid-poor apolipoproteins—principally apoA-I—to nucleate nascent HDL particles; loss-of-function mutations cause Tangier disease [PMID:10882340, PMID:11111099, PMID:11483617]. The purified protein reconstituted in liposomes hydrolyzes ATP in a manner preferentially stimulated by phosphatidylcholine and sphingomyelin and inhibited by specific sterols, establishing its direct enzymatic mechanism [PMID:16500904], and it operates as an extracellular phospholipid translocase that extracts outer-leaflet phospholipids through a hydrophobic gateway/annulus tunnel in its extracellular domain rather than as an inner-to-outer floppase [PMID:35974019]. ABCA1 activity generates two classes of cell-surface apoA-I binding sites—a minor direct ABCA1/apoA-I site and a dominant high-capacity site formed by apoA-I engaging ABCA1-generated lipid domains, the latter requiring the apoA-I C-terminus and driving HDL assembly [PMID:17478755]. ApoA-I binding additionally triggers JAK2/STAT3, PKA, PKC, and CDC42 signaling that feeds back on lipid efflux, protein stability, and inflammation [PMID:22064972]. The transporter cycles between the plasma membrane and endosomes via clathrin/Rab5-mediated retroendocytosis with Rab4-dependent recycling that contributes to efflux [PMID:19170766], and it partitions into lipid rafts and phagosomes in association with syntaxin 13 and flotillin-1 [PMID:15469992]. ABCA1 abundance is tightly controlled transcriptionally—induced by LXR/RXR, RAR, and AMPK–LXRα, and repressed by ORP8, TRAK2, and CXCL12/CXCR4–GSK3β/TCF21 signaling [PMID:14560020, PMID:28655204, PMID:27343431, PMID:31662443]—and post-translationally through calpain-mediated degradation accelerated by PLD2-dependent serine phosphorylation, OSBP, and AGE–RAGE–ubiquitin/lysosomal pathways [PMID:16118212, PMID:18450749, PMID:29097054]. Beyond efflux, ABCA1 restrains TLR4-driven macrophage inflammation through membrane lipid remodeling [PMID:19797709], governs beta-cell cholesterol homeostasis and insulin secretion [PMID:17322896, PMID:22315319], directs hepatic HDL assembly and VLDL secretion [PMID:22001232], maintains astrocyte apoE lipidation and neuroinflammatory tone [PMID:23376685], and acts as a myeloid tumor suppressor by limiting IL-3Rβ/MAPK/JAK2 signaling [PMID:32160545].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140657 ATP-dependent activity, GO:0016787 hydrolase activity, GO:0005215 transporter activity, GO:0008289 lipid binding, GO:0140104 molecular carrier activity
 - **localization:** GO:0005886 plasma membrane, GO:0005768 endosome, GO:0005764 lysosome

--- a/projects/AFFINAGE_EVALUATION/results/example-ACADM-deep-research-affinage.md
+++ b/projects/AFFINAGE_EVALUATION/results/example-ACADM-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 22
 citation_count: 24
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACADM (human)
@@ -22,9 +23,7 @@ note: >-
 
 ACADM encodes the mitochondrial flavoenzyme MCAD, which catalyzes the rate-determining first dehydrogenation step of medium-chain fatty acid β-oxidation; in MCAD-deficient cells decanoyl-CoA is readily shortened to octanoyl-CoA but octanoyl-CoA cannot be further oxidized, producing the characteristic accumulation of octanoyl-, decanoyl-, and decenoylcarnitine [PMID:7551818]. Catalysis proceeds through an FAD-dependent reductive half-reaction with octanoyl-CoA that generates kinetically distinct MCAD-FADH2–octenoyl-CoA charge-transfer complexes, and the enzyme's latent oxidase activity is suppressed while these charge-transfer species persist [PMID:7626613]; electrons are relayed to electron-transferring flavoprotein (ETF), and disease variants can alter both substrate chain-length dependence and ETF interaction [PMID:37257730]. Proper FAD incorporation is coupled to cofactor affinity, proteolytic and thermal stability, and correct tetramer assembly, with FAD supplementation able to structurally rescue some variants [PMID:37257730]. Newly imported MCAD monomers are folded along an ATP-dependent chaperone pathway in which they first bind mitochondrial hsp70 and are then transferred to hsp60 before release as mature tetramers [PMID:7905878]. The prevalent K304E (K329E) disease mutation does not impair import but introduces a charge that destabilizes the hsp60–MCAD complex against ATP-driven release and impairs subunit docking and tetramer stability; the neutral K304Q substitution restores far more activity, demonstrating that the glutamate negative charge is responsible [PMID:8104486, PMID:7905878, PMID:7730333]. Systematic variant studies separate folding/assembly defects, which are rescuable by chaperonin co-overexpression or permissive temperature, from purely catalytic lesions such as R256T that yield well-folded but inactive enzyme [PMID:16128823, PMID:24966162], and a large class of ACADM disease alleles act not on protein but on pre-mRNA splicing, disrupting exonic splicing enhancers/silencers or activating cryptic splice sites to cause exon skipping and NMD-mediated transcript loss [PMID:17273963, PMID:23810226, PMID:15171999]. Beyond classic β-oxidation, MCAD is transcriptionally repressed via the CAV1/SREBP1 axis in hepatocellular carcinoma [PMID:33975883], is phosphorylated downstream of PINK1 kinase in a pathway linking mitochondrial function to fatty acid metabolism [PMID:29563254], and re-oxidizes microbiota-derived phenylpropionic acid in a host-microbe co-metabolic pathway generating hippuric acid [PMID:36720857]. Loss of MCAD impairs hepatic glucose homeostasis under metabolic stress [PMID:18459129].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0016491 oxidoreductase activity, GO:0016740 transferase activity
 - **localization:** GO:0005739 mitochondrion

--- a/projects/AFFINAGE_EVALUATION/results/example-ACAT1-deep-research-affinage.md
+++ b/projects/AFFINAGE_EVALUATION/results/example-ACAT1-deep-research-affinage.md
@@ -8,27 +8,22 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 37
 citation_count: 38
-gates_passed: False
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ACAT1 (human)
-
-> ⚠️ **CAUTION — trust gate(s) tripped; review before using:**
->
-> - Accession mismatch: local review uses `P24752` but the Affinage record's prefetch UniProt accession is `P35610`.
 
 ## Current model (mechanistic narrative)
 
 ACAT1 is a cholesterol-esterifying enzyme that maintains intracellular cholesterol homeostasis and, through this lipid-handling role, governs membrane sterol pools in macrophages, neurons, and adipocytes [PMID:32433614, PMID:9857049, PMID:39481851]. In the ER membrane it assembles as a dimer-of-dimers tetramer in which each protomer presents converging cytosolic and transmembrane tunnels that admit acyl-CoA and cholesterol, respectively, to a shared catalytic site; long-chain unsaturated acyl-CoA (preferentially oleoyl-CoA) is conjugated to free cholesterol, and the enzyme behaves allosterically with sigmoidal kinetics toward its cholesterol substrate [PMID:32433614, PMID:32433613, PMID:9857049]. Catalysis depends on a cytosolic-facing active-site serine (Ser269) and on histidines H386 and H460, and substrate recognition is stereospecific for the 3β-hydroxyl steroid configuration [PMID:11071899, PMID:16647063, PMID:20964445]. ACAT1 accounts for the dominant fraction of cholesterol-esterifying activity in human liver, adrenal, macrophage, and kidney tissue, and is enriched at mitochondria-associated ER membranes, where its inhibition raises local cholesterol and strengthens ER–mitochondria contacts [PMID:9717734, PMID:36982602]. In macrophages, ACAT1 controls the balance between cholesterol esterification and efflux and is transcriptionally driven by TNF-α through an NF-κB element in its promoter; myeloid ACAT1 ablation attenuates atherosclerotic lesion formation, adipose inflammation, and TLR4-dependent inflammatory signaling [PMID:15499044, PMID:19189937, PMID:31495784, PMID:36982689]. In neurons, ACAT1 activity controls plasma-membrane and ER free-cholesterol pools and thereby modulates APP processing and amyloid-β generation, placing cholesterol esterification upstream of amyloidogenesis [PMID:20133765, PMID:26474739]. Beyond its esterase function, mitochondrial ACAT1 acts as a protein acetyltransferase that acetylates PDHA1 (K321) and PDP1 (K202) to inhibit the pyruvate dehydrogenase complex and promote the Warburg effect, opposed by the deacetylase SIRT3 [PMID:24486017]. The human enzyme is unusual in arising from a chimeric mRNA assembled by interchromosomal trans-splicing, which additionally yields a 56-kDa ER-localized isoform via IRES-dependent translation from a GGC start codon [PMID:10196189, PMID:15319423].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0016740 transferase activity, GO:0140096 catalytic activity, acting on a protein, GO:0008289 lipid binding, GO:0098772 molecular function regulator activity
 - **localization:** GO:0005783 endoplasmic reticulum, GO:0005739 mitochondrion, GO:0005764 lysosome, GO:0031410 cytoplasmic vesicle

--- a/projects/AFFINAGE_EVALUATION/results/example-ADA-deep-research-affinage.md
+++ b/projects/AFFINAGE_EVALUATION/results/example-ADA-deep-research-affinage.md
@@ -8,29 +8,22 @@ self_evaluation_pairwise: loss
 faith_pct: 100.0
 n_discoveries: 30
 citation_count: 30
-gates_passed: False
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for ADA (human)
-
-> ⚠️ **CAUTION — trust gate(s) tripped; review before using:**
->
-> - Affinage's own head-to-head self-evaluation scored this record `pairwise = loss` (not `win`) vs the curated UniProt reference — treat the narrative with extra scepticism.
->
-> - Possible symbol collision: the narrative's opening names a non-human context ("e. coli") despite a human record — verify the narrative describes human ADA and not a same-symbol protein (cf. the ADA case).
 
 ## Current model (mechanistic narrative)
 
 The ADA symbol in this corpus resolves into three biologically distinct proteins, and the timeline is dominated by the bacterial Ada DNA-alkylation-repair regulator rather than the human adenosine deaminase. The E. coli Ada protein is a bifunctional suicide methyltransferase that, in its repair role, irreversibly transfers methyl groups from O6-methylguanine in alkylated DNA to its own cysteine residues [PMID:2987251], with the active-site cysteine buried in the 19-kDa C-terminal domain whose structure has been solved [PMID:8156986]. A second methyltransferase activity in the N-terminal domain accepts methyl from methylphosphotriesters at Cys-69, and this specific modification—not the C-terminal Cys-321 methylation—converts Ada into a sequence-specific transcriptional activator of the adaptive response to alkylating agents [PMID:2843522, PMID:2648001]. Methylated Ada binds the ada/alkA regulatory sequence (AAAGCGCA) upstream of the promoter and recruits RNA polymerase through direct contact with the C-terminal domain of the alpha subunit and with the C-terminal region of sigma70 (notably Glu575), defining Ada as a class I activator [PMID:3139888, PMID:8468304, PMID:9582376]. The repair-to-activator switch is electrostatic rather than ligand-exchange-based: structural and spectroscopic analyses show S-methyl-Cys69 remains zinc-coordinated, and neutralization of negative charge at the zinc-thiolate center remodels a surface patch to convert phosphate repulsion into attraction for promoter DNA [PMID:9383376, PMID:11284682, PMID:16209950]. The response is self-limiting: unmethylated Ada antagonizes its own activation [PMID:7937881], and an endogenous protease cleaves Ada into a 20-kDa N-terminal fragment that activates alkA but represses ada, terminating the adaptive response [PMID:3058696, PMID:2254928]. A separate set of findings describes the eukaryotic ADA/Ada2/Ada3 transcriptional co-activator subunits, which scaffold the GCN5 histone acetyltransferase within the ADA and SAGA complexes to acetylate nucleosomal histone H3K14, antagonize chromatin-mediated repression together with SWI/SNF, and mediate activation by nuclear receptors, with complex-specific ADA2 isoforms (ATAC ADA2a vs SAGA ADA2b) differentially stimulating GCN5 [PMID:9224714, PMID:9343382, PMID:26468280]. A third set addresses human ADA enzymatic activity, whose deficiency causes toxic purine accumulation impairing TCR signaling [PMID:18218852], Treg suppressive function via the CD39/CD73/adenosine axis [PMID:22184407], bone homeostasis via RANKL/OPG imbalance [PMID:19633200], and brain adenosine receptor signaling [PMID:28074903]. These three groups describe unrelated proteins sharing the ADA/Ada symbol.
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0140097 catalytic activity, acting on DNA, GO:0016740 transferase activity, GO:0003677 DNA binding, GO:0140110 transcription regulator activity, GO:0140096 catalytic activity, acting on a protein
 - **localization:** *(none)*

--- a/projects/AFFINAGE_EVALUATION/results/example-GPX4-deep-research-affinage.md
+++ b/projects/AFFINAGE_EVALUATION/results/example-GPX4-deep-research-affinage.md
@@ -8,12 +8,13 @@ self_evaluation_pairwise: win
 faith_pct: 100.0
 n_discoveries: 37
 citation_count: 37
-gates_passed: True
 note: >-
-  Machine-fetched from the Affinage API (Cheeseman Lab). This is external
-  precomputed research to be treated as a preliminary source, NOT a curated
-  annotation. Affinage is human-only and LLM-generated; verify claims against
-  the cited PMIDs before use.
+  Verbatim machine-fetched record from the Affinage API (Cheeseman Lab),
+  reproduced as-is as an external deep-research source (like a
+  falcon/perplexity report). It is Affinage-authored, LLM-generated, and
+  human-only. Curatorial assessment of this record — relevance, correctness,
+  trust gates, whether to import its GO grounding — is the reviewer's and
+  belongs in the gene review's references[].reference_review, not in this file.
 ---
 
 # Affinage mechanistic annotation for GPX4 (human)
@@ -22,9 +23,7 @@ note: >-
 
 GPX4 is a selenocysteine-dependent glutathione peroxidase that constitutes the central cellular defense against iron-dependent lipid peroxidation, and its loss precipitates ferroptotic cell death [PMID:24439385, PMID:31634900]. It is uniquely capable of reducing esterified phospholipid hydroperoxides within membranes to non-toxic lipid alcohols, a reaction no other enzyme performs in a cellular context [PMID:31634900, PMID:34931062]; an electrostatic cationic patch mediates membrane and cardiolipin binding adjacent to the catalytic site [PMID:34492183], and the selenolate active-site catalysis is specifically required to resist irreversible overoxidation, distinguishing GPX4 from a cysteine variant and being essential for neuronal survival in vivo [PMID:29290465]. This antioxidant function makes GPX4 a survival dependency in therapy-resistant high-mesenchymal persister cancer cells [PMID:29088702], and a patient-derived R152H active-site loop mutation that abolishes activity links GPX4 dysfunction to human disease [PMID:34931062]. Beyond its canonical hydroperoxidase role, GPX4 acts as a protein-thiol peroxidase that cross-links mitochondrial capsule proteins during spermatogenesis [PMID:11568459], and alternative-promoter usage generates cytosolic, mitochondrial, and arginine-rich nuclear isoforms with distinct localizations [PMID:12751792, PMID:14583338]. GPX4 abundance is set by a dense post-translational network: stabilizing palmitoylation at C66/C75 (ZDHHC20/ZDHHC8, reversed by APT2) [PMID:39833225, PMID:40108413], R152 symmetric dimethylation by PRMT5 that excludes the Cullin1-FBW7 ligase [PMID:40033101], S104 phosphorylation by CKB that blocks chaperone-mediated autophagy [PMID:37156912], stabilizing deubiquitination (USP8, OTUD5, OTUB1 recruited by CST1) and linear ubiquitination by LUBAC [PMID:36369321, PMID:36279464, PMID:38598341, PMID:38110369], opposed by degradative ubiquitination (STUB1 at K191, NEDD4L, copper-induced modification of C107/C148) and selective/chaperone-mediated autophagy via TAX1BP1, p62/TRAF6, legumain-HSC70, and FUNDC1-mediated mitochondrial import [PMID:36622894, PMID:38110356, PMID:33431801, PMID:36828120, PMID:40394165], with transcriptional and m6A control by STAT3 and the PKA-ALKBH5 axis [PMID:35859150, PMID:39901038]. Functionally, GPX4-maintained redox homeostasis sustains follicular helper T cell and germinal center responses [PMID:34413521], enables cGAS-STING innate immunity by preventing lipid-peroxidation-driven STING carbonylation at C88 [PMID:32541831], confers host resistance to Mycobacterium tuberculosis [PMID:36069923], and in adipocytes suppresses metabolic inflammation independently of overt ferroptotic death [PMID:35031697]. Direct covalent modification of C66 by itaconate allosterically activates the enzyme to protect neurons [PMID:38719928].
 
-## Affinage mechanism profile (its own GO/Reactome grounding)
-
-_Recorded for reference. The AIGR evaluation found this grounding is coarse (collapses to general parents) and can contradict the narrative — do not import these GO ids directly; re-ground from the narrative + PMIDs._
+## Affinage mechanism profile (Affinage's own GO/Reactome grounding)
 
 - **molecular_activity:** GO:0016491 oxidoreductase activity, GO:0140098 catalytic activity, acting on RNA, GO:0008289 lipid binding, GO:0003677 DNA binding, GO:0016209 antioxidant activity
 - **localization:** GO:0005829 cytosol, GO:0005739 mitochondrion, GO:0005634 nucleus, GO:0005886 plasma membrane

--- a/projects/AFFINAGE_EVALUATION/results/fa-cohort.md
+++ b/projects/AFFINAGE_EVALUATION/results/fa-cohort.md
@@ -47,12 +47,12 @@ primary papers folded into the review.
 | [PALB2](fa-cohort/PALB2.md) | N | win (35) | 2 | **1** | ChAM nucleosome binding (GO:0031491) + the primary KEAP1 paper; layer says histone-vs-nucleosome / catalytic-on-DNA |
 | [RAD51C](fa-cohort/RAD51C.md) | O | win (42) | 5 | **1** | ICL repair / FANCO founding paper (GO:0036297); does **not** claim RAD51C is itself an endonuclease — AIGR's over-annotation of GO:0008821 stands |
 | [SLX4](fa-cohort/SLX4.md) | P | win (57) | 3 | **1** | SLX4-complex SUMO E3 ligase (GO:0061665, non-core); narrative correctly frames SLX4 as nuclease-dead scaffold |
-| [ERCC4](fa-cohort/ERCC4.md) | Q | **tie / CAUTION** (40) | 1 | 0 | The FANCQ disease-defining paper (PMID:23623386); CAUTION warranted vs the GO layer, not the (sound) prose |
+| [ERCC4](fa-cohort/ERCC4.md) | Q | **tie / gate tripped** (40) | 1 | 0 | The FANCQ disease-defining paper (PMID:23623386); flag warranted vs the GO layer, not the (sound) prose |
 | [RAD51](fa-cohort/RAD51.md) | R | win (45) | 3 | 0 | Foundational Gupta/Radding 1997 recombinase paper; RNA/TERRA left as documented candidate |
 | [UBE2T](fa-cohort/UBE2T.md) | T | win (35) | 1 | 0 | Anchored polyubiquitination; declines the large single-study cancer-substrate / RNF8 / NER set |
 | [XRCC2](fa-cohort/XRCC2.md) | U | win (29) | 5 | **1** | ICL repair / FANCU (GO:0036297); narrative *reinforces* "not an ATP-dependent damage sensor" |
 | [RFWD3](fa-cohort/RFWD3.md) | W | win (17) | 2 | 0 | Two RFWD3-focused fork-remodeling papers; p53/MDM2 correctly non-core |
-| [BRCA1](fa-cohort/BRCA1.md) | S | **tie / CAUTION** (22) | 3 | 0 | Anchored HR/E3/H2AK127 terms; CAUTION warranted vs GO layer (spurious RNA-catalytic term), not the prose; ~70 protein-binding REMOVEs untouched |
+| [BRCA1](fa-cohort/BRCA1.md) | S | **tie / gate tripped** (22) | 3 | 0 | Anchored HR/E3/H2AK127 terms; flag warranted vs GO layer (spurious RNA-catalytic term), not the prose; ~70 protein-binding REMOVEs untouched |
 | [BRCA2](fa-cohort/BRCA2.md) | D1 | win (27) | 3 | 0 | 3 canonical primary papers (Yang 2002 structure, fork protection, single-molecule RAD51 loading) replacing indirect support |
 | [MAD2L2](fa-cohort/MAD2L2.md) | V | win (47) | 2 | **1** | Shieldin-independent fork-resection protection (GO:0110027) + the previously-uncited FANCV disease paper |
 
@@ -79,7 +79,7 @@ SLX4 nuclease-dead). This is the opposite of the redundancy the project page wor
 genuinely hard, adaptor-heavy pathway the narrative pulled real, checkable literature the
 GOA-seeded review had not surfaced.
 
-**3. The two `tie`/CAUTION records (ERCC4, BRCA1) were correctly flagged, but for the GO layer,
+**3. The two `tie` records (ERCC4, BRCA1) were correctly gate-flagged, but for the GO layer,
 not the prose.** In both, the narrative was factually sound and PMID-dense with no fabrication or
 mis-attribution; the `tie` tracked the coarse/wrong-branch GO grounding (a spurious RNA-catalytic
 term on BRCA1; RNA-binding + parent-level catalytic terms on ERCC4) plus a breadth-over-focus

--- a/projects/AFFINAGE_EVALUATION/results/fa-cohort/BRCA1.md
+++ b/projects/AFFINAGE_EVALUATION/results/fa-cohort/BRCA1.md
@@ -1,6 +1,6 @@
 # BRCA1 (FANCS) — AIGR vs Affinage
 
-**Affinage record:** run 2026-06-09 · 22 discoveries · self-eval pairwise = **tie** (CAUTION) · faith 100% · gates **not** passed (tie gate tripped).
+**Affinage record:** run 2026-06-09 · 22 discoveries · self-eval pairwise = **tie** · faith 100% · trust gate tripped at generation time (the `tie` gate).
 
 The Affinage record for BRCA1 is a strong, PMID-dense (22 citations) mechanistic narrative that
 correctly centers BRCA1 on error-free homologous recombination as a RING/BARD1 E3-ligase tumor
@@ -34,7 +34,7 @@ result that BRCA1/BARD1 ligase activity is *not* essential in vivo for FANCD2 mo
 | ATR-Ser1423 phosphorylation, CRM1/p53 nuclear export | Emphasized as BRCA1 biology (PMID:11114888, 15087457) | Not annotated as BRCA1 function | **AIGR right to exclude.** These describe regulation *of* BRCA1 (BRCA1 as substrate / its localization control), not molecular functions/processes executed by BRCA1. Out of scope. |
 | Transcriptional targets (SIRT1, ERα, VDAC3/GPX4 ferroptosis, BRCA1/E2F1/Rb autorepression) | Presented alongside core roles (PMID:18851829, 19887647, 38552003, 20068145) | Transcriptional/metabolic roles already KEEP_AS_NON_CORE or MARK_AS_OVER_ANNOTATED | **AIGR right.** These are peripheral/tissue-specific or indirect (the ferroptosis and atherosclerosis links are downstream); AIGR's non-core/over-annotated treatment is the correct altitude. No change. |
 
-## Was the CAUTION warranted?
+## Was the trust-gate flag warranted?
 
 **Mildly warranted, but the narrative held up well.** The `pairwise = tie` self-eval almost certainly
 reflects that BRCA1's curated UniProt reference is itself exhaustive (BRCA1 is among the most-studied
@@ -71,11 +71,11 @@ conservative bar for a high-quality already-QA'd review.
 
 AIGR and Affinage agree on BRCA1's core RING/BARD1 E3-ligase and homologous-recombination biology, and
 Affinage's narrative was factually clean under extra scrutiny. Its coarse `mechanism_profile` GO layer
-is, as the CAUTION implies, the untrustworthy part — one wrong-branch RNA-catalytic term and a mis-
+is, as the flag implies, the untrustworthy part — one wrong-branch RNA-catalytic term and a mis-
 branched ligase parent that were correctly not imported. Affinage's real value was its dense, well-
 anchored narrative supplying three canonical primary papers — Nacson 2020 (separation-of-function HR
 alleles), Zong 2019 (RNF168-redundant PALB2 loading), and Hu 2021 (cryo-EM H2A-K127 ubiquitylation
 opposing 53BP1) — that the review had under-cited. These were incorporated conservatively as added
 references + verbatim `supported_by` on existing annotations, with no change to any curation decision,
-no reversal of the aggressive protein-binding REMOVEs, and no new terms. The **CAUTION was warranted as
-a flag against the GO layer but not against the prose.** File remains ✓ Valid.
+no reversal of the aggressive protein-binding REMOVEs, and no new terms. The **flag was warranted
+against the GO layer but not against the prose.** File remains ✓ Valid.

--- a/projects/AFFINAGE_EVALUATION/results/fa-cohort/ERCC4.md
+++ b/projects/AFFINAGE_EVALUATION/results/fa-cohort/ERCC4.md
@@ -1,6 +1,6 @@
 # ERCC4 (FANCQ / XPF) — AIGR vs Affinage
 
-**Affinage record:** run 2026-06-09 · 40 discoveries · 41 citations · self-eval pairwise = **tie** (CAUTION) · gates **not** passed (`gates_passed: False`).
+**Affinage record:** run 2026-06-09 · 40 discoveries · 41 citations · self-eval pairwise = **tie** · trust gate tripped at generation time (the `tie` gate).
 
 ## Agreement (brief)
 
@@ -30,7 +30,7 @@ which specialized roles rise to annotation.
 | Cytoplasmic mislocalization / nuclear import interdependence | Emphasizes XPF stability requires ERCC1 (PMID:20418188), ERCC1 nuclear import requires XPF (PMID:28130555), USP45 deubiquitylation (PMID:25538220) | Not annotated as separate functions; localization captured by nucleus/chromosome/complex terms | **AIGR (defensible).** These are regulatory/stability mechanisms of the heterodimer, already implied by the complex-membership and localization annotations; not additional GO functions. |
 | FA-Q disease grounding | Cites PMID:23623386 for biallelic ERCC4 → Fanconi anemia with separable NER/ICL activities | Description named FANCQ but **cited nothing** for it | **Affinage surfaces a real gap.** PMID:23623386 now incorporated (below) onto the ICL-repair annotation. |
 
-## Was the CAUTION warranted?
+## Was the trust-gate flag warranted?
 
 **Partly — as a prompt for scrutiny, not as a verdict on accuracy.** The `tie` self-eval and
 tripped gate correctly flagged that this record should not be trusted wholesale, and two
@@ -46,7 +46,7 @@ That said, the **factual narrative is strong and PMID-dense**: no fabricated or 
 claims were found on spot-check, and the core mechanistic account (5' incision, ss/ds
 junction specificity, ICL unhooking, SLX4/FANCD2 order, auto-inhibition) is accurate and
 well-cited. So the `tie` reflects **coarse GO grounding + breadth-over-focus**, not factual
-unreliability. The CAUTION was a reasonable trigger for skeptical reading; the underlying
+unreliability. The flag was a reasonable trigger for skeptical reading; the underlying
 literature synthesis held up.
 
 ## Papers incorporated into the review
@@ -70,5 +70,5 @@ MARK_AS_OVER_ANNOTATED decisions, and deliberate exclusion of the specialized/th
 phenotypes Affinage foregrounds. Affinage's value here was **breadth of primary citation** — it
 surfaced exactly one real gap (the FANCQ disease-defining paper, PMID:23623386), now incorporated.
 Its coarse `mechanism_profile` (parent-level catalytic terms + spurious RNA binding) should not be
-imported, consistent with the CAUTION. Net: AIGR ahead on grounding and focus; Affinage a useful
+imported, consistent with the flag. Net: AIGR ahead on grounding and focus; Affinage a useful
 citation net that justified one conservative, validated addition.


### PR DESCRIPTION
## Summary

Restructure Affinage deep-research output to be a **verbatim external-provider record** (like falcon/perplexity reports), with no AIGR interpretation or trust gates embedded in the file. Trust-gate warnings are now printed to stderr for the operator to record in the gene review's `reference_review`, keeping the file faithful to what Affinage returned.

**Key changes:**
- Remove `gates_passed` frontmatter field from all generated files
- Remove CAUTION banners and trust-gate adjudication from file content
- Move gate results to stderr output (operator-facing, not written to file)
- Update module docstring and README to clarify the design principle: the file reproduces exactly what the provider returned, with curatorial judgment belonging in the gene review's `references[].reference_review`, not in the source file
- Update frontmatter note to emphasize verbatim reproduction and external-source status
- Refactor `run_gates()` to compute warnings for stderr, not for file embedding

This prevents laundering AIGR's own opinion into something that looks like the provider said it, while still helping reviewers form their judgment via the two cheap trust checks (human-only gate + accession/organism cross-check).

## Validation

N/A — this is a documentation and output-format change to the Affinage integration tool. No gene reviews are affected; the tool is not yet wired into the main pipeline.

## Test plan

- [ ] Verify `python affinage_deep_research.py human GPX4` prints gate warnings to stderr
- [ ] Verify generated `*-deep-research-affinage.md` files contain no `gates_passed` field and no CAUTION banners
- [ ] Verify frontmatter note correctly describes the file as a verbatim provider record

https://claude.ai/code/session_01UFg8Vf9TmCgspDdCQ7gjNA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Large-scale markdown and documentation-only changes to external research artifacts; no application logic or curated annotation data paths appear in the diff.
> 
> **Overview**
> **Affinage `*-deep-research-affinage.md` files are reframed as verbatim external-provider dumps** (same role as falcon/perplexity reports), not semi-curated notes with embedded AIGR judgment.
> 
> Across the regenerated human gene files, **`gates_passed` is dropped from frontmatter**, the **`note` now states that relevance, trust, and GO-import decisions belong in the gene review's `references[].reference_review`**, and **in-file ⚠️ CAUTION / trust-gate banners are removed** so pairwise losses, symbol-collision warnings, etc. are no longer written into the artifact. The **"do not import these GO ids"** disclaimer under the mechanism profile is also removed; the section is retitled to **Affinage's own GO/Reactome grounding** while leaving Affinage's terms in the body.
> 
> **`projects/AFFINAGE_EVALUATION/README.md`** documents the contract: trust checks (human-only, accession match, narrative organism sniff, Affinage `pairwise`) should surface on **stderr** for the operator, not in the markdown file. **`projects/AFFINAGE_EVALUATION.md`** is tweaked so ERCC4/BRCA1 `tie` cases are described as gate-flagged via frontmatter/stderr and recorded in **`reference_review`**, not via embedded CAUTION text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66223bac7c98c1bc10b30b72a0631608502fc81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->