### PR TITLE
Use controlled maturity for conidiation project

### DIFF
--- a/projects/CONIDIATION.md
+++ b/projects/CONIDIATION.md
@@ -5,7 +5,7 @@ description: >-
   of fungal conidium (asexual spore) formation, plus its upstream activation,
   repressive gating, spore maturation, and structural output.
 autolink_gene_symbols: false
-status: DESIGN
+maturity: MATURE
 ---
 
 # Conidiation regulatory cascade — module design proposal


### PR DESCRIPTION
## What changed

Replace the retired top-level `status: DESIGN` field in `projects/CONIDIATION.md` with the controlled lifecycle field `maturity: MATURE`.

## Why

The project-frontmatter policy rejects the legacy `status` key. `MATURE` reflects the current project state: the conidiation module and its grounded gene reviews form a substantial, stable body of work, while the project page still records an uncited downstream edge and open questions, so `COMPLETE` would overstate closure.

## Impact

Restores the controlled-maturity frontmatter check without changing any project biology, module data, or rendered content directly.

## Root cause

CONIDIATION was added after the bulk frontmatter migration and retained its original free-text lifecycle field.

## Validation

- Targeted CONIDIATION maturity check through `just pytest`: 1 passed, 1401 deselected
- Full project-frontmatter selection through `just pytest`: 576 passed, 826 deselected
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line frontmatter metadata change with no runtime, auth, or data-path impact; validated by existing project-frontmatter tests.
> 
> **Overview**
> Updates **`projects/CONIDIATION.md`** YAML frontmatter only: drops the retired top-level **`status: DESIGN`** key and sets the controlled lifecycle field **`maturity: MATURE`**.
> 
> **`MATURE`** matches a substantial, stable conidiation module and gene-review corpus while the project page still documents open questions and uncited edges—so **`COMPLETE`** would overstate closure. No module YAML, gene reviews, or rendered biology change; this aligns CONIDIATION with the bulk frontmatter migration and restores the targeted project-frontmatter checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3796c1f1b344d666275acc97d67dbb6d72a526da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->