### PR TITLE
Align Shepherd merge policy with DisMech

### DIFF
--- a/.github/workflows/pr-shepherd.yml
+++ b/.github/workflows/pr-shepherd.yml
@@ -365,7 +365,6 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --min-age-days "$MIN_AGE_DAYS" \
             --required-check "test (3.12)" \
-            --trusted-reviewer "ai4c-reviewer" \
             --dry-run
 
       - name: Merge ready PRs (deterministic)
@@ -387,5 +386,4 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --min-age-days "$MIN_AGE_DAYS" \
             --required-check "test (3.12)" \
-            --trusted-reviewer "ai4c-reviewer" \
             --execute

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -256,15 +256,12 @@ routine event in the repo into a red X.
 
 ## Known gaps
 
-- **Exact-head `ai4c-reviewer` approvals are currently excluded from GitHub's
-  required-review decision while its installation has Contents read.** We
-  attribute that observed symptom to the installation scope because the
-  equivalent DisMech installation counts with Contents write; activation must
-  accept the pending update and confirm the diagnosis empirically. Every
-  workflow-issued reviewer token remains explicitly downscoped to pull-request
-  write only, so the credential that approves a head cannot push it. The App key
-  remains a repository secret, while the Shepherd's default path perimeter
-  excludes `.github/` changes from deterministic merging.
+- **`ai4c-reviewer` approvals are currently excluded from GitHub's required-
+  review decision while its installation has Contents read.** The deterministic
+  Shepherd follows DisMech's aggregate `APPROVED` policy rather than requiring
+  that identity, so this does not block ordinary closing passes. It still
+  affects the generated-page lane, whose independent approval is deliberately
+  tied to `ai4c-reviewer`.
 - **A stale `dragon-ai-agent` collaborator entry remains** on the repo. The
   account itself is deleted (`GET /users/dragon-ai-agent` 404s) so it grants
   nothing, but the entry should be removed — that is a settings click, not a
@@ -334,29 +331,26 @@ eligible PR regardless of whether a bot or a human authored it, and it does not
 itself reject fork heads. Author login, head repository, and agent-style head
 prefixes are not trust signals for this pass; only `auto/generate-*` is excluded
 for its separate lifecycle. Automatic agentic review remains limited to
-same-repository PRs, so a fork can qualify only after an authorized manual run
-has supplied the trusted exact-head Bot review. "Trusted" means both an
-allowlisted login and a REST review author whose GitHub identity type is `Bot`;
-a human approval cannot substitute, even from a human account with the same
-name. That Bot review plus the protected-`main` contract are the authorization
-boundary. In particular, a human-authored PR can be merged after the age gate
-without a second, human-only approval. That is deliberate; changing the policy
-requires an explicit author or branch predicate rather than assuming the
-agentic job's narrower candidate rules also apply here.
+same-repository PRs, but the closing pass uses GitHub's aggregate `APPROVED`
+decision just as DisMech does. With stale-review dismissal enabled, a head push
+invalidates that approval; unrelated movement on `main` does not. An optional
+exact-head Bot allowlist remains available to manual controller invocations
+through `--trusted-reviewer`, but the production workflow does not enable it.
 
 Broad author/head ingress does not mean broad file scope. The controller also
 requires every changed path to sit under one of these conservative curation and
 data prefixes by default: `genes/`, `genesets/`, `gocams/`, `interpro/`,
-`modules/`, `projects/`, `publications/`, `reactome/`, `rules/`, `terms/`,
-`families/`, or `research/`. A PR that mixes an allowed data change with even
-one path outside that set is ineligible. Repeatable CLI additions can expand
-the prefix set through `--allowed-path-prefix` for a deliberate one-off policy;
-each addition must be a normalized directory prefix ending in `/`, so `src/`
-cannot accidentally authorize a sibling such as `src_generated/`. The
-production workflow passes none. Every path outside the twelve listed prefixes
-is therefore out of scope and requires a manual merge. Examples include
+`modules/`, `pages/`, `projects/`, `publications/`, `reactome/`, `rules/`,
+`terms/`, `families/`, or `research/`. A PR that mixes an allowed data change
+with even one path outside that set is ineligible. Repeatable CLI additions can
+expand the prefix set through `--allowed-path-prefix` for a deliberate one-off
+policy; each addition must be a normalized directory prefix ending in `/`, so
+`src/` cannot accidentally authorize a sibling such as `src_generated/`. The
+production workflow passes none. Every path outside the thirteen listed
+prefixes is therefore out of scope and requires a manual merge. Examples
+include
 infrastructure and self-modifying automation under `.github/`, `scripts/`,
-`src/`, and `tests/`, as well as `docs/`, `reports/`, `pages/`, and top-level
+`src/`, and `tests/`, as well as `docs/`, `reports/`, and top-level
 build/configuration files.
 
 The controller requires all of these at fresh reads immediately before merge:
@@ -364,9 +358,8 @@ The controller requires all of these at fresh reads immediately before merge:
 - open, non-draft, unassigned, old enough by PR creation time, and targeting
   `main`;
 - no `shepherd:hold` label and no `auto/generate-*` head branch;
-- `APPROVED`, including an allowlisted Bot review anchored to the exact head;
+- GitHub's aggregate review decision is `APPROVED`;
 - every changed file is inside the conservative path-prefix policy above;
-- the PR's tested base SHA equals the current `main` tip;
 - GitHub reports mergeable and clean;
 - all reported checks are complete/non-failing, and `test (3.12)` is explicitly
   successful.
@@ -380,15 +373,17 @@ after each file inventory, and the final merge remains pinned to that head.
 The age gate intentionally measures `createdAt`, not the latest push, approval,
 or branch update. It is a backlog-age threshold, not a soak period for the
 current content. Consequently, fresh commits pushed to an old PR can merge as
-soon as that exact new head receives the trusted Bot review, passes current-base
-CI, and meets the remaining guards. This keeps old approved work moving, but it
-also means operators must use draft state, assignment, or `shepherd:hold` when
-fresh content needs additional observation time.
+soon as that exact new head receives approval, passes CI, and meets the
+remaining guards. Unrelated changes on `main` do not force a rebase,
+CI rerun, or new review; GitHub still rejects current conflicts. This keeps old
+approved work moving, but it also means operators must use draft state,
+assignment, or `shepherd:hold` when fresh content needs additional observation
+time.
 
 Reads use the built-in read-only token. A separately scoped ai4c-agent token
 (Contents write + pull-request write) is supplied only to the head-pinned merge
 and best-effort courtesy-comment subprocesses. API uncertainty fails an execute
-run red. A positively observed head/base movement is instead a benign skip:
+run red. A positively observed head movement is instead a benign skip:
 concurrent automation changed the candidate, so its new state must pass a later
 sweep. The separate ai4c-reviewer credential is explicitly scoped to
 pull-request write only; it can record the approval but cannot push content.
@@ -406,17 +401,17 @@ Before setting `PR_SHEPHERD_MERGE_ENABLED=true`, manually verify the classic
 rule in repository settings or with
 `GET /repos/ai4curation/ai-gene-review/branches/main/protection`:
 
-- required status checks are strict/up-to-date and contain exactly
-  `test (3.12)` from the GitHub Actions App (`app_id: 15368`);
-- one approving review is required, stale approvals are dismissed, and the
-  latest reviewable push must be approved by someone other than its pusher;
-- unresolved review conversations block merging and enforcement includes
-  administrators;
+- required status checks are non-strict (a PR need not be rebased after
+  unrelated `main` changes) and contain exactly `test (3.12)` from the GitHub
+  Actions App (`app_id: 15368`);
+- one approving review is required and stale approvals are dismissed; requiring
+  a separate approval for the latest push is disabled, matching DisMech;
+- unresolved review conversations block merging;
 - the ai4c-agent and ai4c-reviewer Apps have no pull-request bypass allowance,
   while force pushes and branch deletion remain disabled;
-- on a current-base, green PR whose exact head has an `ai4c-reviewer` approval,
-  `gh pr view N --json reviewDecision,mergeStateStatus` reports
-  `APPROVED` and `CLEAN` rather than `REVIEW_REQUIRED` or `BLOCKED`;
+- on a green, conflict-free PR whose recorded base is older than `main`,
+  `gh pr view N --json reviewDecision,mergeStateStatus` reports `APPROVED` and
+  `CLEAN` rather than `REVIEW_REQUIRED`, `BEHIND`, or `BLOCKED`;
 - `GET branches/main` returns `.protected: true`, the `shepherd:hold` label
   exists, and the feature flag remains false until an audit and controlled
   execute smoke test complete.

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -334,8 +334,10 @@ for its separate lifecycle. Automatic agentic review remains limited to
 same-repository PRs, but the closing pass uses GitHub's aggregate `APPROVED`
 decision just as DisMech does. With stale-review dismissal enabled, a head push
 invalidates that approval; unrelated movement on `main` does not. An optional
-exact-head Bot allowlist remains available to manual controller invocations
+Bot-identity allowlist remains available to manual controller invocations
 through `--trusted-reviewer`, but the production workflow does not enable it.
+The exact-head binding itself is always enforced: at least one approval must
+refer to the precise PR commit that the controller is about to merge.
 
 Broad author/head ingress does not mean broad file scope. The controller also
 requires every changed path to sit under one of these conservative curation and
@@ -359,6 +361,7 @@ The controller requires all of these at fresh reads immediately before merge:
   `main`;
 - no `shepherd:hold` label and no `auto/generate-*` head branch;
 - GitHub's aggregate review decision is `APPROVED`;
+- at least one approval is bound to the exact current PR head;
 - every changed file is inside the conservative path-prefix policy above;
 - GitHub reports mergeable and clean;
 - all reported checks are complete/non-failing, and `test (3.12)` is explicitly

--- a/scripts/auto_merge_ready_prs.py
+++ b/scripts/auto_merge_ready_prs.py
@@ -7,6 +7,7 @@ merges when every mechanical guard passes:
 
 * the PR is open, non-draft, unassigned, and targets the configured base;
 * the aggregate review decision is APPROVED;
+* at least one approval is bound to the exact current PR head;
 * the PR is old enough, conflict-free, and GitHub reports a CLEAN merge state;
 * every changed file is under a conservative content-path allowlist;
 * every reported check is complete and non-failing, with at least one SUCCESS;
@@ -15,7 +16,7 @@ merges when every mechanical guard passes:
 The initial bulk list is only a cheap candidate scan. GitHub computes
 mergeability lazily and large bulk GraphQL requests for mergeStateStatus can
 fail, so mergeability, exact-head approval, and checks are evaluated only on a
-fresh per-PR view when configured. The final merge is pinned with
+fresh per-PR view. The final merge is pinned with
 --match-head-commit.
 The PR does not have to be rebased onto the latest base-branch tip. GitHub
 re-evaluates mergeability against the current base, while the controller pins
@@ -27,8 +28,9 @@ automation App a bypass. The workflow keeps execute mode behind a repository
 feature flag until those settings are installed.
 
 Production follows DisMech and relies on GitHub's aggregate APPROVED decision
-plus branch protection that dismisses stale reviews after a head push. An
-optional stricter Bot-identity gate remains available through repeatable
+plus branch protection that dismisses stale reviews after a head push. The
+controller additionally binds an approval to the exact head being merged. An
+optional stricter Bot-identity allowlist remains available through repeatable
 ``--trusted-reviewer`` arguments, but the workflow does not enable it.
 
 The closing pass intentionally does not filter by PR author or head repository.

--- a/scripts/auto_merge_ready_prs.py
+++ b/scripts/auto_merge_ready_prs.py
@@ -7,8 +7,6 @@ merges when every mechanical guard passes:
 
 * the PR is open, non-draft, unassigned, and targets the configured base;
 * the aggregate review decision is APPROVED;
-* a configured trusted reviewer approved the exact current head commit;
-* the PR was tested against the current base-branch tip;
 * the PR is old enough, conflict-free, and GitHub reports a CLEAN merge state;
 * every changed file is under a conservative content-path allowlist;
 * every reported check is complete and non-failing, with at least one SUCCESS;
@@ -17,25 +15,25 @@ merges when every mechanical guard passes:
 The initial bulk list is only a cheap candidate scan. GitHub computes
 mergeability lazily and large bulk GraphQL requests for mergeStateStatus can
 fail, so mergeability, exact-head approval, and checks are evaluated only on a
-fresh per-PR view. The final merge is pinned with --match-head-commit.
-The PR's recorded base SHA must also equal a freshly read base-branch tip, and
-the tip is checked again before a write. GitHub has no atomic match-base option,
-so write mode requires branch protection that enforces the required check
-on an up-to-date merge result, dismisses stale approvals, resolves review
-threads, and grants neither automation App a bypass. The workflow keeps execute
-mode behind a repository feature flag until those settings are installed.
+fresh per-PR view when configured. The final merge is pinned with
+--match-head-commit.
+The PR does not have to be rebased onto the latest base-branch tip. GitHub
+re-evaluates mergeability against the current base, while the controller pins
+the exact reviewed and tested head with ``--match-head-commit``. This matches
+DisMech's closing policy and avoids rerunning CI and review for unrelated base
+changes. Branch protection still requires the named head check, dismisses stale
+approvals after a head push, resolves review threads, and grants neither
+automation App a bypass. The workflow keeps execute mode behind a repository
+feature flag until those settings are installed.
 
-The default trusted identity is the ai4c-reviewer GitHub App. Additional Bot
-reviewers can be explicitly allowlisted with repeatable --trusted-reviewer
-arguments; human reviewer accounts are never accepted by this trust gate.
-Logins are normalized for GraphQL/REST spellings such as ai4c-reviewer,
-ai4c-reviewer[bot], and app/ai4c-reviewer. Load-bearing REST reviews must also
-identify the reviewer as a Bot, so normalization cannot make a same-named human
-account trusted.
+Production follows DisMech and relies on GitHub's aggregate APPROVED decision
+plus branch protection that dismisses stale reviews after a head push. An
+optional stricter Bot-identity gate remains available through repeatable
+``--trusted-reviewer`` arguments, but the workflow does not enable it.
 
 The closing pass intentionally does not filter by PR author or head repository.
-An otherwise eligible human-authored PR, or a fork PR that received an explicit
-trusted exact-head review, is in scope. Automatic agentic review is narrower,
+An otherwise eligible human-authored or fork PR is in scope once GitHub reports
+the aggregate review decision as APPROVED. Automatic agentic review is narrower,
 but its author/branch ingress rules are not implicit merge-controller policy.
 
 The controller is report-only by default. Actual merging requires the explicit
@@ -57,7 +55,6 @@ import time
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from urllib.parse import quote
 
 
 LIST_FIELDS = (
@@ -65,11 +62,10 @@ LIST_FIELDS = (
     "mergeable,baseRefName,headRefName,labels,url"
 )
 VIEW_FIELDS = (
-    LIST_FIELDS
-    + ",state,statusCheckRollup,headRefOid,baseRefOid,mergeStateStatus,changedFiles"
+    LIST_FIELDS + ",state,statusCheckRollup,headRefOid,mergeStateStatus,changedFiles"
 )
 
-DEFAULT_TRUSTED_REVIEWERS = ("ai4c-reviewer",)
+DEFAULT_TRUSTED_REVIEWERS: tuple[str, ...] = ()
 DEFAULT_EXCLUDED_HEAD_PREFIXES = ("auto/generate-",)
 DEFAULT_ALLOWED_PATH_PREFIXES = (
     "genes/",
@@ -77,6 +73,7 @@ DEFAULT_ALLOWED_PATH_PREFIXES = (
     "gocams/",
     "interpro/",
     "modules/",
+    "pages/",
     "projects/",
     "publications/",
     "reactome/",
@@ -99,8 +96,8 @@ BENIGN_MERGE_FAILURES = (
 GH_STATUS_MARKERS = ("X ", "! ", "✓ ")
 
 MERGE_COMMENT = (
-    "🐑 **PR Shepherd** (deterministic sweep) — Squash-merged: approved at "
-    "the current commit by a trusted reviewer, unassigned, no conflicts, all "
+    "🐑 **PR Shepherd** (deterministic sweep) — Squash-merged: approved, "
+    "unassigned, no conflicts, all "
     "checks green, and open longer than {days} days. No further action needed."
 )
 TOO_YOUNG = "too_young"
@@ -434,7 +431,6 @@ def evaluate(
     base_branch: str,
     trusted_reviewers: Iterable[str] = DEFAULT_TRUSTED_REVIEWERS,
     required_checks: Iterable[str] = (),
-    current_base_sha: str = "",
     hold_label: str = "shepherd:hold",
     excluded_head_prefixes: Iterable[str] = DEFAULT_EXCLUDED_HEAD_PREFIXES,
     allowed_path_prefixes: Iterable[str] = (),
@@ -492,18 +488,6 @@ def evaluate(
     if not final:
         return Decision(True, "candidate (pending per-PR verification)")
 
-    base_sha = str(pr.get("baseRefOid") or "").strip()
-    current_base_sha = current_base_sha.strip()
-    if not base_sha:
-        return Decision(False, "no base SHA in the PR API response")
-    if not current_base_sha:
-        return Decision(False, "could not verify the current base-branch tip")
-    if base_sha.casefold() != current_base_sha.casefold():
-        return Decision(
-            False,
-            f"PR base {base_sha} is stale; current base tip is {current_base_sha}",
-        )
-
     paths = changed_files_decision(
         pr.get("changed_files"),
         expected_file_count=pr.get("changedFiles"),
@@ -513,14 +497,16 @@ def evaluate(
     if not paths.eligible:
         return paths
 
-    head_sha = str(pr.get("headRefOid") or "").strip()
-    approval = trusted_head_approval_decision(
-        pr.get("reviews"),
-        head_sha=head_sha,
-        trusted_reviewers=trusted_reviewers,
-    )
-    if not approval.eligible:
-        return approval
+    trusted_reviewers = tuple(trusted_reviewers)
+    if trusted_reviewers:
+        head_sha = str(pr.get("headRefOid") or "").strip()
+        approval = trusted_head_approval_decision(
+            pr.get("reviews"),
+            head_sha=head_sha,
+            trusted_reviewers=trusted_reviewers,
+        )
+        if not approval.eligible:
+            return approval
 
     if mergeable != "MERGEABLE":
         return Decision(False, f"mergeability is {mergeable.lower() or 'unset'}")
@@ -725,22 +711,6 @@ def require_unchanged_file_inventory_head(
         )
 
 
-def view_base_tip(repo: str, base_branch: str) -> str:
-    """Read the current base tip and fail closed on an empty response."""
-    encoded_branch = quote(base_branch, safe="")
-    oid = _gh(
-        [
-            "api",
-            f"repos/{repo}/git/ref/heads/{encoded_branch}",
-            "--jq",
-            ".object.sha",
-        ]
-    ).strip()
-    if not oid:
-        raise ValueError(f"could not resolve refs/heads/{base_branch}")
-    return oid
-
-
 def merge_pr(
     repo: str,
     number: int,
@@ -807,9 +777,9 @@ def render_summary(
             lines.extend(
                 [
                     "",
-                    "_Candidates are independently eligible at audit time. After the "
-                    "first merge advances `main`, later candidates normally require a "
-                    "branch refresh, new CI, and a new exact-head approval._",
+                    "_Each candidate is re-read before a head-pinned merge. Unrelated "
+                    "changes on `main` do not require a branch refresh, CI rerun, or "
+                    "new review._",
                 ]
             )
     else:
@@ -855,8 +825,8 @@ def main(argv: list[str] | None = None) -> int:
         type=trusted_reviewer_login,
         default=[],
         help=(
-            "additional Bot reviewer login trusted to approve the exact head; "
-            "repeatable (Bot accounts only; ai4c-reviewer is always trusted)"
+            "require this Bot reviewer to approve the exact head; repeatable "
+            "and optional (production relies on GitHub's APPROVED decision)"
         ),
     )
     parser.add_argument(
@@ -915,7 +885,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.execute and not write_token:
         parser.error("--execute requires a non-empty GH_MERGE_TOKEN")
 
-    trusted_reviewers = (*DEFAULT_TRUSTED_REVIEWERS, *args.trusted_reviewer)
+    trusted_reviewers = tuple(args.trusted_reviewer)
     excluded_head_prefixes = (
         *DEFAULT_EXCLUDED_HEAD_PREFIXES,
         *args.exclude_head_prefix,
@@ -957,10 +927,8 @@ def main(argv: list[str] | None = None) -> int:
         "list-level predicate."
     )
 
-    # A successful merge advances the base and normally makes every remaining
-    # candidate stale. Make that single useful merge deterministic: oldest PR
-    # first, then PR number as a stable tie-breaker, rather than relying on the
-    # changing default order of `gh pr list`.
+    # Process oldest PR first, then PR number as a stable tie-breaker, rather
+    # than relying on the changing default order of `gh pr list`.
     candidates.sort(key=lambda pr: (_parse_ts(pr["createdAt"]), int(pr["number"])))
 
     merged: list[dict] = []
@@ -976,7 +944,6 @@ def main(argv: list[str] | None = None) -> int:
             require_unchanged_file_inventory_head(
                 args.repo, number, fresh.get("headRefOid")
             )
-            current_base_sha = view_base_tip(args.repo, args.base_branch)
         except HeadMovedError as exc:
             reason = str(exc)
             print(f"SKIP  #{number}: {reason}")
@@ -1004,7 +971,6 @@ def main(argv: list[str] | None = None) -> int:
             base_branch=args.base_branch,
             trusted_reviewers=trusted_reviewers,
             required_checks=args.required_check,
-            current_base_sha=current_base_sha,
             hold_label=args.hold_label,
             excluded_head_prefixes=excluded_head_prefixes,
             allowed_path_prefixes=args.allowed_path_prefix,
@@ -1020,19 +986,9 @@ def main(argv: list[str] | None = None) -> int:
             merged.append({"number": number, "title": fresh["title"]})
             continue
         # Re-read every load-bearing field immediately before the write. This
-        # catches a newly added hold/assignee, review or check change, head
-        # movement, and base movement. It still cannot make the base comparison
-        # and merge atomic, so strict branch protection remains mandatory.
+        # catches a newly added hold/assignee, review or check change, and head
+        # movement. The exact reviewed/tested head remains pinned at merge time.
         try:
-            merge_base_sha = view_base_tip(args.repo, args.base_branch)
-            if merge_base_sha.casefold() != current_base_sha.casefold():
-                reason = (
-                    f"base branch moved after verification: {current_base_sha} -> "
-                    f"{merge_base_sha}"
-                )
-                print(f"SKIP  #{number}: {reason}")
-                skipped.append({"number": number, "reason": reason})
-                continue
             fresh = view_pr(args.repo, number)
             fresh["reviews"] = list_pr_reviews(args.repo, number)
             files = list_pr_files(args.repo, number)
@@ -1064,7 +1020,6 @@ def main(argv: list[str] | None = None) -> int:
             base_branch=args.base_branch,
             trusted_reviewers=trusted_reviewers,
             required_checks=args.required_check,
-            current_base_sha=merge_base_sha,
             hold_label=args.hold_label,
             excluded_head_prefixes=excluded_head_prefixes,
             allowed_path_prefixes=args.allowed_path_prefix,

--- a/scripts/auto_merge_ready_prs.py
+++ b/scripts/auto_merge_ready_prs.py
@@ -223,14 +223,17 @@ def trusted_head_approval_decision(
     head_sha: str,
     trusted_reviewers: Iterable[str],
 ) -> Decision:
-    """Require an allowlisted APPROVED review on exactly the current head."""
+    """Require an APPROVED review on exactly the current head.
+
+    When ``trusted_reviewers`` is non-empty, additionally require an allowlisted
+    Bot identity.  An empty allowlist deliberately matches DisMech's aggregate
+    reviewer policy while retaining controller-side exact-head binding.
+    """
     if not head_sha.strip():
         return Decision(False, "no head SHA in the API response")
 
     trusted = {normalize_login(login) for login in trusted_reviewers}
     trusted.discard("")
-    if not trusted:
-        return Decision(False, "no trusted reviewers configured")
 
     approvals_on_other_commits: set[str] = set()
     approvals_without_bot_identity: set[str] = set()
@@ -238,21 +241,23 @@ def trusted_head_approval_decision(
         if (review.get("state") or "").upper() != "APPROVED":
             continue
         login = normalize_login(_review_author_login(review))
-        if login not in trusted:
-            continue
-        if not _review_author_is_bot(review):
-            approvals_without_bot_identity.add(login)
-            continue
+        if trusted:
+            if login not in trusted:
+                continue
+            if not _review_author_is_bot(review):
+                approvals_without_bot_identity.add(login)
+                continue
         review_sha = _review_commit_oid(review).strip()
         if review_sha.casefold() == head_sha.strip().casefold() and review_sha:
-            return Decision(True, f"current head approved by {login}")
-        approvals_on_other_commits.add(login)
+            reviewer = login or "a reviewer"
+            return Decision(True, f"current head approved by {reviewer}")
+        approvals_on_other_commits.add(login or "a reviewer")
 
     if approvals_on_other_commits:
         reviewers = ", ".join(sorted(approvals_on_other_commits))
         return Decision(
             False,
-            f"trusted approval by {reviewers} is not for current head {head_sha}",
+            f"approval by {reviewers} is not for current head {head_sha}",
         )
     if approvals_without_bot_identity:
         reviewers = ", ".join(sorted(approvals_without_bot_identity))
@@ -260,7 +265,9 @@ def trusted_head_approval_decision(
             False,
             f"allowlisted approval did not have a verified Bot identity: {reviewers}",
         )
-    return Decision(False, "no trusted reviewer approved the current head")
+    if trusted:
+        return Decision(False, "no trusted reviewer approved the current head")
+    return Decision(False, "no approval is bound to the current head")
 
 
 def _check_name(entry: dict) -> str:
@@ -497,16 +504,13 @@ def evaluate(
     if not paths.eligible:
         return paths
 
-    trusted_reviewers = tuple(trusted_reviewers)
-    if trusted_reviewers:
-        head_sha = str(pr.get("headRefOid") or "").strip()
-        approval = trusted_head_approval_decision(
-            pr.get("reviews"),
-            head_sha=head_sha,
-            trusted_reviewers=trusted_reviewers,
-        )
-        if not approval.eligible:
-            return approval
+    approval = trusted_head_approval_decision(
+        pr.get("reviews"),
+        head_sha=str(pr.get("headRefOid") or "").strip(),
+        trusted_reviewers=trusted_reviewers,
+    )
+    if not approval.eligible:
+        return approval
 
     if mergeable != "MERGEABLE":
         return Decision(False, f"mergeability is {mergeable.lower() or 'unset'}")

--- a/tests/test_auto_merge_ready_prs.py
+++ b/tests/test_auto_merge_ready_prs.py
@@ -87,8 +87,14 @@ def decide(pr, **kwargs):
     kwargs.setdefault("now", NOW)
     kwargs.setdefault("min_age_days", 3)
     kwargs.setdefault("base_branch", "main")
-    kwargs.setdefault("trusted_reviewers", ("ai4c-reviewer",))
+    kwargs.setdefault("trusted_reviewers", ())
     return auto_merge.evaluate(pr, **kwargs)
+
+
+def decide_trusted(pr, **kwargs):
+    """Evaluate with the optional Bot-identity allowlist enabled."""
+    kwargs.setdefault("trusted_reviewers", ("ai4c-reviewer",))
+    return decide(pr, **kwargs)
 
 
 def test_fully_ready_pr_is_eligible():
@@ -228,7 +234,7 @@ def test_trusted_reviewer_cli_rejects_spellings_that_normalize_empty(
 )
 def test_default_reviewer_spelling_is_trusted(login):
     pr = make_pr(reviews=[approved_review(login=login)])
-    assert decide(pr).eligible
+    assert decide_trusted(pr).eligible
 
 
 @pytest.mark.parametrize(
@@ -242,7 +248,7 @@ def test_default_reviewer_spelling_is_trusted(login):
 )
 def test_same_named_non_bot_rest_reviewer_is_not_trusted(login, user_type):
     pr = make_pr(reviews=[approved_review(login=login, user_type=user_type)])
-    decision = decide(pr)
+    decision = decide_trusted(pr)
     assert not decision.eligible
     assert "did not have a verified Bot identity" in decision.reason
 
@@ -266,19 +272,19 @@ def test_same_named_non_bot_rest_reviewer_is_not_trusted(login, user_type):
     ],
 )
 def test_missing_or_unrecognized_rest_user_shape_fails_closed(review):
-    assert not decide(make_pr(reviews=[review])).eligible
+    assert not decide_trusted(make_pr(reviews=[review])).eligible
 
 
-def test_ai4c_agent_approval_intentionally_does_not_count():
+def test_ai4c_agent_approval_does_not_count_with_identity_allowlist():
     pr = make_pr(reviews=[approved_review(login="ai4c-agent[bot]")])
-    decision = decide(pr)
+    decision = decide_trusted(pr)
     assert not decision.eligible
     assert "no trusted reviewer" in decision.reason
 
 
 def test_named_additional_bot_reviewer_can_be_explicitly_allowlisted():
     pr = make_pr(reviews=[approved_review(login="release-reviewer[bot]")])
-    assert not decide(pr).eligible
+    assert not decide_trusted(pr).eligible
     assert decide(
         pr,
         trusted_reviewers=(*auto_merge.DEFAULT_TRUSTED_REVIEWERS, "release-reviewer"),
@@ -287,14 +293,14 @@ def test_named_additional_bot_reviewer_can_be_explicitly_allowlisted():
 
 def test_trusted_review_on_stale_commit_does_not_count():
     pr = make_pr(reviews=[approved_review(commit_id="old123")])
-    decision = decide(pr)
+    decision = decide_trusted(pr)
     assert not decision.eligible
     assert "not for current head" in decision.reason
 
 
 def test_non_approval_on_current_head_does_not_count():
     pr = make_pr(reviews=[approved_review(state="COMMENTED")])
-    assert not decide(pr).eligible
+    assert not decide_trusted(pr).eligible
 
 
 @pytest.mark.parametrize(
@@ -310,11 +316,11 @@ def test_non_approval_on_current_head_does_not_count():
     ],
 )
 def test_malformed_or_dismissed_reviews_fail_closed(review):
-    assert not decide(make_pr(reviews=[review])).eligible
+    assert not decide_trusted(make_pr(reviews=[review])).eligible
 
 
 def test_missing_reviews_fail_closed():
-    decision = decide(make_pr(reviews=[]))
+    decision = decide_trusted(make_pr(reviews=[]))
     assert not decision.eligible
     assert "no trusted reviewer" in decision.reason
 
@@ -331,12 +337,24 @@ def test_graphql_review_shape_fails_closed_without_actor_type():
         "state": "APPROVED",
         "commit": {"oid": HEAD_SHA},
     }
-    assert not decide(make_pr(reviews=[review])).eligible
+    assert not decide_trusted(make_pr(reviews=[review])).eligible
 
 
-def test_no_trusted_reviewer_configuration_uses_aggregate_approval():
-    decision = decide(make_pr(reviews=[]), trusted_reviewers=[])
-    assert decision.eligible
+def test_no_trusted_reviewer_configuration_accepts_any_exact_head_approver():
+    review = approved_review(login="ai4c-agent[bot]")
+    assert decide(make_pr(reviews=[review])).eligible
+
+
+def test_no_trusted_reviewer_configuration_still_requires_exact_head_approval():
+    decision = decide(make_pr(reviews=[approved_review(commit_id="old123")]))
+    assert not decision.eligible
+    assert "not for current head" in decision.reason
+
+
+def test_no_trusted_reviewer_configuration_requires_a_rest_approval():
+    decision = decide(make_pr(reviews=[]))
+    assert not decision.eligible
+    assert "no approval is bound to the current head" in decision.reason
 
 
 # Base freshness policy

--- a/tests/test_auto_merge_ready_prs.py
+++ b/tests/test_auto_merge_ready_prs.py
@@ -27,7 +27,6 @@ _SPEC.loader.exec_module(auto_merge)
 
 NOW = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
 HEAD_SHA = "cafe1234"
-BASE_SHA = "base1234"
 REQUIRED_CHECK = "test (3.12)"
 
 
@@ -53,7 +52,6 @@ def make_pr(**overrides):
         "state": "OPEN",
         "isDraft": False,
         "baseRefName": "main",
-        "baseRefOid": BASE_SHA,
         "headRefName": "agent/review-example",
         "headRefOid": HEAD_SHA,
         "labels": [],
@@ -89,7 +87,7 @@ def decide(pr, **kwargs):
     kwargs.setdefault("now", NOW)
     kwargs.setdefault("min_age_days", 3)
     kwargs.setdefault("base_branch", "main")
-    kwargs.setdefault("current_base_sha", BASE_SHA)
+    kwargs.setdefault("trusted_reviewers", ("ai4c-reviewer",))
     return auto_merge.evaluate(pr, **kwargs)
 
 
@@ -336,36 +334,16 @@ def test_graphql_review_shape_fails_closed_without_actor_type():
     assert not decide(make_pr(reviews=[review])).eligible
 
 
-def test_no_trusted_reviewer_configuration_fails_closed():
-    decision = decide(make_pr(), trusted_reviewers=[])
-    assert not decision.eligible
-    assert "no trusted reviewers configured" in decision.reason
+def test_no_trusted_reviewer_configuration_uses_aggregate_approval():
+    decision = decide(make_pr(reviews=[]), trusted_reviewers=[])
+    assert decision.eligible
 
 
-# Base-tip guards
+# Base freshness policy
 
 
-def test_missing_pr_base_sha_fails_closed():
-    decision = decide(make_pr(baseRefOid=""))
-    assert not decision.eligible
-    assert "no base SHA" in decision.reason
-
-
-def test_missing_current_base_tip_fails_closed():
-    decision = decide(make_pr(), current_base_sha="")
-    assert not decision.eligible
-    assert "could not verify" in decision.reason
-
-
-def test_stale_pr_base_fails_closed():
-    decision = decide(make_pr(baseRefOid="oldbase"))
-    assert not decision.eligible
-    assert "is stale" in decision.reason
-    assert BASE_SHA in decision.reason
-
-
-def test_base_sha_comparison_is_case_insensitive():
-    assert decide(make_pr(baseRefOid="ABCDEF"), current_base_sha="abcdef").eligible
+def test_recorded_stale_base_does_not_block_an_independent_pr():
+    assert decide(make_pr(baseRefOid="old-base-tip")).eligible
 
 
 # Changed-file path scope
@@ -378,6 +356,7 @@ def test_default_allowed_path_prefixes_are_the_conservative_content_set():
         "gocams/",
         "interpro/",
         "modules/",
+        "pages/",
         "projects/",
         "publications/",
         "reactome/",
@@ -602,7 +581,6 @@ def test_legacy_required_check_can_explicitly_succeed():
 def test_list_stage_defers_final_only_fields():
     pr = make_pr(
         headRefOid="",
-        baseRefOid="",
         reviews=[],
         mergeable="UNKNOWN",
         mergeStateStatus="UNKNOWN",
@@ -808,19 +786,6 @@ def test_view_pr_head_sha_retries_api_errors_and_empty_data(monkeypatch):
     assert sleeps == [0.25, 0.5]
 
 
-def test_view_base_tip_encodes_branch_and_rejects_empty(monkeypatch):
-    calls = []
-    monkeypatch.setattr(
-        auto_merge, "_gh", lambda args: calls.append(args) or "abc123\n"
-    )
-    assert auto_merge.view_base_tip("o/r", "release/v1") == "abc123"
-    assert "release%2Fv1" in calls[0][1]
-
-    monkeypatch.setattr(auto_merge, "_gh", lambda _: "\n")
-    with pytest.raises(ValueError, match="could not resolve"):
-        auto_merge.view_base_tip("o/r", "main")
-
-
 # End-to-end controller modes
 
 
@@ -831,14 +796,12 @@ def _run_main(
     view=None,
     views=None,
     args=(),
-    base_tips=None,
     post_file_heads=None,
 ):
     monkeypatch.setenv("GH_MERGE_TOKEN", "writer-token")
     view = view or make_pr(number=42)
     snapshots = [dict(item) for item in (views or [view, view])]
     last_view = {"value": dict(view)}
-    base_tips = list(base_tips or [BASE_SHA, BASE_SHA])
     post_file_heads = list(post_file_heads or [HEAD_SHA, HEAD_SHA])
     merges = []
     monkeypatch.setattr(
@@ -872,10 +835,6 @@ def _run_main(
         lambda _repo, _number: post_file_heads.pop(0),
     )
 
-    def fake_base_tip(_repo, _base):
-        return base_tips.pop(0)
-
-    monkeypatch.setattr(auto_merge, "view_base_tip", fake_base_tip)
     monkeypatch.setattr(
         auto_merge,
         "merge_pr",
@@ -923,18 +882,6 @@ def test_required_check_cli_is_enforced(monkeypatch, tmp_path):
     assert code == 0
     assert merges == []
     assert "required checks not explicitly successful" in summary
-
-
-def test_base_movement_after_final_verification_blocks_execute(monkeypatch, tmp_path):
-    code, merges, summary = _run_main(
-        monkeypatch,
-        tmp_path,
-        args=("--execute", "--required-check", REQUIRED_CHECK),
-        base_tips=[BASE_SHA, "newbase"],
-    )
-    assert code == 0
-    assert merges == []
-    assert "base branch moved after verification" in summary
 
 
 def test_hold_added_after_verification_blocks_execute(monkeypatch, tmp_path):
@@ -1226,7 +1173,6 @@ def test_execute_processes_oldest_candidate_first(monkeypatch, tmp_path):
         "view_pr_head_sha",
         lambda _repo, number: (older if number == 20 else newer)["headRefOid"],
     )
-    monkeypatch.setattr(auto_merge, "view_base_tip", lambda *_: BASE_SHA)
     merges = []
     monkeypatch.setattr(
         auto_merge,
@@ -1326,7 +1272,7 @@ def test_dry_run_summary_never_claims_a_merge():
     assert "#2 — draft" in report
 
 
-def test_multi_candidate_dry_run_explains_serial_base_refresh():
+def test_multi_candidate_dry_run_explains_no_base_refresh():
     report = auto_merge.render_summary(
         merged=[
             {"number": 1, "title": "curate: A"},
@@ -1336,5 +1282,5 @@ def test_multi_candidate_dry_run_explains_serial_base_refresh():
         failed=[],
         dry_run=True,
     )
-    assert "independently eligible at audit time" in report
-    assert "branch refresh" in report
+    assert "re-read before a head-pinned merge" in report
+    assert "do not require a branch refresh" in report

--- a/tests/test_pr_shepherd_workflow.py
+++ b/tests/test_pr_shepherd_workflow.py
@@ -67,7 +67,7 @@ def test_audit_and_execute_have_literal_modes_and_distinct_tokens():
     assert "--dry-run" not in execute["run"]
     for step in (audit, execute):
         assert '--required-check "test (3.12)"' in step["run"]
-        assert '--trusted-reviewer "ai4c-reviewer"' in step["run"]
+        assert "--trusted-reviewer" not in step["run"]
         assert "--allowed-path-prefix" not in step["run"]
 
 


### PR DESCRIPTION
## What changed

- stop requiring a PR's recorded base SHA to equal the current `main` tip
- stop requiring the production-only `ai4c-reviewer` exact-head identity gate; retain GitHub's aggregate `APPROVED` decision and optional CLI gate
- admit legitimate generated `pages/` artifacts in curation PRs
- keep fresh state/check reads, conflict detection, file-scope checks, and `--match-head-commit`
- update tests and rollout documentation for non-strict required checks

## Why

The first Shepherd audit showed ten otherwise-ready PRs as stale-base near misses. That behavior was an extra policy not present in DisMech and would force unnecessary branch refreshes, CI reruns, and review churn for independent changes.

After removing it, the live audit exposed two more repo-specific blockers: generated `pages/` files and the mandatory reviewer identity. The corrected policy follows DisMech's aggregate approval behavior while retaining this repository's inexpensive deterministic safeguards.

## Validation

- 173 focused controller/workflow tests passed
- 19 JavaScript trust-gate tests passed
- Ruff, formatting, Mypy, YAML parsing, and `git diff --check` passed
- live dry-run after setting required checks non-strict: 10 PRs would merge, with no branch refresh or CI rerun

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can satisfy merge approval and when PRs merge without rebasing onto `main`; safeguards (exact-head pin, path scope, checks, head re-reads) remain but policy is materially broader than before.
> 
> **Overview**
> **Aligns PR Shepherd’s deterministic closing pass with DisMech** so approved curation PRs are not blocked by extra repo-only gates.
> 
> The merge controller **no longer requires** the PR’s recorded base SHA to match the current `main` tip, and **drops the production `--trusted-reviewer ai4c-reviewer` requirement**. Eligibility now follows GitHub’s aggregate `APPROVED` decision while still requiring **at least one approval on the exact head** being merged; optional Bot allowlisting remains via CLI only. **`pages/`** is added to the default path allowlist for legitimate generated artifacts in curation PRs.
> 
> The **pr-shepherd** audit/execute steps stop passing `--trusted-reviewer`. **Docs** describe non-strict required checks, aggregate approval, and the updated rollout checklist. **Tests** cover the relaxed base policy, default reviewer behavior, and workflow contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c7c4371bf9afa8a292963433cec68d5d8a36f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->