### PR TITLE
Add ISMB 2026 presentation link to main and BioReason READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ just stats-open           # Generate and open in browser
 - **Evaluation Form**: [https://go.lbl.gov/gene-eval](https://go.lbl.gov/gene-eval) - Detailed expert feedback form
 - **Project Slides**: [Overview Presentation](https://docs.google.com/presentation/d/1xBFIQE0jt7K6kFg4zFzUwLDHtnDWat2ZVDarhcpA3_4/edit?slide=id.p#slide=id.p)
 
+### Presentations
+
+- **ISMB 2026 (Function COSI)**: Caufield JH, Joachimiak MP, Mungall CJ. *Agentic evaluation of AI function prediction pipelines.* Washington, DC, 14 July 2026. Slides: [doi:10.5281/zenodo.21810552](https://doi.org/10.5281/zenodo.21810552)
+
 ### Documentation Pages
 
 - **Voting System Guide**: Learn how to provide feedback on AI curation decisions

--- a/projects/BIOREASON_COMPARISON.md
+++ b/projects/BIOREASON_COMPARISON.md
@@ -23,6 +23,8 @@ Systematic evaluation of BioReason-Pro functional summaries and reasoning traces
 
 📄 **[Read the manuscript (PDF)](BIOREASON_COMPARISON/article/manuscript.pdf)** &nbsp;·&nbsp; 🖥 **[View the slide deck](BIOREASON_COMPARISON/article/slides.html)** &nbsp;·&nbsp; 📝 [Abstract](BIOREASON_COMPARISON/article/abstract.md)
 
+🎤 **Presented at ISMB 2026** (Function COSI, Washington DC, 14 July 2026): Caufield JH, Joachimiak MP, Mungall CJ. *Agentic evaluation of AI function prediction pipelines.* Slides archived at [doi:10.5281/zenodo.21810552](https://doi.org/10.5281/zenodo.21810552)
+
 **Explore the evaluations interactively:**
 - [BioReason-Pro SFT evaluation](BIOREASON_COMPARISON/sft-eval.html) — ARGO95 primary cohort: 95 genes, 955 predictions; the browser also includes supplemental source cohorts
 - [GO-GPT leaf evaluation](BIOREASON_COMPARISON/gogpt-eval.html) — ARGO139 collected cohort; unresolved terms are explicitly pending


### PR DESCRIPTION
Adds a link to the archived slides for the ISMB 2026 Function COSI talk, **"Agentic evaluation of AI function prediction pipelines"** (Caufield JH, Joachimiak MP, Mungall CJ; Washington DC, 14 July 2026), deposited at [doi:10.5281/zenodo.21810552](https://doi.org/10.5281/zenodo.21810552).

- `README.md` — new **Presentations** subsection under Resources
- `projects/BIOREASON_COMPARISON.md` — presentation line next to the existing manuscript/slide-deck/abstract row

Record metadata (title, authors, date, resource type) was verified against the Zenodo record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)