### PR TITLE
Add manual Shepherd draft merging

### DIFF
--- a/.github/workflows/pr-shepherd.yml
+++ b/.github/workflows/pr-shepherd.yml
@@ -37,6 +37,11 @@ on:
         required: false
         default: "3"
         type: string
+      include_drafts:
+        description: "Include approved drafts (execute marks eligible drafts ready)"
+        required: true
+        default: false
+        type: boolean
       model:
         description: "Optional model ID override (blank = use the configured default in agent-config.yaml)"
         required: false
@@ -302,6 +307,9 @@ jobs:
             (vars.PR_SHEPHERD_MERGE_ENABLED == 'true' && 'execute' || 'audit') ||
             inputs.merge_mode || 'audit' }}
       MIN_AGE_DAYS: ${{ inputs.min_age_days || '3' }}
+      INCLUDE_DRAFTS: >-
+        ${{ github.event_name == 'workflow_dispatch' &&
+            inputs.include_drafts && 'true' || 'false' }}
 
     steps:
       - name: Checkout trusted default branch
@@ -361,10 +369,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          draft_args=()
+          if [ "$INCLUDE_DRAFTS" = "true" ]; then
+            draft_args+=(--include-drafts)
+          fi
           uv run --python 3.12 --no-project python scripts/auto_merge_ready_prs.py \
             --repo "$GITHUB_REPOSITORY" \
             --min-age-days "$MIN_AGE_DAYS" \
             --required-check "test (3.12)" \
+            "${draft_args[@]}" \
             --dry-run
 
       - name: Merge ready PRs (deterministic)
@@ -382,8 +395,13 @@ jobs:
             echo "::error::The scoped merge token is empty."
             exit 1
           fi
+          draft_args=()
+          if [ "$INCLUDE_DRAFTS" = "true" ]; then
+            draft_args+=(--include-drafts)
+          fi
           uv run --python 3.12 --no-project python scripts/auto_merge_ready_prs.py \
             --repo "$GITHUB_REPOSITORY" \
             --min-age-days "$MIN_AGE_DAYS" \
             --required-check "test (3.12)" \
+            "${draft_args[@]}" \
             --execute

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -320,7 +320,8 @@ Manual dispatch exposes three independent controls:
 - `merge_mode=audit|execute|off` selects the closing pass.
 - `include_drafts=true` includes otherwise eligible approved drafts. Audit mode
   only reports them; execute mode marks each verified draft ready, re-reads all
-  merge guards, and only then performs the head-pinned merge.
+  merge guards, and only then performs the head-pinned merge. If any later
+  guard or the merge fails, it restores the PR to draft state.
 
 Schedules audit by default. They execute only while the repository variable
 `PR_SHEPHERD_MERGE_ENABLED` is exactly `true`. Manual execute also requires that

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -314,10 +314,13 @@ may update a branch or repair review feedback, but it cannot approve, merge, or
 enable auto-merge. A separate `merge-ready` job starts on a fresh runner and
 re-reads GitHub state before it will squash-merge anything.
 
-Manual dispatch exposes two independent controls:
+Manual dispatch exposes three independent controls:
 
 - `run_agent=false` skips the LLM job, which permits a deterministic-only run;
 - `merge_mode=audit|execute|off` selects the closing pass.
+- `include_drafts=true` includes otherwise eligible approved drafts. Audit mode
+  only reports them; execute mode marks each verified draft ready, re-reads all
+  merge guards, and only then performs the head-pinned merge.
 
 Schedules audit by default. They execute only while the repository variable
 `PR_SHEPHERD_MERGE_ENABLED` is exactly `true`. Manual execute also requires that
@@ -357,8 +360,8 @@ build/configuration files.
 
 The controller requires all of these at fresh reads immediately before merge:
 
-- open, non-draft, unassigned, old enough by PR creation time, and targeting
-  `main`;
+- open, unassigned, old enough by PR creation time, and targeting `main`;
+- non-draft unless a manual run explicitly sets `include_drafts=true`;
 - no `shepherd:hold` label and no `auto/generate-*` head branch;
 - GitHub's aggregate review decision is `APPROVED`;
 - at least one approval is bound to the exact current PR head;

--- a/scripts/auto_merge_ready_prs.py
+++ b/scripts/auto_merge_ready_prs.py
@@ -47,6 +47,7 @@ as a visible workflow guard. The ``shepherd:hold`` label, assignment, and the
 separate ``auto/generate-*`` lane always veto this controller. Draft state also
 vetoes by default; ``--include-drafts`` makes an eligible draft auditable and,
 in execute mode, marks it ready before the final full re-read and merge.
+If any post-transition guard or merge fails, the controller restores draft state.
 """
 
 from __future__ import annotations
@@ -521,7 +522,12 @@ def evaluate(
     if mergeable != "MERGEABLE":
         return Decision(False, f"mergeability is {mergeable.lower() or 'unset'}")
     merge_state = (pr.get("mergeStateStatus") or "").upper()
-    if merge_state != "CLEAN":
+    draft_preflight_state = (
+        bool(pr.get("isDraft"))
+        and include_drafts
+        and merge_state in {"BLOCKED", "DRAFT"}
+    )
+    if merge_state != "CLEAN" and not draft_preflight_state:
         return Decision(
             False, f"merge state is {merge_state.lower() or 'unset'}, not clean"
         )
@@ -778,6 +784,14 @@ def mark_pr_ready(repo: str, number: int, write_token: str) -> None:
     _gh(["pr", "ready", str(number), "--repo", repo], token=write_token)
 
 
+def mark_pr_draft(repo: str, number: int, write_token: str) -> None:
+    """Restore draft state after an opted-in ready transition did not merge."""
+    write_token = write_token.strip()
+    if not write_token:
+        raise ValueError("refusing to restore draft state without a write token")
+    _gh(["pr", "ready", str(number), "--repo", repo, "--undo"], token=write_token)
+
+
 def render_summary(
     merged: list[dict],
     skipped: list[dict],
@@ -1017,7 +1031,8 @@ def main(argv: list[str] | None = None) -> int:
             )
             merged.append({"number": number, "title": fresh["title"]})
             continue
-        if fresh.get("isDraft"):
+        marked_ready = bool(fresh.get("isDraft"))
+        if marked_ready:
             try:
                 mark_pr_ready(args.repo, number, write_token)
             except (subprocess.CalledProcessError, ValueError) as exc:
@@ -1030,71 +1045,86 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"FAIL  #{number}: {reason}", file=sys.stderr)
                 failed.append({"number": number, "reason": reason})
                 continue
-        # Re-read every load-bearing field immediately before the write. This
-        # catches a newly added hold/assignee, review or check change, and head
-        # movement. The exact reviewed/tested head remains pinned at merge time.
+        merge_completed = False
         try:
-            fresh = view_pr(args.repo, number)
-            fresh["reviews"] = list_pr_reviews(args.repo, number)
-            files = list_pr_files(args.repo, number)
-            fresh["changed_files"] = list(files.filenames)
-            fresh["previous_changed_filenames"] = list(files.previous_filenames)
-            require_unchanged_file_inventory_head(
-                args.repo, number, fresh.get("headRefOid")
-            )
-        except HeadMovedError as exc:
-            reason = str(exc)
-            print(f"SKIP  #{number}: {reason}")
-            skipped.append({"number": number, "reason": reason})
-            continue
-        except (subprocess.CalledProcessError, ValueError) as exc:
-            detail = (
-                _gh_error(exc)
-                if isinstance(exc, subprocess.CalledProcessError)
-                else str(exc)
-            )
-            reason = f"could not perform final re-verification: {detail}"
-            print(f"FAIL  #{number}: {reason}", file=sys.stderr)
-            failed.append({"number": number, "reason": reason})
-            continue
-
-        final_decision = evaluate(
-            fresh,
-            now=datetime.now(timezone.utc),
-            min_age_days=args.min_age_days,
-            base_branch=args.base_branch,
-            trusted_reviewers=trusted_reviewers,
-            required_checks=args.required_check,
-            hold_label=args.hold_label,
-            excluded_head_prefixes=excluded_head_prefixes,
-            allowed_path_prefixes=args.allowed_path_prefix,
-            # If the first verified view was a draft, execute mode has just
-            # marked it ready. Require that transition to be visible before
-            # writing; also catch a non-draft PR changed back to draft here.
-            include_drafts=False,
-        )
-        if not final_decision.eligible:
-            reason = f"state changed after verification: {final_decision.reason}"
-            print(f"SKIP  #{number}: {reason}")
-            skipped.append({"number": number, "reason": reason})
-            continue
-        try:
-            merge_pr(
-                args.repo,
-                number,
-                args.min_age_days,
-                fresh["headRefOid"],
-                write_token,
-            )
-        except subprocess.CalledProcessError as exc:
-            reason = _gh_error(exc)
-            if is_benign_merge_failure(exc.stderr or reason):
+            # Re-read every load-bearing field immediately before the write.
+            # This catches a newly added hold/assignee, review or check change,
+            # and head movement. The exact reviewed/tested head remains pinned.
+            try:
+                fresh = view_pr(args.repo, number)
+                fresh["reviews"] = list_pr_reviews(args.repo, number)
+                files = list_pr_files(args.repo, number)
+                fresh["changed_files"] = list(files.filenames)
+                fresh["previous_changed_filenames"] = list(files.previous_filenames)
+                require_unchanged_file_inventory_head(
+                    args.repo, number, fresh.get("headRefOid")
+                )
+            except HeadMovedError as exc:
+                reason = str(exc)
                 print(f"SKIP  #{number}: {reason}")
                 skipped.append({"number": number, "reason": reason})
-            else:
+                continue
+            except (subprocess.CalledProcessError, ValueError) as exc:
+                detail = (
+                    _gh_error(exc)
+                    if isinstance(exc, subprocess.CalledProcessError)
+                    else str(exc)
+                )
+                reason = f"could not perform final re-verification: {detail}"
                 print(f"FAIL  #{number}: {reason}", file=sys.stderr)
                 failed.append({"number": number, "reason": reason})
-            continue
+                continue
+
+            final_decision = evaluate(
+                fresh,
+                now=datetime.now(timezone.utc),
+                min_age_days=args.min_age_days,
+                base_branch=args.base_branch,
+                trusted_reviewers=trusted_reviewers,
+                required_checks=args.required_check,
+                hold_label=args.hold_label,
+                excluded_head_prefixes=excluded_head_prefixes,
+                allowed_path_prefixes=args.allowed_path_prefix,
+                # Require a successful ready transition and catch a PR changed
+                # back to draft between the two verification reads.
+                include_drafts=False,
+            )
+            if not final_decision.eligible:
+                reason = f"state changed after verification: {final_decision.reason}"
+                print(f"SKIP  #{number}: {reason}")
+                skipped.append({"number": number, "reason": reason})
+                continue
+            try:
+                merge_pr(
+                    args.repo,
+                    number,
+                    args.min_age_days,
+                    fresh["headRefOid"],
+                    write_token,
+                )
+                merge_completed = True
+            except subprocess.CalledProcessError as exc:
+                reason = _gh_error(exc)
+                if is_benign_merge_failure(exc.stderr or reason):
+                    print(f"SKIP  #{number}: {reason}")
+                    skipped.append({"number": number, "reason": reason})
+                else:
+                    print(f"FAIL  #{number}: {reason}", file=sys.stderr)
+                    failed.append({"number": number, "reason": reason})
+                continue
+        finally:
+            if marked_ready and not merge_completed:
+                try:
+                    mark_pr_draft(args.repo, number, write_token)
+                except (subprocess.CalledProcessError, ValueError) as exc:
+                    detail = (
+                        _gh_error(exc)
+                        if isinstance(exc, subprocess.CalledProcessError)
+                        else str(exc)
+                    )
+                    reason = f"could not restore draft state: {detail}"
+                    print(f"FAIL  #{number}: {reason}", file=sys.stderr)
+                    failed.append({"number": number, "reason": reason})
         print(f"MERGED #{number}: {fresh['title']}")
         merged.append({"number": number, "title": fresh["title"]})
 

--- a/scripts/auto_merge_ready_prs.py
+++ b/scripts/auto_merge_ready_prs.py
@@ -99,6 +99,7 @@ BENIGN_MERGE_FAILURES = (
     "pull request is closed",
     "no commits between",
 )
+PR_GONE_MERGE_FAILURES = ("already merged", "pull request is closed")
 GH_STATUS_MARKERS = ("X ", "! ", "✓ ")
 
 MERGE_COMMENT = (
@@ -568,6 +569,12 @@ def _gh_error(exc: subprocess.CalledProcessError) -> str:
 def is_benign_merge_failure(stderr: str) -> bool:
     lowered = stderr.lower()
     return any(marker in lowered for marker in BENIGN_MERGE_FAILURES)
+
+
+def is_pr_gone_merge_failure(stderr: str) -> bool:
+    """Return true when a benign merge race left no open PR to re-draft."""
+    lowered = stderr.lower()
+    return any(marker in lowered for marker in PR_GONE_MERGE_FAILURES)
 
 
 def list_open_prs(repo: str, limit: int, base_branch: str) -> list[dict]:
@@ -1046,6 +1053,7 @@ def main(argv: list[str] | None = None) -> int:
                 failed.append({"number": number, "reason": reason})
                 continue
         merge_completed = False
+        pr_gone = False
         try:
             # Re-read every load-bearing field immediately before the write.
             # This catches a newly added hold/assignee, review or check change,
@@ -1105,7 +1113,9 @@ def main(argv: list[str] | None = None) -> int:
                 merge_completed = True
             except subprocess.CalledProcessError as exc:
                 reason = _gh_error(exc)
-                if is_benign_merge_failure(exc.stderr or reason):
+                merge_error = exc.stderr or reason
+                if is_benign_merge_failure(merge_error):
+                    pr_gone = is_pr_gone_merge_failure(merge_error)
                     print(f"SKIP  #{number}: {reason}")
                     skipped.append({"number": number, "reason": reason})
                 else:
@@ -1113,7 +1123,7 @@ def main(argv: list[str] | None = None) -> int:
                     failed.append({"number": number, "reason": reason})
                 continue
         finally:
-            if marked_ready and not merge_completed:
+            if marked_ready and not merge_completed and not pr_gone:
                 try:
                     mark_pr_draft(args.repo, number, write_token)
                 except (subprocess.CalledProcessError, ValueError) as exc:

--- a/scripts/auto_merge_ready_prs.py
+++ b/scripts/auto_merge_ready_prs.py
@@ -5,7 +5,8 @@ This is intended as the non-agentic closing step of the PR Shepherd. It never
 judges a change. It re-reads GitHub state immediately before merging and only
 merges when every mechanical guard passes:
 
-* the PR is open, non-draft, unassigned, and targets the configured base;
+* the PR is open, unassigned, targets the configured base, and is non-draft
+  unless a manual run explicitly opts approved drafts into the pass;
 * the aggregate review decision is APPROVED;
 * at least one approval is bound to the exact current PR head;
 * the PR is old enough, conflict-free, and GitHub reports a CLEAN merge state;
@@ -42,8 +43,10 @@ The controller is report-only by default. Actual merging requires the explicit
 ``--execute`` flag and a separate ``GH_MERGE_TOKEN`` credential. Read operations
 continue to use the read-only ``GH_TOKEN``; the writer credential is injected
 only into the merge and courtesy-comment subprocesses. ``--dry-run`` is retained
-as a visible workflow guard. The ``shepherd:hold`` label, assignment, draft
-state, and the separate ``auto/generate-*`` lane all veto this controller.
+as a visible workflow guard. The ``shepherd:hold`` label, assignment, and the
+separate ``auto/generate-*`` lane always veto this controller. Draft state also
+vetoes by default; ``--include-drafts`` makes an eligible draft auditable and,
+in execute mode, marks it ready before the final full re-read and merge.
 """
 
 from __future__ import annotations
@@ -443,6 +446,7 @@ def evaluate(
     hold_label: str = "shepherd:hold",
     excluded_head_prefixes: Iterable[str] = DEFAULT_EXCLUDED_HEAD_PREFIXES,
     allowed_path_prefixes: Iterable[str] = (),
+    include_drafts: bool = False,
     final: bool = True,
 ) -> Decision:
     """Apply cheap list guards or the complete final merge predicate."""
@@ -451,7 +455,7 @@ def evaluate(
         return Decision(False, "no state in the API response")
     if state and state != "OPEN":
         return Decision(False, f"not open (state={state.lower()})")
-    if pr.get("isDraft"):
+    if pr.get("isDraft") and not include_drafts:
         return Decision(False, "draft")
     if pr.get("baseRefName") != base_branch:
         return Decision(
@@ -764,6 +768,16 @@ def merge_pr(
         )
 
 
+def mark_pr_ready(repo: str, number: int, write_token: str) -> None:
+    """Convert a verified draft to ready immediately before its final re-read."""
+    write_token = write_token.strip()
+    if not write_token:
+        raise ValueError(
+            "refusing to mark a draft ready without a dedicated write token"
+        )
+    _gh(["pr", "ready", str(number), "--repo", repo], token=write_token)
+
+
 def render_summary(
     merged: list[dict],
     skipped: list[dict],
@@ -824,6 +838,14 @@ def main(argv: list[str] | None = None) -> int:
         type=positive_int,
         default=300,
         help="max open PRs to scan (default: 300)",
+    )
+    parser.add_argument(
+        "--include-drafts",
+        action="store_true",
+        help=(
+            "consider approved drafts; execute marks an otherwise eligible draft "
+            "ready immediately before final verification (default: exclude drafts)"
+        ),
     )
     parser.add_argument(
         "--trusted-reviewer",
@@ -919,6 +941,7 @@ def main(argv: list[str] | None = None) -> int:
             hold_label=args.hold_label,
             excluded_head_prefixes=excluded_head_prefixes,
             allowed_path_prefixes=args.allowed_path_prefix,
+            include_drafts=args.include_drafts,
             final=False,
         )
         if decision.eligible:
@@ -980,17 +1003,33 @@ def main(argv: list[str] | None = None) -> int:
             hold_label=args.hold_label,
             excluded_head_prefixes=excluded_head_prefixes,
             allowed_path_prefixes=args.allowed_path_prefix,
+            include_drafts=args.include_drafts,
         )
         if not decision.eligible:
             print(f"SKIP  #{number}: {decision.reason}")
             skipped.append({"number": number, "reason": decision.reason})
             continue
         if dry_run:
+            action = "mark ready and merge" if fresh.get("isDraft") else "merge"
             print(
-                f"DRY-RUN would merge #{number}: {fresh['title']} — {decision.reason}"
+                f"DRY-RUN would {action} #{number}: {fresh['title']} — "
+                f"{decision.reason}"
             )
             merged.append({"number": number, "title": fresh["title"]})
             continue
+        if fresh.get("isDraft"):
+            try:
+                mark_pr_ready(args.repo, number, write_token)
+            except (subprocess.CalledProcessError, ValueError) as exc:
+                detail = (
+                    _gh_error(exc)
+                    if isinstance(exc, subprocess.CalledProcessError)
+                    else str(exc)
+                )
+                reason = f"could not mark verified draft ready: {detail}"
+                print(f"FAIL  #{number}: {reason}", file=sys.stderr)
+                failed.append({"number": number, "reason": reason})
+                continue
         # Re-read every load-bearing field immediately before the write. This
         # catches a newly added hold/assignee, review or check change, and head
         # movement. The exact reviewed/tested head remains pinned at merge time.
@@ -1029,6 +1068,10 @@ def main(argv: list[str] | None = None) -> int:
             hold_label=args.hold_label,
             excluded_head_prefixes=excluded_head_prefixes,
             allowed_path_prefixes=args.allowed_path_prefix,
+            # If the first verified view was a draft, execute mode has just
+            # marked it ready. Require that transition to be visible before
+            # writing; also catch a non-draft PR changed back to draft here.
+            include_drafts=False,
         )
         if not final_decision.eligible:
             reason = f"state changed after verification: {final_decision.reason}"

--- a/tests/test_auto_merge_ready_prs.py
+++ b/tests/test_auto_merge_ready_prs.py
@@ -824,6 +824,7 @@ def _run_main(
     list_view=None,
     ready_calls=None,
     draft_calls=None,
+    merge_error=None,
 ):
     monkeypatch.setenv("GH_MERGE_TOKEN", "writer-token")
     view = view or make_pr(number=42)
@@ -874,13 +875,13 @@ def _run_main(
         "mark_pr_draft",
         lambda repo, number, _token: draft_calls.append((repo, number)),
     )
-    monkeypatch.setattr(
-        auto_merge,
-        "merge_pr",
-        lambda repo, number, days, head, _token: merges.append(
-            (repo, number, days, head)
-        ),
-    )
+
+    def fake_merge(repo, number, days, head, _token):
+        if merge_error is not None:
+            raise merge_error
+        merges.append((repo, number, days, head))
+
+    monkeypatch.setattr(auto_merge, "merge_pr", fake_merge)
     summary = tmp_path / "summary.md"
     code = auto_merge.main(["--repo", "o/r", "--summary-file", str(summary), *args])
     return code, merges, summary.read_text()
@@ -992,6 +993,59 @@ def test_include_drafts_restores_draft_after_final_guard_failure(monkeypatch, tm
     assert merges == []
     assert draft_calls == [("o/r", 42)]
     assert "state changed after verification: held by label" in summary
+
+
+@pytest.mark.parametrize("message", ["already merged", "pull request is closed"])
+def test_include_drafts_does_not_redraft_a_pr_that_is_gone(
+    monkeypatch, tmp_path, message
+):
+    draft = make_pr(number=42, isDraft=True, mergeStateStatus="DRAFT")
+    ready = make_pr(number=42, isDraft=False)
+    draft_calls = []
+    error = subprocess.CalledProcessError(1, "gh", stderr=message)
+    code, merges, summary = _run_main(
+        monkeypatch,
+        tmp_path,
+        views=[draft, ready],
+        list_view=draft,
+        draft_calls=draft_calls,
+        merge_error=error,
+        args=(
+            "--execute",
+            "--required-check",
+            REQUIRED_CHECK,
+            "--include-drafts",
+        ),
+    )
+    assert code == 0
+    assert merges == []
+    assert draft_calls == []
+    assert message in summary
+
+
+def test_include_drafts_redrafts_after_open_pr_merge_race(monkeypatch, tmp_path):
+    draft = make_pr(number=42, isDraft=True, mergeStateStatus="BLOCKED")
+    ready = make_pr(number=42, isDraft=False)
+    draft_calls = []
+    error = subprocess.CalledProcessError(1, "gh", stderr="head branch was modified")
+    code, merges, summary = _run_main(
+        monkeypatch,
+        tmp_path,
+        views=[draft, ready],
+        list_view=draft,
+        draft_calls=draft_calls,
+        merge_error=error,
+        args=(
+            "--execute",
+            "--required-check",
+            REQUIRED_CHECK,
+            "--include-drafts",
+        ),
+    )
+    assert code == 0
+    assert merges == []
+    assert draft_calls == [("o/r", 42)]
+    assert "head branch was modified" in summary
 
 
 def test_execute_merges_and_pins_verified_head(monkeypatch, tmp_path):
@@ -1330,6 +1384,32 @@ def test_execute_processes_oldest_candidate_first(monkeypatch, tmp_path):
 # Merge invocation and reporting
 
 
+def test_ready_and_redraft_use_only_the_dedicated_writer(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        auto_merge,
+        "_gh",
+        lambda args, *, token=None: calls.append((args, token)) or "",
+    )
+    auto_merge.mark_pr_ready("o/r", 7, "writer-token")
+    auto_merge.mark_pr_draft("o/r", 7, "writer-token")
+    assert calls == [
+        (["pr", "ready", "7", "--repo", "o/r"], "writer-token"),
+        (["pr", "ready", "7", "--repo", "o/r", "--undo"], "writer-token"),
+    ]
+
+
+@pytest.mark.parametrize("function", ["mark_pr_ready", "mark_pr_draft"])
+def test_ready_state_writes_refuse_empty_token(monkeypatch, function):
+    monkeypatch.setattr(
+        auto_merge,
+        "_gh",
+        lambda *_args, **_kwargs: pytest.fail("gh must not run without a token"),
+    )
+    with pytest.raises(ValueError):
+        getattr(auto_merge, function)("o/r", 7, "  ")
+
+
 def test_merge_pr_always_pins_the_head(monkeypatch):
     calls = []
     monkeypatch.setattr(
@@ -1384,6 +1464,9 @@ GH_REFUSAL = (
 
 def test_benign_race_and_error_rendering():
     assert auto_merge.is_benign_merge_failure(GH_REFUSAL)
+    assert not auto_merge.is_pr_gone_merge_failure(GH_REFUSAL)
+    assert auto_merge.is_pr_gone_merge_failure("pull request is closed")
+    assert auto_merge.is_pr_gone_merge_failure("already merged")
     exc = subprocess.CalledProcessError(1, "gh", stderr=GH_REFUSAL)
     assert auto_merge._gh_error(exc).startswith("Pull request")
     assert "--admin" not in auto_merge._gh_error(exc)

--- a/tests/test_auto_merge_ready_prs.py
+++ b/tests/test_auto_merge_ready_prs.py
@@ -101,6 +101,12 @@ def test_fully_ready_pr_is_eligible():
     assert decide(make_pr()).eligible
 
 
+def test_approved_draft_requires_explicit_opt_in():
+    pr = make_pr(isDraft=True)
+    assert not decide(pr).eligible
+    assert decide(pr, include_drafts=True).eligible
+
+
 def test_required_check_can_be_enabled():
     assert decide(make_pr(), required_checks=[REQUIRED_CHECK]).eligible
 
@@ -815,6 +821,8 @@ def _run_main(
     views=None,
     args=(),
     post_file_heads=None,
+    list_view=None,
+    ready_calls=None,
 ):
     monkeypatch.setenv("GH_MERGE_TOKEN", "writer-token")
     view = view or make_pr(number=42)
@@ -822,10 +830,11 @@ def _run_main(
     last_view = {"value": dict(view)}
     post_file_heads = list(post_file_heads or [HEAD_SHA, HEAD_SHA])
     merges = []
+    ready_calls = ready_calls if ready_calls is not None else []
     monkeypatch.setattr(
         auto_merge,
         "list_open_prs",
-        lambda _repo, _limit, _base: [make_pr(number=42)],
+        lambda _repo, _limit, _base: [dict(list_view or make_pr(number=42))],
     )
 
     def fake_view_pr(_repo, _number):
@@ -855,6 +864,11 @@ def _run_main(
 
     monkeypatch.setattr(
         auto_merge,
+        "mark_pr_ready",
+        lambda repo, number, _token: ready_calls.append((repo, number)),
+    )
+    monkeypatch.setattr(
+        auto_merge,
         "merge_pr",
         lambda repo, number, days, head, _token: merges.append(
             (repo, number, days, head)
@@ -878,6 +892,70 @@ def test_explicit_dry_run_never_merges(monkeypatch, tmp_path):
     assert code == 0
     assert merges == []
     assert "Would merge 1" in summary
+
+
+def test_include_drafts_audit_reports_without_marking_ready(monkeypatch, tmp_path):
+    draft = make_pr(number=42, isDraft=True)
+    ready_calls = []
+    code, merges, summary = _run_main(
+        monkeypatch,
+        tmp_path,
+        view=draft,
+        list_view=draft,
+        ready_calls=ready_calls,
+        args=("--dry-run", "--include-drafts"),
+    )
+    assert code == 0
+    assert merges == []
+    assert ready_calls == []
+    assert "Would merge 1" in summary
+
+
+def test_include_drafts_execute_marks_ready_then_reverifies_and_merges(
+    monkeypatch, tmp_path
+):
+    draft = make_pr(number=42, isDraft=True)
+    ready = make_pr(number=42, isDraft=False)
+    ready_calls = []
+    code, merges, summary = _run_main(
+        monkeypatch,
+        tmp_path,
+        views=[draft, ready],
+        list_view=draft,
+        ready_calls=ready_calls,
+        args=(
+            "--execute",
+            "--required-check",
+            REQUIRED_CHECK,
+            "--include-drafts",
+        ),
+    )
+    assert code == 0
+    assert ready_calls == [("o/r", 42)]
+    assert merges == [("o/r", 42, 3, HEAD_SHA)]
+    assert "Merged 1" in summary
+
+
+def test_include_drafts_execute_requires_ready_transition(monkeypatch, tmp_path):
+    draft = make_pr(number=42, isDraft=True)
+    ready_calls = []
+    code, merges, summary = _run_main(
+        monkeypatch,
+        tmp_path,
+        views=[draft, draft],
+        list_view=draft,
+        ready_calls=ready_calls,
+        args=(
+            "--execute",
+            "--required-check",
+            REQUIRED_CHECK,
+            "--include-drafts",
+        ),
+    )
+    assert code == 0
+    assert ready_calls == [("o/r", 42)]
+    assert merges == []
+    assert "state changed after verification: draft" in summary
 
 
 def test_execute_merges_and_pins_verified_head(monkeypatch, tmp_path):

--- a/tests/test_auto_merge_ready_prs.py
+++ b/tests/test_auto_merge_ready_prs.py
@@ -102,7 +102,7 @@ def test_fully_ready_pr_is_eligible():
 
 
 def test_approved_draft_requires_explicit_opt_in():
-    pr = make_pr(isDraft=True)
+    pr = make_pr(isDraft=True, mergeStateStatus="DRAFT")
     assert not decide(pr).eligible
     assert decide(pr, include_drafts=True).eligible
 
@@ -823,6 +823,7 @@ def _run_main(
     post_file_heads=None,
     list_view=None,
     ready_calls=None,
+    draft_calls=None,
 ):
     monkeypatch.setenv("GH_MERGE_TOKEN", "writer-token")
     view = view or make_pr(number=42)
@@ -831,6 +832,7 @@ def _run_main(
     post_file_heads = list(post_file_heads or [HEAD_SHA, HEAD_SHA])
     merges = []
     ready_calls = ready_calls if ready_calls is not None else []
+    draft_calls = draft_calls if draft_calls is not None else []
     monkeypatch.setattr(
         auto_merge,
         "list_open_prs",
@@ -869,6 +871,11 @@ def _run_main(
     )
     monkeypatch.setattr(
         auto_merge,
+        "mark_pr_draft",
+        lambda repo, number, _token: draft_calls.append((repo, number)),
+    )
+    monkeypatch.setattr(
+        auto_merge,
         "merge_pr",
         lambda repo, number, days, head, _token: merges.append(
             (repo, number, days, head)
@@ -895,7 +902,7 @@ def test_explicit_dry_run_never_merges(monkeypatch, tmp_path):
 
 
 def test_include_drafts_audit_reports_without_marking_ready(monkeypatch, tmp_path):
-    draft = make_pr(number=42, isDraft=True)
+    draft = make_pr(number=42, isDraft=True, mergeStateStatus="DRAFT")
     ready_calls = []
     code, merges, summary = _run_main(
         monkeypatch,
@@ -914,15 +921,17 @@ def test_include_drafts_audit_reports_without_marking_ready(monkeypatch, tmp_pat
 def test_include_drafts_execute_marks_ready_then_reverifies_and_merges(
     monkeypatch, tmp_path
 ):
-    draft = make_pr(number=42, isDraft=True)
+    draft = make_pr(number=42, isDraft=True, mergeStateStatus="DRAFT")
     ready = make_pr(number=42, isDraft=False)
     ready_calls = []
+    draft_calls = []
     code, merges, summary = _run_main(
         monkeypatch,
         tmp_path,
         views=[draft, ready],
         list_view=draft,
         ready_calls=ready_calls,
+        draft_calls=draft_calls,
         args=(
             "--execute",
             "--required-check",
@@ -932,19 +941,22 @@ def test_include_drafts_execute_marks_ready_then_reverifies_and_merges(
     )
     assert code == 0
     assert ready_calls == [("o/r", 42)]
+    assert draft_calls == []
     assert merges == [("o/r", 42, 3, HEAD_SHA)]
     assert "Merged 1" in summary
 
 
 def test_include_drafts_execute_requires_ready_transition(monkeypatch, tmp_path):
-    draft = make_pr(number=42, isDraft=True)
+    draft = make_pr(number=42, isDraft=True, mergeStateStatus="DRAFT")
     ready_calls = []
+    draft_calls = []
     code, merges, summary = _run_main(
         monkeypatch,
         tmp_path,
         views=[draft, draft],
         list_view=draft,
         ready_calls=ready_calls,
+        draft_calls=draft_calls,
         args=(
             "--execute",
             "--required-check",
@@ -954,8 +966,32 @@ def test_include_drafts_execute_requires_ready_transition(monkeypatch, tmp_path)
     )
     assert code == 0
     assert ready_calls == [("o/r", 42)]
+    assert draft_calls == [("o/r", 42)]
     assert merges == []
     assert "state changed after verification: draft" in summary
+
+
+def test_include_drafts_restores_draft_after_final_guard_failure(monkeypatch, tmp_path):
+    draft = make_pr(number=42, isDraft=True, mergeStateStatus="BLOCKED")
+    held = make_pr(number=42, labels=[{"name": "shepherd:hold"}])
+    draft_calls = []
+    code, merges, summary = _run_main(
+        monkeypatch,
+        tmp_path,
+        views=[draft, held],
+        list_view=draft,
+        draft_calls=draft_calls,
+        args=(
+            "--execute",
+            "--required-check",
+            REQUIRED_CHECK,
+            "--include-drafts",
+        ),
+    )
+    assert code == 0
+    assert merges == []
+    assert draft_calls == [("o/r", 42)]
+    assert "state changed after verification: held by label" in summary
 
 
 def test_execute_merges_and_pins_verified_head(monkeypatch, tmp_path):

--- a/tests/test_pr_shepherd_workflow.py
+++ b/tests/test_pr_shepherd_workflow.py
@@ -52,7 +52,12 @@ def test_merge_controller_is_a_separate_job_with_trusted_checkout():
 
 
 def test_audit_and_execute_have_literal_modes_and_distinct_tokens():
-    merge_job = _workflow(SHEPHERD)["jobs"]["merge-ready"]
+    workflow = _workflow(SHEPHERD)
+    # PyYAML 1.1 parses the unquoted workflow key `on` as boolean true.
+    include_drafts = workflow[True]["workflow_dispatch"]["inputs"]["include_drafts"]
+    assert include_drafts["type"] == "boolean"
+    assert include_drafts["default"] is False
+    merge_job = workflow["jobs"]["merge-ready"]
     audit = _step(merge_job, "Audit merge-ready PRs (deterministic)")
     execute = _step(merge_job, "Merge ready PRs (deterministic)")
 
@@ -69,6 +74,8 @@ def test_audit_and_execute_have_literal_modes_and_distinct_tokens():
         assert '--required-check "test (3.12)"' in step["run"]
         assert "--trusted-reviewer" not in step["run"]
         assert "--allowed-path-prefix" not in step["run"]
+        assert "draft_args+=(--include-drafts)" in step["run"]
+        assert '"${draft_args[@]}"' in step["run"]
 
 
 def test_execute_is_feature_gated_main_only_and_narrowly_scoped():


### PR DESCRIPTION
## What changed

- add a manual-only `include_drafts` workflow-dispatch option
- keep scheduled Shepherd runs excluding drafts
- in audit mode, report eligible drafts without changing them
- in execute mode, mark an otherwise eligible draft ready, then re-read every merge guard before the head-pinned squash merge

## Why

The PR-tending agent commonly leaves completed PRs in draft state. Those PRs can already have exact-head approval and green CI, but the deterministic controller intentionally skipped every draft with no operator override.

This adds the explicit override while preserving the controller's approval, exact-head, path, age, hold, assignment, mergeability, and required-check gates.

## Validation

- `uv run pytest -q tests/test_auto_merge_ready_prs.py tests/test_pr_shepherd_workflow.py` (179 passed)
- Ruff check and format check
- mypy
- 19 JavaScript trust-gate tests
- yamllint
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Execute mode can flip draft→ready and auto-merge PRs when manually enabled, though existing approval, path, check, and re-verification gates remain; rollback on failure limits leaving PRs stuck non-draft.
> 
> **Overview**
> **Manual Shepherd runs** can now set **`include_drafts=true`** on workflow dispatch. Scheduled runs still exclude drafts.
> 
> The deterministic merge controller gains **`--include-drafts`**: approved drafts pass the usual guards when opted in. **Audit/dry-run** only reports them; **execute** calls **`gh pr ready`**, runs the same final re-read with drafts disallowed again, then head-pinned squash merge. If ready transition, re-verification, or merge fails (but the PR is still open), it **`gh pr ready --undo`** to restore draft state. Benign “already merged / closed” races skip re-drafting.
> 
> Workflow wiring sets `INCLUDE_DRAFTS` only from manual dispatch; audit and execute steps forward the flag to the script. Docs describe the third dispatch knob; tests cover opt-in, ready/merge, rollback, and workflow YAML contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01b58a06609e24ab8a003bc63646f4e94c9f44ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->