### PR TITLE
Reject non-ARBA post-enrichment analysis at API boundaries

### DIFF
--- a/examples/render_rule_review_demo.py
+++ b/examples/render_rule_review_demo.py
@@ -13,6 +13,7 @@ Example:
 """
 
 import argparse
+import re
 from pathlib import Path
 
 from ai_gene_review.etl.arba import ARBAClient
@@ -54,6 +55,12 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if re.fullmatch(r"ARBA[0-9]{8}", args.rule_id) is None:
+        parser.error(
+            f"unsupported rule ID {args.rule_id!r}; post-enrichment analysis "
+            "currently supports ARBA######## IDs only"
+        )
 
     rule_id = args.rule_id
     output_dir = args.output_dir

--- a/src/ai_gene_review/etl/rule_analysis.py
+++ b/src/ai_gene_review/etl/rule_analysis.py
@@ -1,4 +1,4 @@
-"""Post-enrichment analysis for ARBA and UniRule rules.
+"""Post-enrichment analysis for ARBA rules.
 
 This module provides deterministic analysis of UniProt rules including:
 - Fetching InterPro2GO mappings from GO Consortium
@@ -1056,7 +1056,9 @@ def analyze_rule_post_enrichment(
         Complete analysis dict suitable for adding to enriched JSON
 
     Raises:
-        ValueError: If rule has more than max_condition_sets condition sets
+        TypeError: If rule is not an ARBARule instance
+        ValueError: If rule does not have an ARBA######## identifier, or has more than
+            max_condition_sets condition sets
 
     Example:
         >>> from ai_gene_review.etl.arba import ARBAClient # doctest: +SKIP
@@ -1067,6 +1069,19 @@ def analyze_rule_post_enrichment(
         >>> "rule_id" in analysis and "ipr2go_redundancy" in analysis # doctest: +SKIP
         True
     """
+    if not isinstance(rule, ARBARule):
+        raise TypeError(
+            "analyze_rule_post_enrichment() requires an ARBARule instance; "
+            f"got {type(rule).__name__}"
+        )
+
+    rule_id = rule.uni_rule_id
+    if not isinstance(rule_id, str) or re.fullmatch(r"ARBA[0-9]{8}", rule_id) is None:
+        raise ValueError(
+            f"unsupported rule ID {rule_id!r}; post-enrichment analysis "
+            "currently supports ARBA######## IDs only"
+        )
+
     # Check condition set limit
     num_condition_sets = len(rule.condition_sets)
     if num_condition_sets > max_condition_sets:

--- a/tests/test_render_rule_review_demo.py
+++ b/tests/test_render_rule_review_demo.py
@@ -1,0 +1,65 @@
+"""Tests for the rule-analysis and HTML-rendering demo command."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "examples" / "render_rule_review_demo.py"
+)
+SPEC = importlib.util.spec_from_file_location("render_rule_review_demo", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+render_rule_review_demo = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = render_rule_review_demo
+SPEC.loader.exec_module(render_rule_review_demo)
+
+
+@pytest.mark.parametrize(
+    ("rule_id", "extra_args"),
+    [
+        ("UR000000070", []),
+        ("UR000000070", ["--skip-analysis"]),
+        ("RULE00000001", []),
+        ("ARBA123", []),
+    ],
+)
+def test_rejects_unsupported_rule_ids_before_client_or_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    rule_id: str,
+    extra_args: list[str],
+) -> None:
+    class UnexpectedClient:
+        def __init__(self, **_kwargs: object) -> None:
+            raise AssertionError("ARBAClient must not be constructed")
+
+    output_dir = tmp_path / "rendered output"
+    monkeypatch.setattr(render_rule_review_demo, "ARBAClient", UnexpectedClient)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT_PATH),
+            rule_id,
+            "--output-dir",
+            str(output_dir),
+            *extra_args,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        render_rule_review_demo.main()
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "post-enrichment analysis currently supports ARBA######## IDs only" in (
+        captured.err
+    )
+    assert captured.out == ""
+    assert not output_dir.exists()

--- a/tests/test_rule_analysis.py
+++ b/tests/test_rule_analysis.py
@@ -13,9 +13,11 @@ Test data is based on ARBA00026249 which has:
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 
+from ai_gene_review.etl import rule_analysis
 from ai_gene_review.etl.arba import ARBARule
 from ai_gene_review.etl.rule_analysis import (
     analyze_interpro_overlap_in_condition_set,
@@ -27,6 +29,7 @@ from ai_gene_review.etl.rule_analysis import (
     get_swissprot_count_for_interpro,
     get_swissprot_count_for_interpro_intersection,
 )
+from ai_gene_review.etl.unirule import UniRule
 
 
 @pytest.fixture
@@ -38,6 +41,83 @@ def arba00026249_rule() -> ARBARule:
 
     data = json.loads(rule_file.read_text())
     return ARBARule.from_json(data)
+
+
+def minimal_rule_json(rule_id: str) -> dict:
+    return {
+        "uniRuleId": rule_id,
+        "information": {"version": "1"},
+        "mainRule": {"conditionSets": [], "annotations": []},
+        "statistics": {
+            "reviewedProteinCount": 0,
+            "unreviewedProteinCount": 0,
+        },
+        "createdDate": "2025-01-01",
+        "modifiedDate": "2025-01-01",
+    }
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected_error", "message"),
+    [
+        (
+            UniRule.from_json(minimal_rule_json("UR000000070")),
+            TypeError,
+            "requires an ARBARule instance; got UniRule",
+        ),
+        (
+            UniRule.from_json(minimal_rule_json("ARBA00026249")),
+            TypeError,
+            "requires an ARBARule instance; got UniRule",
+        ),
+        (
+            ARBARule.from_json(minimal_rule_json("UR000000070")),
+            ValueError,
+            "post-enrichment analysis currently supports ARBA######## IDs only",
+        ),
+        (
+            ARBARule.from_json(minimal_rule_json("TEST00000001")),
+            ValueError,
+            "post-enrichment analysis currently supports ARBA######## IDs only",
+        ),
+        (
+            ARBARule.from_json(minimal_rule_json("ARBA123")),
+            ValueError,
+            "post-enrichment analysis currently supports ARBA######## IDs only",
+        ),
+        (
+            ARBARule.from_json(minimal_rule_json("arba00026249")),
+            ValueError,
+            "post-enrichment analysis currently supports ARBA######## IDs only",
+        ),
+        (
+            ARBARule.from_json(minimal_rule_json("ARBA00026249-extra")),
+            ValueError,
+            "post-enrichment analysis currently supports ARBA######## IDs only",
+        ),
+    ],
+)
+def test_analyze_rule_post_enrichment_rejects_non_arba_before_io(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    candidate: ARBARule | UniRule,
+    expected_error: type[Exception],
+    message: str,
+) -> None:
+    def unexpected_cache_access(_cache_dir: Path) -> dict[str, list[str]]:
+        raise AssertionError("InterPro2GO cache must not be accessed")
+
+    cache_dir = tmp_path / "analysis cache"
+    monkeypatch.setattr(
+        rule_analysis,
+        "fetch_interpro2go_mappings",
+        unexpected_cache_access,
+    )
+
+    with pytest.raises(expected_error, match=message):
+        analyze_rule_post_enrichment(cast(ARBARule, candidate), cache_dir)
+
+    assert not cache_dir.exists()
 
 
 @pytest.mark.integration
@@ -402,7 +482,7 @@ def test_analyze_rule_post_enrichment_no_interpro(tmp_path):
     )
 
     rule = ARBARule(
-        uni_rule_id="TEST00000001",
+        uni_rule_id="ARBA99999999",
         version="1",
         condition_sets=[
             ConditionSet(
@@ -432,7 +512,7 @@ def test_analyze_rule_post_enrichment_no_interpro(tmp_path):
 
     result = analyze_rule_post_enrichment(rule, tmp_path)
 
-    assert result["rule_id"] == "TEST00000001"
+    assert result["rule_id"] == "ARBA99999999"
 
     # Should have condition set summary but no InterPro overlap
     assert "condition_sets_summary" in result


### PR DESCRIPTION
## Summary

- require a real `ARBARule` with an exact `ARBA########` identifier before post-enrichment analysis
- reject unsupported IDs in the render-analysis demo before output, client, cache, or network work
- add hermetic regressions for UniRule objects, cache-parsed UniRule data, malformed IDs, and `--skip-analysis`

## Validation

- `PYTEST_ADDOPTS="-q tests/test_rule_analysis.py -k \"rejects_non_arba or no_interpro\"" just pytest`
- `PYTEST_ADDOPTS="-q tests/test_render_rule_review_demo.py" just pytest`
- `just format`
- `just test` (1,432 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`

This is the separate library/API safety follow-up identified while shepherding #2449.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change with fail-fast behavior; no change to successful ARBA analysis paths beyond stricter input checks.
> 
> **Overview**
> **Post-enrichment analysis** is now explicitly **ARBA-only**: `analyze_rule_post_enrichment()` raises **`TypeError`** for non-`ARBARule` inputs and **`ValueError`** unless `uni_rule_id` matches **`ARBA########`** (exact eight digits), before InterPro2GO cache or UniProt work runs.
> 
> The **`render_rule_review_demo`** example applies the same ID check at parse time (including with **`--skip-analysis`**), so bad IDs exit with code 2 without creating output dirs or constructing **`ARBAClient`**.
> 
> Hermetic tests cover **`UniRule`** objects, malformed IDs, and demo early exit; the no-InterPro integration test now uses a valid **`ARBA99999999`** ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c873984c9d024ccc82213b5718cd81f6bff6173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->