### PR TITLE
Make assay paper row order deterministic

### DIFF
--- a/projects/ASSAY_TO_FUNCTION/mine_papers.py
+++ b/projects/ASSAY_TO_FUNCTION/mine_papers.py
@@ -438,9 +438,9 @@ def main() -> None:
             any_resolved = True
             cls, ft = det
             full_text = full_text or ft
-            for c in cls:
-                if c not in class_src:
-                    class_src[c] = (pm, role)
+            for name in catalog:
+                if name in cls and name not in class_src:
+                    class_src[name] = (pm, role)
         if not any_resolved:
             continue
         n_resolved += 1
@@ -452,8 +452,11 @@ def main() -> None:
         go_label = term.get("label", "") or ""
         aspect = aspect_map.get(go_id, "?")
 
-        for name, (pmid, role) in class_src.items():
-            spec = catalog[name]
+        for name, spec in catalog.items():
+            source = class_src.get(name)
+            if source is None:
+                continue
+            pmid, role = source
             aligned = bool(
                 go_id in spec["_overmapped"]
                 or (spec["_aligned"] and spec["_aligned"].search(go_label))

--- a/tests/test_assay_mining_wrapper.py
+++ b/tests/test_assay_mining_wrapper.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import os
 import subprocess
 from pathlib import Path
 
@@ -66,13 +67,18 @@ readouts:
     return genes_dir, pubs_dir, catalog
 
 
-def run_just(*args: str) -> subprocess.CompletedProcess[str]:
+def run_just(
+    *args: str, extra_env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(extra_env or {})
     return subprocess.run(
         ["just", *args],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
         check=False,
+        env=env,
         timeout=30,
     )
 
@@ -150,4 +156,83 @@ def test_assay_mine_supporting_paper_matched_string_counts_once_per_paper(
         "paper_action_crosstab_all.tsv",
         "paper_matched_string_counts.tsv",
         "paper_readout_matches.tsv",
+    ]
+
+
+def test_supporting_paper_rows_follow_catalog_order_across_hash_seeds(
+    tmp_path: Path,
+) -> None:
+    genes_dir = tmp_path / "ordered genes"
+    gene_dir = genes_dir / "TEST" / "GENE"
+    gene_dir.mkdir(parents=True)
+    (gene_dir / "GENE-ai-review.yaml").write_text(
+        """
+id: UniProtKB:TEST
+gene_symbol: GENE
+existing_annotations:
+  - term:
+      id: GO:0006986
+      label: response to unfolded protein
+    evidence_type: IDA
+    original_reference_id: PMID:1
+    review:
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:2
+"""
+    )
+    (gene_dir / "GENE-goa.tsv").write_text(
+        "GO TERM\tGO ASPECT\nGO:0006986\tbiological_process\n"
+    )
+
+    pubs_dir = tmp_path / "ordered publications"
+    pubs_dir.mkdir()
+    (pubs_dir / "PMID_1.md").write_text(
+        "full_text_available: true\nMTT assay and LC3 puncta were measured.\n"
+    )
+    (pubs_dir / "PMID_2.md").write_text(
+        "full_text_available: true\nUPRE reporter and MTT assay were measured.\n"
+    )
+
+    catalog = tmp_path / "nonlexical catalog.yaml"
+    catalog.write_text(
+        r"""
+readouts:
+  UPR_ER_STRESS:
+    patterns: ['\bUPRE reporter']
+  VIABILITY_PROLIFERATION:
+    patterns: ['\bMTT assay']
+  AUTOPHAGY_FLUX:
+    patterns: ['\bLC3 puncta']
+"""
+    )
+
+    outputs = []
+    for seed in ("1", "2"):
+        out_dir = tmp_path / f"seed {seed} output"
+        result = run_just(
+            "assay-mine-supporting",
+            "--genes-dir",
+            str(genes_dir),
+            "--pubs-dir",
+            str(pubs_dir),
+            "--catalog",
+            str(catalog),
+            "--out-dir",
+            str(out_dir),
+            extra_env={"PYTHONHASHSEED": seed},
+        )
+        assert result.returncode == 0, result.stderr
+        outputs.append(out_dir / "paper_readout_matches.tsv")
+
+    assert outputs[0].read_bytes() == outputs[1].read_bytes()
+    with outputs[0].open(newline="") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    assert [
+        (row["readout_class"], row["pmid"], row["ref_role"])
+        for row in rows
+    ] == [
+        ("UPR_ER_STRESS", "2", "supporting"),
+        ("VIABILITY_PROLIFERATION", "1", "primary"),
+        ("AUTOPHAGY_FLUX", "1", "primary"),
     ]


### PR DESCRIPTION
## Summary

- emit paper readout rows in catalog order instead of Python set iteration order
- retain the first primary/supporting paper that establishes each readout class
- add an end-to-end wrapper regression that compares output across two Python hash seeds and verifies global catalog order

## Validation

- `PYTEST_ADDOPTS='-k supporting_paper_rows_follow_catalog_order_across_hash_seeds' just pytest` (1 passed)
- `just format`
- `just test` (1,409 pytest tests; 132 doctests; mypy and Ruff clean)
- `git diff --check`

Generated assay reports are intentionally excluded; they will be regenerated through the public wrappers in the separate baseline refresh after generator fixes land.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deterministic ordering and test-only harness changes; no change to readout detection or which paper is credited per class.
> 
> **Overview**
> **Paper readout mining** (`mine_papers.py`) now writes `paper_readout_matches.tsv` rows in **readout catalog order** instead of dict/set iteration order, so outputs are stable across Python hash seeds and easier to diff.
> 
> When unioning readouts across primary and supporting PMIDs, the miner still records the **first** paper (primary preferred) that establishes each class; only the **emit** loop walks `catalog.items()` and skips classes with no source. Provenance behavior is unchanged.
> 
> Adds an end-to-end **`assay-mine-supporting`** test that runs with two `PYTHONHASHSEED` values, asserts byte-identical TSVs, and checks the expected `(readout_class, pmid, ref_role)` sequence. `run_just` accepts optional `extra_env` for that harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f4fea3bd217acbec55245aa0d013a8575989b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->