### PR TITLE
Deduplicate GO term cache

### DIFF
--- a/cache/go/terms.csv
+++ b/cache/go/terms.csv
@@ -722,7 +722,6 @@ GO:0004095,carnitine O-palmitoyltransferase activity,2026-05-08T22:12:02.939406
 GO:0004096,catalase activity,2026-03-22T22:38:14.237952
 GO:0004099,chitin deacetylase activity,2026-06-21T22:19:21.052249
 GO:0004100,chitin synthase activity,2026-06-21T22:19:32.993810
-GO:0004115,"3',5'-cyclic-AMP phosphodiesterase activity",2026-07-25T13:10:53.081844
 GO:0004107,chorismate synthase activity,2026-07-24T17:47:16.351268
 GO:0004109,coproporphyrinogen oxidase activity,2026-07-24T17:47:17.314773
 GO:0004115,"3',5'-cyclic-AMP phosphodiesterase activity",2026-07-24T14:04:52.161445


### PR DESCRIPTION
## Summary

- remove the misplaced duplicate `GO:0004115` row from `cache/go/terms.csv`
- restore the cache invariant of strictly sorted, one-row-per-CURIE data

## Root cause

The cache contained two identical-label rows for `GO:0004115`. A newer timestamped row had been inserted before `GO:0004107`, while the older duplicate remained at the correct sorted position. The repository `just fix-caches` wrapper normalized the file using the cache loader semantics (last occurrence wins), producing a one-line deletion.

## Impact

`tests/test_cache_sorted.py::test_cache_sorted_and_deduped[cache/go/terms.csv]` no longer fails, and future three-way merges can rely on deterministic cache ordering.

## Validation

- `just fix-caches` — normalized exactly one file
- `just lint-caches` — all 10 cache files sorted and deduplicated
- `just pytest` — cache test module passed; repository total was 1,358 passed and 3 unrelated baseline failures in benchmark sidecars and `projects/CONIDIATION.md` frontmatter
- `git diff --check` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line cache data cleanup with no application logic or runtime behavior changes.
> 
> **Overview**
> Removes a **misplaced duplicate** `GO:0004115` entry from `cache/go/terms.csv` so the file again has one row per CURIE in strict GO ID order.
> 
> The deleted row was an extra copy of the same term (newer timestamp) sitting before `GO:0004107`; the canonical row after `GO:0004109` is unchanged. This restores the cache invariant enforced by `test_cache_sorted_and_deduped` and avoids noisy three-way merges on the GO terms cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a9dc6474bed01d9356c22ce00616d6f83e94f12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->