### PR TITLE
Preserve assay wrapper argument boundaries

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -626,12 +626,18 @@ assay-mine-supporting *args:
         --out-dir projects/ASSAY_TO_FUNCTION/reports/with_supporting \
         "$@"
 
-assay-flag *args="":
-    uv run python projects/ASSAY_TO_FUNCTION/flag_candidates.py {{args}}
+[positional-arguments]
+assay-flag *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    uv run python projects/ASSAY_TO_FUNCTION/flag_candidates.py "$@"
 
 # Consolidate the 60-class catalog + mined matches into summary TSV/MD + figure.
-assay-consolidate *args="":
-    uv run --with matplotlib python projects/ASSAY_TO_FUNCTION/consolidate.py {{args}}
+[positional-arguments]
+assay-consolidate *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    uv run --with matplotlib python projects/ASSAY_TO_FUNCTION/consolidate.py "$@"
 
 # Stage (human-gated) OpenScientist hypothesis prompts from flagged_candidates.tsv.
 # This writes committed prompt.md files and prints submit commands but NEVER
@@ -640,8 +646,11 @@ assay-consolidate *args="":
 # Examples:
 #   just assay-stage-hypotheses --discriminator indirect_ligand --max 5
 #   just assay-stage-hypotheses --gene STAT3 --go-id GO:0030335
-assay-stage-hypotheses *args="":
-    uv run python projects/ASSAY_TO_FUNCTION/stage_hypotheses.py {{args}}
+[positional-arguments]
+assay-stage-hypotheses *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    uv run python projects/ASSAY_TO_FUNCTION/stage_hypotheses.py "$@"
 
 # Term deep research (open-ended biological concepts)
 # Examples:

--- a/tests/test_assay_wrapper_forwarding.py
+++ b/tests/test_assay_wrapper_forwarding.py
@@ -1,0 +1,83 @@
+"""Argument-boundary tests for the remaining ASSAY_TO_FUNCTION wrappers."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    ("recipe", "fixed_argv"),
+    [
+        (
+            "assay-flag",
+            ["run", "python", "projects/ASSAY_TO_FUNCTION/flag_candidates.py"],
+        ),
+        (
+            "assay-consolidate",
+            [
+                "run",
+                "--with",
+                "matplotlib",
+                "python",
+                "projects/ASSAY_TO_FUNCTION/consolidate.py",
+            ],
+        ),
+        (
+            "assay-stage-hypotheses",
+            ["run", "python", "projects/ASSAY_TO_FUNCTION/stage_hypotheses.py"],
+        ),
+    ],
+)
+def test_assay_wrappers_preserve_exact_argument_boundaries(
+    tmp_path: Path,
+    recipe: str,
+    fixed_argv: list[str],
+) -> None:
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["ASSAY_WRAPPER_ARGV_LOG"], "w") as handle:
+    json.dump(sys.argv[1:], handle)
+"""
+    )
+    fake_uv.chmod(0o755)
+
+    log_path = tmp_path / "argv log.json"
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["ASSAY_WRAPPER_ARGV_LOG"] = str(log_path)
+    tail = [
+        "--input",
+        str(tmp_path / "input set (draft), v1?.tsv"),
+        "--label",
+        "multiword value; exact?",
+        "--",
+        "A -- B",
+    ]
+
+    for forwarded, expected in ((tail, fixed_argv + tail), ([], fixed_argv)):
+        result = subprocess.run(
+            ["just", recipe, *forwarded],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert json.loads(log_path.read_text()) == expected


### PR DESCRIPTION
## Summary

- convert the remaining three ASSAY_TO_FUNCTION passthrough recipes to Just positional-argument mode
- forward exact argument boundaries through Bash `"$@"`, including a genuinely empty variadic tail
- test all three public recipes through real `just` invocations with a temp fake `uv`, covering spaces, punctuation, a literal separator, and zero arguments

## Validation

- `PYTEST_ADDOPTS='-k assay_wrappers_preserve_exact_argument_boundaries' just pytest` (3 passed)
- `just format`
- `just test` after rebasing onto current main (1,412 pytest tests; 132 doctests; mypy and Ruff clean)
- independent host Bash 3.2.57 wrapper check (3 passed)
- `git diff --check`

The fake executable prevents the flagger, consolidator, staging code, report writers, network, and provider jobs from running during the focused test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tool and test-only changes; no application logic or data paths are modified beyond how optional flags reach existing Python entrypoints.
> 
> **Overview**
> Aligns **`assay-flag`**, **`assay-consolidate`**, and **`assay-stage-hypotheses`** with the other ASSAY passthrough recipes: **`[positional-arguments]`**, a small Bash wrapper with **`set -euo pipefail`**, and **`"$@"`** instead of Just’s **`{{args}}`** interpolation.
> 
> That change keeps each CLI token intact (paths with spaces/punctuation, a literal **`--`**, and an empty variadic tail) when arguments are forwarded to **`uv run`**.
> 
> Adds **`tests/test_assay_wrapper_forwarding.py`**, which runs real **`just`** invocations with a fake **`uv`** on **`PATH`** and asserts the logged argv matches the expected fixed prefix plus forwarded args (or prefix only when no extra args are passed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c72af8a82119b529bf092d4e964c02bc05dfe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->