### PR TITLE
Normalize multiline assay match fields

### DIFF
--- a/projects/ASSAY_TO_FUNCTION/mine_papers.py
+++ b/projects/ASSAY_TO_FUNCTION/mine_papers.py
@@ -260,6 +260,11 @@ def load_catalog(path: Path) -> dict[str, dict[str, Any]]:
     return catalog
 
 
+def normalize_match_text(value: str) -> str:
+    """Collapse regex-matched whitespace for single-line TSV fields."""
+    return re.sub(r"\s+", " ", value).strip()
+
+
 def build_aspect_map(genes_dir: Path) -> dict[str, str]:
     """Map GO id -> aspect (MF/BP/CC) by scanning every *-goa.tsv once."""
     aspect: dict[str, str] = {}
@@ -320,7 +325,8 @@ class PubCache:
                     # record the distinct matched substrings for QC (cheap: only
                     # runs on the rare screen-passing papers)
                     for mm in rx.finditer(text):
-                        self.matched_counts[name][mm.group(0).lower()] += 1
+                        matched = normalize_match_text(mm.group(0)).lower()
+                        self.matched_counts[name][matched] += 1
         result = (classes, "full_text_available: true" in low)
         self._cache[pmid] = result
         return result

--- a/projects/ASSAY_TO_FUNCTION/mine_readouts.py
+++ b/projects/ASSAY_TO_FUNCTION/mine_readouts.py
@@ -65,6 +65,11 @@ def evidence_text(review: dict[str, Any]) -> str:
     return "\n".join(parts)
 
 
+def normalize_match_text(value: str) -> str:
+    """Collapse regex-matched whitespace for single-line TSV fields."""
+    return re.sub(r"\s+", " ", value).strip()
+
+
 def snippet_around(text: str, match: re.Match, width: int = 80) -> str:
     start = max(0, match.start() - width)
     end = min(len(text), match.end() + width)
@@ -140,7 +145,7 @@ def main() -> None:
                             "readout_class": readout_name,
                             "proximity": spec.get("proximity", ""),
                             "convergence": spec.get("convergence", ""),
-                            "matched": m.group(0),
+                            "matched": normalize_match_text(m.group(0)),
                             "snippet": snippet_around(text, m),
                             "file": str(path),
                         }

--- a/tests/test_assay_mining_wrapper.py
+++ b/tests/test_assay_mining_wrapper.py
@@ -27,7 +27,9 @@ existing_annotations:
     original_reference_id: PMID:1
     review:
       action: ACCEPT
-      summary: UPRE reporter assay
+      summary: |-
+        UPRE
+          reporter assay
       supported_by:
         - reference_id: PMID:2
 """
@@ -42,7 +44,7 @@ existing_annotations:
         "full_text_available: true\nNo assay vocabulary here.\n"
     )
     (pubs_dir / "PMID_2.md").write_text(
-        "full_text_available: true\nA UPRE reporter assay was performed.\n"
+        "full_text_available: true\nA UPRE\n  reporter assay was performed.\n"
     )
 
     catalog = root / "catalog with spaces.yaml"
@@ -54,7 +56,7 @@ readouts:
     convergence: high
     aligned_label_regex: 'unfolded protein'
     commonly_overmapped_to: [GO:0006986]
-    patterns: ['\bUPRE\b']
+    patterns: ['\bUPRE\s+reporter']
 """
     )
     return genes_dir, pubs_dir, catalog
@@ -86,7 +88,20 @@ def test_assay_mine_preserves_shared_paths_for_both_miners(tmp_path: Path) -> No
     )
 
     assert result.returncode == 0, result.stderr
-    assert (out_dir / "readout_matches.tsv").exists()
+    with (out_dir / "readout_matches.tsv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    assert [row["matched"] for row in rows] == ["UPRE reporter"]
+    assert [row["snippet"] for row in rows] == ["UPRE reporter assay"]
+    assert len((out_dir / "readout_matches.tsv").read_text().splitlines()) == 2
+    with (out_dir / "matched_string_counts.tsv").open(newline="") as handle:
+        counts = list(csv.DictReader(handle, delimiter="\t"))
+    assert counts == [
+        {
+            "readout_class": "UPR_ER_STRESS",
+            "matched_string": "upre reporter",
+            "count": "1",
+        }
+    ]
     assert (out_dir / "paper_readout_matches.tsv").exists()
 
 
@@ -112,6 +127,18 @@ def test_assay_mine_supporting_routes_only_paper_outputs(tmp_path: Path) -> None
     assert [(row["pmid"], row["ref_role"]) for row in rows] == [
         ("2", "supporting")
     ]
+    with (out_dir / "paper_matched_string_counts.tsv").open(newline="") as handle:
+        counts = list(csv.DictReader(handle, delimiter="\t"))
+    assert counts == [
+        {
+            "readout_class": "UPR_ER_STRESS",
+            "matched_string": "upre reporter",
+            "papers": "1",
+        }
+    ]
+    assert len(
+        (out_dir / "paper_matched_string_counts.tsv").read_text().splitlines()
+    ) == 2
     assert sorted(path.name for path in out_dir.iterdir()) == [
         "paper_action_crosstab_aligned.tsv",
         "paper_action_crosstab_all.tsv",


### PR DESCRIPTION
## Summary

- collapse whitespace only in regex-derived match strings before TSV serialization
- preserve original publication/review text, regex matching, case decisions, and match offsets
- extend both public assay-mining wrapper tests with multiline matches and physical-line assertions

## Why

Current assay reports contain quoted multiline `matched` / `matched_string` fields whenever a catalog `\s+` pattern spans a newline. The TSVs parse, but they no longer have one record per physical line and `git diff --check` reports spaces before embedded newlines.

## Validation

- focused `just pytest` wrapper: 2 passed
- `just test`: 1,408 pytest passed; 132 doctests passed; mypy and Ruff clean
- `git diff --check`

Generated reports are deliberately excluded; they will be refreshed in a separate baseline PR after this code fix merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-only normalization for TSV fields; regex detection and source text are untouched, with coverage added in integration tests.
> 
> **Overview**
> Assay-mining TSVs now **collapse whitespace in regex-derived match strings** (`matched`, `matched_string` / QC count keys) via shared `normalize_match_text`, so records stay one physical line per row and avoid embedded newlines when catalog patterns use `\s+` across line breaks.
> 
> **`mine_readouts.py`** normalizes the `matched` column before write; **`mine_papers.py`** does the same for paper-corpus `matched_string` QC tallies. Source text, regex matching, offsets, and case handling are unchanged—only serialized match text is normalized.
> 
> Wrapper tests use multiline review YAML and publication text plus a `\bUPRE\s+reporter` pattern, and assert normalized `matched`/`snippet` values, `matched_string_counts` / `paper_matched_string_counts` content, and header-plus-one-data-line TSV shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 400d1714a00501da57bcc6a77a32d3fa1fde6d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->