### PR TITLE
Show rule validation warnings in verbose mode

### DIFF
--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -2796,6 +2796,8 @@ def rules_validate(
             valid_count += 1
             if verbose:
                 typer.echo(f"✓ {yaml_file}")
+                for issue in report.issues:
+                    _print_issue(issue)
         else:
             invalid_count += 1
             typer.echo(f"✗ {yaml_file}", err=True)

--- a/tests/test_rule_review_validation.py
+++ b/tests/test_rule_review_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import yaml
@@ -12,9 +13,14 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def run_rules_validate(review_path: Path) -> subprocess.CompletedProcess[str]:
+def run_rules_validate(
+    review_path: Path,
+    *args: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.pop("VIRTUAL_ENV", None)
+    env.update(extra_env or {})
     return subprocess.run(
         [
             "just",
@@ -23,6 +29,7 @@ def run_rules_validate(review_path: Path) -> subprocess.CompletedProcess[str]:
             "--working-directory",
             str(REPO_ROOT),
             "rules-validate",
+            *args,
             str(review_path),
         ],
         cwd=REPO_ROOT,
@@ -49,6 +56,42 @@ def write_rule_review(path: Path, *, include_rule_type: bool) -> None:
     path.write_text(yaml.safe_dump(review, sort_keys=False))
 
 
+def install_warning_validator(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import os
+import sys
+
+if sys.argv[1:3] != ["run", "ai-gene-review"]:
+    raise SystemExit(f"unexpected uv arguments: {sys.argv[1:]}")
+os.execv(
+    os.environ["RULE_VALIDATE_PYTHON"],
+    [
+        os.environ["RULE_VALIDATE_PYTHON"],
+        "-c",
+        "from ai_gene_review.cli import app; app()",
+        *sys.argv[3:],
+    ],
+)
+"""
+    )
+    fake_uv.chmod(0o755)
+    fake_validator = fake_bin / "linkml-validate"
+    fake_validator.write_text(
+        """#!/usr/bin/env python3
+print("[WARNING] synthetic schema warning")
+"""
+    )
+    fake_validator.chmod(0o755)
+    return fake_bin, {
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "RULE_VALIDATE_PYTHON": sys.executable,
+    }
+
+
 def test_rules_validate_accepts_schema_valid_review(tmp_path: Path) -> None:
     review_path = tmp_path / "valid-review.yaml"
     write_rule_review(review_path, include_rule_type=True)
@@ -71,3 +114,18 @@ def test_rules_validate_rejects_schema_invalid_review(tmp_path: Path) -> None:
     assert "rule_type" in output
     assert "required property" in output
     assert "✗ 1 invalid, 0 valid" in output
+
+
+def test_rules_validate_verbose_displays_schema_warnings(tmp_path: Path) -> None:
+    review_path = tmp_path / "warning-review.yaml"
+    write_rule_review(review_path, include_rule_type=True)
+    _, env = install_warning_validator(tmp_path)
+
+    result = run_rules_validate(review_path, "--verbose", extra_env=env)
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 0, output
+    assert f"✓ {review_path}" in result.stdout
+    assert "synthetic schema warning" in output
+    assert "⚠" in output
+    assert "✓ All 1 review(s) valid" in result.stdout


### PR DESCRIPTION
## Summary
- print warning-only RuleReview validation issues when rules-validate runs with --verbose
- retain successful exit and valid-file summary behavior
- add a hermetic end-to-end regression through the public just rules-validate wrapper

## Stacking
This focused PR targets PR #2462 branch because warning reports become reachable through the schema runner introduced there. Merge this PR into that branch, then rerun #2462 review and CI.

## Validation
- PYTEST_ADDOPTS="-q tests/test_rule_review_validation.py" just pytest (3 passed)
- just format
- just mypy
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output-only change for verbose rule validation plus test harness; no change to pass/fail logic or data handling.
> 
> **Overview**
> **`rules-validate`** now prints warning-level validation issues (via `_print_issue`) for files that still pass schema validation when **`--verbose`** is used, matching the behavior reviewers expect from the main `validate` command.
> 
> A hermetic regression runs **`just rules-validate`** end-to-end with a fake **`linkml-validate`** that emits a synthetic warning, asserting exit code 0, the warning text, and the ⚠ formatting still appear alongside the valid summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb2b756097ae4880bd004edfe175f9065eacb759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->