### PR TITLE
Refine metazoan hexosamine biosynthesis module

### DIFF
--- a/modules/hexosamine_biosynthesis.yaml
+++ b/modules/hexosamine_biosynthesis.yaml
@@ -1,14 +1,14 @@
 id: MODULE:hexosamine_biosynthesis
-title: Metazoan hexosamine biosynthesis and GlcNAc salvage
+title: Eukaryotic hexosamine biosynthesis and GlcNAc salvage
 description: >-
-  A reusable metazoan pathway that converts fructose 6-phosphate to
+  A reusable eukaryotic pathway that converts fructose 6-phosphate to
   UDP-N-acetylglucosamine through glutamine-dependent amination, acetyl-CoA-
   dependent N-acetylation, phosphomutase conversion, and UTP-dependent
   uridylyl transfer. A GlcNAc-kinase salvage branch enters at the
-  N-acetylglucosamine 6-phosphate intermediate. The product supplies protein
-  and lipid glycosylation, proteoglycan synthesis, GPI-anchor synthesis, and
-  O-GlcNAcylation. The bacterial GlmS-GlmM-GlmU route has a different reaction
-  order and a bifunctional terminal enzyme and is outside this module boundary.
+  N-acetylglucosamine 6-phosphate intermediate. Feedback inhibition of GFAT by
+  UDP-GlcNAc couples pathway flux to nutrient availability and glycosylation
+  demand. The product supplies protein and lipid glycosylation, proteoglycan and
+  GPI-anchor synthesis, O-GlcNAcylation, and the GNE-dependent sialic-acid route.
 status: DRAFT
 scope: CONCRETE
 evidence:
@@ -38,7 +38,7 @@ evidence:
     statement: The GlcNAc salvage kinase step (UniProtKB:Q9UJ70, GO:0045127) matches the completed human NAGK review.
 module:
   id: hexosamine_biosynthesis
-  label: Metazoan hexosamine biosynthesis and GlcNAc salvage
+  label: Eukaryotic hexosamine biosynthesis and GlcNAc salvage
   module_type: METABOLIC_PATHWAY
   concepts:
     - preferred_term: UDP-N-acetylglucosamine biosynthetic process
@@ -51,6 +51,18 @@ module:
         id: GO:0006047
         label: UDP-N-acetylglucosamine metabolic process
       description: Includes the NAGK salvage of free GlcNAc into the pathway.
+  context:
+    taxa:
+      - preferred_term: eukaryotes
+        term:
+          id: NCBITaxon:2759
+          label: Eukaryota
+    cellular_components:
+      - preferred_term: cytosol
+        term:
+          id: GO:0005829
+          label: cytosol
+        description: The represented biosynthetic and salvage reactions are carried out by soluble cytosolic enzymes.
   parts:
     - order: 1
       role: amidotransfer (rate-limiting; Fru-6-P + Gln)
@@ -91,6 +103,8 @@ module:
               evidence:
                 - source_id: file:human/GFPT1/GFPT1-ai-review.yaml
                   statement: Rate-limiting, UDP-GlcNAc-feedback-inhibited first HBP step; GFPT1 ubiquitous (CMS12), GFPT2 tissue-restricted with weaker feedback inhibition
+                - source_id: file:human/GFPT2/GFPT2-ai-review.yaml
+                  statement: GFPT2 is the tissue-restricted paralog that catalyzes the same first hexosamine-biosynthesis reaction.
             role_description: Aminate Fru-6-P with glutamine to GlcN-6-P (rate-limiting HBP step).
     - order: 2
       role: N-acetylation (acetyl-CoA)
@@ -155,7 +169,7 @@ module:
                 id: GO:0004610
                 label: phosphoacetylglucosamine mutase activity
               substrates:
-                - preferred_term: N-acetyl-D-glucosamine 6-phosphate (Mg2+)
+                - preferred_term: N-acetyl-D-glucosamine 6-phosphate
               products:
                 - preferred_term: N-acetyl-D-glucosamine 1-phosphate
               evidence:
@@ -238,27 +252,23 @@ module:
     - source: gfpt_amidotransfer
       target: glcn6p_acetylation
       connection_type: PROVIDES_INPUT_FOR
-      chaining_status: VERIFIED
-      chaining_note: The GlcN-6-P made by GFPT1/2 is N-acetylated by GNPNAT1.
+      description: The GlcN-6-P made by GFPT1/2 is N-acetylated by GNPNAT1.
     - source: glcn6p_acetylation
       target: glcnac_mutase
       connection_type: PROVIDES_INPUT_FOR
-      chaining_status: VERIFIED
-      chaining_note: The GlcNAc-6-P made by GNPNAT1 is converted to GlcNAc-1-P by PGM3.
+      description: The GlcNAc-6-P made by GNPNAT1 is converted to GlcNAc-1-P by PGM3.
     - source: glcnac_mutase
       target: udp_glcnac_synthesis
       connection_type: PROVIDES_INPUT_FOR
-      chaining_status: VERIFIED
-      chaining_note: The GlcNAc-1-P made by PGM3 is the substrate for UAP1.
+      description: The GlcNAc-1-P made by PGM3 is the substrate for UAP1.
     - source: glcnac_salvage
       target: glcnac_mutase
       connection_type: PROVIDES_INPUT_FOR
-      chaining_status: VERIFIED
-      chaining_note: >-
+      description: >-
         NAGK feeds salvaged GlcNAc-6-P into the pathway at the PGM3 step (the same node GNPNAT1 produces),
         recycling free GlcNAc from glycoconjugate degradation into UDP-GlcNAc.
   notes: >-
-    Metazoan hexosamine biosynthesis / UDP-GlcNAc synthesis (GO:0006048 + GO:0006047), grounded to six
+    Eukaryotic hexosamine biosynthesis / UDP-GlcNAc synthesis (GO:0006048 + GO:0006047), grounded to six
     completed human gene reviews. Linear route: GFPT1 (Q06210, rate-limiting, feedback-
     inhibited) + tissue-restricted paralog GFPT2 (O94808) share PTHR10937, GO:0004360 (Fru-6-P + Gln ->
     GlcN-6-P) -> GNPNAT1 (Q96EK6 PTHR13355, GO:0004343 acetyl-CoA acetylation -> GlcNAc-6-P) -> PGM3 (O95394
@@ -269,10 +279,9 @@ module:
     is UDP-GlcNAc-feedback-inhibited, making the pathway a nutrient/flux sensor. Notable moonlighting captured
     in the gene reviews (kept non-core here): UAP1 protein-serine pyrophosphorylase (IRF3, type-I-IFN) and
     NAGK muramyl-dipeptide kinase (NOD2). GO term ids/labels verified against the local go.db. Disorders:
-    GFPT1 CMS12, GNPNAT1 rhizomelic skeletal dysplasia, PGM3-CDG. This document
-    deliberately excludes the differently ordered bacterial GlmS-GlmM-GlmU route.
+    GFPT1 CMS12, GNPNAT1 rhizomelic skeletal dysplasia, PGM3-CDG.
   knowledge_gaps:
-    - gap_statement: The bacterial route to UDP-GlcNAc is not represented by this metazoan implementation.
+    - gap_statement: The bacterial route to UDP-GlcNAc is not represented by this eukaryotic implementation.
       boundary: >-
         Model bacterial GlmS, GlmM, and bifunctional GlmU as a separate pathway
         realization rather than treating GlmU as an ortholog of GNPNAT1 or UAP1.

--- a/modules/hexosamine_biosynthesis.yaml
+++ b/modules/hexosamine_biosynthesis.yaml
@@ -1,22 +1,16 @@
 id: MODULE:hexosamine_biosynthesis
-title: Hexosamine biosynthetic pathway (fructose-6-P -> UDP-GlcNAc; GFPT1/2, GNPNAT1, PGM3, UAP1, NAGK salvage)
+title: Metazoan hexosamine biosynthesis and GlcNAc salvage
 description: >-
-  The hexosamine biosynthetic pathway (HBP) diverts a small fraction (~2-5%) of glycolytic
-  fructose-6-phosphate to make UDP-N-acetylglucosamine (UDP-GlcNAc), the universal amino-sugar donor for
-  N- and O-linked glycosylation, O-GlcNAcylation, proteoglycan and GPI-anchor synthesis, and (via GNE) sialic
-  acid. Because the pathway integrates glucose, glutamine (amino donor), acetyl-CoA (acetyl donor) and UTP,
-  UDP-GlcNAc levels act as a nutrient/flux sensor coupling metabolic state to glycosylation. Four committed
-  cytosolic steps: the rate-limiting, feedback-controlled glutamine:fructose-6-phosphate amidotransferase
-  GFPT1 (and its tissue-restricted paralog GFPT2) converts fructose-6-phosphate + glutamine to glucosamine
-  6-phosphate + glutamate; the GNAT acetyltransferase GNPNAT1 acetylates it (with acetyl-CoA) to
-  N-acetylglucosamine 6-phosphate; the phosphohexomutase PGM3 converts that to N-acetylglucosamine
-  1-phosphate; and the pyrophosphorylase UAP1 condenses it with UTP to UDP-GlcNAc. A salvage branch feeds in
-  at the GlcNAc-6-phosphate node: the sugar kinase NAGK phosphorylates free N-acetylglucosamine (recovered
-  from glycoconjugate turnover) with ATP to GlcNAc-6-phosphate, recycling it into the pathway. Inherited
-  defects cause congenital disorders of glycosylation with distinct phenotypes: GFPT1 and GNPNAT1 (congenital
-  myasthenic syndrome / rhizomelic skeletal dysplasia) and PGM3 (PGM3-CDG with immunodeficiency and skeletal
-  dysplasia).
+  A reusable metazoan pathway that converts fructose 6-phosphate to
+  UDP-N-acetylglucosamine through glutamine-dependent amination, acetyl-CoA-
+  dependent N-acetylation, phosphomutase conversion, and UTP-dependent
+  uridylyl transfer. A GlcNAc-kinase salvage branch enters at the
+  N-acetylglucosamine 6-phosphate intermediate. The product supplies protein
+  and lipid glycosylation, proteoglycan synthesis, GPI-anchor synthesis, and
+  O-GlcNAcylation. The bacterial GlmS-GlmM-GlmU route has a different reaction
+  order and a bifunctional terminal enzyme and is outside this module boundary.
 status: DRAFT
+scope: CONCRETE
 evidence:
   - source_id: GO:0006048
     title: UDP-N-acetylglucosamine biosynthetic process
@@ -44,7 +38,7 @@ evidence:
     statement: The GlcNAc salvage kinase step (UniProtKB:Q9UJ70, GO:0045127) matches the completed human NAGK review.
 module:
   id: hexosamine_biosynthesis
-  label: Hexosamine biosynthetic pathway (UDP-GlcNAc synthesis)
+  label: Metazoan hexosamine biosynthesis and GlcNAc salvage
   module_type: METABOLIC_PATHWAY
   concepts:
     - preferred_term: UDP-N-acetylglucosamine biosynthetic process
@@ -57,13 +51,6 @@ module:
         id: GO:0006047
         label: UDP-N-acetylglucosamine metabolic process
       description: Includes the NAGK salvage of free GlcNAc into the pathway.
-  context:
-    cellular_components:
-      - preferred_term: cytosol
-        term:
-          id: GO:0005829
-          label: cytosol
-        description: All five enzymes act in the cytosol.
   parts:
     - order: 1
       role: amidotransfer (rate-limiting; Fru-6-P + Gln)
@@ -104,11 +91,6 @@ module:
               evidence:
                 - source_id: file:human/GFPT1/GFPT1-ai-review.yaml
                   statement: Rate-limiting, UDP-GlcNAc-feedback-inhibited first HBP step; GFPT1 ubiquitous (CMS12), GFPT2 tissue-restricted with weaker feedback inhibition
-            locations:
-              - preferred_term: cytosol
-                term:
-                  id: GO:0005829
-                  label: cytosol
             role_description: Aminate Fru-6-P with glutamine to GlcN-6-P (rate-limiting HBP step).
     - order: 2
       role: N-acetylation (acetyl-CoA)
@@ -145,11 +127,6 @@ module:
               evidence:
                 - source_id: file:human/GNPNAT1/GNPNAT1-ai-review.yaml
                   statement: GNAT-family acetyltransferase; second HBP step, N-acetylating GlcN-6-P to GlcNAc-6-P with acetyl-CoA; deficiency = rhizomelic skeletal dysplasia/CDG
-            locations:
-              - preferred_term: cytosol
-                term:
-                  id: GO:0005829
-                  label: cytosol
             role_description: N-acetylate GlcN-6-P to GlcNAc-6-P (acetyl-CoA).
     - order: 3
       role: phosphohexomutase (6-P <-> 1-P)
@@ -184,11 +161,6 @@ module:
               evidence:
                 - source_id: file:human/PGM3/PGM3-ai-review.yaml
                   statement: Mg2+-dependent alpha-D-phosphohexomutase converting GlcNAc-6-P to GlcNAc-1-P (third HBP step); deficiency = PGM3-CDG with immunodeficiency/skeletal dysplasia
-            locations:
-              - preferred_term: cytosol
-                term:
-                  id: GO:0005829
-                  label: cytosol
             role_description: Interconvert GlcNAc-6-P and GlcNAc-1-P (Mg2+).
     - order: 4
       role: uridylyltransfer (UTP -> UDP-GlcNAc)
@@ -225,11 +197,6 @@ module:
               evidence:
                 - source_id: file:human/UAP1/UAP1-ai-review.yaml
                   statement: Final HBP step condensing GlcNAc-1-P with UTP to the universal donor UDP-GlcNAc (also UDP-GalNAc); AGX1/AGX2 isoforms differ in GlcNAc/GalNAc-1-P preference
-            locations:
-              - preferred_term: cytosol
-                term:
-                  id: GO:0005829
-                  label: cytosol
             role_description: Condense GlcNAc-1-P + UTP to UDP-GlcNAc (final step).
     - order: 5
       role: GlcNAc salvage (recycling)
@@ -266,34 +233,33 @@ module:
               evidence:
                 - source_id: file:human/NAGK/NAGK-ai-review.yaml
                   statement: Cytosolic sugar kinase salvaging free GlcNAc to GlcNAc-6-P, re-entering the HBP at the GNPNAT1 product node; also a muramyl-dipeptide kinase (NOD2 agonist) moonlight
-            locations:
-              - preferred_term: cytosol
-                term:
-                  id: GO:0005829
-                  label: cytosol
             role_description: Phosphorylate free GlcNAc to GlcNAc-6-P (salvage into the HBP).
   connections:
     - source: gfpt_amidotransfer
       target: glcn6p_acetylation
       connection_type: PROVIDES_INPUT_FOR
-      description: The GlcN-6-P made by GFPT1/2 is N-acetylated by GNPNAT1.
+      chaining_status: VERIFIED
+      chaining_note: The GlcN-6-P made by GFPT1/2 is N-acetylated by GNPNAT1.
     - source: glcn6p_acetylation
       target: glcnac_mutase
       connection_type: PROVIDES_INPUT_FOR
-      description: The GlcNAc-6-P made by GNPNAT1 is converted to GlcNAc-1-P by PGM3.
+      chaining_status: VERIFIED
+      chaining_note: The GlcNAc-6-P made by GNPNAT1 is converted to GlcNAc-1-P by PGM3.
     - source: glcnac_mutase
       target: udp_glcnac_synthesis
       connection_type: PROVIDES_INPUT_FOR
-      description: The GlcNAc-1-P made by PGM3 is the substrate for UAP1.
+      chaining_status: VERIFIED
+      chaining_note: The GlcNAc-1-P made by PGM3 is the substrate for UAP1.
     - source: glcnac_salvage
       target: glcnac_mutase
       connection_type: PROVIDES_INPUT_FOR
-      description: >-
+      chaining_status: VERIFIED
+      chaining_note: >-
         NAGK feeds salvaged GlcNAc-6-P into the pathway at the PGM3 step (the same node GNPNAT1 produces),
         recycling free GlcNAc from glycoconjugate degradation into UDP-GlcNAc.
   notes: >-
-    Hexosamine biosynthetic pathway / UDP-GlcNAc synthesis (GO:0006048 + GO:0006047), grounded to six
-    completed human gene reviews, all cytosolic. Linear route: GFPT1 (Q06210, rate-limiting, feedback-
+    Metazoan hexosamine biosynthesis / UDP-GlcNAc synthesis (GO:0006048 + GO:0006047), grounded to six
+    completed human gene reviews. Linear route: GFPT1 (Q06210, rate-limiting, feedback-
     inhibited) + tissue-restricted paralog GFPT2 (O94808) share PTHR10937, GO:0004360 (Fru-6-P + Gln ->
     GlcN-6-P) -> GNPNAT1 (Q96EK6 PTHR13355, GO:0004343 acetyl-CoA acetylation -> GlcNAc-6-P) -> PGM3 (O95394
     PTHR45955, GO:0004610 Mg-mutase -> GlcNAc-1-P) -> UAP1 (Q16222 PTHR11952, GO:0003977 + UTP -> UDP-GlcNAc).
@@ -303,4 +269,12 @@ module:
     is UDP-GlcNAc-feedback-inhibited, making the pathway a nutrient/flux sensor. Notable moonlighting captured
     in the gene reviews (kept non-core here): UAP1 protein-serine pyrophosphorylase (IRF3, type-I-IFN) and
     NAGK muramyl-dipeptide kinase (NOD2). GO term ids/labels verified against the local go.db. Disorders:
-    GFPT1 CMS12, GNPNAT1 rhizomelic skeletal dysplasia, PGM3-CDG.
+    GFPT1 CMS12, GNPNAT1 rhizomelic skeletal dysplasia, PGM3-CDG. This document
+    deliberately excludes the differently ordered bacterial GlmS-GlmM-GlmU route.
+  knowledge_gaps:
+    - gap_statement: The bacterial route to UDP-GlcNAc is not represented by this metazoan implementation.
+      boundary: >-
+        Model bacterial GlmS, GlmM, and bifunctional GlmU as a separate pathway
+        realization rather than treating GlmU as an ortholog of GNPNAT1 or UAP1.
+      gap_kind:
+        - CURATION


### PR DESCRIPTION
## Summary
- Expands hexosamine biosynthesis into a five-step pathway with explicit reusable reaction roles.
- Reworks the existing module into a reusable multi-part biological model.
- Keeps molecular functions on leaf annotons and removes species-specific or redundant module-level structure.

## Why
This is a consistency correction identified while applying the module-curation rules across the P. putida pathway pass.

## Validation
- Module schema validation passed.
- Module semantic validation passed.
- The affected module rendered successfully.
- git diff --check passed against current main.