### PR TITLE
Preserve custom rule cache in initialization next steps

### DIFF
--- a/src/ai_gene_review/etl/rule_review_init.py
+++ b/src/ai_gene_review/etl/rule_review_init.py
@@ -4,9 +4,12 @@ This module provides functions to create initial rule review YAML files
 that include all necessary fields and TODO placeholders for AI-assisted review.
 """
 
+import shlex
 from pathlib import Path
 from typing import Union
+
 import yaml
+
 from ai_gene_review.etl.arba import ARBAClient
 from ai_gene_review.etl.unirule import UniRuleClient
 from ai_gene_review.etl.rule_enrichment import enrich_rule_json
@@ -96,11 +99,21 @@ def init_rule_review(
     print(f"✓ Created {review_path}")
     print("\nNext steps:")
     if rule_type == 'ARBA':
-        print(f"  1. Run: just analyze-rule {rule_id}")
-        print(f"  2. Run: just sync-rule-review-single {rule_id}")
+        cache_text = str(cache_dir)
+        analyze_command = shlex.join(
+            ["just", "analyze-rule", rule_id, "--cache-dir", cache_text]
+        )
+        sync_command = shlex.join(
+            ["just", "sync-rule-review-single", rule_id, cache_text]
+        )
+        render_command = shlex.join(
+            ["just", "render-rule", rule_id, cache_text]
+        )
+        print(f"  1. Run: {analyze_command}")
+        print(f"  2. Run: {sync_command}")
         print(f"  3. Run: just rules-deep-research-perplexity {rule_id}")
         print(f"  4. Edit {review_path} to fill in TODO placeholders")
-        print(f"  5. Run: just render-rule {rule_id}")
+        print(f"  5. Run: {render_command}")
     else:
         print(f"  1. Run: just rules-deep-research-perplexity {rule_id}")
         print(f"  2. Edit {review_path} to fill in TODO placeholders")

--- a/tests/test_rule_review_wrapper_forwarding.py
+++ b/tests/test_rule_review_wrapper_forwarding.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -53,7 +54,7 @@ def run_just(
 
 def test_init_rule_review_wrapper_uses_custom_cache_dir(tmp_path: Path) -> None:
     rule_id = "ARBA00026249"
-    cache_dir = tmp_path / "rule cache (draft), v1?"
+    cache_dir = tmp_path / "rule cache (draft), v1? $CACHE's"
     rule_dir = write_enriched_rule(cache_dir, rule_id)
 
     result = run_just(
@@ -68,9 +69,17 @@ def test_init_rule_review_wrapper_uses_custom_cache_dir(tmp_path: Path) -> None:
     review = yaml.safe_load(review_path.read_text())
     assert review["id"] == rule_id
     assert review["rule_type"] == "ARBA"
-    assert f"just analyze-rule {rule_id}" in result.stdout
-    assert f"just sync-rule-review-single {rule_id}" in result.stdout
-    assert f"just render-rule {rule_id}" in result.stdout
+    run_commands = [
+        shlex.split(line.split("Run: ", 1)[1])
+        for line in result.stdout.splitlines()
+        if "Run: " in line
+    ]
+    assert run_commands == [
+        ["just", "analyze-rule", rule_id, "--cache-dir", str(cache_dir)],
+        ["just", "sync-rule-review-single", rule_id, str(cache_dir)],
+        ["just", "rules-deep-research-perplexity", rule_id],
+        ["just", "render-rule", rule_id, str(cache_dir)],
+    ]
 
 
 def test_init_unirule_omits_unsupported_analysis_next_steps(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- print cache-aware ARBA analyze, sync, and render follow-up commands after `init-rule-review`
- serialize copy-paste commands with `shlex.join` so custom paths retain exact argv boundaries
- strengthen the public-`just` regression with spaces, shell punctuation, a literal dollar sign, and an apostrophe
- leave the intentionally separate UniRule and deep-research behavior unchanged

## Validation

- `PYTEST_ADDOPTS='-q tests/test_rule_review_wrapper_forwarding.py -k "init_rule_review_wrapper_uses_custom_cache_dir or init_unirule_omits_unsupported_analysis_next_steps"' just pytest` (2 passed)
- `PYTEST_ADDOPTS='-q tests/test_rule_review_wrapper_forwarding.py' just pytest` (11 passed)
- `just test` (1,445 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `just format`
- `git diff --check`

Separate follow-up after #2460; based on its merge commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI hints and test-only changes; no runtime rule-fetch or review logic altered.
> 
> **Overview**
> After **`init-rule-review`** with a non-default **`--cache-dir`**, ARBA “next steps” now print **`analyze-rule`**, **`sync-rule-review-single`**, and **`render-rule`** commands that pass the same cache path instead of implying the default `rules/arba` layout.
> 
> Those follow-up lines are built with **`shlex.join`** so paths with spaces, `$`, and apostrophes stay copy-paste safe as a single shell command. UniRule messaging and the separate **`rules-deep-research-perplexity`** step are unchanged.
> 
> The public **`just`** regression test now uses a nastier cache path and asserts the printed **`Run:`** lines round-trip through **`shlex.split`** to the expected argv lists (including deep research and render with cache).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92fca528f6f40e0bd05356416bb0fa79a8dd86d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->