### PR TITLE
Count assay match strings once per paper

### DIFF
--- a/projects/ASSAY_TO_FUNCTION/mine_papers.py
+++ b/projects/ASSAY_TO_FUNCTION/mine_papers.py
@@ -324,8 +324,12 @@ class PubCache:
                     classes.add(name)
                     # record the distinct matched substrings for QC (cheap: only
                     # runs on the rare screen-passing papers)
+                    seen_matches: set[str] = set()
                     for mm in rx.finditer(text):
                         matched = normalize_match_text(mm.group(0)).lower()
+                        if matched in seen_matches:
+                            continue
+                        seen_matches.add(matched)
                         self.matched_counts[name][matched] += 1
         result = (classes, "full_text_available: true" in low)
         self._cache[pmid] = result

--- a/tests/test_assay_mining_wrapper.py
+++ b/tests/test_assay_mining_wrapper.py
@@ -44,7 +44,9 @@ existing_annotations:
         "full_text_available: true\nNo assay vocabulary here.\n"
     )
     (pubs_dir / "PMID_2.md").write_text(
-        "full_text_available: true\nA UPRE\n  reporter assay was performed.\n"
+        "full_text_available: true\n"
+        "A UPRE reporter assay, a UPRE   reporter assay, and a UPRE\n"
+        "  reporter assay were performed.\n"
     )
 
     catalog = root / "catalog with spaces.yaml"
@@ -56,7 +58,9 @@ readouts:
     convergence: high
     aligned_label_regex: 'unfolded protein'
     commonly_overmapped_to: [GO:0006986]
-    patterns: ['\bUPRE\s+reporter']
+    patterns:
+      - '\bUPRE[ \t]+reporter'
+      - '\bUPRE\n[ \t]+reporter'
 """
     )
     return genes_dir, pubs_dir, catalog
@@ -105,7 +109,9 @@ def test_assay_mine_preserves_shared_paths_for_both_miners(tmp_path: Path) -> No
     assert (out_dir / "paper_readout_matches.tsv").exists()
 
 
-def test_assay_mine_supporting_routes_only_paper_outputs(tmp_path: Path) -> None:
+def test_assay_mine_supporting_paper_matched_string_counts_once_per_paper(
+    tmp_path: Path,
+) -> None:
     genes_dir, pubs_dir, catalog = make_assay_fixture(tmp_path)
     out_dir = tmp_path / "supporting output with spaces"
 


### PR DESCRIPTION
## Summary

- deduplicate normalized matched strings within each readout class and cached paper
- preserve deterministic first-seen ordering for tied QC rows
- add a public-wrapper regression with repeated inline, variable-space, and newline matches

## Why

`paper_matched_string_counts.tsv` labels its metric `papers`, and the implementation comments/documentation say each string is counted once per unique paper. `PubCache.detect` instead incremented once per regex occurrence. On the current corpus, about 78% of keys are inflated and aggregate counts are overstated by roughly 85%.

## Validation

- focused `just pytest` wrapper: 1 passed
- `just test`: 1,408 pytest passed; 132 doctests passed; mypy and Ruff clean
- `git diff --check`

Generated reports are deliberately excluded; they will be refreshed in a separate baseline PR after all generator fixes merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mining logic change only affects QC tallying in `PubCache.detect`, not readout class detection or annotation joins; covered by a focused wrapper test.
> 
> **Overview**
> **`PubCache.detect`** now increments **`paper_matched_string_counts.tsv`** at most once per normalized matched substring per readout class **per cached paper**, using a per-paper `seen_matches` set after `normalize_match_text`. Repeated regex hits (extra spaces, newlines) that collapse to the same string no longer inflate the **`papers`** column.
> 
> The assay mining wrapper test fixture was extended with multiple UPRE reporter phrasings and catalog patterns spanning inline and newline whitespace. **`test_assay_mine_supporting_paper_matched_string_counts_once_per_paper`** asserts **`papers: "1"`** for that string when running **`assay-mine-supporting`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a88c45cdccbe30fad474cfed3ce2a0496347c59d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->