### PR TITLE
Forward init-rule-review cache options

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -2274,8 +2274,13 @@ clean-imodulondb-cache:
 #   just init-rule-review UR000000070 --cache-dir rules/unirule
 # If you get "Review file already exists" error:
 #   rm rules/arba/ARBA00026249/ARBA00026249-review.yaml  # Then re-run init-rule-review
-init-rule-review rule_id *args="":
-    uv run python -c "from ai_gene_review.etl.rule_review_init import init_rule_review; from pathlib import Path; init_rule_review('{{rule_id}}', cache_dir=Path('rules/arba'))"
+[positional-arguments]
+init-rule-review rule_id *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rule_id="$1"
+    shift
+    uv run ai-gene-review init-rule-review "$rule_id" "$@"
 
 # Sync ARBA rules with GO annotations from UniProt (stores in rules/arba/)
 # By default only syncs rules that have GO term annotations

--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -2674,6 +2674,27 @@ def rules_export(
     typer.echo(f"✓ GO summary written to {summary_path}")
 
 
+@app.command("init-rule-review")
+def init_rule_review_cli(
+    rule_id: Annotated[
+        str,
+        typer.Argument(help="ARBA or UniRule identifier"),
+    ],
+    cache_dir: Annotated[
+        Path,
+        typer.Option(
+            "--cache-dir",
+            "-d",
+            help="Family-specific rules cache directory",
+        ),
+    ] = Path("rules/arba"),
+) -> None:
+    """Create a rule-review YAML stub without overwriting an existing review."""
+    from ai_gene_review.etl.rule_review_init import init_rule_review
+
+    init_rule_review(rule_id, cache_dir=cache_dir)
+
+
 @app.command()
 def rules_validate(
     files: Annotated[

--- a/tests/test_rule_review_wrapper_forwarding.py
+++ b/tests/test_rule_review_wrapper_forwarding.py
@@ -1,0 +1,95 @@
+"""End-to-end tests for rule-review wrapper argument forwarding."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_just(
+    *args: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(extra_env or {})
+    return subprocess.run(
+        ["just", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=120,
+    )
+
+
+def test_init_rule_review_wrapper_uses_custom_cache_dir(tmp_path: Path) -> None:
+    rule_id = "ARBA00026249"
+    cache_dir = tmp_path / "rule cache (draft), v1?"
+    rule_dir = cache_dir / rule_id
+    rule_dir.mkdir(parents=True)
+    (rule_dir / f"{rule_id}.enriched.json").write_text(
+        json.dumps(
+            {
+                "rule_set": {"condition_sets": [], "annotations": []},
+                "reviewed_protein_count": 0,
+                "unreviewed_protein_count": 0,
+            }
+        )
+    )
+
+    result = run_just(
+        "init-rule-review",
+        rule_id,
+        "--cache-dir",
+        str(cache_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    review_path = rule_dir / f"{rule_id}-review.yaml"
+    review = yaml.safe_load(review_path.read_text())
+    assert review["id"] == rule_id
+    assert review["rule_type"] == "ARBA"
+
+
+def test_init_rule_review_wrapper_forwards_no_empty_tail(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["RULE_WRAPPER_ARGV_LOG"], "w") as handle:
+    json.dump(sys.argv[1:], handle)
+"""
+    )
+    fake_uv.chmod(0o755)
+
+    log_path = tmp_path / "argv log.json"
+    env = {
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "RULE_WRAPPER_ARGV_LOG": str(log_path),
+    }
+    result = run_just(
+        "init-rule-review",
+        "ARBA00026249",
+        extra_env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == [
+        "run",
+        "ai-gene-review",
+        "init-rule-review",
+        "ARBA00026249",
+    ]


### PR DESCRIPTION
## Summary

- expose rule-review initialization through the project Typer CLI
- replace the hard-coded inline wrapper with exact positional forwarding to that CLI
- make the documented `--cache-dir` option work while preserving the no-overwrite default
- add a real `just` → CLI → initializer regression using a pre-seeded temporary cache path with spaces and punctuation

## Validation

- pre-fix focused regression: custom-cache case failed against hard-coded `rules/arba`
- `PYTEST_ADDOPTS='-k init_rule_review_wrapper' just pytest` (2 passed after fix)
- `just init-rule-review ARBA00026249 --help`
- `just format`
- `just test` after review hardening (1,414 pytest tests; 132 doctests; mypy and Ruff clean)
- independent Bash 3.2/layer review: no implementation blockers
- `git diff --check`

The end-to-end test pre-seeds enriched JSON, so no rule fetch or network call occurs and its write is confined to `tmp_path`. A separate temp fake-`uv` case asserts the exact zero-tail argv without touching any repository rule file or provider.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1a56586ccaa59e3341621409ad7e81c98b646149. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->