### PR TITLE
Preserve hypothesis wrapper arguments

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -294,86 +294,161 @@ gene-hypothesis-list organism gene *args="":
 # Examples:
 #   just gene-hypothesis-research openscientist human TP53 --annotation-term-id GO:0003677 --dry-run
 #   just gene-hypothesis-research falcon human TP53 --focus-type core-function --hypothesis "TP53 directly binds DNA"
-gene-hypothesis-research provider organism gene *args="":
+[positional-arguments]
+gene-hypothesis-research provider organism gene *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    provider="{{provider}}"
-    args=( {{args}} )
+    provider="$1"
+    organism="$2"
+    gene="$3"
+    shift 3
+    args=("$@")
     # OpenScientist defaults: >=3 iterations for a real run, and a generous job
     # timeout. Fold-discovery / structural runs routinely exceed the upstream
     # 3600s default (they cancel mid-analysis), so default to 7200s -- the
     # maximum the API allows (OpenScientistParams.timeout is capped at le=7200).
     # Keep --timeout-seconds (subprocess wall) above this; the script default does.
     if [[ "$provider" == "openscientist" ]]; then
+        has_separator=false
+        has_max_iterations=false
+        has_timeout=false
+        expect_param=false
+        for arg in "${args[@]}"; do
+            if [[ "$has_separator" == false ]]; then
+                if [[ "$arg" == "--" ]]; then has_separator=true; fi
+                continue
+            fi
+            if [[ "$expect_param" == true ]]; then
+                if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
+                if [[ "$arg" == timeout=* ]]; then has_timeout=true; fi
+                expect_param=false
+                continue
+            fi
+            case "$arg" in
+                --param) expect_param=true ;;
+                --param=max_iterations=*) has_max_iterations=true ;;
+                --param=timeout=*) has_timeout=true ;;
+            esac
+        done
         extra=()
-        if [[ "${args[*]}" != *"max_iterations"* ]]; then extra+=(--param max_iterations=3); fi
-        if [[ "${args[*]}" != *"timeout="* ]]; then extra+=(--param timeout=7200); fi
+        if [[ "$has_max_iterations" == false ]]; then extra+=(--param max_iterations=3); fi
+        if [[ "$has_timeout" == false ]]; then extra+=(--param timeout=7200); fi
         if [[ ${#extra[@]} -gt 0 ]]; then
-            if [[ " ${args[*]} " == *" -- "* ]]; then
+            if [[ "$has_separator" == true ]]; then
                 args+=("${extra[@]}")
             else
                 args+=(-- "${extra[@]}")
             fi
         fi
     fi
-    uv run python scripts/gene_hypothesis_deep_research.py run {{organism}} {{gene}} "$provider" "${args[@]}"
+    uv run python scripts/gene_hypothesis_deep_research.py run "$organism" "$gene" "$provider" "${args[@]}"
 
 # Run focused deep research for every core_functions[*] record in one gene
 # Existing provider outputs are skipped unless --overwrite is supplied.
 # Examples:
 #   just gene-hypothesis-research-all-core openscientist human SCO1 --dry-run
 #   just gene-hypothesis-research-all-core openscientist human SCO1 -- --param use_hypotheses=true
-gene-hypothesis-research-all-core provider organism gene *args="":
+[positional-arguments]
+gene-hypothesis-research-all-core provider organism gene *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    provider="{{provider}}"
-    args=( {{args}} )
+    provider="$1"
+    organism="$2"
+    gene="$3"
+    shift 3
+    args=("$@")
     # OpenScientist defaults: >=3 iterations for a real run, and a generous job
     # timeout. Fold-discovery / structural runs routinely exceed the upstream
     # 3600s default (they cancel mid-analysis), so default to 7200s -- the
     # maximum the API allows (OpenScientistParams.timeout is capped at le=7200).
     # Keep --timeout-seconds (subprocess wall) above this; the script default does.
     if [[ "$provider" == "openscientist" ]]; then
+        has_separator=false
+        has_max_iterations=false
+        has_timeout=false
+        expect_param=false
+        for arg in "${args[@]}"; do
+            if [[ "$has_separator" == false ]]; then
+                if [[ "$arg" == "--" ]]; then has_separator=true; fi
+                continue
+            fi
+            if [[ "$expect_param" == true ]]; then
+                if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
+                if [[ "$arg" == timeout=* ]]; then has_timeout=true; fi
+                expect_param=false
+                continue
+            fi
+            case "$arg" in
+                --param) expect_param=true ;;
+                --param=max_iterations=*) has_max_iterations=true ;;
+                --param=timeout=*) has_timeout=true ;;
+            esac
+        done
         extra=()
-        if [[ "${args[*]}" != *"max_iterations"* ]]; then extra+=(--param max_iterations=3); fi
-        if [[ "${args[*]}" != *"timeout="* ]]; then extra+=(--param timeout=7200); fi
+        if [[ "$has_max_iterations" == false ]]; then extra+=(--param max_iterations=3); fi
+        if [[ "$has_timeout" == false ]]; then extra+=(--param timeout=7200); fi
         if [[ ${#extra[@]} -gt 0 ]]; then
-            if [[ " ${args[*]} " == *" -- "* ]]; then
+            if [[ "$has_separator" == true ]]; then
                 args+=("${extra[@]}")
             else
                 args+=(-- "${extra[@]}")
             fi
         fi
     fi
-    uv run python scripts/gene_hypothesis_deep_research.py run-all-core {{organism}} {{gene}} "$provider" "${args[@]}"
+    uv run python scripts/gene_hypothesis_deep_research.py run-all-core "$organism" "$gene" "$provider" "${args[@]}"
 
 # Run one synthesis query over all core_functions[*] records in one gene
 # Examples:
 #   just gene-hypothesis-research-combined-core openscientist human SCO1 --dry-run
 #   just gene-hypothesis-research-combined-core openscientist human SCO1 -- --param use_hypotheses=true
-gene-hypothesis-research-combined-core provider organism gene *args="":
+[positional-arguments]
+gene-hypothesis-research-combined-core provider organism gene *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    provider="{{provider}}"
-    args=( {{args}} )
+    provider="$1"
+    organism="$2"
+    gene="$3"
+    shift 3
+    args=("$@")
     # OpenScientist defaults: >=3 iterations for a real run, and a generous job
     # timeout. Fold-discovery / structural runs routinely exceed the upstream
     # 3600s default (they cancel mid-analysis), so default to 7200s -- the
     # maximum the API allows (OpenScientistParams.timeout is capped at le=7200).
     # Keep --timeout-seconds (subprocess wall) above this; the script default does.
     if [[ "$provider" == "openscientist" ]]; then
+        has_separator=false
+        has_max_iterations=false
+        has_timeout=false
+        expect_param=false
+        for arg in "${args[@]}"; do
+            if [[ "$has_separator" == false ]]; then
+                if [[ "$arg" == "--" ]]; then has_separator=true; fi
+                continue
+            fi
+            if [[ "$expect_param" == true ]]; then
+                if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
+                if [[ "$arg" == timeout=* ]]; then has_timeout=true; fi
+                expect_param=false
+                continue
+            fi
+            case "$arg" in
+                --param) expect_param=true ;;
+                --param=max_iterations=*) has_max_iterations=true ;;
+                --param=timeout=*) has_timeout=true ;;
+            esac
+        done
         extra=()
-        if [[ "${args[*]}" != *"max_iterations"* ]]; then extra+=(--param max_iterations=3); fi
-        if [[ "${args[*]}" != *"timeout="* ]]; then extra+=(--param timeout=7200); fi
+        if [[ "$has_max_iterations" == false ]]; then extra+=(--param max_iterations=3); fi
+        if [[ "$has_timeout" == false ]]; then extra+=(--param timeout=7200); fi
         if [[ ${#extra[@]} -gt 0 ]]; then
-            if [[ " ${args[*]} " == *" -- "* ]]; then
+            if [[ "$has_separator" == true ]]; then
                 args+=("${extra[@]}")
             else
                 args+=(-- "${extra[@]}")
             fi
         fi
     fi
-    uv run python scripts/gene_hypothesis_deep_research.py run-combined-core {{organism}} {{gene}} "$provider" "${args[@]}"
+    uv run python scripts/gene_hypothesis_deep_research.py run-combined-core "$organism" "$gene" "$provider" "${args[@]}"
 
 # Find independent literature support for a gene-function hypothesis via deep research
 # Recall-tuned (expect false positives an agent then sifts); general-purpose,
@@ -383,19 +458,41 @@ gene-hypothesis-research-combined-core provider organism gene *args="":
 #   just gene-function-support asta human TP53 --hypothesis "TP53 is a sequence-specific DNA-binding transcription factor" --dry-run
 #   just gene-function-support asta human TP53 --annotation-term-id GO:0003700
 #   just gene-function-support asta human TP53 --term-id GO:0003700 --term-label "DNA-binding transcription factor activity"
-gene-function-support provider organism gene *args="":
+[positional-arguments]
+gene-function-support provider organism gene *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    provider="{{provider}}"
-    args=( {{args}} )
-    if [[ "$provider" == "openscientist" && "${args[*]}" != *"max_iterations"* ]]; then
-        if [[ " ${args[*]} " == *" -- "* ]]; then
+    provider="$1"
+    organism="$2"
+    gene="$3"
+    shift 3
+    args=("$@")
+    has_separator=false
+    has_max_iterations=false
+    expect_param=false
+    for arg in "${args[@]}"; do
+        if [[ "$has_separator" == false ]]; then
+            if [[ "$arg" == "--" ]]; then has_separator=true; fi
+            continue
+        fi
+        if [[ "$expect_param" == true ]]; then
+            if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
+            expect_param=false
+            continue
+        fi
+        case "$arg" in
+            --param) expect_param=true ;;
+            --param=max_iterations=*) has_max_iterations=true ;;
+        esac
+    done
+    if [[ "$provider" == "openscientist" && "$has_max_iterations" == false ]]; then
+        if [[ "$has_separator" == true ]]; then
             args+=(--param max_iterations=3)
         else
             args+=(-- --param max_iterations=3)
         fi
     fi
-    uv run python scripts/gene_hypothesis_deep_research.py run-function-support {{organism}} {{gene}} "$provider" "${args[@]}"
+    uv run python scripts/gene_hypothesis_deep_research.py run-function-support "$organism" "$gene" "$provider" "${args[@]}"
 
 # List IBA annotations that are candidates for support-finding research
 # By default only IBAs lacking independent PMID/DOI support are listed.
@@ -415,19 +512,41 @@ gene-iba-support-list organism gene *args="":
 #   just gene-iba-support-research asta human CFAP300 --dry-run
 #   just gene-iba-support-research asta human CFAP300 --annotation-term-id GO:0005737
 #   just gene-iba-support-research asta human CFAP300 --include-supported
-gene-iba-support-research provider organism gene *args="":
+[positional-arguments]
+gene-iba-support-research provider organism gene *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    provider="{{provider}}"
-    args=( {{args}} )
-    if [[ "$provider" == "openscientist" && "${args[*]}" != *"max_iterations"* ]]; then
-        if [[ " ${args[*]} " == *" -- "* ]]; then
+    provider="$1"
+    organism="$2"
+    gene="$3"
+    shift 3
+    args=("$@")
+    has_separator=false
+    has_max_iterations=false
+    expect_param=false
+    for arg in "${args[@]}"; do
+        if [[ "$has_separator" == false ]]; then
+            if [[ "$arg" == "--" ]]; then has_separator=true; fi
+            continue
+        fi
+        if [[ "$expect_param" == true ]]; then
+            if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
+            expect_param=false
+            continue
+        fi
+        case "$arg" in
+            --param) expect_param=true ;;
+            --param=max_iterations=*) has_max_iterations=true ;;
+        esac
+    done
+    if [[ "$provider" == "openscientist" && "$has_max_iterations" == false ]]; then
+        if [[ "$has_separator" == true ]]; then
             args+=(--param max_iterations=3)
         else
             args+=(-- --param max_iterations=3)
         fi
     fi
-    uv run python scripts/gene_hypothesis_deep_research.py run-iba-support {{organism}} {{gene}} "$provider" "${args[@]}"
+    uv run python scripts/gene_hypothesis_deep_research.py run-iba-support "$organism" "$gene" "$provider" "${args[@]}"
 
 # ============== ASSAY_TO_FUNCTION readout-mining pipeline ==============
 

--- a/project.justfile
+++ b/project.justfile
@@ -286,8 +286,14 @@ index-research-artifacts *args="":
 # Examples:
 #   just gene-hypothesis-list human TP53
 #   just gene-hypothesis-list human TP53 --missing-provider openscientist
-gene-hypothesis-list organism gene *args="":
-    uv run python scripts/gene_hypothesis_deep_research.py list {{organism}} {{gene}} {{args}}
+[positional-arguments]
+gene-hypothesis-list organism gene *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    organism="$1"
+    gene="$2"
+    shift 2
+    uv run python scripts/gene_hypothesis_deep_research.py list "$organism" "$gene" "$@"
 
 # Run focused deep research for one gene-level curation hypothesis
 # Dry-run is recommended while selecting a source record.
@@ -313,23 +319,25 @@ gene-hypothesis-research provider organism gene *args:
         has_max_iterations=false
         has_timeout=false
         expect_param=false
-        for arg in "${args[@]}"; do
-            if [[ "$has_separator" == false ]]; then
-                if [[ "$arg" == "--" ]]; then has_separator=true; fi
-                continue
-            fi
-            if [[ "$expect_param" == true ]]; then
-                if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
-                if [[ "$arg" == timeout=* ]]; then has_timeout=true; fi
-                expect_param=false
-                continue
-            fi
-            case "$arg" in
-                --param) expect_param=true ;;
-                --param=max_iterations=*) has_max_iterations=true ;;
-                --param=timeout=*) has_timeout=true ;;
-            esac
-        done
+        if [[ ${#args[@]} -gt 0 ]]; then
+            for arg in "${args[@]}"; do
+                if [[ "$has_separator" == false ]]; then
+                    if [[ "$arg" == "--" ]]; then has_separator=true; fi
+                    continue
+                fi
+                if [[ "$expect_param" == true ]]; then
+                    if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
+                    if [[ "$arg" == timeout=* ]]; then has_timeout=true; fi
+                    expect_param=false
+                    continue
+                fi
+                case "$arg" in
+                    --param) expect_param=true ;;
+                    --param=max_iterations=*) has_max_iterations=true ;;
+                    --param=timeout=*) has_timeout=true ;;
+                esac
+            done
+        fi
         extra=()
         if [[ "$has_max_iterations" == false ]]; then extra+=(--param max_iterations=3); fi
         if [[ "$has_timeout" == false ]]; then extra+=(--param timeout=7200); fi
@@ -341,7 +349,11 @@ gene-hypothesis-research provider organism gene *args:
             fi
         fi
     fi
-    uv run python scripts/gene_hypothesis_deep_research.py run "$organism" "$gene" "$provider" "${args[@]}"
+    if [[ ${#args[@]} -gt 0 ]]; then
+        uv run python scripts/gene_hypothesis_deep_research.py run "$organism" "$gene" "$provider" "${args[@]}"
+    else
+        uv run python scripts/gene_hypothesis_deep_research.py run "$organism" "$gene" "$provider"
+    fi
 
 # Run focused deep research for every core_functions[*] record in one gene
 # Existing provider outputs are skipped unless --overwrite is supplied.
@@ -367,23 +379,25 @@ gene-hypothesis-research-all-core provider organism gene *args:
         has_max_iterations=false
         has_timeout=false
         expect_param=false
-        for arg in "${args[@]}"; do
-            if [[ "$has_separator" == false ]]; then
-                if [[ "$arg" == "--" ]]; then has_separator=true; fi
-                continue
-            fi
-            if [[ "$expect_param" == true ]]; then
-                if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
-                if [[ "$arg" == timeout=* ]]; then has_timeout=true; fi
-                expect_param=false
-                continue
-            fi
-            case "$arg" in
-                --param) expect_param=true ;;
-                --param=max_iterations=*) has_max_iterations=true ;;
-                --param=timeout=*) has_timeout=true ;;
-            esac
-        done
+        if [[ ${#args[@]} -gt 0 ]]; then
+            for arg in "${args[@]}"; do
+                if [[ "$has_separator" == false ]]; then
+                    if [[ "$arg" == "--" ]]; then has_separator=true; fi
+                    continue
+                fi
+                if [[ "$expect_param" == true ]]; then
+                    if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
+                    if [[ "$arg" == timeout=* ]]; then has_timeout=true; fi
+                    expect_param=false
+                    continue
+                fi
+                case "$arg" in
+                    --param) expect_param=true ;;
+                    --param=max_iterations=*) has_max_iterations=true ;;
+                    --param=timeout=*) has_timeout=true ;;
+                esac
+            done
+        fi
         extra=()
         if [[ "$has_max_iterations" == false ]]; then extra+=(--param max_iterations=3); fi
         if [[ "$has_timeout" == false ]]; then extra+=(--param timeout=7200); fi
@@ -395,7 +409,11 @@ gene-hypothesis-research-all-core provider organism gene *args:
             fi
         fi
     fi
-    uv run python scripts/gene_hypothesis_deep_research.py run-all-core "$organism" "$gene" "$provider" "${args[@]}"
+    if [[ ${#args[@]} -gt 0 ]]; then
+        uv run python scripts/gene_hypothesis_deep_research.py run-all-core "$organism" "$gene" "$provider" "${args[@]}"
+    else
+        uv run python scripts/gene_hypothesis_deep_research.py run-all-core "$organism" "$gene" "$provider"
+    fi
 
 # Run one synthesis query over all core_functions[*] records in one gene
 # Examples:
@@ -420,23 +438,25 @@ gene-hypothesis-research-combined-core provider organism gene *args:
         has_max_iterations=false
         has_timeout=false
         expect_param=false
-        for arg in "${args[@]}"; do
-            if [[ "$has_separator" == false ]]; then
-                if [[ "$arg" == "--" ]]; then has_separator=true; fi
-                continue
-            fi
-            if [[ "$expect_param" == true ]]; then
-                if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
-                if [[ "$arg" == timeout=* ]]; then has_timeout=true; fi
-                expect_param=false
-                continue
-            fi
-            case "$arg" in
-                --param) expect_param=true ;;
-                --param=max_iterations=*) has_max_iterations=true ;;
-                --param=timeout=*) has_timeout=true ;;
-            esac
-        done
+        if [[ ${#args[@]} -gt 0 ]]; then
+            for arg in "${args[@]}"; do
+                if [[ "$has_separator" == false ]]; then
+                    if [[ "$arg" == "--" ]]; then has_separator=true; fi
+                    continue
+                fi
+                if [[ "$expect_param" == true ]]; then
+                    if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
+                    if [[ "$arg" == timeout=* ]]; then has_timeout=true; fi
+                    expect_param=false
+                    continue
+                fi
+                case "$arg" in
+                    --param) expect_param=true ;;
+                    --param=max_iterations=*) has_max_iterations=true ;;
+                    --param=timeout=*) has_timeout=true ;;
+                esac
+            done
+        fi
         extra=()
         if [[ "$has_max_iterations" == false ]]; then extra+=(--param max_iterations=3); fi
         if [[ "$has_timeout" == false ]]; then extra+=(--param timeout=7200); fi
@@ -448,7 +468,11 @@ gene-hypothesis-research-combined-core provider organism gene *args:
             fi
         fi
     fi
-    uv run python scripts/gene_hypothesis_deep_research.py run-combined-core "$organism" "$gene" "$provider" "${args[@]}"
+    if [[ ${#args[@]} -gt 0 ]]; then
+        uv run python scripts/gene_hypothesis_deep_research.py run-combined-core "$organism" "$gene" "$provider" "${args[@]}"
+    else
+        uv run python scripts/gene_hypothesis_deep_research.py run-combined-core "$organism" "$gene" "$provider"
+    fi
 
 # Find independent literature support for a gene-function hypothesis via deep research
 # Recall-tuned (expect false positives an agent then sifts); general-purpose,
@@ -467,24 +491,28 @@ gene-function-support provider organism gene *args:
     gene="$3"
     shift 3
     args=("$@")
+    # Support runs have a 5400s Python wall timeout, so only add the iteration
+    # default here; a 7200s provider timeout would outlive the wrapper process.
     has_separator=false
     has_max_iterations=false
     expect_param=false
-    for arg in "${args[@]}"; do
-        if [[ "$has_separator" == false ]]; then
-            if [[ "$arg" == "--" ]]; then has_separator=true; fi
-            continue
-        fi
-        if [[ "$expect_param" == true ]]; then
-            if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
-            expect_param=false
-            continue
-        fi
-        case "$arg" in
-            --param) expect_param=true ;;
-            --param=max_iterations=*) has_max_iterations=true ;;
-        esac
-    done
+    if [[ ${#args[@]} -gt 0 ]]; then
+        for arg in "${args[@]}"; do
+            if [[ "$has_separator" == false ]]; then
+                if [[ "$arg" == "--" ]]; then has_separator=true; fi
+                continue
+            fi
+            if [[ "$expect_param" == true ]]; then
+                if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
+                expect_param=false
+                continue
+            fi
+            case "$arg" in
+                --param) expect_param=true ;;
+                --param=max_iterations=*) has_max_iterations=true ;;
+            esac
+        done
+    fi
     if [[ "$provider" == "openscientist" && "$has_max_iterations" == false ]]; then
         if [[ "$has_separator" == true ]]; then
             args+=(--param max_iterations=3)
@@ -492,7 +520,11 @@ gene-function-support provider organism gene *args:
             args+=(-- --param max_iterations=3)
         fi
     fi
-    uv run python scripts/gene_hypothesis_deep_research.py run-function-support "$organism" "$gene" "$provider" "${args[@]}"
+    if [[ ${#args[@]} -gt 0 ]]; then
+        uv run python scripts/gene_hypothesis_deep_research.py run-function-support "$organism" "$gene" "$provider" "${args[@]}"
+    else
+        uv run python scripts/gene_hypothesis_deep_research.py run-function-support "$organism" "$gene" "$provider"
+    fi
 
 # List IBA annotations that are candidates for support-finding research
 # By default only IBAs lacking independent PMID/DOI support are listed.
@@ -500,8 +532,14 @@ gene-function-support provider organism gene *args:
 #   just gene-iba-support-list human CFAP300
 #   just gene-iba-support-list human CFAP300 --missing-provider asta
 #   just gene-iba-support-list human CFAP300 --include-supported
-gene-iba-support-list organism gene *args="":
-    uv run python scripts/gene_hypothesis_deep_research.py list-iba {{organism}} {{gene}} {{args}}
+[positional-arguments]
+gene-iba-support-list organism gene *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    organism="$1"
+    gene="$2"
+    shift 2
+    uv run python scripts/gene_hypothesis_deep_research.py list-iba "$organism" "$gene" "$@"
 
 # Find independent literature support for a gene's IBA annotations via deep research
 # Thin wrapper over gene-function-support: feeds each IBA annotation in as a
@@ -521,24 +559,28 @@ gene-iba-support-research provider organism gene *args:
     gene="$3"
     shift 3
     args=("$@")
+    # Support runs have a 5400s Python wall timeout, so only add the iteration
+    # default here; a 7200s provider timeout would outlive the wrapper process.
     has_separator=false
     has_max_iterations=false
     expect_param=false
-    for arg in "${args[@]}"; do
-        if [[ "$has_separator" == false ]]; then
-            if [[ "$arg" == "--" ]]; then has_separator=true; fi
-            continue
-        fi
-        if [[ "$expect_param" == true ]]; then
-            if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
-            expect_param=false
-            continue
-        fi
-        case "$arg" in
-            --param) expect_param=true ;;
-            --param=max_iterations=*) has_max_iterations=true ;;
-        esac
-    done
+    if [[ ${#args[@]} -gt 0 ]]; then
+        for arg in "${args[@]}"; do
+            if [[ "$has_separator" == false ]]; then
+                if [[ "$arg" == "--" ]]; then has_separator=true; fi
+                continue
+            fi
+            if [[ "$expect_param" == true ]]; then
+                if [[ "$arg" == max_iterations=* ]]; then has_max_iterations=true; fi
+                expect_param=false
+                continue
+            fi
+            case "$arg" in
+                --param) expect_param=true ;;
+                --param=max_iterations=*) has_max_iterations=true ;;
+            esac
+        done
+    fi
     if [[ "$provider" == "openscientist" && "$has_max_iterations" == false ]]; then
         if [[ "$has_separator" == true ]]; then
             args+=(--param max_iterations=3)
@@ -546,7 +588,11 @@ gene-iba-support-research provider organism gene *args:
             args+=(-- --param max_iterations=3)
         fi
     fi
-    uv run python scripts/gene_hypothesis_deep_research.py run-iba-support "$organism" "$gene" "$provider" "${args[@]}"
+    if [[ ${#args[@]} -gt 0 ]]; then
+        uv run python scripts/gene_hypothesis_deep_research.py run-iba-support "$organism" "$gene" "$provider" "${args[@]}"
+    else
+        uv run python scripts/gene_hypothesis_deep_research.py run-iba-support "$organism" "$gene" "$provider"
+    fi
 
 # ============== ASSAY_TO_FUNCTION readout-mining pipeline ==============
 

--- a/project.justfile
+++ b/project.justfile
@@ -272,15 +272,24 @@ deep-research-interpro-family interpro_id provider="falcon" *args="":
 
 # Fetch Edison/Falcon artifacts for a deep research trajectory and attach them to a report
 # Example: just fetch-research-artifacts <trajectory-id> genes/human/TP53/TP53-deep-research-falcon.md
-fetch-research-artifacts trajectory_id research_file *args="":
-    uv run python scripts/fetch_edison_artifacts.py {{trajectory_id}} {{research_file}} {{args}}
+[positional-arguments]
+fetch-research-artifacts trajectory_id research_file *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    trajectory_id="$1"
+    research_file="$2"
+    shift 2
+    uv run python scripts/fetch_edison_artifacts.py "$trajectory_id" "$research_file" "$@"
 
 # Index Edison/Falcon artifacts recorded in deep research report frontmatter
 # Examples:
 #   just index-research-artifacts
 #   just index-research-artifacts --check
-index-research-artifacts *args="":
-    uv run python scripts/index_research_artifacts.py {{args}}
+[positional-arguments]
+index-research-artifacts *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    uv run python scripts/index_research_artifacts.py "$@"
 
 # List focused hypothesis research candidates for one gene
 # Examples:

--- a/tests/test_gene_hypothesis_deep_research.py
+++ b/tests/test_gene_hypothesis_deep_research.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -454,3 +455,170 @@ def test_dry_run_does_not_create_output_directory(tmp_path: Path) -> None:
     assert result.status == "DRY_RUN"
     assert result.output_file.name == "perplexity-lite.md"
     assert not result.output_file.parent.exists()
+
+
+def test_just_wrapper_preserves_quoted_free_text_arguments(tmp_path: Path) -> None:
+    """The public Just wrapper must not flatten quoted variadic arguments."""
+    genes_root = make_gene_workspace(tmp_path / "workspace with spaces")
+    hypothesis = (
+        "Native TEST asks A -- B (or C)? max_iterations is prose; keep punctuation."
+    )
+    context = (
+        "The token timeout= is prose; distinguish native activity from engineered variants."
+    )
+    repo_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            "just",
+            "gene-hypothesis-research",
+            "openscientist",
+            "human",
+            "TEST",
+            "--genes-root",
+            str(genes_root),
+            "--focus-type",
+            "function-assignment",
+            "--hypothesis",
+            hypothesis,
+            "--slug",
+            "quoted-args",
+            "--term-id",
+            "GO:0003756",
+            "--term-label",
+            "protein disulfide isomerase activity",
+            "--context",
+            context,
+            "--dry-run",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"hypothesis_text={hypothesis}" in result.stdout
+    assert context in result.stdout
+    assert "max_iterations=3" in result.stdout
+    assert "timeout=7200" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("recipe", "iba_workspace", "selector_args", "expects_timeout"),
+    [
+        ("gene-hypothesis-research-all-core", False, [], True),
+        ("gene-hypothesis-research-combined-core", False, [], True),
+        (
+            "gene-function-support",
+            False,
+            ["--hypothesis", "TEST has a function (variant A, or B)?"],
+            False,
+        ),
+        ("gene-iba-support-research", True, [], False),
+    ],
+)
+def test_just_wrappers_preserve_arguments_before_and_after_separator(
+    tmp_path: Path,
+    recipe: str,
+    iba_workspace: bool,
+    selector_args: list[str],
+    expects_timeout: bool,
+) -> None:
+    """Every shebang wrapper must forward exact positional argument boundaries."""
+    workspace = tmp_path / "workspace (quoted)"
+    if iba_workspace:
+        genes_root = make_iba_workspace(workspace)
+        gene = "IBAT"
+    else:
+        genes_root = make_gene_workspace(workspace)
+        gene = "TEST"
+    template = tmp_path / "template (review), v1?.md"
+    provider_value = "note=A -- B, with spaces (exact)?"
+    repo_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            "just",
+            recipe,
+            "openscientist",
+            "human",
+            gene,
+            "--genes-root",
+            str(genes_root),
+            "--template",
+            str(template),
+            *selector_args,
+            "--dry-run",
+            "--",
+            "--param",
+            provider_value,
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert str(template) in result.stdout
+    assert provider_value in result.stdout
+    assert "max_iterations=3" in result.stdout
+    assert ("timeout=7200" in result.stdout) is expects_timeout
+
+
+def test_just_wrapper_respects_exact_openscientist_param_overrides(
+    tmp_path: Path,
+) -> None:
+    """Explicit provider params suppress only their matching defaults."""
+    genes_root = make_gene_workspace(tmp_path)
+    repo_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            "just",
+            "gene-hypothesis-research",
+            "openscientist",
+            "human",
+            "TEST",
+            "--genes-root",
+            str(genes_root),
+            "--focus-type",
+            "function-assignment",
+            "--hypothesis",
+            "TEST has an exact function.",
+            "--slug",
+            "explicit-params",
+            "--dry-run",
+            "--",
+            "--param",
+            "max_iterations=7",
+            "--param=timeout=6000",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "max_iterations=7" in result.stdout
+    assert "timeout=6000" in result.stdout
+    assert "max_iterations=3" not in result.stdout
+    assert "timeout=7200" not in result.stdout
+
+
+def test_positional_wrapper_variadics_have_no_empty_default() -> None:
+    """Positional variadics must not inject an empty fourth argument."""
+    justfile = (Path(__file__).resolve().parents[1] / "project.justfile").read_text()
+    recipes = [
+        "gene-hypothesis-research",
+        "gene-hypothesis-research-all-core",
+        "gene-hypothesis-research-combined-core",
+        "gene-function-support",
+        "gene-iba-support-research",
+    ]
+
+    for recipe in recipes:
+        assert f"{recipe} provider organism gene *args:" in justfile
+        assert f'{recipe} provider organism gene *args="":' not in justfile

--- a/tests/test_gene_hypothesis_deep_research.py
+++ b/tests/test_gene_hypothesis_deep_research.py
@@ -495,6 +495,7 @@ def test_just_wrapper_preserves_quoted_free_text_arguments(tmp_path: Path) -> No
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
 
     assert result.returncode == 0, result.stderr
@@ -558,6 +559,7 @@ def test_just_wrappers_preserve_arguments_before_and_after_separator(
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
 
     assert result.returncode == 0, result.stderr
@@ -599,6 +601,7 @@ def test_just_wrapper_respects_exact_openscientist_param_overrides(
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
 
     assert result.returncode == 0, result.stderr
@@ -608,17 +611,68 @@ def test_just_wrapper_respects_exact_openscientist_param_overrides(
     assert "timeout=7200" not in result.stdout
 
 
-def test_positional_wrapper_variadics_have_no_empty_default() -> None:
-    """Positional variadics must not inject an empty fourth argument."""
-    justfile = (Path(__file__).resolve().parents[1] / "project.justfile").read_text()
-    recipes = [
-        "gene-hypothesis-research",
-        "gene-hypothesis-research-all-core",
-        "gene-hypothesis-research-combined-core",
-        "gene-function-support",
-        "gene-iba-support-research",
-    ]
+@pytest.mark.parametrize(
+    ("recipe", "iba_workspace", "gene"),
+    [
+        ("gene-hypothesis-list", False, "TEST"),
+        ("gene-iba-support-list", True, "IBAT"),
+    ],
+)
+def test_just_list_wrappers_preserve_genes_root_with_spaces(
+    tmp_path: Path,
+    recipe: str,
+    iba_workspace: bool,
+    gene: str,
+) -> None:
+    """List wrappers must preserve a multiword genes-root argument."""
+    workspace = tmp_path / "workspace with spaces"
+    genes_root = (
+        make_iba_workspace(workspace)
+        if iba_workspace
+        else make_gene_workspace(workspace)
+    )
+    repo_root = Path(__file__).resolve().parents[1]
 
-    for recipe in recipes:
-        assert f"{recipe} provider organism gene *args:" in justfile
-        assert f'{recipe} provider organism gene *args="":' not in justfile
+    result = subprocess.run(
+        [
+            "just",
+            recipe,
+            "human",
+            gene,
+            "--genes-root",
+            str(genes_root),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert gene in result.stdout
+
+
+def test_just_research_wrapper_handles_empty_variadic_tail() -> None:
+    """A zero-length variadic tail must reach Python without an empty argument."""
+    repo_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            "just",
+            "gene-hypothesis-research",
+            "falcon",
+            "human",
+            "AIGR_NO_SUCH_GENE",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 2
+    assert "--hypothesis is required" in result.stderr
+    assert "unbound variable" not in result.stderr
+    assert "unrecognized arguments" not in result.stderr

--- a/tests/test_gene_hypothesis_deep_research.py
+++ b/tests/test_gene_hypothesis_deep_research.py
@@ -653,7 +653,8 @@ def test_just_list_wrappers_preserve_genes_root_with_spaces(
     assert gene in result.stdout
 
 
-def test_just_research_wrapper_handles_empty_variadic_tail() -> None:
+@pytest.mark.parametrize("provider", ["falcon", "openscientist"])
+def test_just_research_wrapper_handles_empty_variadic_tail(provider: str) -> None:
     """A zero-length variadic tail must reach Python without an empty argument."""
     repo_root = Path(__file__).resolve().parents[1]
 
@@ -661,7 +662,7 @@ def test_just_research_wrapper_handles_empty_variadic_tail() -> None:
         [
             "just",
             "gene-hypothesis-research",
-            "falcon",
+            provider,
             "human",
             "AIGR_NO_SUCH_GENE",
         ],

--- a/tests/test_research_artifacts.py
+++ b/tests/test_research_artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
@@ -149,3 +150,53 @@ trajectory_id: same-tid
         "human/GENE/GENE-deep-research-falcon.md",
         "human/GENE/GENE-deep-research-openai.md",
     ]
+
+
+def test_fetch_research_artifacts_wrapper_preserves_spaced_report_path(tmp_path):
+    """The Just wrapper must pass a missing multiword path as one argument."""
+    report = tmp_path / "missing report with spaces.md"
+
+    result = subprocess.run(
+        [
+            "just",
+            "fetch-research-artifacts",
+            "trajectory-1",
+            str(report),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 1
+    assert f"research file not found: {report}" in result.stderr
+    assert "unrecognized arguments" not in result.stderr
+
+
+def test_index_research_artifacts_wrapper_preserves_spaced_paths(tmp_path):
+    """The Just wrapper must preserve root and output path boundaries."""
+    genes_root = tmp_path / "genes with spaces"
+    genes_root.mkdir()
+    output = tmp_path / "reports with spaces" / "artifact index.yaml"
+
+    result = subprocess.run(
+        [
+            "just",
+            "index-research-artifacts",
+            "--root",
+            str(genes_root),
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.exists()
+    assert "Indexed 0 reports" in result.stdout


### PR DESCRIPTION
## Summary

- preserve quoted and empty-safe variadic arguments across all five hypothesis Just wrappers
- detect OpenScientist overrides only from exact provider parameters after the separator
- add real Just-to-Bash-to-Python dry-run regressions for punctuation, spaces, defaults, and overrides

## Validation

- uv run pytest tests/test_gene_hypothesis_deep_research.py -q (22 passed)
- uv run ruff check tests/test_gene_hypothesis_deep_research.py
- just --list
- git diff --check

The repository-wide Just formatter check is already non-clean on main; this PR does not reformat unrelated recipes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI/Just forwarding and default-param heuristics; Python research logic is unchanged, with subprocess tests covering the new behavior.
> 
> **Overview**
> **Just recipe wrappers** for gene-hypothesis deep research, function/IBA support, and research-artifact fetch/index no longer pass variadic flags through Just’s `{{args}}` expansion. They use `[positional-arguments]` bash shebangs that forward `"$@"` so quoted text, spaces, and `--` provider params stay intact.
> 
> **OpenScientist defaults** (`max_iterations=3`, and `timeout=7200` on full hypothesis runs) are injected only when matching `--param` values appear **after** `--`, so prose like `max_iterations` in `--hypothesis` no longer blocks defaults. Explicit overrides suppress only the param they set. Support recipes still default iterations only (no 7200s timeout).
> 
> **Regression tests** run real `just …` dry-runs for punctuation, spaced paths, empty extra args, and param overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927ff920c56a39500ec4b9f4bb7e66b90e3ede51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->