### PR TITLE
Refine mammalian GABA shunt module

### DIFF
--- a/modules/gaba_shunt.yaml
+++ b/modules/gaba_shunt.yaml
@@ -1,23 +1,15 @@
 id: MODULE:gaba_shunt
-title: GABA shunt (glutamate -> GABA -> succinate); GAD1 / GABA-transaminase / SSADH deficiencies
+title: Mammalian GABA synthesis and shunt catabolism
 description: >-
-  The GABA shunt is the pathway that synthesises and degrades the major inhibitory
-  neurotransmitter gamma-aminobutyric acid (GABA), routing glutamate carbon around the
-  alpha-ketoglutarate-to-succinate segment of the TCA cycle. Glutamate decarboxylase
-  (GAD1/GAD67, with the synaptic GAD2/GAD65 paralog) uses pyridoxal-5'-phosphate to
-  decarboxylate L-glutamate to GABA + CO2 in the cytosol. GABA is then catabolised in the
-  mitochondrial matrix: 4-aminobutyrate aminotransferase (ABAT, GABA transaminase) uses
-  PLP to transfer GABA's amino group to 2-oxoglutarate, forming succinate semialdehyde +
-  L-glutamate; and succinate-semialdehyde dehydrogenase (ALDH5A1, SSADH) oxidises
-  succinate semialdehyde with NAD+ to succinate, which enters the TCA cycle. The shunt
-  thus both produces the inhibitory transmitter and feeds its carbon skeleton into
-  central energy metabolism (regenerating glutamate for another cycle). Inherited defects
-  cause distinct neurological disorders: GAD1 mutations cause spastic paraplegia / cerebral
-  palsy / developmental epileptic encephalopathy; ABAT deficiency causes GABA-transaminase
-  deficiency (severe neonatal epileptic encephalopathy with elevated GABA); and ALDH5A1
-  deficiency causes succinic semialdehyde dehydrogenase deficiency (4-hydroxybutyric /
-  gamma-hydroxybutyric aciduria).
+  A reusable mammalian pathway in which pyridoxal-phosphate-dependent glutamate
+  decarboxylase produces gamma-aminobutyrate (GABA), mitochondrial GABA
+  transaminase converts it to succinate semialdehyde, and succinate-semialdehyde
+  dehydrogenase oxidizes that intermediate to succinate. The pathway couples
+  neurotransmitter metabolism to the tricarboxylic-acid cycle while bypassing
+  the 2-oxoglutarate-to-succinate segment. Cytosolic GABA synthesis and
+  mitochondrial catabolism are distinct leaf-localized steps.
 status: DRAFT
+scope: CONCRETE
 evidence:
   - source_id: GO:0006540
     title: GABA shunt
@@ -46,7 +38,7 @@ evidence:
       the completed human ALDH5A1 review.
 module:
   id: gaba_shunt
-  label: GABA shunt (glutamate -> GABA -> succinate)
+  label: Mammalian GABA synthesis and shunt catabolism
   module_type: METABOLIC_PATHWAY
   concepts:
     - preferred_term: GABA shunt
@@ -56,14 +48,6 @@ module:
       description: >-
         Synthesis of GABA from glutamate and its catabolism to succinate, bypassing part
         of the TCA cycle.
-  context:
-    cellular_components:
-      - preferred_term: mitochondrial matrix
-        term:
-          id: GO:0005759
-          label: mitochondrial matrix
-        description: >-
-          GABA catabolism (ABAT, ALDH5A1) is mitochondrial; GABA synthesis (GAD1) is cytosolic.
   parts:
     - order: 1
       role: GABA synthesis (glutamate decarboxylation)
@@ -211,15 +195,17 @@ module:
     - source: gad_step
       target: abat_step
       connection_type: PROVIDES_INPUT_FOR
-      description: >-
+      chaining_status: VERIFIED
+      chaining_note: >-
         The GABA made by glutamate decarboxylase is transaminated by ABAT (after transport
         into the mitochondrial matrix).
     - source: abat_step
       target: aldh5a1_step
       connection_type: PROVIDES_INPUT_FOR
-      description: The succinate semialdehyde from ABAT is oxidised to succinate by ALDH5A1.
+      chaining_status: VERIFIED
+      chaining_note: The succinate semialdehyde from ABAT is oxidised to succinate by ALDH5A1.
   notes: >-
-    The GABA shunt grounded to the human enzymes glutamate decarboxylase GAD1 (UniProtKB:Q99259,
+    The mammalian GABA shunt is grounded to the human enzymes glutamate decarboxylase GAD1 (UniProtKB:Q99259,
     GO:0004351, EC 4.1.1.15), 4-aminobutyrate aminotransferase ABAT (P80404, GO:0034386, EC
     2.6.1.19) and succinate-semialdehyde dehydrogenase ALDH5A1 (P51649, GO:0004777, EC 1.2.1.24).
     GO molecular-function terms were taken from the human GOA records; Reactome reaction ids and
@@ -234,3 +220,10 @@ module:
     GABA-transaminase deficiency; ALDH5A1 -> succinic semialdehyde dehydrogenase deficiency
     (GHB/4-hydroxybutyric aciduria). ABAT's secondary beta-amino-acid transaminase activity links
     to pyrimidine (thymine) catabolism.
+  knowledge_gaps:
+    - gap_statement: The mitochondrial GABA-import step is not represented by a confidently assigned participant in this module.
+      boundary: >-
+        The chemical handoff from GAD-produced GABA to matrix ABAT is retained,
+        but a transporter should not be asserted without direct molecular evidence.
+      gap_kind:
+        - BIOLOGY

--- a/modules/gaba_shunt.yaml
+++ b/modules/gaba_shunt.yaml
@@ -1,13 +1,15 @@
 id: MODULE:gaba_shunt
-title: Mammalian GABA synthesis and shunt catabolism
+title: Mammalian GABA shunt (glutamate to GABA to succinate)
 description: >-
-  A reusable mammalian pathway in which pyridoxal-phosphate-dependent glutamate
-  decarboxylase produces gamma-aminobutyrate (GABA), mitochondrial GABA
-  transaminase converts it to succinate semialdehyde, and succinate-semialdehyde
-  dehydrogenase oxidizes that intermediate to succinate. The pathway couples
-  neurotransmitter metabolism to the tricarboxylic-acid cycle while bypassing
-  the 2-oxoglutarate-to-succinate segment. Cytosolic GABA synthesis and
-  mitochondrial catabolism are distinct leaf-localized steps.
+  The mammalian GABA shunt couples cytosolic neurotransmitter synthesis to
+  mitochondrial catabolism. PLP-dependent GAD1/2 decarboxylate L-glutamate to
+  GABA and carbon dioxide in the cytosol. After GABA enters the mitochondrial
+  matrix, PLP-dependent ABAT transfers its amino group to 2-oxoglutarate,
+  producing succinate semialdehyde and regenerating L-glutamate; ALDH5A1 then
+  uses NAD+ to oxidize the semialdehyde to succinate and NADH. The shunt feeds
+  the TCA cycle while bypassing its 2-oxoglutarate-to-succinate segment. GAD1,
+  ABAT, and ALDH5A1 deficiencies cause inherited neurological or metabolic
+  disorders, including GABA-transaminase and succinate-semialdehyde-dehydrogenase deficiencies.
 status: DRAFT
 scope: CONCRETE
 evidence:
@@ -38,7 +40,7 @@ evidence:
       the completed human ALDH5A1 review.
 module:
   id: gaba_shunt
-  label: Mammalian GABA synthesis and shunt catabolism
+  label: Mammalian GABA shunt (glutamate to GABA to succinate)
   module_type: METABOLIC_PATHWAY
   concepts:
     - preferred_term: GABA shunt
@@ -219,7 +221,11 @@ module:
     succinate segment. Disorders: GAD1 -> spastic paraplegia / cerebral palsy / DEE; ABAT ->
     GABA-transaminase deficiency; ALDH5A1 -> succinic semialdehyde dehydrogenase deficiency
     (GHB/4-hydroxybutyric aciduria). ABAT's secondary beta-amino-acid transaminase activity links
-    to pyrimidine (thymine) catabolism.
+    to pyrimidine (thymine) catabolism. This concrete mammalian realization
+    should not be broadened to cover the P. putida GabT/GabD pathway; bacterial
+    GABA transport, regulation, and enzyme implementations belong in a separate
+    bacterial module, with a future abstract GABA-shunt motif available to link
+    the two realizations through `conforms_to`.
   knowledge_gaps:
     - gap_statement: The mitochondrial GABA-import step is not represented by a confidently assigned participant in this module.
       boundary: >-
@@ -227,3 +233,12 @@ module:
         but a transporter should not be asserted without direct molecular evidence.
       gap_kind:
         - BIOLOGY
+      dark_aspect: RESIDUAL_SUBGAP
+      status: OPEN
+      significance: >-
+        GABA must cross the mitochondrial inner membrane to connect cytosolic
+        synthesis to matrix ABAT, so identifying the carrier is necessary to
+        explain control and tissue variation of mammalian GABA-shunt flux.
+      resolution: >-
+        Identify the inner-membrane carrier by mitochondrial transport assays,
+        loss-of-function genetics, and rescue with a molecularly defined transporter.


### PR DESCRIPTION
## Summary
- Refines the existing three-reaction module as a concrete mammalian GABA shunt; no new reaction or transport part is added.
- Removes the incorrect module-wide mitochondrial-matrix context while retaining cytosolic GAD and matrix ABAT/ALDH5A1 locations on their leaf activities.
- Keeps the two chemically continuous handoffs explicitly verified and records the unidentified mitochondrial GABA importer as a biological knowledge gap.
- Restores a standalone biological description, the canonical GABA-shunt title, and complete knowledge-gap metadata.

## Why
The prior module-wide compartment implied that GABA synthesis and catabolism occur together in the matrix. Mammalian GABA synthesis is cytosolic, whereas the catabolic arm is mitochondrial, and the inner-membrane importer connecting them is not confidently identified. The concrete mammalian realization remains separate from the P. putida GabT/GabD pathway.

## Validation
- Module schema validation passed.
- Module semantic validation passed with zero warnings.
- The affected module rendered successfully.
- `git diff --check` passed.