### PR TITLE
Add supporting-reference assay mining wrapper

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -608,9 +608,23 @@ gene-iba-support-research provider organism gene *args:
 # Mine review prose and the publications corpus for assay/readout usage, then
 # QC + flag re-review candidates. Always inspect reports/*matched_string_counts*
 # for substring false positives before trusting a class total.
-assay-mine *args="":
-    uv run python projects/ASSAY_TO_FUNCTION/mine_readouts.py {{args}}
-    uv run python projects/ASSAY_TO_FUNCTION/mine_papers.py {{args}}
+[positional-arguments]
+assay-mine *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    uv run python projects/ASSAY_TO_FUNCTION/mine_readouts.py "$@"
+    uv run python projects/ASSAY_TO_FUNCTION/mine_papers.py "$@"
+
+# Broader, paper-only join across primary and supporting references. Keep its
+# outputs separate from the canonical primary-reference reports by default.
+[positional-arguments]
+assay-mine-supporting *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    uv run python projects/ASSAY_TO_FUNCTION/mine_papers.py \
+        --include-supporting \
+        --out-dir projects/ASSAY_TO_FUNCTION/reports/with_supporting \
+        "$@"
 
 assay-flag *args="":
     uv run python projects/ASSAY_TO_FUNCTION/flag_candidates.py {{args}}

--- a/tests/test_assay_mining_wrapper.py
+++ b/tests/test_assay_mining_wrapper.py
@@ -1,0 +1,120 @@
+"""End-to-end tests for the public ASSAY_TO_FUNCTION mining wrappers."""
+
+from __future__ import annotations
+
+import csv
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def make_assay_fixture(root: Path) -> tuple[Path, Path, Path]:
+    """Create one annotation whose supporting paper, but not primary, has a readout."""
+    genes_dir = root / "genes with spaces"
+    gene_dir = genes_dir / "TEST" / "GENE"
+    gene_dir.mkdir(parents=True)
+    (gene_dir / "GENE-ai-review.yaml").write_text(
+        """
+id: UniProtKB:TEST
+gene_symbol: GENE
+existing_annotations:
+  - term:
+      id: GO:0006986
+      label: response to unfolded protein
+    evidence_type: IDA
+    original_reference_id: PMID:1
+    review:
+      action: ACCEPT
+      summary: UPRE reporter assay
+      supported_by:
+        - reference_id: PMID:2
+"""
+    )
+    (gene_dir / "GENE-goa.tsv").write_text(
+        "GO TERM\tGO ASPECT\nGO:0006986\tbiological_process\n"
+    )
+
+    pubs_dir = root / "publications with spaces"
+    pubs_dir.mkdir()
+    (pubs_dir / "PMID_1.md").write_text(
+        "full_text_available: true\nNo assay vocabulary here.\n"
+    )
+    (pubs_dir / "PMID_2.md").write_text(
+        "full_text_available: true\nA UPRE reporter assay was performed.\n"
+    )
+
+    catalog = root / "catalog with spaces.yaml"
+    catalog.write_text(
+        r"""
+readouts:
+  UPR_ER_STRESS:
+    proximity: phenotypic
+    convergence: high
+    aligned_label_regex: 'unfolded protein'
+    commonly_overmapped_to: [GO:0006986]
+    patterns: ['\bUPRE\b']
+"""
+    )
+    return genes_dir, pubs_dir, catalog
+
+
+def run_just(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["just", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def test_assay_mine_preserves_shared_paths_for_both_miners(tmp_path: Path) -> None:
+    genes_dir, _pubs_dir, catalog = make_assay_fixture(tmp_path)
+    out_dir = tmp_path / "canonical output with spaces"
+
+    result = run_just(
+        "assay-mine",
+        "--genes-dir",
+        str(genes_dir),
+        "--catalog",
+        str(catalog),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (out_dir / "readout_matches.tsv").exists()
+    assert (out_dir / "paper_readout_matches.tsv").exists()
+
+
+def test_assay_mine_supporting_routes_only_paper_outputs(tmp_path: Path) -> None:
+    genes_dir, pubs_dir, catalog = make_assay_fixture(tmp_path)
+    out_dir = tmp_path / "supporting output with spaces"
+
+    result = run_just(
+        "assay-mine-supporting",
+        "--genes-dir",
+        str(genes_dir),
+        "--pubs-dir",
+        str(pubs_dir),
+        "--catalog",
+        str(catalog),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    with (out_dir / "paper_readout_matches.tsv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    assert [(row["pmid"], row["ref_role"]) for row in rows] == [
+        ("2", "supporting")
+    ]
+    assert sorted(path.name for path in out_dir.iterdir()) == [
+        "paper_action_crosstab_aligned.tsv",
+        "paper_action_crosstab_all.tsv",
+        "paper_matched_string_counts.tsv",
+        "paper_readout_matches.tsv",
+    ]


### PR DESCRIPTION
## Summary

- preserve exact argument boundaries in the existing `assay-mine` wrapper
- add a paper-only `assay-mine-supporting` recipe that injects `--include-supporting` and defaults to `reports/with_supporting`
- cover both recipes end to end with tiny real gene/publication/catalog fixtures and spaced paths

## Bug

`assay-mine` forwarded one flattened variadic tail to both miners. Paper-only options such as `--include-supporting` and `--pubs-dir` are rejected by `mine_readouts.py`, so there was no wrapper-compliant way to regenerate the committed `with_supporting` paper artifacts. Flattening also broke path arguments containing spaces.

The dedicated recipe invokes only `mine_papers.py`, keeps broader weak-link outputs separate from canonical reports, and permits an explicit later `--out-dir` override for isolated runs.

## Validation

- `just --list`
- focused wrapper tests: 2 passed
- full `just test`: 1,387 pytest passed; 132 doctests passed / 37 skipped; mypy clean; Ruff clean
- `git diff --check`

No assay catalog or generated report data is changed in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Just recipes and new wrapper tests; mining scripts and report data are untouched.
> 
> **Overview**
> Fixes **ASSAY_TO_FUNCTION** `just` wrappers so CLI flags reach the miners correctly and adds a dedicated path for supporting-reference paper mining.
> 
> **`assay-mine`** is now a bash recipe with `[positional-arguments]` and passes `"$@"` to both `mine_readouts.py` and `mine_papers.py`, instead of one flattened `{{args}}` tail. That restores paths with spaces and stops paper-only flags (e.g. `--include-supporting`, `--pubs-dir`) from being forwarded to `mine_readouts.py`, which rejected them.
> 
> **`assay-mine-supporting`** is new: it runs only `mine_papers.py` with `--include-supporting` and default output under `reports/with_supporting`, while still allowing overrides via `"$@"` (e.g. `--out-dir`).
> 
> **`tests/test_assay_mining_wrapper.py`** adds two end-to-end `just` tests with spaced paths—canonical dual-miner outputs and supporting-only paper matches tagged `ref_role=supporting`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a21937d56c2ce23a2477ea2fd871c84d43da017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->