### PR TITLE
Preserve analyze-rule arguments and honor force

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -2399,54 +2399,76 @@ _validate-arba-analysis-id rule_id:
 # Example: just analyze-rule ARBA00026249
 # Example: just analyze-rule ARBA00026249 --cache-dir rules/arba
 # NOTE: Skips analysis if enriched.json AND analysis.yaml already exist (lazy evaluation)
-analyze-rule rule_id *args="": (_validate-arba-analysis-id rule_id)
+[positional-arguments]
+analyze-rule rule_id *args: (_validate-arba-analysis-id rule_id)
     #!/usr/bin/env bash
     set -euo pipefail  # Fail fast on errors, undefined variables, and pipe failures
 
-    cache_dir="rules/arba"
-    if [[ "{{args}}" == *"--cache-dir"* ]]; then
-        cache_dir=$(echo "{{args}}" | sed -n 's/.*--cache-dir \([^ ]*\).*/\1/p')
-    fi
+    rule_id="$1"
+    shift
 
-    # Extract rule type from ID
-    if [[ "{{rule_id}}" == ARBA* ]]; then
-        rule_dir="$cache_dir/{{rule_id}}"
-    else
-        rule_dir="$cache_dir/{{rule_id}}"
-    fi
+    cache_dir="rules/arba"
+    force=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --cache-dir)
+                if [[ $# -lt 2 ]]; then
+                    printf "error: --cache-dir requires a path\n" >&2
+                    exit 2
+                fi
+                if [[ -z "$2" || "$2" == --* ]]; then
+                    printf "error: --cache-dir requires a path\n" >&2
+                    exit 2
+                fi
+                cache_dir="$2"
+                shift 2
+                ;;
+            --force)
+                force=true
+                shift
+                ;;
+            *)
+                printf "error: unsupported analyze-rule argument '%s'\n" "$1" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    rule_dir="$cache_dir/$rule_id"
 
     mkdir -p "$rule_dir"
 
     # Check if analysis files already exist (lazy evaluation)
-    enriched_file="$rule_dir/{{rule_id}}.enriched.json"
-    analysis_yaml="$rule_dir/{{rule_id}}-analysis.yaml"
+    enriched_file="$rule_dir/$rule_id.enriched.json"
+    analysis_yaml="$rule_dir/$rule_id-analysis.yaml"
 
-    if [ -f "$enriched_file" ] && [ -f "$analysis_yaml" ]; then
-        echo "✓ Analysis files already exist for {{rule_id}}, skipping expensive rebuild"
+    if [[ "$force" == false && -f "$enriched_file" && -f "$analysis_yaml" ]]; then
+        echo "✓ Analysis files already exist for $rule_id, skipping expensive rebuild"
         echo "  - $enriched_file"
         echo "  - $analysis_yaml"
         echo "  Use --force to rebuild (add to args)"
         exit 0
     fi
 
-    echo "Analyzing {{rule_id}}..."
+    echo "Analyzing $rule_id..."
 
     # Run analysis once and save all formats (efficient)
-    uv run python examples/rule_analysis_demo.py {{rule_id}} \
+    uv run python examples/rule_analysis_demo.py "$rule_id" \
         --cache-dir "$cache_dir" \
         --output-dir "$rule_dir" \
         --no-report
 
     echo ""
     echo "✓ Analysis complete. Files created:"
-    echo "  - $rule_dir/{{rule_id}}-analysis.yaml"
-    echo "  - $rule_dir/{{rule_id}}-analysis.json"
-    echo "  - $rule_dir/{{rule_id}}-analysis.txt"
-    echo "  - $rule_dir/{{rule_id}}-heatmap.png"
+    echo "  - $rule_dir/$rule_id-analysis.yaml"
+    echo "  - $rule_dir/$rule_id-analysis.json"
+    echo "  - $rule_dir/$rule_id-analysis.txt"
+    echo "  - $rule_dir/$rule_id-heatmap.png"
     echo ""
     echo "Text report:"
     echo "----------------------------------------"
-    cat "$rule_dir/{{rule_id}}-analysis.txt"
+    cat "$rule_dir/$rule_id-analysis.txt"
 
 # ============== AI4CUI Dashboard ==============
 

--- a/tests/test_rule_analysis_demo.py
+++ b/tests/test_rule_analysis_demo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import subprocess
 import sys
@@ -34,6 +35,32 @@ def run_just(
         env=env,
         timeout=30,
     )
+
+
+def install_recording_uv(tmp_path: Path) -> Path:
+    """Install a fake uv executable that records its exact argument vector."""
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+Path(os.environ["RULE_ANALYSIS_UV_MARKER"]).write_text(json.dumps(args))
+if "examples/rule_analysis_demo.py" in args and "--output-dir" in args:
+    rule_id = args[args.index("examples/rule_analysis_demo.py") + 1]
+    output_dir = Path(args[args.index("--output-dir") + 1])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / f"{rule_id}-analysis.txt").write_text("fake report\\n")
+raise SystemExit(int(os.environ.get("RULE_ANALYSIS_UV_EXIT", "0")))
+"""
+    )
+    fake_uv.chmod(0o755)
+    return fake_bin
 
 
 @pytest.mark.parametrize(
@@ -153,5 +180,168 @@ raise SystemExit(99)
     assert "post-enrichment analysis currently supports ARBA######## IDs only" in (
         result.stderr
     )
+    assert not cache_dir.exists()
+    assert not marker.exists()
+
+
+def test_analyze_rule_wrapper_preserves_spaced_cache_path_when_skipping(
+    tmp_path: Path,
+) -> None:
+    rule_id = "ARBA00026249"
+    cache_dir = tmp_path / "analysis cache (draft), v1?"
+    rule_dir = cache_dir / rule_id
+    rule_dir.mkdir(parents=True)
+    (rule_dir / f"{rule_id}.enriched.json").write_text("{}")
+    (rule_dir / f"{rule_id}-analysis.yaml").write_text("analysis: present\n")
+
+    fake_bin = install_recording_uv(tmp_path)
+    marker = tmp_path / "uv invocation.json"
+    result = run_just(
+        "analyze-rule",
+        rule_id,
+        "--cache-dir",
+        str(cache_dir),
+        extra_env={
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "RULE_ANALYSIS_UV_MARKER": str(marker),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "skipping expensive rebuild" in result.stdout
+    assert not marker.exists()
+
+
+def test_analyze_rule_wrapper_force_runs_with_exact_arguments(tmp_path: Path) -> None:
+    rule_id = "ARBA00026249"
+    cache_dir = tmp_path / "analysis cache (draft), v1?"
+    rule_dir = cache_dir / rule_id
+    rule_dir.mkdir(parents=True)
+    (rule_dir / f"{rule_id}.enriched.json").write_text("{}")
+    (rule_dir / f"{rule_id}-analysis.yaml").write_text("analysis: present\n")
+
+    fake_bin = install_recording_uv(tmp_path)
+    marker = tmp_path / "uv invocation.json"
+    result = run_just(
+        "analyze-rule",
+        rule_id,
+        "--cache-dir",
+        str(cache_dir),
+        "--force",
+        extra_env={
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "RULE_ANALYSIS_UV_MARKER": str(marker),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(marker.read_text()) == [
+        "run",
+        "python",
+        "examples/rule_analysis_demo.py",
+        rule_id,
+        "--cache-dir",
+        str(cache_dir),
+        "--output-dir",
+        str(rule_dir),
+        "--no-report",
+    ]
+
+
+def test_analyze_rule_wrapper_accepts_empty_optional_tail(tmp_path: Path) -> None:
+    rule_id = "ARBA00026249"
+    working_directory = tmp_path / "isolated working directory"
+    working_directory.mkdir()
+    fake_bin = install_recording_uv(tmp_path)
+    marker = tmp_path / "uv invocation.json"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "RULE_ANALYSIS_UV_MARKER": str(marker),
+        }
+    )
+
+    result = subprocess.run(
+        [
+            "just",
+            "--justfile",
+            str(SCRIPT_PATH.parents[1] / "justfile"),
+            "--working-directory",
+            str(working_directory),
+            "analyze-rule",
+            rule_id,
+        ],
+        cwd=SCRIPT_PATH.parents[1],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(marker.read_text()) == [
+        "run",
+        "python",
+        "examples/rule_analysis_demo.py",
+        rule_id,
+        "--cache-dir",
+        "rules/arba",
+        "--output-dir",
+        f"rules/arba/{rule_id}",
+        "--no-report",
+    ]
+    assert (
+        working_directory / "rules" / "arba" / rule_id / f"{rule_id}-analysis.txt"
+    ).exists()
+
+
+def test_analyze_rule_wrapper_rejects_unknown_argument_before_io(
+    tmp_path: Path,
+) -> None:
+    rule_id = "ARBA00026249"
+    cache_dir = tmp_path / "isolated-cache"
+    fake_bin = install_recording_uv(tmp_path)
+    marker = tmp_path / "uv invocation.json"
+    result = run_just(
+        "analyze-rule",
+        rule_id,
+        "--cache-dir",
+        str(cache_dir),
+        "--unknown",
+        extra_env={
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "RULE_ANALYSIS_UV_MARKER": str(marker),
+        },
+    )
+
+    assert result.returncode == 2
+    assert "unsupported analyze-rule argument '--unknown'" in result.stderr
+    assert not cache_dir.exists()
+    assert not marker.exists()
+
+
+def test_analyze_rule_wrapper_rejects_missing_cache_path_before_io(
+    tmp_path: Path,
+) -> None:
+    rule_id = "ARBA00026249"
+    cache_dir = tmp_path / "isolated-cache"
+    fake_bin = install_recording_uv(tmp_path)
+    marker = tmp_path / "uv invocation.json"
+    result = run_just(
+        "analyze-rule",
+        rule_id,
+        "--cache-dir",
+        str(cache_dir),
+        "--cache-dir",
+        extra_env={
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "RULE_ANALYSIS_UV_MARKER": str(marker),
+        },
+    )
+
+    assert result.returncode == 2
+    assert "--cache-dir requires a path" in result.stderr
     assert not cache_dir.exists()
     assert not marker.exists()


### PR DESCRIPTION
## Summary

- preserve exact `analyze-rule` argument boundaries with Just positional arguments
- parse `--cache-dir` and `--force` before filesystem work, rejecting malformed tails with exit code 2
- make `--force` bypass lazy output detection without forwarding it to the Python analyzer
- cover the public Just wrapper with hermetic zero-tail, spaced-path, skip, force, and error-path regressions

## Validation

- `PYTEST_ADDOPTS="-q tests/test_rule_analysis_demo.py" just pytest` (11 passed)
- `just format`
- `just test` (1,437 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`

This is the separate wrapper-parser follow-up queued after #2453.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the Just wrapper and test harness around rule analysis; behavior is clearer and better tested with no auth or data-path risk beyond local cache dirs.
> 
> **Overview**
> The **`analyze-rule`** Just recipe now uses **`[positional-arguments]`** and a bash argument loop instead of template/`sed` parsing, so **`--cache-dir`** paths with spaces and other special characters are preserved end-to-end.
> 
> **`--cache-dir`** and **`--force`** are parsed before any filesystem work; malformed tails (unknown flags, a bare **`--cache-dir`**) exit with code **2** without creating cache dirs or invoking **`uv`**. **`--force`** skips the lazy “analysis already exists” shortcut but is **not** passed through to **`rule_analysis_demo.py`**.
> 
> Hermetic tests in **`tests/test_rule_analysis_demo.py`** record fake **`uv`** invocations and cover skip-with-spaced-path, force rebuild args, default empty tail, and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 457e9e2b1bcbe6abfc1fee879f11dd64af419c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->