### PR TITLE
Preserve render-all rule cache paths

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -1402,16 +1402,18 @@ render-rule rule_id cache_dir="rules/arba": (analyze-rule rule_id "--cache-dir" 
     uv run python -c 'import sys; from pathlib import Path; from ai_gene_review.etl.rule_analysis import render_rule_review_html; render_rule_review_html(sys.argv[1], Path(sys.argv[2]))' "$rule_id" "$cache_dir"
 
 # Render all rule reviews as HTML (automatically analyzes first if needed)
+[positional-arguments]
 render-all-rules cache_dir="rules/arba":
     #!/usr/bin/env bash
-    echo "Rendering all rule reviews in {{cache_dir}}..."
+    cache_dir="$1"
+    echo "Rendering all rule reviews in $cache_dir..."
     count=0
-    for review_yaml in {{cache_dir}}/*/*-review.yaml; do
+    for review_yaml in "$cache_dir"/*/*-review.yaml; do
         if [ -f "$review_yaml" ]; then
             rule_id=$(basename "$review_yaml" | sed 's/-review.yaml$//')
             echo "  Processing $rule_id..."
             # Use just to call render-rule which has analyze-rule as dependency
-            just render-rule "$rule_id" "{{cache_dir}}"
+            just render-rule "$rule_id" "$cache_dir"
             count=$((count + 1))
         fi
     done

--- a/tests/test_rule_review_wrapper_forwarding.py
+++ b/tests/test_rule_review_wrapper_forwarding.py
@@ -253,13 +253,14 @@ def test_rule_wrapper_analysis_dependency_uses_custom_cache(
         ]
 
 
-def test_render_all_rules_analysis_dependency_uses_custom_cache(
+def test_render_all_rules_preserves_custom_cache_argument(
     tmp_path: Path,
 ) -> None:
     rule_id = "ARBA00026249"
+    cache_name = "custom cache (draft), v1? $RULE_RENDER_CACHE_TOKEN"
     working_directory = tmp_path / "isolated working directory"
     working_directory.mkdir()
-    cache_dir = working_directory / "custom-cache"
+    cache_dir = working_directory / cache_name
     seed_analysis_outputs(cache_dir, rule_id)
     fake_bin, log_path = install_recording_uv(tmp_path)
 
@@ -268,16 +269,36 @@ def test_render_all_rules_analysis_dependency_uses_custom_cache(
         fake_bin,
         log_path,
         "render-all-rules",
-        "custom-cache",
+        cache_name,
+        extra_env={"RULE_RENDER_CACHE_TOKEN": "expanded"},
     )
 
     assert result.returncode == 0, result.stderr
+    assert cache_name in result.stdout
     assert "Rendered 1 rule reviews" in result.stdout
-    invocations = read_argv_log(log_path)
-    assert not any("examples/rule_analysis_demo.py" in argv for argv in invocations)
-    render_invocations = [argv for argv in invocations if argv[:3] == ["run", "python", "-c"]]
-    assert len(render_invocations) == 1
+    assert read_argv_log(log_path) == [
+        ["run", "python", "-c", RENDER_RULE_CODE, rule_id, cache_name]
+    ]
     assert not (working_directory / "rules" / "arba" / rule_id).exists()
+
+
+def test_render_all_rules_preserves_default_cache_argument(tmp_path: Path) -> None:
+    working_directory = tmp_path / "isolated working directory"
+    working_directory.mkdir()
+    fake_bin, log_path = install_recording_uv(tmp_path)
+
+    result = run_isolated_just(
+        working_directory,
+        fake_bin,
+        log_path,
+        "render-all-rules",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Rendering all rule reviews in rules/arba" in result.stdout
+    assert "Rendered 0 rule reviews" in result.stdout
+    assert not log_path.exists()
+    assert not (working_directory / "rules").exists()
 
 
 def test_sync_rule_review_single_preserves_default_cache_argument(


### PR DESCRIPTION
## Summary

- make `render-all-rules` consume its cache path positionally
- preserve spaces, punctuation, and literal dollar-prefixed text while retaining the intentional review-file glob
- verify nested render forwarding and the unchanged zero-review default through isolated public-Just tests

## Validation

- `PYTEST_ADDOPTS="-q tests/test_rule_review_wrapper_forwarding.py" just pytest` (10 passed)
- `just format`
- `just test` (1,444 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`

Fail-fast behavior remains intentionally unchanged for its separate queued fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tool recipe and forwarding tests only; no runtime auth, data, or rendering logic changes beyond correct cache path handling.
> 
> **Overview**
> **`render-all-rules`** now takes its cache directory as a **positional** argument (with `[positional-arguments]`) and passes it through the bash recipe via `"$1"` instead of Just template `{{cache_dir}}`, so paths with spaces, punctuation, and literal `$…` text are not split or expanded incorrectly.
> 
> The loop still globs `"$cache_dir"/*/*-review.yaml` and forwards the same string to nested **`render-rule`** calls. Tests were updated to assert exact **`uv run python -c …`** forwarding for awkward cache names and to cover the default **`rules/arba`** path when no reviews exist (no **`uv`** invocations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc1002c4f71f9734285ef22ecad0e493041967ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->