### PR TITLE
Fix ARBA00004173 stats Ruff violations

### DIFF
--- a/rules/arba/ARBA00004173/ARBA00004173-stats.py
+++ b/rules/arba/ARBA00004173/ARBA00004173-stats.py
@@ -1,4 +1,5 @@
-import json, re
+import json
+import re
 from collections import Counter
 RD='rules/arba/ARBA00004173/'
 raw=json.load(open(RD+'ARBA00004173.json'))
@@ -14,7 +15,8 @@ single_ff=0
 for s in cs:
     sig=[c for c in s['conditions'] if c['type']!='taxon']
     shapes[tuple(sorted(c['type'] for c in sig))]+=1
-    if len(sig)==1 and sig[0]['type']=='FunFam id': single_ff+=1
+    if len(sig)==1 and sig[0]['type']=='FunFam id':
+        single_ff+=1
 print('single_funfam_only_sets: %d (%.1f%%)' % (single_ff, 100*single_ff/len(cs)))
 unlabeled_ff=0
 for s in ecs:
@@ -32,9 +34,11 @@ print('sets_with_a_signature_label_matching_mitochondri*: %d (%.1f%%)' % (mito, 
 ipr={v['value'] for s in cs for c in s['conditions'] if c['type']=='InterPro id' for v in c['conditionValues']}
 m={}
 for line in open(RD+'../_interpro2go.txt'):
-    if line.startswith('!'): continue
+    if line.startswith('!'):
+        continue
     mm=re.match(r'InterPro:(IPR\d+)\s+.*?>\s*GO:(.*?)\s*;\s*(GO:\d+)', line)
-    if mm: m.setdefault(mm.group(1),set()).add(mm.group(3))
+    if mm:
+        m.setdefault(mm.group(1),set()).add(mm.group(3))
 mapped=[i for i in ipr if i in m]
 mito_mapped=[i for i in mapped if 'GO:0005739' in m[i]]
 print('distinct_InterPro_ids: %d ; with_any_InterPro2GO_mapping: %d ; mapped_to_GO:0005739: %d'
@@ -46,8 +50,10 @@ def sigsets(p):
 mine=sigsets(RD+'ARBA00004173.json')
 print('distinct_signature_sets_within_rule: %d (of %d -> no exact duplicates)' % (len(set(mine)), len(mine)))
 try:
-    cyto=set(sigsets('/tmp/ARBA00004496.json')); pero=set(sigsets('/tmp/ARBA00004275.json'))
-    sc=sum(1 for s in mine if s in cyto); sp=sum(1 for s in mine if s in pero)
+    cyto=set(sigsets('/tmp/ARBA00004496.json'))
+    pero=set(sigsets('/tmp/ARBA00004275.json'))
+    sc=sum(1 for s in mine if s in cyto)
+    sp=sum(1 for s in mine if s in pero)
     print('signature_sets_shared_with_ARBA00004496_Cytoplasm: %d (%.1f%%)' % (sc, 100*sc/len(mine)))
     print('signature_sets_shared_with_ARBA00004275_Peroxisome: %d (%.1f%%)' % (sp, 100*sp/len(mine)))
     print('shared_with_both: %d' % sum(1 for s in mine if s in cyto and s in pero))


### PR DESCRIPTION
## What changed

- split the combined `json`/`re` import
- expand one-line conditionals and semicolon-separated assignments into separate statements
- preserve the script calculations, file paths, and output behavior

## Why

`just format` failed on `rules/arba/ARBA00004173/ARBA00004173-stats.py` with six Ruff E401/E701/E702 violations. This standalone rule-analysis script was newly visible to the repository-wide Ruff check.

## Impact

This is a formatting-only repair. It restores the Ruff gate without changing the ARBA statistics logic.

## Validation

- `just format` — passed
- `just test` — 1,359 passed; two unrelated baseline failures remain because committed BioReason/GO-GPT derived sidecars are stale:
  - `tests/test_bioreason_benchmark_policy.py::test_generated_sidecars_match_current_sources`
  - `tests/test_gogpt_compare_levels.py::test_committed_three_level_report_matches_current_reviews`
- `git diff --check` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting-only edits to an analysis script; no runtime or data-handling behavior changes.
> 
> **Overview**
> Brings **`rules/arba/ARBA00004173/ARBA00004173-stats.py`** in line with Ruff so `just format` passes on this standalone ARBA rule statistics script.
> 
> **Import and layout:** `json` and `re` are imported on separate lines (E401). One-line `if` bodies and semicolon-chained assignments in the FunFam counter, InterPro2GO parser, and sibling-rule comparison block are expanded onto multiple lines (E701/E702).
> 
> **Behavior:** Calculations, paths, prints, and the `/tmp` sibling JSON comparison are unchanged—formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2b4d9b6368d20aa4d86c31590393e42fcb9fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->