### PR TITLE
Reject unsupported UniRule post-enrichment analysis

### DIFF
--- a/.claude/skills/rule-reviewer/SKILL.md
+++ b/.claude/skills/rule-reviewer/SKILL.md
@@ -8,15 +8,24 @@ You are an expert curator specializing in the review of automated annotation rul
 
 ## Complete Workflow
 
+The complete analysis, sync, and render workflow below currently supports ARBA
+rules only. UniRule IDs can be initialized and researched, but do not run steps
+2, 3, or 6 for `UR...` IDs until a UniRule-specific analysis is available.
+
 ### Step 1: Initialize the Review
 
 ```bash
-just init-rule-review RULE_ID
+# ARBA: starts the complete workflow below
+just init-rule-review ARBA00026249
+
+# UniRule: initialization and research only
+just init-rule-review UR000000070 --cache-dir rules/unirule
 ```
 
 This creates:
-- `rules/arba/RULE_ID/RULE_ID-review.yaml` with all required fields and TODO placeholders
-- `rules/arba/RULE_ID/RULE_ID.enriched.json` (if missing)
+- `rules/arba/ARBA_ID/ARBA_ID-review.yaml` or
+  `rules/unirule/UR_ID/UR_ID-review.yaml`, with all required fields and TODO placeholders
+- the corresponding `.enriched.json` file (if missing)
 
 **IMPORTANT**: This will FAIL if review YAML already exists (prevents accidental overwrites). To refresh, manually delete the review YAML first.
 

--- a/docs/rule_review_html.md
+++ b/docs/rule_review_html.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This feature provides HTML rendering for ARBA/UniRule reviews, similar to the existing gene review HTML rendering. The HTML output combines:
+This feature provides HTML rendering for ARBA reviews, similar to the existing gene review HTML rendering. The HTML output combines:
 
 - The rule review YAML (source of truth)
 - Quantitative analysis statistics
@@ -99,10 +99,6 @@ just render-rule ARBA00026249
 
 # Render all rules that have review YAML files
 just render-all-rules
-
-# Use a custom cache directory
-just render-rule ARBA00026249 rules/unirule
-just render-all-rules rules/unirule
 ```
 
 ### Basic Python API
@@ -181,7 +177,7 @@ Assessment badges:
 Located in `src/ai_gene_review/etl/rule_analysis.py`
 
 **Parameters:**
-- `rule_id`: ARBA/UniRule identifier
+- `rule_id`: ARBA identifier
 - `cache_dir`: Directory containing rule files
 - `output_path`: Optional custom output path
 - `template_path`: Optional custom template

--- a/docs/rule_review_workflow.md
+++ b/docs/rule_review_workflow.md
@@ -1,6 +1,7 @@
 # Rule Review Workflow
 
-This document describes the complete workflow for reviewing ARBA and UniRule annotation rules.
+This document describes the complete post-enrichment workflow for reviewing ARBA annotation rules.
+Review initialization also supports UniRule rules, but the analysis-dependent steps do not yet do so.
 
 ## Overview
 
@@ -15,7 +16,7 @@ The rule review workflow consists of several distinct phases, each with specific
 
 ## Quick Start
 
-For a new rule, run these commands in order:
+For a new ARBA rule, run these commands in order:
 
 ```bash
 # 1. Initialize the review file
@@ -298,16 +299,12 @@ This automatically analyzes any rules that don't have analysis files yet.
 6. **Keep analysis and review files in sync** - if you re-analyze, re-sync
 7. **Use deep research output** to inform your manual review of TODO placeholders
 
-## Advanced: Custom Cache Directory
+## UniRule Analysis Limitation
 
-For UniRule reviews, use a different cache directory:
-
-```bash
-just init-rule-review UR000000070 --cache-dir rules/unirule
-just analyze-rule UR000000070 --cache-dir rules/unirule
-just sync-rule-review-single UR000000070 rules/unirule
-just render-rule UR000000070 rules/unirule
-```
+`just init-rule-review` supports UniRule IDs, but post-enrichment `analyze-rule`
+currently supports `ARBA########` IDs only. Analysis-dependent sync and render
+workflows must not be used for `UR...` IDs until a UniRule-specific analysis
+implementation is available.
 
 ## See Also
 

--- a/examples/rule_analysis_demo.py
+++ b/examples/rule_analysis_demo.py
@@ -21,6 +21,7 @@ Example usage:
 
 import argparse
 import json
+import re
 from pathlib import Path
 
 from ai_gene_review.etl.arba import ARBAClient
@@ -74,6 +75,12 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if re.fullmatch(r"ARBA[0-9]{8}", args.rule_id) is None:
+        parser.error(
+            f"unsupported rule ID {args.rule_id!r}; "
+            "post-enrichment analysis currently supports ARBA######## IDs only"
+        )
 
     # Fetch rule
     print(f"Fetching rule {args.rule_id}...")

--- a/project.justfile
+++ b/project.justfile
@@ -2387,7 +2387,17 @@ sync-ipr2go cache_dir="rules/arba":
 # Example: just analyze-rule ARBA00026249
 # Example: just analyze-rule ARBA00026249 --cache-dir rules/arba
 # NOTE: Skips analysis if enriched.json AND analysis.yaml already exist (lazy evaluation)
-analyze-rule rule_id *args="":
+[positional-arguments]
+_validate-arba-analysis-id rule_id:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rule_id="$1"
+    if [[ ! "$rule_id" =~ ^ARBA[0-9]{8}$ ]]; then
+        printf "error: unsupported rule ID '%s'; post-enrichment analysis currently supports ARBA######## IDs only\n" "$rule_id" >&2
+        exit 2
+    fi
+
+analyze-rule rule_id *args="": (_validate-arba-analysis-id rule_id)
     #!/usr/bin/env bash
     set -euo pipefail  # Fail fast on errors, undefined variables, and pipe failures
 

--- a/project.justfile
+++ b/project.justfile
@@ -2263,12 +2263,14 @@ clean-imodulondb-cache:
 # This creates:
 #   - {cache_dir}/{rule_id}/{rule_id}-review.yaml with all required fields (WILL NOT OVERWRITE)
 #   - {cache_dir}/{rule_id}/{rule_id}.enriched.json (if missing)
-# Then run these commands in order:
+# For ARBA rules, then run these commands in order:
 #   1. just analyze-rule {rule_id}      # Generate analysis files
 #   2. just sync-rule-review-single {rule_id}  # Populate entries field
 #   3. just rules-deep-research-perplexity {rule_id}  # Research literature
 #   4. Edit the review YAML to fill in TODO placeholders
 #   5. just render-rule {rule_id}       # Generate HTML
+# For UniRule, continue with deep research and manual editing only;
+# post-enrichment analysis-dependent workflows currently support ARBA IDs only.
 # Examples:
 #   just init-rule-review ARBA00026249
 #   just init-rule-review UR000000070 --cache-dir rules/unirule
@@ -2375,6 +2377,16 @@ sync-ipr2go cache_dir="rules/arba":
     @echo "Syncing InterPro2GO mappings to {{cache_dir}}..."
     uv run python -c "from ai_gene_review.etl.rule_analysis import fetch_interpro2go_mappings; from pathlib import Path; mappings = fetch_interpro2go_mappings(Path('{{cache_dir}}')); print(f'✓ Cached {len(mappings)} InterPro → GO mappings')"
 
+[positional-arguments]
+_validate-arba-analysis-id rule_id:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rule_id="$1"
+    if [[ ! "$rule_id" =~ ^ARBA[0-9]{8}$ ]]; then
+        printf "error: unsupported rule ID '%s'; post-enrichment analysis currently supports ARBA######## IDs only\n" "$rule_id" >&2
+        exit 2
+    fi
+
 # Analyze an ARBA rule for InterPro overlap and ipr2go redundancy
 # Outputs YAML, JSON, and text formats
 # DEPENDENCIES:
@@ -2387,16 +2399,6 @@ sync-ipr2go cache_dir="rules/arba":
 # Example: just analyze-rule ARBA00026249
 # Example: just analyze-rule ARBA00026249 --cache-dir rules/arba
 # NOTE: Skips analysis if enriched.json AND analysis.yaml already exist (lazy evaluation)
-[positional-arguments]
-_validate-arba-analysis-id rule_id:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    rule_id="$1"
-    if [[ ! "$rule_id" =~ ^ARBA[0-9]{8}$ ]]; then
-        printf "error: unsupported rule ID '%s'; post-enrichment analysis currently supports ARBA######## IDs only\n" "$rule_id" >&2
-        exit 2
-    fi
-
 analyze-rule rule_id *args="": (_validate-arba-analysis-id rule_id)
     #!/usr/bin/env bash
     set -euo pipefail  # Fail fast on errors, undefined variables, and pipe failures

--- a/src/ai_gene_review/etl/rule_review_init.py
+++ b/src/ai_gene_review/etl/rule_review_init.py
@@ -95,11 +95,19 @@ def init_rule_review(
 
     print(f"✓ Created {review_path}")
     print("\nNext steps:")
-    print(f"  1. Run: just analyze-rule {rule_id}")
-    print(f"  2. Run: just sync-rule-review-single {rule_id}")
-    print(f"  3. Run: just rules-deep-research-perplexity {rule_id}")
-    print(f"  4. Edit {review_path} to fill in TODO placeholders")
-    print(f"  5. Run: just render-rule {rule_id}")
+    if rule_type == 'ARBA':
+        print(f"  1. Run: just analyze-rule {rule_id}")
+        print(f"  2. Run: just sync-rule-review-single {rule_id}")
+        print(f"  3. Run: just rules-deep-research-perplexity {rule_id}")
+        print(f"  4. Edit {review_path} to fill in TODO placeholders")
+        print(f"  5. Run: just render-rule {rule_id}")
+    else:
+        print(f"  1. Run: just rules-deep-research-perplexity {rule_id}")
+        print(f"  2. Edit {review_path} to fill in TODO placeholders")
+        print(
+            "  Note: Post-enrichment analysis-dependent workflows currently "
+            "support ARBA IDs only."
+        )
 
     return review_path
 

--- a/tests/test_rule_analysis_demo.py
+++ b/tests/test_rule_analysis_demo.py
@@ -1,0 +1,157 @@
+"""Tests for the post-enrichment rule-analysis command."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "examples" / "rule_analysis_demo.py"
+SPEC = importlib.util.spec_from_file_location("rule_analysis_demo", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+rule_analysis_demo = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = rule_analysis_demo
+SPEC.loader.exec_module(rule_analysis_demo)
+
+
+def run_just(
+    *args: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(extra_env or {})
+    return subprocess.run(
+        ["just", *args],
+        cwd=SCRIPT_PATH.parents[1],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize(
+    "rule_id",
+    [
+        "UR000000070",
+        "RULE00000001",
+        "ARBA123",
+    ],
+)
+def test_rejects_unsupported_rule_ids_before_client_or_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    rule_id: str,
+) -> None:
+    class UnexpectedClient:
+        def __init__(self, **_kwargs: object) -> None:
+            raise AssertionError("ARBAClient must not be constructed")
+
+    cache_dir = tmp_path / "rule cache"
+    output_dir = tmp_path / "analysis output"
+    monkeypatch.setattr(rule_analysis_demo, "ARBAClient", UnexpectedClient)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT_PATH),
+            rule_id,
+            "--cache-dir",
+            str(cache_dir),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        rule_analysis_demo.main()
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "post-enrichment analysis currently supports ARBA######## IDs only" in (
+        captured.err
+    )
+    assert captured.out == ""
+    assert not cache_dir.exists()
+    assert not output_dir.exists()
+
+
+def test_accepts_exact_arba_rule_id_format(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    rule_id = "ARBA00026249"
+    cache_dir = tmp_path / "rule cache"
+    fetched_ids: list[str] = []
+
+    class LocalClient:
+        def __init__(self, *, cache_dir: Path) -> None:
+            assert cache_dir == tmp_path / "rule cache"
+
+        def fetch_rule(self, requested_id: str) -> None:
+            fetched_ids.append(requested_id)
+            return None
+
+    monkeypatch.setattr(rule_analysis_demo, "ARBAClient", LocalClient)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(SCRIPT_PATH), rule_id, "--cache-dir", str(cache_dir), "--no-report"],
+    )
+
+    assert rule_analysis_demo.main() == 1
+    assert fetched_ids == [rule_id]
+    assert not cache_dir.exists()
+
+
+@pytest.mark.parametrize(
+    "rule_id",
+    [
+        "UR000000070",
+        "ARBA00026249; echo unsafe",
+    ],
+)
+def test_analyze_rule_wrapper_rejects_unsupported_ids_before_io(
+    tmp_path: Path,
+    rule_id: str,
+) -> None:
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import os
+from pathlib import Path
+
+Path(os.environ["RULE_ANALYSIS_UV_MARKER"]).write_text("invoked")
+raise SystemExit(99)
+"""
+    )
+    fake_uv.chmod(0o755)
+
+    cache_dir = tmp_path / "rule-cache"
+    marker = tmp_path / "uv-invoked"
+    result = run_just(
+        "analyze-rule",
+        rule_id,
+        "--cache-dir",
+        str(cache_dir),
+        extra_env={
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "RULE_ANALYSIS_UV_MARKER": str(marker),
+        },
+    )
+
+    assert result.returncode == 2
+    assert "post-enrichment analysis currently supports ARBA######## IDs only" in (
+        result.stderr
+    )
+    assert not cache_dir.exists()
+    assert not marker.exists()

--- a/tests/test_rule_review_wrapper_forwarding.py
+++ b/tests/test_rule_review_wrapper_forwarding.py
@@ -13,6 +13,21 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def write_enriched_rule(cache_dir: Path, rule_id: str) -> Path:
+    rule_dir = cache_dir / rule_id
+    rule_dir.mkdir(parents=True)
+    (rule_dir / f"{rule_id}.enriched.json").write_text(
+        json.dumps(
+            {
+                "rule_set": {"condition_sets": [], "annotations": []},
+                "reviewed_protein_count": 0,
+                "unreviewed_protein_count": 0,
+            }
+        )
+    )
+    return rule_dir
+
+
 def run_just(
     *args: str,
     extra_env: dict[str, str] | None = None,
@@ -33,17 +48,7 @@ def run_just(
 def test_init_rule_review_wrapper_uses_custom_cache_dir(tmp_path: Path) -> None:
     rule_id = "ARBA00026249"
     cache_dir = tmp_path / "rule cache (draft), v1?"
-    rule_dir = cache_dir / rule_id
-    rule_dir.mkdir(parents=True)
-    (rule_dir / f"{rule_id}.enriched.json").write_text(
-        json.dumps(
-            {
-                "rule_set": {"condition_sets": [], "annotations": []},
-                "reviewed_protein_count": 0,
-                "unreviewed_protein_count": 0,
-            }
-        )
-    )
+    rule_dir = write_enriched_rule(cache_dir, rule_id)
 
     result = run_just(
         "init-rule-review",
@@ -57,6 +62,31 @@ def test_init_rule_review_wrapper_uses_custom_cache_dir(tmp_path: Path) -> None:
     review = yaml.safe_load(review_path.read_text())
     assert review["id"] == rule_id
     assert review["rule_type"] == "ARBA"
+    assert f"just analyze-rule {rule_id}" in result.stdout
+    assert f"just sync-rule-review-single {rule_id}" in result.stdout
+    assert f"just render-rule {rule_id}" in result.stdout
+
+
+def test_init_unirule_omits_unsupported_analysis_next_steps(tmp_path: Path) -> None:
+    rule_id = "UR000000070"
+    cache_dir = tmp_path / "unirule cache"
+    rule_dir = write_enriched_rule(cache_dir, rule_id)
+
+    result = run_just(
+        "init-rule-review",
+        rule_id,
+        "--cache-dir",
+        str(cache_dir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    review = yaml.safe_load((rule_dir / f"{rule_id}-review.yaml").read_text())
+    assert review["rule_type"] == "UniRule"
+    assert "rules-deep-research-perplexity" in result.stdout
+    assert "currently support ARBA IDs only" in result.stdout
+    assert "analyze-rule" not in result.stdout
+    assert "sync-rule-review-single" not in result.stdout
+    assert "render-rule" not in result.stdout
 
 
 def test_init_rule_review_wrapper_forwards_no_empty_tail(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- reject non-`ARBA########` IDs at the public `just analyze-rule` boundary before cache creation or lazy exit
- keep the Python command guarded before client, cache, network, or output activity
- tailor initialization guidance so UniRule users are never sent into rejected analysis/sync/render commands
- document that post-enrichment analysis-dependent workflows are currently ARBA-only
- add hermetic unit and real-Just regressions, including shell-metacharacter input

## Safety context

Cached UniRule data can otherwise be parsed through the ARBA path and trigger unbounded external InterPro expansion. This PR fails closed at the supported wrapper and Python command boundaries; UniRule initialization and research remain supported. The existing `analyze-rule` variadic argument/`--force` parser is intentionally left for a separate PR.

## Validation

- `PYTEST_ADDOPTS='-q tests/test_rule_analysis_demo.py tests/test_rule_review_wrapper_forwarding.py' just pytest` (9 passed)
- `just test` (1421 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`
- independent read-only review: no blockers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a safety boundary that blocks UniRule/malformed IDs from expensive or incorrect ARBA analysis; ARBA happy path behavior is unchanged aside from stricter ID format validation.
> 
> **Overview**
> **Fails closed** on post-enrichment rule analysis so only `ARBA########` IDs run through the ARBA analysis path. UniRule init and deep research stay supported; analyze/sync/render guidance is scoped to ARBA.
> 
> `just analyze-rule` now depends on `_validate-arba-analysis-id`, which exits with code 2 before cache creation or invoking `uv`/`rule_analysis_demo.py`. `examples/rule_analysis_demo.py` applies the same `ARBA[0-9]{8}` check via `argparse` before `ARBAClient` or output directories are touched.
> 
> `init_rule_review` prints **ARBA** next steps (analyze → sync → research → edit → render) versus **UniRule** steps (research and manual edit only, with an ARBA-only analysis note). Docs and the rule-reviewer skill were updated to match; misleading UniRule `analyze-rule` / custom-cache examples were removed.
> 
> New tests cover early rejection for invalid IDs (including shell-metacharacter input) and UniRule init stdout omitting unsupported commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da14f87803705cd7e38ed332779d4634b2e73e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->