### PR TITLE
Forward custom rule caches to analysis dependencies

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -1393,7 +1393,7 @@ render-module module:
 # CREATES:
 #   - {rule_id}-review.html
 # Example: just render-rule ARBA00026249
-render-rule rule_id cache_dir="rules/arba": (analyze-rule rule_id)
+render-rule rule_id cache_dir="rules/arba": (analyze-rule rule_id "--cache-dir" cache_dir)
     uv run python -c "from ai_gene_review.etl.rule_analysis import render_rule_review_html; from pathlib import Path; render_rule_review_html('{{rule_id}}', Path('{{cache_dir}}'))"
 
 # Render all rule reviews as HTML (automatically analyzes first if needed)
@@ -2334,7 +2334,7 @@ rules-validate *args="":
 #   - Requires {rule_id}-review.yaml to exist (create with init-rule-review first)
 #   - Requires {rule_id}-analysis.yaml (created automatically by analyze-rule dependency)
 # Example: just sync-rule-review-single ARBA00027128
-sync-rule-review-single rule_id cache_dir="rules/arba": (analyze-rule rule_id)
+sync-rule-review-single rule_id cache_dir="rules/arba": (analyze-rule rule_id "--cache-dir" cache_dir)
     uv run ai-gene-review rules-sync {{cache_dir}}/{{rule_id}}/{{rule_id}}-review.yaml
 
 # Sync rule review YAML files with analysis data (pairwise_overlap sections)

--- a/tests/test_rule_review_wrapper_forwarding.py
+++ b/tests/test_rule_review_wrapper_forwarding.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -123,3 +124,143 @@ with open(os.environ["RULE_WRAPPER_ARGV_LOG"], "w") as handle:
         "init-rule-review",
         "ARBA00026249",
     ]
+
+
+def seed_analysis_outputs(cache_dir: Path, rule_id: str) -> None:
+    rule_dir = write_enriched_rule(cache_dir, rule_id)
+    (rule_dir / f"{rule_id}-analysis.yaml").write_text("analysis: present\n")
+    (rule_dir / f"{rule_id}-review.yaml").write_text(
+        f"id: {rule_id}\nrule_type: ARBA\nentries: []\n"
+    )
+
+
+def install_recording_uv(tmp_path: Path) -> tuple[Path, Path]:
+    fake_bin = tmp_path / "recording bin"
+    fake_bin.mkdir()
+    log_path = tmp_path / "uv argv.jsonl"
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+with Path(os.environ["RULE_WRAPPER_ARGV_LOG"]).open("a") as handle:
+    handle.write(json.dumps(args) + "\\n")
+
+if "examples/rule_analysis_demo.py" in args and "--output-dir" in args:
+    rule_id = args[args.index("examples/rule_analysis_demo.py") + 1]
+    output_dir = Path(args[args.index("--output-dir") + 1])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / f"{rule_id}-analysis.txt").write_text("fake report\\n")
+"""
+    )
+    fake_uv.chmod(0o755)
+    return fake_bin, log_path
+
+
+def run_isolated_just(
+    working_directory: Path,
+    fake_bin: Path,
+    log_path: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "RULE_WRAPPER_ARGV_LOG": str(log_path),
+            "JUST_JUSTFILE": str(REPO_ROOT / "justfile"),
+            "JUST_WORKING_DIRECTORY": str(working_directory),
+        }
+    )
+    return subprocess.run(
+        [
+            "just",
+            "--justfile",
+            str(REPO_ROOT / "justfile"),
+            "--working-directory",
+            str(working_directory),
+            *args,
+        ],
+        cwd=working_directory,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+
+def read_argv_log(log_path: Path) -> list[list[str]]:
+    return [json.loads(line) for line in log_path.read_text().splitlines()]
+
+
+@pytest.mark.parametrize("recipe", ["render-rule", "sync-rule-review-single"])
+def test_rule_wrapper_analysis_dependency_uses_custom_cache(
+    tmp_path: Path,
+    recipe: str,
+) -> None:
+    rule_id = "ARBA00026249"
+    working_directory = tmp_path / "isolated working directory"
+    working_directory.mkdir()
+    cache_dir = working_directory / "custom-cache"
+    seed_analysis_outputs(cache_dir, rule_id)
+    fake_bin, log_path = install_recording_uv(tmp_path)
+
+    result = run_isolated_just(
+        working_directory,
+        fake_bin,
+        log_path,
+        recipe,
+        rule_id,
+        "custom-cache",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "skipping expensive rebuild" in result.stdout
+    invocations = read_argv_log(log_path)
+    assert not any("examples/rule_analysis_demo.py" in argv for argv in invocations)
+    assert not (working_directory / "rules" / "arba" / rule_id).exists()
+    if recipe == "render-rule":
+        assert len(invocations) == 1
+        assert invocations[0][:3] == ["run", "python", "-c"]
+        assert "Path('custom-cache')" in invocations[0][3]
+    else:
+        assert invocations == [
+            [
+                "run",
+                "ai-gene-review",
+                "rules-sync",
+                f"custom-cache/{rule_id}/{rule_id}-review.yaml",
+            ]
+        ]
+
+
+def test_render_all_rules_analysis_dependency_uses_custom_cache(
+    tmp_path: Path,
+) -> None:
+    rule_id = "ARBA00026249"
+    working_directory = tmp_path / "isolated working directory"
+    working_directory.mkdir()
+    cache_dir = working_directory / "custom-cache"
+    seed_analysis_outputs(cache_dir, rule_id)
+    fake_bin, log_path = install_recording_uv(tmp_path)
+
+    result = run_isolated_just(
+        working_directory,
+        fake_bin,
+        log_path,
+        "render-all-rules",
+        "custom-cache",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Rendered 1 rule reviews" in result.stdout
+    invocations = read_argv_log(log_path)
+    assert not any("examples/rule_analysis_demo.py" in argv for argv in invocations)
+    render_invocations = [argv for argv in invocations if argv[:3] == ["run", "python", "-c"]]
+    assert len(render_invocations) == 1
+    assert not (working_directory / "rules" / "arba" / rule_id).exists()


### PR DESCRIPTION
## Summary

- forward each `render-rule` cache path to its `analyze-rule` prerequisite
- forward each `sync-rule-review-single` cache path to the same prerequisite
- verify direct render/sync and transitive `render-all-rules` behavior through public Just recipes in an isolated working directory

## Validation

- `PYTEST_ADDOPTS="-q tests/test_rule_review_wrapper_forwarding.py" just pytest` (6 passed)
- `just format`
- `just test` (1,440 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`

This is the separate dependency-forwarding follow-up after #2454.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Just recipe wiring and test coverage only; no production runtime or data-path changes beyond correct cache forwarding for rule review workflows.
> 
> **Overview**
> **`render-rule`** and **`sync-rule-review-single`** now pass the recipe’s `cache_dir` into their **`analyze-rule`** prerequisite as `--cache-dir`, so analysis and lazy skip logic run against the same directory as render/sync instead of always defaulting to `rules/arba`.
> 
> End-to-end tests in **`test_rule_review_wrapper_forwarding.py`** exercise **`render-rule`**, **`sync-rule-review-single`**, and transitive **`render-all-rules`** with a custom cache in an isolated working directory, asserting analysis is skipped when outputs exist, no analysis demo runs, and nothing is written under the default `rules/arba` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25d520fa616b797299c71d3df982e31564f80fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->