### PR TITLE
Preserve fetch-gene wrapper arguments

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -93,21 +93,35 @@ sync-codex-skills:
 # Use --force to overwrite existing UniProt and GOA files
 # Example: just fetch-gene 9BACT F0JBF1 --alias HgcB
 # Example: just fetch-gene human TP53 --force
-fetch-gene organism gene *args="":
+[positional-arguments]
+fetch-gene organism gene *args:
     #!/usr/bin/env bash
+    set -euo pipefail
+    organism="$1"
+    gene="$2"
+    shift 2
+
+    force=0
+    for arg in "$@"; do
+        if [[ "$arg" == "--force" || "$arg" == "-f" ]]; then
+            force=1
+            break
+        fi
+    done
+
     # Check if gene directory already exists and warn if --force not used
-    gene_dir="genes/{{organism}}/{{gene}}"
-    if [[ "{{args}}" != *"--force"* ]] && [ -d "$gene_dir" ]; then
-        uniprot_file="$gene_dir/{{gene}}-uniprot.txt"
-        goa_file="$gene_dir/{{gene}}-goa.tsv"
+    gene_dir="genes/$organism/$gene"
+    if (( force == 0 )) && [ -d "$gene_dir" ]; then
+        uniprot_file="$gene_dir/$gene-uniprot.txt"
+        goa_file="$gene_dir/$gene-goa.tsv"
         if [ -f "$uniprot_file" ] || [ -f "$goa_file" ]; then
-            echo "⚠️  Gene data for {{organism}}/{{gene}} already exists."
+            echo "⚠️  Gene data for $organism/$gene already exists."
             echo "   To prevent churn, existing files will not be overwritten unless they differ from remote."
-            echo "   Use 'just fetch-gene {{organism}} {{gene}} --force' to force overwrite."
+            echo "   Use 'just fetch-gene $organism $gene --force' to force overwrite."
             echo ""
         fi
     fi
-    uv run --no-dev ai-gene-review fetch-gene {{organism}} {{gene}} --output-dir . {{args}}
+    uv run --no-dev ai-gene-review fetch-gene "$organism" "$gene" --output-dir . "$@"
 
 # Fetch ncRNA gene data from RNAcentral
 # Use --alias to specify a custom directory name and file prefix

--- a/tests/test_fetch_gene_wrapper.py
+++ b/tests/test_fetch_gene_wrapper.py
@@ -1,0 +1,123 @@
+"""Argument-boundary tests for the public gene-fetch wrapper."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_fake_uv(tmp_path: Path) -> tuple[Path, Path]:
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["FETCH_GENE_ARGV_LOG"], "w") as handle:
+    json.dump(sys.argv[1:], handle)
+"""
+    )
+    fake_uv.chmod(0o755)
+    return fake_bin, tmp_path / "argv log.json"
+
+
+def _run_fetch_gene(
+    tmp_path: Path, fake_bin: Path, log_path: Path, *args: str
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["FETCH_GENE_ARGV_LOG"] = str(log_path)
+    return subprocess.run(
+        [
+            "just",
+            "--justfile",
+            str(REPO_ROOT / "justfile"),
+            "--working-directory",
+            str(tmp_path),
+            "fetch-gene",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+
+def test_fetch_gene_wrapper_preserves_exact_argument_boundaries(tmp_path: Path) -> None:
+    fake_bin, log_path = _write_fake_uv(tmp_path)
+    organism = "TESTORG"
+    gene = "Gene Symbol"
+
+    result = _run_fetch_gene(tmp_path, fake_bin, log_path, organism, gene)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == [
+        "run",
+        "--no-dev",
+        "ai-gene-review",
+        "fetch-gene",
+        organism,
+        gene,
+        "--output-dir",
+        ".",
+    ]
+
+    tail = [
+        "--alias",
+        "Alias (draft), v1? $GENE_ALIAS",
+        "--uniprot-id",
+        "P12345",
+        "--no-seed",
+        "--force",
+    ]
+    result = _run_fetch_gene(tmp_path, fake_bin, log_path, organism, gene, *tail)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == [
+        "run",
+        "--no-dev",
+        "ai-gene-review",
+        "fetch-gene",
+        organism,
+        gene,
+        "--output-dir",
+        ".",
+        *tail,
+    ]
+
+
+def test_fetch_gene_wrapper_recognizes_force_as_an_exact_flag(tmp_path: Path) -> None:
+    fake_bin, log_path = _write_fake_uv(tmp_path)
+    organism = "TESTORG"
+    gene = "EUG1"
+    gene_dir = tmp_path / "genes" / organism / gene
+    gene_dir.mkdir(parents=True)
+    (gene_dir / f"{gene}-uniprot.txt").write_text("existing\n")
+
+    result = _run_fetch_gene(
+        tmp_path,
+        fake_bin,
+        log_path,
+        organism,
+        gene,
+        "--alias",
+        "not--force",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "already exists" in result.stdout
+
+    result = _run_fetch_gene(
+        tmp_path, fake_bin, log_path, organism, gene, "-f"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "already exists" not in result.stdout
+    assert json.loads(log_path.read_text())[-1] == "-f"


### PR DESCRIPTION
## Summary
- forward `fetch-gene` arguments through Just as exact Bash positional parameters
- quote organism, gene, and every CLI tail argument
- recognize only exact `--force` / `-f` flags when suppressing the existing-file warning
- add hermetic real-Just regressions for empty tails, spaced/metacharacter values, and force-warning behavior

## Validation
- `PYTEST_ADDOPTS='-q tests/test_fetch_gene_wrapper.py' just pytest` (2 passed)
- `just test` (1,640 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the Just/Bash CLI wrapper and new tests; no application fetch logic or data paths beyond safer argument forwarding.
> 
> **Overview**
> **`just fetch-gene`** is now implemented as a Bash recipe with **`[positional-arguments]`**, so organism, gene, and trailing CLI flags reach **`uv run … fetch-gene`** as separate, quoted arguments instead of being merged or split by Just templating.
> 
> The pre-fetch “already exists” warning only treats exact **`--force`** / **`-f`** as force; values like **`--alias not--force`** no longer suppress the warning. **`set -euo pipefail`** was added for stricter shell behavior.
> 
> New hermetic tests run real **`just`** against a fake **`uv`** and assert argv for spaced/metacharacter values and force-warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dabc68780ab3006921248563aee92525b1f226c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->