### PR TITLE
Preserve sync-rule custom cache paths

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -2334,8 +2334,13 @@ rules-validate *args="":
 #   - Requires {rule_id}-review.yaml to exist (create with init-rule-review first)
 #   - Requires {rule_id}-analysis.yaml (created automatically by analyze-rule dependency)
 # Example: just sync-rule-review-single ARBA00027128
+[positional-arguments]
 sync-rule-review-single rule_id cache_dir="rules/arba": (analyze-rule rule_id "--cache-dir" cache_dir)
-    uv run ai-gene-review rules-sync {{cache_dir}}/{{rule_id}}/{{rule_id}}-review.yaml
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rule_id="$1"
+    cache_dir="$2"
+    uv run ai-gene-review rules-sync "$cache_dir/$rule_id/$rule_id-review.yaml"
 
 # Sync rule review YAML files with analysis data (pairwise_overlap sections)
 # Examples:

--- a/tests/test_rule_review_wrapper_forwarding.py
+++ b/tests/test_rule_review_wrapper_forwarding.py
@@ -206,7 +206,7 @@ def test_rule_wrapper_analysis_dependency_uses_custom_cache(
     rule_id = "ARBA00026249"
     working_directory = tmp_path / "isolated working directory"
     working_directory.mkdir()
-    cache_dir = working_directory / "custom-cache"
+    cache_dir = working_directory / "custom cache"
     seed_analysis_outputs(cache_dir, rule_id)
     fake_bin, log_path = install_recording_uv(tmp_path)
 
@@ -216,7 +216,7 @@ def test_rule_wrapper_analysis_dependency_uses_custom_cache(
         log_path,
         recipe,
         rule_id,
-        "custom-cache",
+        "custom cache",
     )
 
     assert result.returncode == 0, result.stderr
@@ -227,14 +227,14 @@ def test_rule_wrapper_analysis_dependency_uses_custom_cache(
     if recipe == "render-rule":
         assert len(invocations) == 1
         assert invocations[0][:3] == ["run", "python", "-c"]
-        assert "Path('custom-cache')" in invocations[0][3]
+        assert "Path('custom cache')" in invocations[0][3]
     else:
         assert invocations == [
             [
                 "run",
                 "ai-gene-review",
                 "rules-sync",
-                f"custom-cache/{rule_id}/{rule_id}-review.yaml",
+                f"custom cache/{rule_id}/{rule_id}-review.yaml",
             ]
         ]
 
@@ -264,3 +264,31 @@ def test_render_all_rules_analysis_dependency_uses_custom_cache(
     render_invocations = [argv for argv in invocations if argv[:3] == ["run", "python", "-c"]]
     assert len(render_invocations) == 1
     assert not (working_directory / "rules" / "arba" / rule_id).exists()
+
+
+def test_sync_rule_review_single_preserves_default_cache_argument(
+    tmp_path: Path,
+) -> None:
+    rule_id = "ARBA00026249"
+    working_directory = tmp_path / "isolated working directory"
+    working_directory.mkdir()
+    seed_analysis_outputs(working_directory / "rules" / "arba", rule_id)
+    fake_bin, log_path = install_recording_uv(tmp_path)
+
+    result = run_isolated_just(
+        working_directory,
+        fake_bin,
+        log_path,
+        "sync-rule-review-single",
+        rule_id,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert read_argv_log(log_path) == [
+        [
+            "run",
+            "ai-gene-review",
+            "rules-sync",
+            f"rules/arba/{rule_id}/{rule_id}-review.yaml",
+        ]
+    ]


### PR DESCRIPTION
## Summary

- make `sync-rule-review-single` a positional Bash wrapper
- preserve spaced custom cache paths as one quoted review-file argument
- lock both custom and default cache behavior through isolated public-Just regressions

## Validation

- `PYTEST_ADDOPTS="-q tests/test_rule_review_wrapper_forwarding.py" just pytest` (7 passed)
- `just format`
- `just test` (1,441 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`

This is the separate wrapper-boundary follow-up identified during #2455.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tooling and test-only changes to a Just recipe wrapper; no application runtime or auth/data paths affected.
> 
> **Overview**
> **`sync-rule-review-single`** no longer builds the review file path with Just template interpolation. It is a **`[positional-arguments]` Bash recipe** (like other rule wrappers) that runs `rules-sync` with `"$cache_dir/$rule_id/$rule_id-review.yaml"`, so a **custom `cache_dir` that contains spaces** stays a single argument instead of being split.
> 
> Tests in **`test_rule_review_wrapper_forwarding.py`** now exercise a spaced cache dir for `render-rule` / `sync-rule-review-single` forwarding, and add **`test_sync_rule_review_single_preserves_default_cache_argument`** to confirm omitting the second argument still syncs under the default **`rules/arba`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0d6ea5f7062c21470a798116b3addcabd5cf182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->