### PR TITLE
Stop rule batch rendering on first failure

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -1405,6 +1405,7 @@ render-rule rule_id cache_dir="rules/arba": (analyze-rule rule_id "--cache-dir" 
 [positional-arguments]
 render-all-rules cache_dir="rules/arba":
     #!/usr/bin/env bash
+    set -euo pipefail
     cache_dir="$1"
     echo "Rendering all rule reviews in $cache_dir..."
     count=0

--- a/tests/test_rule_review_wrapper_forwarding.py
+++ b/tests/test_rule_review_wrapper_forwarding.py
@@ -160,6 +160,11 @@ if "examples/rule_analysis_demo.py" in args and "--output-dir" in args:
     output_dir = Path(args[args.index("--output-dir") + 1])
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / f"{rule_id}-analysis.txt").write_text("fake report\\n")
+
+failed_rule = os.environ.get("RULE_WRAPPER_FAIL_RENDER_FOR")
+if args[:3] == ["run", "python", "-c"] and len(args) > 4 and args[4] == failed_rule:
+    print(f"forced render failure for {failed_rule}", file=sys.stderr)
+    raise SystemExit(23)
 """
     )
     fake_uv.chmod(0o755)
@@ -174,6 +179,7 @@ def run_isolated_just(
     extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
+    env.pop("RULE_WRAPPER_FAIL_RENDER_FOR", None)
     env.update(
         {
             "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
@@ -299,6 +305,33 @@ def test_render_all_rules_preserves_default_cache_argument(tmp_path: Path) -> No
     assert "Rendered 0 rule reviews" in result.stdout
     assert not log_path.exists()
     assert not (working_directory / "rules").exists()
+
+
+def test_render_all_rules_stops_at_first_failed_render(tmp_path: Path) -> None:
+    rule_ids = ["ARBA00000001", "ARBA00000002", "ARBA00000003"]
+    working_directory = tmp_path / "isolated working directory"
+    working_directory.mkdir()
+    cache_dir = working_directory / "custom-cache"
+    for rule_id in reversed(rule_ids):
+        seed_analysis_outputs(cache_dir, rule_id)
+    fake_bin, log_path = install_recording_uv(tmp_path)
+
+    result = run_isolated_just(
+        working_directory,
+        fake_bin,
+        log_path,
+        "render-all-rules",
+        "custom-cache",
+        extra_env={"RULE_WRAPPER_FAIL_RENDER_FOR": rule_ids[1]},
+    )
+
+    assert result.returncode == 23
+    assert f"Processing {rule_ids[0]}" in result.stdout
+    assert f"Processing {rule_ids[1]}" in result.stdout
+    assert f"Processing {rule_ids[2]}" not in result.stdout
+    assert "✓ Rendered" not in result.stdout
+    assert f"forced render failure for {rule_ids[1]}" in result.stderr
+    assert [argv[4] for argv in read_argv_log(log_path)] == rule_ids[:2]
 
 
 def test_sync_rule_review_single_preserves_default_cache_argument(


### PR DESCRIPTION
## Summary

- enable strict Bash failure propagation in `render-all-rules`
- stop before counting a failed render or starting later rules
- suppress the misleading success summary and preserve the nested render exit status
- retain successful zero-match behavior

## Validation

- `PYTEST_ADDOPTS="-q tests/test_rule_review_wrapper_forwarding.py -k \"render_all_rules\"" just pytest` (3 passed)
- `just format`
- `just test` (1,445 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`

This is the separate fail-fast follow-up queued after #2458.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling and test-only changes; no production runtime or data-path impact.
> 
> **Overview**
> **`render-all-rules`** now runs with **`set -euo pipefail`**, matching **`render-rule`**, so a failed nested **`just render-rule`** aborts the batch instead of continuing and printing **"✓ Rendered N rule reviews"**.
> 
> Adds **`test_render_all_rules_stops_at_first_failed_render`**, which uses a fake **`uv`** hook (**`RULE_WRAPPER_FAIL_RENDER_FOR`**) to assert exit code **23**, only the first two rules are processed, and no success summary appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc74e39e2bcc2106cdd285a6d1390ea6f4eaf3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->