### PR TITLE
Fix rule review schema validation

### DIFF
--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -2796,6 +2796,8 @@ def rules_validate(
             valid_count += 1
             if verbose:
                 typer.echo(f"✓ {yaml_file}")
+                for issue in report.issues:
+                    _print_issue(issue)
         else:
             invalid_count += 1
             typer.echo(f"✗ {yaml_file}", err=True)

--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -643,6 +643,45 @@ def _validate_gene_review_cli(
     return report
 
 
+def _validate_rule_review_cli(
+    yaml_file: Path,
+    schema_path: Path,
+) -> ValidationReport:
+    """Validate one rule review with the standard LinkML CLI tools."""
+    yaml_file = yaml_file.resolve()
+    schema_path = schema_path.resolve()
+    report = ValidationReport(file_path=yaml_file, is_valid=True)
+
+    if not yaml_file.exists():
+        report.add_issue(
+            ValidationSeverity.ERROR,
+            f"File not found: {yaml_file}",
+            path=None,
+            validation_category="FileValidator",
+            check_type="file_exists",
+        )
+        return report
+
+    project_root = get_project_root()
+    _run_validation_command(
+        report,
+        "Schema validation",
+        [
+            *_tool_command("linkml-validate"),
+            "--schema",
+            str(schema_path),
+            "--target-class",
+            "RuleReview",
+            str(yaml_file),
+        ],
+        "SchemaValidator",
+        "linkml_validate",
+        cwd=project_root,
+    )
+
+    return report
+
+
 def _validate_multiple_files_cli(
     yaml_files: list[Path],
     schema_path: Path,
@@ -2716,9 +2755,7 @@ def rules_validate(
 ):
     """Validate rule review YAML files against the LinkML schema.
 
-    Validates RuleReview files including:
-    - Schema compliance (RuleReview class)
-    - PMID title verification (catches hallucinated references)
+    Validates RuleReview files for schema compliance with the RuleReview class.
 
     Examples:
         # Validate a specific review
@@ -2730,8 +2767,6 @@ def rules_validate(
         # Validate with verbose output
         ai-gene-review rules-validate --all -v
     """
-    from ai_gene_review.validation.validator import validate_rule_review
-
     # Collect files to validate
     all_files: list[Path] = []
 
@@ -2752,9 +2787,10 @@ def rules_validate(
     # Track results
     valid_count = 0
     invalid_count = 0
+    schema_path = get_schema_path()
 
     for yaml_file in all_files:
-        report = validate_rule_review(yaml_file)
+        report = _validate_rule_review_cli(yaml_file, schema_path)
 
         if report.is_valid:
             valid_count += 1

--- a/tests/test_rule_review_validation.py
+++ b/tests/test_rule_review_validation.py
@@ -1,0 +1,73 @@
+"""Public-wrapper regressions for rule-review validation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_rules_validate(review_path: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    return subprocess.run(
+        [
+            "just",
+            "--justfile",
+            str(REPO_ROOT / "justfile"),
+            "--working-directory",
+            str(REPO_ROOT),
+            "rules-validate",
+            str(review_path),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=120,
+    )
+
+
+def write_rule_review(path: Path, *, include_rule_type: bool) -> None:
+    review = {
+        "id": "ARBA00000001",
+        "rule": {
+            "rule_id": "ARBA00000001",
+            "condition_sets": [],
+            "entries": [],
+        },
+        "action": "UNDECIDED",
+    }
+    if include_rule_type:
+        review["rule_type"] = "ARBA"
+    path.write_text(yaml.safe_dump(review, sort_keys=False))
+
+
+def test_rules_validate_accepts_schema_valid_review(tmp_path: Path) -> None:
+    review_path = tmp_path / "valid-review.yaml"
+    write_rule_review(review_path, include_rule_type=True)
+
+    result = run_rules_validate(review_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "✓ All 1 review(s) valid" in result.stdout
+
+
+def test_rules_validate_rejects_schema_invalid_review(tmp_path: Path) -> None:
+    review_path = tmp_path / "invalid-review.yaml"
+    write_rule_review(review_path, include_rule_type=False)
+
+    result = run_rules_validate(review_path)
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0
+    assert "Schema validation failed" in output
+    assert "rule_type" in output
+    assert "required property" in output
+    assert "✗ 1 invalid, 0 valid" in output

--- a/tests/test_rule_review_validation.py
+++ b/tests/test_rule_review_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import yaml
@@ -12,9 +13,14 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def run_rules_validate(review_path: Path) -> subprocess.CompletedProcess[str]:
+def run_rules_validate(
+    review_path: Path,
+    *args: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.pop("VIRTUAL_ENV", None)
+    env.update(extra_env or {})
     return subprocess.run(
         [
             "just",
@@ -23,6 +29,7 @@ def run_rules_validate(review_path: Path) -> subprocess.CompletedProcess[str]:
             "--working-directory",
             str(REPO_ROOT),
             "rules-validate",
+            *args,
             str(review_path),
         ],
         cwd=REPO_ROOT,
@@ -49,6 +56,42 @@ def write_rule_review(path: Path, *, include_rule_type: bool) -> None:
     path.write_text(yaml.safe_dump(review, sort_keys=False))
 
 
+def install_warning_validator(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import os
+import sys
+
+if sys.argv[1:3] != ["run", "ai-gene-review"]:
+    raise SystemExit(f"unexpected uv arguments: {sys.argv[1:]}")
+os.execv(
+    os.environ["RULE_VALIDATE_PYTHON"],
+    [
+        os.environ["RULE_VALIDATE_PYTHON"],
+        "-c",
+        "from ai_gene_review.cli import app; app()",
+        *sys.argv[3:],
+    ],
+)
+"""
+    )
+    fake_uv.chmod(0o755)
+    fake_validator = fake_bin / "linkml-validate"
+    fake_validator.write_text(
+        """#!/usr/bin/env python3
+print("[WARNING] synthetic schema warning")
+"""
+    )
+    fake_validator.chmod(0o755)
+    return fake_bin, {
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "RULE_VALIDATE_PYTHON": sys.executable,
+    }
+
+
 def test_rules_validate_accepts_schema_valid_review(tmp_path: Path) -> None:
     review_path = tmp_path / "valid-review.yaml"
     write_rule_review(review_path, include_rule_type=True)
@@ -71,3 +114,18 @@ def test_rules_validate_rejects_schema_invalid_review(tmp_path: Path) -> None:
     assert "rule_type" in output
     assert "required property" in output
     assert "✗ 1 invalid, 0 valid" in output
+
+
+def test_rules_validate_verbose_displays_schema_warnings(tmp_path: Path) -> None:
+    review_path = tmp_path / "warning-review.yaml"
+    write_rule_review(review_path, include_rule_type=True)
+    _, env = install_warning_validator(tmp_path)
+
+    result = run_rules_validate(review_path, "--verbose", extra_env=env)
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 0, output
+    assert f"✓ {review_path}" in result.stdout
+    assert "synthetic schema warning" in output
+    assert "⚠" in output
+    assert "✓ All 1 review(s) valid" in result.stdout


### PR DESCRIPTION
## Summary
- restore RuleReview schema validation in the rules-validate CLI using the standard LinkML validator command
- report schema failures through the existing validation report path
- add end-to-end regressions through the public just rules-validate wrapper
- narrow the command documentation to its current schema-only contract

## Validation
- PYTEST_ADDOPTS="-q tests/test_rule_review_validation.py" just pytest (2 passed)
- just test (1447 pytest passed; 132 doctests passed; mypy and Ruff clean)
- just format
- git diff --check

## Deliberate follow-ups
- restore the separately lost reference/PMID validation through the project reference-validator wrapper
- migrate the 12 pre-existing structurally invalid tracked rule reviews; corrected --all behavior now exposes them, and no CI workflow currently invokes that corpus command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI validation wiring with regression tests; no auth or data migration. `--all` may now surface pre-existing invalid tracked reviews that the stub previously ignored.
> 
> **Overview**
> **`rules-validate` again enforces LinkML schema compliance** for rule review YAML by routing each file through the same `linkml-validate` + `ValidationReport` path used for gene reviews, targeting the **`RuleReview`** class instead of the old `validate_rule_review` helper that effectively only checked that the file existed.
> 
> The command help is trimmed to **schema-only** (PMID/reference checks are explicitly out of scope for now). **`--verbose`** on passing files also prints schema **warnings** via `_print_issue`.
> 
> New **`tests/test_rule_review_validation.py`** exercises the public **`just rules-validate`** entrypoint: valid reviews pass, missing required fields (e.g. `rule_type`) fail with schema errors, and verbose mode surfaces validator warnings when `linkml-validate` is stubbed on `PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 765e5e487b709754039ca90667a54b479e467731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->