### PR TITLE
Expand mammalian proline metabolism module

### DIFF
--- a/modules/proline_metabolism.yaml
+++ b/modules/proline_metabolism.yaml
@@ -1,14 +1,15 @@
 id: MODULE:proline_metabolism
 title: Mammalian proline-P5C biosynthesis and catabolism
 description: >-
-  A reusable mammalian pathway that interconverts L-glutamate, L-ornithine,
-  delta-1-pyrroline-5-carboxylate (P5C), and L-proline. Bifunctional P5C
-  synthase first phosphorylates and then reduces glutamate to glutamate
-  5-semialdehyde/P5C; ornithine aminotransferase provides a parallel entry into
-  the same intermediate pool. Pyrroline-5-carboxylate reductases produce
+  Mammalian proline metabolism interconverts L-glutamate, L-ornithine,
+  delta-1-pyrroline-5-carboxylate (P5C), and L-proline in mitochondria.
+  Bifunctional P5C synthase first phosphorylates and then reduces glutamate to
+  glutamate 5-semialdehyde/P5C. Ornithine aminotransferase reversibly connects
+  the same intermediate pool to ornithine, supporting either proline synthesis
+  or arginine/ornithine degradation. Pyrroline-5-carboxylate reductases produce
   proline, whereas proline dehydrogenase and P5C dehydrogenase return proline
-  carbon to glutamate. This document models the mammalian enzyme architecture;
-  bacterial ProB-ProA and fused PutA realizations are separate variants.
+  carbon to glutamate. ALDH4A1 also provides a shared downstream oxidation step
+  in trans-4-hydroxy-L-proline degradation.
 status: DRAFT
 scope: CONCRETE
 evidence:
@@ -18,6 +19,12 @@ evidence:
   - source_id: GO:0006562
     title: L-proline catabolic process
     statement: The PRODH and ALDH4A1 reactions provide the mammalian catabolic arm.
+  - source_id: GO:0006527
+    title: L-arginine catabolic process
+    statement: OAT can route ornithine-derived carbon through P5C toward glutamate during arginine and ornithine degradation.
+  - source_id: GO:0019470
+    title: trans-4-hydroxy-L-proline catabolic process
+    statement: ALDH4A1 provides a downstream glutamate-forming step shared with trans-4-hydroxy-L-proline degradation.
   - source_id: file:human/ALDH18A1/ALDH18A1-ai-review.yaml
     title: ALDH18A1 gene review (human)
     statement: The review independently supports glutamate 5-kinase and glutamate-5-semialdehyde dehydrogenase activities for bifunctional P5C synthase.
@@ -40,10 +47,17 @@ notes: >-
   This revision exposes each chemical transformation as its own part. ALDH18A1
   therefore appears in two consecutive leaves because its kinase and reductase
   domains perform distinct reactions. PYCR1 and PYCR2 are representatives of
-  one family-level terminal reduction role rather than duplicate steps. OAT is
-  a parallel source of the shared P5C/glutamate-5-semialdehyde pool. Disease and
-  signaling consequences remain in the gene reviews and are outside the core
-  reaction chain.
+  one family-level terminal reduction role rather than duplicate steps. The
+  shared PYCR location is conservatively mitochondrial: matrix localization is
+  directly curated for PYCR1, whereas PYCR2 is curated only to mitochondrion.
+  OAT is reversible and can route the shared P5C/glutamate-5-semialdehyde pool
+  toward either proline or glutamate. GO:0010133, the former proline-to-glutamate
+  catabolism term, is obsolete, so GO:0006562 is used. OAT and PRODH cofactors
+  are retained explicitly as pyridoxal 5'-phosphate (the chemistry underlying
+  GO:0030170) and FAD (the chemistry underlying GO:0071949), respectively.
+  Bacterial ProB-ProA and fused PutA architectures require separate concrete
+  modules. Disease and signaling consequences remain outside this reaction
+  chain.
 module:
   id: proline_metabolism
   label: Mammalian proline-P5C biosynthesis and catabolism
@@ -59,6 +73,13 @@ module:
         id: GO:0006562
         label: L-proline catabolic process
       description: L-proline is oxidized through P5C/glutamate 5-semialdehyde to L-glutamate.
+  context:
+    taxa:
+      - preferred_term: Mammalia
+        term:
+          id: NCBITaxon:40674
+          label: Mammalia
+        description: This concrete module represents the mammalian enzyme architecture.
   parts:
     - order: 1
       role: ATP-dependent activation of glutamate
@@ -77,9 +98,9 @@ module:
                   id: GO:0004349
                   label: glutamate 5-kinase activity
               family:
-                preferred_term: metazoan P5C synthase family
+                preferred_term: delta-1-pyrroline-5-carboxylate synthase subfamily
                 term:
-                  id: PANTHER:PTHR11063
+                  id: PANTHER:PTHR11063:SF8
                   label: DELTA-1-PYRROLINE-5-CARBOXYLATE SYNTHASE
                 representative_members:
                   - preferred_term: human ALDH18A1
@@ -94,13 +115,27 @@ module:
                 label: glutamate 5-kinase activity
               substrates:
                 - preferred_term: L-glutamate
+                  term:
+                    id: CHEBI:29985
+                    label: L-glutamate
                 - preferred_term: ATP
+                  term:
+                    id: CHEBI:30616
+                    label: ATP
               products:
-                - preferred_term: L-glutamate 5-phosphate
+                - preferred_term: L-glutamyl 5-phosphate
+                  term:
+                    id: CHEBI:58274
+                    label: L-glutamyl 5-phosphate
                 - preferred_term: ADP
+                  term:
+                    id: CHEBI:456216
+                    label: ADP
               evidence:
                 - source_id: file:human/ALDH18A1/ALDH18A1-ai-review.yaml
                   statement: The curated review accepts GO:0004349 as one of ALDH18A1's two core catalytic activities.
+                - source_id: RHEA:14877
+                  statement: RHEA:14877 defines the balanced L-glutamate and ATP to L-glutamyl 5-phosphate and ADP reaction.
             processes:
               - preferred_term: L-proline biosynthetic process
                 term:
@@ -129,9 +164,9 @@ module:
                   id: GO:0004350
                   label: glutamate-5-semialdehyde dehydrogenase activity
               family:
-                preferred_term: metazoan P5C synthase family
+                preferred_term: delta-1-pyrroline-5-carboxylate synthase subfamily
                 term:
-                  id: PANTHER:PTHR11063
+                  id: PANTHER:PTHR11063:SF8
                   label: DELTA-1-PYRROLINE-5-CARBOXYLATE SYNTHASE
                 representative_members:
                   - preferred_term: human ALDH18A1
@@ -145,15 +180,36 @@ module:
                 id: GO:0004350
                 label: glutamate-5-semialdehyde dehydrogenase activity
               substrates:
-                - preferred_term: L-glutamate 5-phosphate
+                - preferred_term: L-glutamyl 5-phosphate
+                  term:
+                    id: CHEBI:58274
+                    label: L-glutamyl 5-phosphate
                 - preferred_term: NADPH
+                  term:
+                    id: CHEBI:57783
+                    label: NADPH
+                - preferred_term: hydron
+                  term:
+                    id: CHEBI:15378
+                    label: hydron
               products:
                 - preferred_term: L-glutamate 5-semialdehyde
+                  term:
+                    id: CHEBI:58066
+                    label: L-glutamate 5-semialdehyde
                 - preferred_term: NADP+
+                  term:
+                    id: CHEBI:58349
+                    label: NADP(+)
                 - preferred_term: phosphate
+                  term:
+                    id: CHEBI:43474
+                    label: phosphate
               evidence:
                 - source_id: file:human/ALDH18A1/ALDH18A1-ai-review.yaml
                   statement: The curated review accepts GO:0004350 as the second core catalytic activity of ALDH18A1.
+                - source_id: RHEA:19541
+                  statement: RHEA:19541 defines the balanced reversible reaction, represented here in its physiological biosynthetic direction.
             processes:
               - preferred_term: L-proline biosynthetic process
                 term:
@@ -199,24 +255,47 @@ module:
                 label: L-ornithine transaminase activity
               substrates:
                 - preferred_term: L-ornithine
+                  term:
+                    id: CHEBI:46911
+                    label: L-ornithine
                 - preferred_term: 2-oxoglutarate
+                  term:
+                    id: CHEBI:16810
+                    label: 2-oxoglutarate
               products:
                 - preferred_term: L-glutamate 5-semialdehyde
+                  term:
+                    id: CHEBI:58066
+                    label: L-glutamate 5-semialdehyde
                 - preferred_term: L-glutamate
+                  term:
+                    id: CHEBI:29985
+                    label: L-glutamate
+              cofactors:
+                - preferred_term: pyridoxal 5'-phosphate
+                  term:
+                    id: CHEBI:597326
+                    label: pyridoxal 5'-phosphate
               evidence:
                 - source_id: file:human/OAT/OAT-ai-review.yaml
                   statement: The curated review accepts the PLP-dependent ornithine transaminase activity that supplies the P5C pool.
+                - source_id: RHEA:25160
+                  statement: RHEA:25160 defines the reversible ornithine and 2-oxoglutarate transamination reaction.
             processes:
               - preferred_term: L-proline biosynthetic process
                 term:
                   id: GO:0055129
                   label: L-proline biosynthetic process
+              - preferred_term: L-arginine catabolic process
+                term:
+                  id: GO:0006527
+                  label: L-arginine catabolic process
             locations:
               - preferred_term: mitochondrial matrix
                 term:
                   id: GO:0005759
                   label: mitochondrial matrix
-            role_description: Links ornithine metabolism to proline synthesis through the shared semialdehyde/P5C intermediate.
+            role_description: Reversibly links ornithine metabolism to the shared semialdehyde/P5C pool, supporting proline synthesis or ornithine degradation to glutamate.
     - order: 3
       role: reduction of P5C to L-proline
       node:
@@ -256,26 +335,41 @@ module:
                 label: pyrroline-5-carboxylate reductase activity
               substrates:
                 - preferred_term: (S)-1-pyrroline-5-carboxylate
+                  term:
+                    id: CHEBI:17388
+                    label: (S)-1-pyrroline-5-carboxylate
                 - preferred_term: NAD(P)H
+                - preferred_term: hydron
+                  term:
+                    id: CHEBI:15378
+                    label: hydron
+                  description: Two hydrons are consumed in either cofactor-specific reaction.
               products:
                 - preferred_term: L-proline
+                  term:
+                    id: CHEBI:60039
+                    label: L-proline
                 - preferred_term: NAD(P)+
               evidence:
                 - source_id: file:human/PYCR1/PYCR1-ai-review.yaml
                   statement: The curated review supports the terminal P5C-to-proline reduction by PYCR1.
                 - source_id: file:human/PYCR2/PYCR2-ai-review.yaml
                   statement: The curated review supports the same terminal reduction by the PYCR2 paralog.
+                - source_id: RHEA:14107
+                  statement: RHEA:14107 defines the physiological NADH-dependent P5C-to-proline reaction.
+                - source_id: RHEA:14111
+                  statement: RHEA:14111 defines the alternative physiological NADPH-dependent P5C-to-proline reaction.
             processes:
               - preferred_term: L-proline biosynthetic process
                 term:
                   id: GO:0055129
                   label: L-proline biosynthetic process
             locations:
-              - preferred_term: mitochondrial matrix
+              - preferred_term: mitochondrion
                 term:
-                  id: GO:0005759
-                  label: mitochondrial matrix
-            role_description: Reduces the shared P5C intermediate to L-proline; PYCR1 and PYCR2 provide paralogous implementations.
+                  id: GO:0005739
+                  label: mitochondrion
+            role_description: Reduces the shared P5C intermediate to L-proline; PYCR1 has direct matrix support, while the merged PYCR2 exemplar is conservatively localized only to mitochondrion.
     - order: 4
       role: FAD-dependent oxidation of L-proline
       node:
@@ -310,13 +404,36 @@ module:
                 label: proline dehydrogenase activity
               substrates:
                 - preferred_term: L-proline
-                - preferred_term: ubiquinone
+                  term:
+                    id: CHEBI:60039
+                    label: L-proline
+                - preferred_term: a quinone
+                  term:
+                    id: CHEBI:132124
+                    label: a quinone
               products:
                 - preferred_term: (S)-1-pyrroline-5-carboxylate
-                - preferred_term: ubiquinol
+                  term:
+                    id: CHEBI:17388
+                    label: (S)-1-pyrroline-5-carboxylate
+                - preferred_term: a quinol
+                  term:
+                    id: CHEBI:24646
+                    label: a quinol
+                - preferred_term: hydron
+                  term:
+                    id: CHEBI:15378
+                    label: hydron
+              cofactors:
+                - preferred_term: FAD
+                  term:
+                    id: CHEBI:57692
+                    label: FAD
               evidence:
                 - source_id: file:human/PRODH/PRODH-ai-review.yaml
                   statement: The curated review supports FAD-dependent oxidation of L-proline to P5C with electron transfer to the respiratory chain.
+                - source_id: RHEA:23784
+                  statement: RHEA:23784 defines the balanced L-proline and quinone oxidation reaction.
             processes:
               - preferred_term: L-proline catabolic process
                 term:
@@ -362,19 +479,45 @@ module:
                 label: L-glutamate gamma-semialdehyde dehydrogenase activity
               substrates:
                 - preferred_term: L-glutamate 5-semialdehyde
+                  term:
+                    id: CHEBI:58066
+                    label: L-glutamate 5-semialdehyde
                 - preferred_term: NAD+
+                  term:
+                    id: CHEBI:57540
+                    label: NAD(+)
                 - preferred_term: water
+                  term:
+                    id: CHEBI:15377
+                    label: water
               products:
                 - preferred_term: L-glutamate
+                  term:
+                    id: CHEBI:29985
+                    label: L-glutamate
                 - preferred_term: NADH
+                  term:
+                    id: CHEBI:57945
+                    label: NADH
+                - preferred_term: hydron
+                  term:
+                    id: CHEBI:15378
+                    label: hydron
+                  description: Two hydrons are produced per reaction.
               evidence:
                 - source_id: file:human/ALDH4A1/ALDH4A1-ai-review.yaml
                   statement: The curated review supports oxidation of glutamate 5-semialdehyde to L-glutamate as the catabolic exit.
+                - source_id: RHEA:30235
+                  statement: RHEA:30235 defines the balanced NAD-dependent oxidation to L-glutamate, NADH, and two hydrons.
             processes:
               - preferred_term: L-proline catabolic process
                 term:
                   id: GO:0006562
                   label: L-proline catabolic process
+              - preferred_term: trans-4-hydroxy-L-proline catabolic process
+                term:
+                  id: GO:0019470
+                  label: trans-4-hydroxy-L-proline catabolic process
             locations:
               - preferred_term: mitochondrial matrix
                 term:
@@ -397,11 +540,16 @@ module:
       connection_type: PROVIDES_INPUT_FOR
       chaining_status: VERIFIED
       chaining_note: OAT supplies the same glutamate-5-semialdehyde/P5C pool used by PYCR.
-    - source: pycr_proline_formation
-      target: prodh_p5c_formation
+    - source: oat_p5c_supply
+      target: aldh4a1_glutamate_formation
       connection_type: PROVIDES_INPUT_FOR
       chaining_status: VERIFIED
-      chaining_note: L-proline produced by PYCR is the substrate for PRODH in the opposing arm of the proline cycle.
+      chaining_note: In the ornithine-degradative direction, OAT supplies glutamate 5-semialdehyde/P5C for ALDH4A1 oxidation to glutamate.
+    - source: pycr_proline_formation
+      target: prodh_p5c_formation
+      connection_type: PRECEDES
+      chaining_status: NOT_APPLICABLE
+      chaining_note: This edge denotes conceptual cycle re-entry, not simultaneous flux; PYCR biosynthesis and PRODH catabolism are opposing, reciprocally controlled arms.
     - source: prodh_p5c_formation
       target: aldh4a1_glutamate_formation
       connection_type: PROVIDES_INPUT_FOR

--- a/modules/proline_metabolism.yaml
+++ b/modules/proline_metabolism.yaml
@@ -1,99 +1,92 @@
 id: MODULE:proline_metabolism
-title: Proline biosynthesis and catabolism (proline/glutamate/ornithine–P5C cycle); ALDH18A1/PYCR1/PYCR2/PRODH/ALDH4A1/OAT
+title: Mammalian proline-P5C biosynthesis and catabolism
 description: >-
-  Proline metabolism interconverts L-proline, L-glutamate and L-ornithine through the shared,
-  reactive intermediate delta-1-pyrroline-5-carboxylate (P5C, in equilibrium with L-glutamate
-  5-semialdehyde), forming a metabolic hub that connects amino-acid, urea-cycle and redox pathways.
-  In the biosynthetic direction, the bifunctional mitochondrial enzyme ALDH18A1 (P5C synthase, P5CS)
-  phosphorylates L-glutamate (glutamate 5-kinase) and reduces it (glutamate-5-semialdehyde
-  dehydrogenase) to glutamate-5-semialdehyde/P5C; alternatively, ornithine aminotransferase (OAT)
-  transaminates L-ornithine with 2-oxoglutarate to yield the same semialdehyde plus glutamate,
-  linking the urea cycle. P5C is then reduced to L-proline by pyrroline-5-carboxylate reductase
-  (PYCR1 and PYCR2). In the catabolic direction, the FAD-dependent inner-membrane proline
-  dehydrogenase PRODH (proline oxidase) oxidises L-proline back to P5C, donating electrons to the
-  respiratory chain, and the NAD-dependent P5C dehydrogenase ALDH4A1 (P5CDH) oxidises
-  glutamate-5-semialdehyde to L-glutamate, completing catabolism. Because PRODH and PYCR run
-  opposing reactions on the shared P5C pool, they constitute the "proline cycle" that shuttles
-  redox equivalents between cytosol and mitochondria and modulates ROS and p53-linked apoptosis.
-  Inherited defects span the pathway: ALDH18A1 and PYCR1 — cutis laxa with progeroid features and
-  neurodevelopmental disease; PYCR2 — hypomyelinating leukodystrophy; PRODH — hyperprolinemia type I
-  (a schizophrenia-susceptibility locus at 22q11); ALDH4A1 — hyperprolinemia type II; OAT — gyrate
-  atrophy of the choroid and retina with hyperornithinemia.
+  A reusable mammalian pathway that interconverts L-glutamate, L-ornithine,
+  delta-1-pyrroline-5-carboxylate (P5C), and L-proline. Bifunctional P5C
+  synthase first phosphorylates and then reduces glutamate to glutamate
+  5-semialdehyde/P5C; ornithine aminotransferase provides a parallel entry into
+  the same intermediate pool. Pyrroline-5-carboxylate reductases produce
+  proline, whereas proline dehydrogenase and P5C dehydrogenase return proline
+  carbon to glutamate. This document models the mammalian enzyme architecture;
+  bacterial ProB-ProA and fused PutA realizations are separate variants.
 status: DRAFT
+scope: CONCRETE
 evidence:
   - source_id: GO:0055129
     title: L-proline biosynthetic process
-    statement: The biosynthetic arm (ALDH18A1, OAT, PYCR1/PYCR2) mediates L-proline biosynthesis (GO:0055129).
+    statement: The ALDH18A1/OAT and PYCR reactions provide the mammalian biosynthetic arm.
   - source_id: GO:0006562
     title: L-proline catabolic process
-    statement: The catabolic arm (PRODH, ALDH4A1) mediates L-proline catabolism (GO:0006562).
+    statement: The PRODH and ALDH4A1 reactions provide the mammalian catabolic arm.
   - source_id: file:human/ALDH18A1/ALDH18A1-ai-review.yaml
     title: ALDH18A1 gene review (human)
-    statement: The glutamate->P5C biosynthetic step (UniProtKB:P54886, GO:0004349/GO:0004350) matches the completed human ALDH18A1 review.
+    statement: The review independently supports glutamate 5-kinase and glutamate-5-semialdehyde dehydrogenase activities for bifunctional P5C synthase.
   - source_id: file:human/OAT/OAT-ai-review.yaml
     title: OAT gene review (human)
-    statement: The ornithine->P5C transamination step (UniProtKB:P04181, GO:0004587) matches the completed human OAT review.
+    statement: The review supports ornithine transamination into the glutamate-5-semialdehyde/P5C pool.
   - source_id: file:human/PYCR1/PYCR1-ai-review.yaml
     title: PYCR1 gene review (human)
-    statement: The P5C->proline reduction step (UniProtKB:P32322, GO:0004735) matches the completed human PYCR1 review.
+    statement: The review supports reduction of P5C to L-proline by PYCR1.
   - source_id: file:human/PYCR2/PYCR2-ai-review.yaml
     title: PYCR2 gene review (human)
-    statement: The P5C->proline reduction step (UniProtKB:Q96C36, GO:0004735) matches the completed human PYCR2 review.
+    statement: The review supports reduction of P5C to L-proline by the PYCR2 paralog.
   - source_id: file:human/PRODH/PRODH-ai-review.yaml
     title: PRODH gene review (human)
-    statement: The proline->P5C oxidation step (UniProtKB:O43272, GO:0004657) matches the completed human PRODH review.
+    statement: The review supports FAD-dependent oxidation of L-proline to P5C at the mitochondrial inner membrane.
   - source_id: file:human/ALDH4A1/ALDH4A1-ai-review.yaml
     title: ALDH4A1 gene review (human)
-    statement: The P5C->glutamate oxidation step (UniProtKB:P30038, GO:0003842) matches the completed human ALDH4A1 review.
+    statement: The review supports NAD-dependent oxidation of glutamate 5-semialdehyde to L-glutamate.
+notes: >-
+  This revision exposes each chemical transformation as its own part. ALDH18A1
+  therefore appears in two consecutive leaves because its kinase and reductase
+  domains perform distinct reactions. PYCR1 and PYCR2 are representatives of
+  one family-level terminal reduction role rather than duplicate steps. OAT is
+  a parallel source of the shared P5C/glutamate-5-semialdehyde pool. Disease and
+  signaling consequences remain in the gene reviews and are outside the core
+  reaction chain.
 module:
   id: proline_metabolism
-  label: Proline biosynthesis and catabolism (proline/P5C cycle)
+  label: Mammalian proline-P5C biosynthesis and catabolism
   module_type: METABOLIC_PATHWAY
   concepts:
     - preferred_term: L-proline biosynthetic process
       term:
         id: GO:0055129
         label: L-proline biosynthetic process
-      description: Glutamate/ornithine -> P5C -> proline.
+      description: Glutamate or ornithine is routed through P5C to L-proline.
     - preferred_term: L-proline catabolic process
       term:
         id: GO:0006562
         label: L-proline catabolic process
-      description: Proline -> P5C -> glutamate.
-  context:
-    cellular_components:
-      - preferred_term: mitochondrial matrix
-        term:
-          id: GO:0005759
-          label: mitochondrial matrix
-        description: Most enzymes of the pathway are matrix enzymes.
-      - preferred_term: mitochondrial inner membrane
-        term:
-          id: GO:0005743
-          label: mitochondrial inner membrane
-        description: The FAD-dependent PRODH is bound to the inner membrane (electrons to the respiratory chain).
+      description: L-proline is oxidized through P5C/glutamate 5-semialdehyde to L-glutamate.
   parts:
     - order: 1
-      role: proline biosynthesis (glutamate/ornithine -> P5C -> proline)
+      role: ATP-dependent activation of glutamate
       node:
-        id: proline_biosynthesis
-        label: Proline biosynthesis (ALDH18A1, OAT, PYCR1, PYCR2)
+        id: aldh18a1_glutamate_phosphorylation
+        label: ALDH18A1 glutamate 5-kinase reaction
         module_type: REACTION
         annotons:
-          - id: aldh18a1_activity
-            label: "ALDH18A1 (P5CS): glutamate -> P5C (bifunctional)"
+          - id: aldh18a1_kinase_activity
+            label: ALDH18A1 glutamate 5-kinase
             participant:
               selector_type: FAMILY
+              required_function:
+                preferred_term: glutamate 5-kinase activity
+                term:
+                  id: GO:0004349
+                  label: glutamate 5-kinase activity
               family:
-                preferred_term: ALDH18A1 / delta-1-pyrroline-5-carboxylate synthase family
+                preferred_term: metazoan P5C synthase family
                 term:
                   id: PANTHER:PTHR11063
                   label: DELTA-1-PYRROLINE-5-CARBOXYLATE SYNTHASE
                 representative_members:
-                  - preferred_term: ALDH18A1 (human)
+                  - preferred_term: human ALDH18A1
                     term:
                       id: UniProtKB:P54886
                       label: Delta-1-pyrroline-5-carboxylate synthase
+                    description: Reviewed bifunctional mammalian P5C synthase exemplar.
             function:
               preferred_term: glutamate 5-kinase activity
               term:
@@ -102,32 +95,103 @@ module:
               substrates:
                 - preferred_term: L-glutamate
                 - preferred_term: ATP
-                - preferred_term: NADPH
               products:
-                - preferred_term: L-glutamate 5-semialdehyde (-> P5C)
+                - preferred_term: L-glutamate 5-phosphate
+                - preferred_term: ADP
               evidence:
                 - source_id: file:human/ALDH18A1/ALDH18A1-ai-review.yaml
-                  statement: bifunctional glutamate 5-kinase (GO:0004349) + glutamate-5-semialdehyde dehydrogenase (GO:0004350); the committed step of proline/ornithine biosynthesis from glutamate
+                  statement: The curated review accepts GO:0004349 as one of ALDH18A1's two core catalytic activities.
+            processes:
+              - preferred_term: L-proline biosynthetic process
+                term:
+                  id: GO:0055129
+                  label: L-proline biosynthetic process
             locations:
               - preferred_term: mitochondrial matrix
                 term:
                   id: GO:0005759
                   label: mitochondrial matrix
-            role_description: Bifunctional P5C synthase; makes glutamate-5-semialdehyde/P5C from glutamate.
-          - id: oat_activity
-            label: "OAT: ornithine -> P5C (transamination)"
+            role_description: The N-terminal kinase domain activates glutamate for reduction by the C-terminal domain.
+    - order: 2
+      role: NADPH-dependent production of glutamate 5-semialdehyde
+      node:
+        id: aldh18a1_semialdehyde_formation
+        label: ALDH18A1 glutamate-5-semialdehyde dehydrogenase reaction
+        module_type: REACTION
+        annotons:
+          - id: aldh18a1_reductase_activity
+            label: ALDH18A1 glutamate-5-semialdehyde dehydrogenase
             participant:
               selector_type: FAMILY
+              required_function:
+                preferred_term: glutamate-5-semialdehyde dehydrogenase activity
+                term:
+                  id: GO:0004350
+                  label: glutamate-5-semialdehyde dehydrogenase activity
               family:
-                preferred_term: OAT / ornithine aminotransferase family
+                preferred_term: metazoan P5C synthase family
+                term:
+                  id: PANTHER:PTHR11063
+                  label: DELTA-1-PYRROLINE-5-CARBOXYLATE SYNTHASE
+                representative_members:
+                  - preferred_term: human ALDH18A1
+                    term:
+                      id: UniProtKB:P54886
+                      label: Delta-1-pyrroline-5-carboxylate synthase
+                    description: Reviewed bifunctional mammalian P5C synthase exemplar.
+            function:
+              preferred_term: glutamate-5-semialdehyde dehydrogenase activity
+              term:
+                id: GO:0004350
+                label: glutamate-5-semialdehyde dehydrogenase activity
+              substrates:
+                - preferred_term: L-glutamate 5-phosphate
+                - preferred_term: NADPH
+              products:
+                - preferred_term: L-glutamate 5-semialdehyde
+                - preferred_term: NADP+
+                - preferred_term: phosphate
+              evidence:
+                - source_id: file:human/ALDH18A1/ALDH18A1-ai-review.yaml
+                  statement: The curated review accepts GO:0004350 as the second core catalytic activity of ALDH18A1.
+            processes:
+              - preferred_term: L-proline biosynthetic process
+                term:
+                  id: GO:0055129
+                  label: L-proline biosynthetic process
+            locations:
+              - preferred_term: mitochondrial matrix
+                term:
+                  id: GO:0005759
+                  label: mitochondrial matrix
+            role_description: The C-terminal reductase domain converts activated glutamate to the semialdehyde that equilibrates with P5C.
+    - order: 2
+      role: ornithine-dependent alternative supply of P5C
+      node:
+        id: oat_p5c_supply
+        label: OAT transamination into the P5C pool
+        module_type: REACTION
+        annotons:
+          - id: oat_activity
+            label: OAT ornithine transaminase
+            participant:
+              selector_type: FAMILY
+              required_function:
+                preferred_term: L-ornithine transaminase activity
+                term:
+                  id: GO:0004587
+                  label: L-ornithine transaminase activity
+              family:
+                preferred_term: ornithine aminotransferase family
                 term:
                   id: PANTHER:PTHR11986
                   label: ORNITHINE AMINOTRANSFERASE
                 representative_members:
-                  - preferred_term: OAT (human)
+                  - preferred_term: human OAT
                     term:
                       id: UniProtKB:P04181
                       label: Ornithine aminotransferase, mitochondrial
+                    description: Reviewed mammalian ornithine aminotransferase exemplar.
             function:
               preferred_term: L-ornithine transaminase activity
               term:
@@ -137,104 +201,108 @@ module:
                 - preferred_term: L-ornithine
                 - preferred_term: 2-oxoglutarate
               products:
-                - preferred_term: L-glutamate 5-semialdehyde (-> P5C)
+                - preferred_term: L-glutamate 5-semialdehyde
                 - preferred_term: L-glutamate
               evidence:
                 - source_id: file:human/OAT/OAT-ai-review.yaml
-                  statement: PLP-dependent (GO:0030170) ornithine delta-aminotransferase linking ornithine (urea cycle) to the P5C/proline pool
+                  statement: The curated review accepts the PLP-dependent ornithine transaminase activity that supplies the P5C pool.
+            processes:
+              - preferred_term: L-proline biosynthetic process
+                term:
+                  id: GO:0055129
+                  label: L-proline biosynthetic process
             locations:
               - preferred_term: mitochondrial matrix
                 term:
                   id: GO:0005759
                   label: mitochondrial matrix
-            role_description: Transaminates ornithine to glutamate-5-semialdehyde/P5C (links urea cycle).
-          - id: pycr1_activity
-            label: "PYCR1: P5C -> proline"
+            role_description: Links ornithine metabolism to proline synthesis through the shared semialdehyde/P5C intermediate.
+    - order: 3
+      role: reduction of P5C to L-proline
+      node:
+        id: pycr_proline_formation
+        label: PYCR-dependent L-proline formation
+        module_type: REACTION
+        annotons:
+          - id: pycr_activity
+            label: Pyrroline-5-carboxylate reductase
             participant:
               selector_type: FAMILY
+              required_function:
+                preferred_term: pyrroline-5-carboxylate reductase activity
+                term:
+                  id: GO:0004735
+                  label: pyrroline-5-carboxylate reductase activity
               family:
-                preferred_term: pyrroline-5-carboxylate reductase (PYCR) family
+                preferred_term: pyrroline-5-carboxylate reductase family
                 term:
                   id: PANTHER:PTHR11645
                   label: PYRROLINE-5-CARBOXYLATE REDUCTASE
                 representative_members:
-                  - preferred_term: PYCR1 (human)
+                  - preferred_term: human PYCR1
                     term:
                       id: UniProtKB:P32322
                       label: Pyrroline-5-carboxylate reductase 1, mitochondrial
-            function:
-              preferred_term: pyrroline-5-carboxylate reductase activity
-              term:
-                id: GO:0004735
-                label: pyrroline-5-carboxylate reductase activity
-              substrates:
-                - preferred_term: (S)-1-pyrroline-5-carboxylate (P5C)
-                - preferred_term: NAD(P)H
-              products:
-                - preferred_term: L-proline
-              evidence:
-                - source_id: file:human/PYCR1/PYCR1-ai-review.yaml
-                  statement: catalyzes the final step of proline biosynthesis (P5C -> L-proline); mitochondrial
-            locations:
-              - preferred_term: mitochondrial matrix
-                term:
-                  id: GO:0005759
-                  label: mitochondrial matrix
-            role_description: Reduces P5C to L-proline (final biosynthetic step).
-          - id: pycr2_activity
-            label: "PYCR2: P5C -> proline"
-            participant:
-              selector_type: FAMILY
-              family:
-                preferred_term: pyrroline-5-carboxylate reductase (PYCR) family
-                term:
-                  id: PANTHER:PTHR11645
-                  label: PYRROLINE-5-CARBOXYLATE REDUCTASE
-                representative_members:
-                  - preferred_term: PYCR2 (human)
+                    description: Reviewed NAD(P)H-dependent mammalian exemplar.
+                  - preferred_term: human PYCR2
                     term:
                       id: UniProtKB:Q96C36
                       label: Pyrroline-5-carboxylate reductase 2
+                    description: Reviewed NADH-preferring mammalian paralog.
             function:
               preferred_term: pyrroline-5-carboxylate reductase activity
               term:
                 id: GO:0004735
                 label: pyrroline-5-carboxylate reductase activity
               substrates:
-                - preferred_term: (S)-1-pyrroline-5-carboxylate (P5C)
-                - preferred_term: NADH
+                - preferred_term: (S)-1-pyrroline-5-carboxylate
+                - preferred_term: NAD(P)H
               products:
                 - preferred_term: L-proline
+                - preferred_term: NAD(P)+
               evidence:
+                - source_id: file:human/PYCR1/PYCR1-ai-review.yaml
+                  statement: The curated review supports the terminal P5C-to-proline reduction by PYCR1.
                 - source_id: file:human/PYCR2/PYCR2-ai-review.yaml
-                  statement: catalyzes the final step of proline biosynthesis (P5C -> L-proline), preferentially using NADH; mitochondrial
+                  statement: The curated review supports the same terminal reduction by the PYCR2 paralog.
+            processes:
+              - preferred_term: L-proline biosynthetic process
+                term:
+                  id: GO:0055129
+                  label: L-proline biosynthetic process
             locations:
               - preferred_term: mitochondrial matrix
                 term:
                   id: GO:0005759
                   label: mitochondrial matrix
-            role_description: Reduces P5C to L-proline (final biosynthetic step; NADH-preferring paralog).
-    - order: 2
-      role: proline catabolism (proline -> P5C -> glutamate)
+            role_description: Reduces the shared P5C intermediate to L-proline; PYCR1 and PYCR2 provide paralogous implementations.
+    - order: 4
+      role: FAD-dependent oxidation of L-proline
       node:
-        id: proline_catabolism
-        label: Proline catabolism (PRODH, ALDH4A1)
+        id: prodh_p5c_formation
+        label: PRODH oxidation of L-proline to P5C
         module_type: REACTION
         annotons:
           - id: prodh_activity
-            label: "PRODH (POX): proline -> P5C (FAD, to ETC)"
+            label: Proline dehydrogenase
             participant:
               selector_type: FAMILY
+              required_function:
+                preferred_term: proline dehydrogenase activity
+                term:
+                  id: GO:0004657
+                  label: proline dehydrogenase activity
               family:
-                preferred_term: PRODH / proline dehydrogenase (oxidase) family
+                preferred_term: proline dehydrogenase family
                 term:
                   id: PANTHER:PTHR13914
                   label: PROLINE DEHYDROGENASE
                 representative_members:
-                  - preferred_term: PRODH (human)
+                  - preferred_term: human PRODH
                     term:
                       id: UniProtKB:O43272
                       label: Proline dehydrogenase 1, mitochondrial
+                    description: Reviewed mammalian proline-dehydrogenase exemplar.
             function:
               preferred_term: proline dehydrogenase activity
               term:
@@ -242,72 +310,108 @@ module:
                 label: proline dehydrogenase activity
               substrates:
                 - preferred_term: L-proline
-                - preferred_term: ubiquinone (via FAD cofactor)
+                - preferred_term: ubiquinone
               products:
-                - preferred_term: (S)-1-pyrroline-5-carboxylate (P5C)
+                - preferred_term: (S)-1-pyrroline-5-carboxylate
                 - preferred_term: ubiquinol
               evidence:
                 - source_id: file:human/PRODH/PRODH-ai-review.yaml
-                  statement: FAD-dependent (GO:0071949) inner-membrane proline oxidase; oxidises L-proline to P5C, donating electrons to the respiratory chain; p53-inducible ROS/apoptosis role (non-core)
+                  statement: The curated review supports FAD-dependent oxidation of L-proline to P5C with electron transfer to the respiratory chain.
+            processes:
+              - preferred_term: L-proline catabolic process
+                term:
+                  id: GO:0006562
+                  label: L-proline catabolic process
             locations:
               - preferred_term: mitochondrial inner membrane
                 term:
                   id: GO:0005743
                   label: mitochondrial inner membrane
-            role_description: Oxidises L-proline to P5C (FAD; electrons to ubiquinone).
+            role_description: Initiates proline catabolism and transfers reducing equivalents into the respiratory chain.
+    - order: 5
+      role: oxidation of glutamate 5-semialdehyde to L-glutamate
+      node:
+        id: aldh4a1_glutamate_formation
+        label: ALDH4A1 completion of proline catabolism
+        module_type: REACTION
+        annotons:
           - id: aldh4a1_activity
-            label: "ALDH4A1 (P5CDH): P5C -> glutamate"
+            label: P5C dehydrogenase
             participant:
               selector_type: FAMILY
+              required_function:
+                preferred_term: L-glutamate gamma-semialdehyde dehydrogenase activity
+                term:
+                  id: GO:0003842
+                  label: L-glutamate gamma-semialdehyde dehydrogenase activity
               family:
-                preferred_term: ALDH4A1 / P5C dehydrogenase family
+                preferred_term: P5C dehydrogenase family
                 term:
                   id: PANTHER:PTHR14516
                   label: DELTA-1-PYRROLINE-5-CARBOXYLATE DEHYDROGENASE
                 representative_members:
-                  - preferred_term: ALDH4A1 (human)
+                  - preferred_term: human ALDH4A1
                     term:
                       id: UniProtKB:P30038
                       label: Delta-1-pyrroline-5-carboxylate dehydrogenase, mitochondrial
+                    description: Reviewed mammalian P5C-dehydrogenase exemplar.
             function:
               preferred_term: L-glutamate gamma-semialdehyde dehydrogenase activity
               term:
                 id: GO:0003842
                 label: L-glutamate gamma-semialdehyde dehydrogenase activity
               substrates:
-                - preferred_term: L-glutamate 5-semialdehyde (from P5C)
+                - preferred_term: L-glutamate 5-semialdehyde
                 - preferred_term: NAD+
+                - preferred_term: water
               products:
                 - preferred_term: L-glutamate
                 - preferred_term: NADH
               evidence:
                 - source_id: file:human/ALDH4A1/ALDH4A1-ai-review.yaml
-                  statement: NAD-dependent P5C dehydrogenase; oxidises glutamate-5-semialdehyde to L-glutamate, completing proline (and hydroxyproline) catabolism
+                  statement: The curated review supports oxidation of glutamate 5-semialdehyde to L-glutamate as the catabolic exit.
+            processes:
+              - preferred_term: L-proline catabolic process
+                term:
+                  id: GO:0006562
+                  label: L-proline catabolic process
             locations:
               - preferred_term: mitochondrial matrix
                 term:
                   id: GO:0005759
                   label: mitochondrial matrix
-            role_description: Oxidises glutamate-5-semialdehyde to L-glutamate (catabolic exit).
+            role_description: Oxidizes the P5C-equilibrated semialdehyde to L-glutamate and completes proline catabolism.
   connections:
-    - source: proline_biosynthesis
-      target: proline_catabolism
+    - source: aldh18a1_glutamate_phosphorylation
+      target: aldh18a1_semialdehyde_formation
       connection_type: PROVIDES_INPUT_FOR
-      description: >-
-        The proline made by PYCR1/PYCR2 is the substrate for PRODH-initiated catabolism; PRODH and
-        PYCR run opposing reactions on the shared P5C pool (the "proline cycle"), and the P5C/
-        glutamate-5-semialdehyde intermediate is common to both arms.
-  notes: >-
-    Proline biosynthesis (GO:0055129) and catabolism (GO:0006562) through the shared P5C/L-glutamate
-    5-semialdehyde intermediate, grounded to the completed human gene reviews: biosynthetic arm
-    ALDH18A1/P5CS (P54886, bifunctional GO:0004349 glutamate 5-kinase + GO:0004350 glutamate-5-
-    semialdehyde dehydrogenase), OAT (P04181, GO:0004587 L-ornithine transaminase + PLP GO:0030170,
-    linking the urea cycle), PYCR1 (P32322) and PYCR2 (Q96C36) (GO:0004735 P5C reductase); catabolic
-    arm PRODH/POX (O43272, GO:0004657 proline dehydrogenase + FAD GO:0071949, inner-membrane,
-    electrons to the respiratory chain) and ALDH4A1/P5CDH (P30038, GO:0003842). PRODH and PYCR
-    constitute the proline cycle that moves redox equivalents and modulates ROS/p53 apoptosis (PRODH's
-    apoptosis role kept non-core). GO term ids/labels verified against the local go.db (note
-    GO:0010133 "L-proline catabolic process to L-glutamate" is obsolete → GO:0006562 used). This
-    connects to the urea cycle (via OAT/ornithine) and glutamate metabolism. Disorders: ALDH18A1/PYCR1
-    — cutis laxa/progeroid; PYCR2 — hypomyelinating leukodystrophy 10; PRODH — hyperprolinemia I
-    (22q11/schizophrenia); ALDH4A1 — hyperprolinemia II; OAT — gyrate atrophy of the choroid/retina.
+      chaining_status: VERIFIED
+      chaining_note: ALDH18A1's kinase domain produces L-glutamate 5-phosphate for its reductase domain.
+    - source: aldh18a1_semialdehyde_formation
+      target: pycr_proline_formation
+      connection_type: PROVIDES_INPUT_FOR
+      chaining_status: VERIFIED
+      chaining_note: Glutamate 5-semialdehyde spontaneously equilibrates with the P5C substrate reduced by PYCR.
+    - source: oat_p5c_supply
+      target: pycr_proline_formation
+      connection_type: PROVIDES_INPUT_FOR
+      chaining_status: VERIFIED
+      chaining_note: OAT supplies the same glutamate-5-semialdehyde/P5C pool used by PYCR.
+    - source: pycr_proline_formation
+      target: prodh_p5c_formation
+      connection_type: PROVIDES_INPUT_FOR
+      chaining_status: VERIFIED
+      chaining_note: L-proline produced by PYCR is the substrate for PRODH in the opposing arm of the proline cycle.
+    - source: prodh_p5c_formation
+      target: aldh4a1_glutamate_formation
+      connection_type: PROVIDES_INPUT_FOR
+      chaining_status: VERIFIED
+      chaining_note: PRODH-derived P5C equilibrates with glutamate 5-semialdehyde, the ALDH4A1 substrate.
+  knowledge_gaps:
+    - gap_statement: This module does not represent bacterial ProB-ProA-ProC or fused PutA architectures.
+      boundary: >-
+        Preserve the six mammalian reaction roles here. Model bacterial enzyme
+        architectures as explicit pathway variants rather than treating PutA as
+        a direct ortholog of either PRODH or ALDH4A1 alone.
+      gap_kind:
+        - CURATION


### PR DESCRIPTION
## Summary
- Expands mammalian proline metabolism into six reaction-level biosynthetic and catabolic parts.
- Splits ALDH18A1 kinase and reductase chemistry while representing PYCR1/PYCR2 as one family-level role.
- Grounds Mammalia scope, leaf functions, compartments, cofactors, metabolites, and reaction continuity with exact identifiers and exemplars.

## Why
This revises an older coarse module to follow the module-curation rules while preserving its mammalian biological scope and curation provenance.

## Validation
- Module schema validation passed.
- Module semantic validation passed; NCBITaxon/ChEBI lookups emitted ontology-unavailable advisories only.
- The affected module rendered successfully.
- `git diff --check` passed.