### PR TITLE
Warn on aliased fetch-gene outputs

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -102,22 +102,37 @@ fetch-gene organism gene *args:
     shift 2
 
     force=0
+    file_prefix="$gene"
+    expect_alias=0
     for arg in "$@"; do
-        if [[ "$arg" == "--force" || "$arg" == "-f" ]]; then
-            force=1
-            break
+        if (( expect_alias == 1 )); then
+            file_prefix="$arg"
+            expect_alias=0
+            continue
         fi
+        case "$arg" in
+            --alias|-a) expect_alias=1 ;;
+            --alias=*) file_prefix="${arg#--alias=}" ;;
+            -a?*) file_prefix="${arg#-a}" ;;
+            -fa) force=1; expect_alias=1 ;;
+            -fa?*) force=1; file_prefix="${arg#-fa}" ;;
+            --force|-f) force=1 ;;
+            --) break ;;
+        esac
     done
+    if [ -z "$file_prefix" ]; then
+        file_prefix="$gene"
+    fi
 
     # Check if gene directory already exists and warn if --force not used
-    gene_dir="genes/$organism/$gene"
+    gene_dir="genes/$organism/$file_prefix"
     if (( force == 0 )) && [ -d "$gene_dir" ]; then
-        uniprot_file="$gene_dir/$gene-uniprot.txt"
-        goa_file="$gene_dir/$gene-goa.tsv"
+        uniprot_file="$gene_dir/$file_prefix-uniprot.txt"
+        goa_file="$gene_dir/$file_prefix-goa.tsv"
         if [ -f "$uniprot_file" ] || [ -f "$goa_file" ]; then
-            echo "⚠️  Gene data for $organism/$gene already exists."
+            echo "⚠️  Gene data for $organism/$file_prefix already exists."
             echo "   To prevent churn, existing files will not be overwritten unless they differ from remote."
-            echo "   Use 'just fetch-gene $organism $gene --force' to force overwrite."
+            echo "   Add --force to this command to force overwrite."
             echo ""
         fi
     fi

--- a/tests/test_fetch_gene_wrapper.py
+++ b/tests/test_fetch_gene_wrapper.py
@@ -109,7 +109,7 @@ def test_fetch_gene_wrapper_recognizes_force_as_an_exact_flag(tmp_path: Path) ->
         log_path,
         organism,
         gene,
-        "--alias",
+        "--uniprot-id",
         "not--force",
     )
     assert result.returncode == 0, result.stderr
@@ -121,3 +121,58 @@ def test_fetch_gene_wrapper_recognizes_force_as_an_exact_flag(tmp_path: Path) ->
     assert result.returncode == 0, result.stderr
     assert "already exists" not in result.stdout
     assert json.loads(log_path.read_text())[-1] == "-f"
+
+
+def test_fetch_gene_wrapper_checks_the_aliased_output_path(tmp_path: Path) -> None:
+    fake_bin, log_path = _write_fake_uv(tmp_path)
+    organism = "TESTORG"
+    gene = "SourceGene"
+    alias = "Alias (draft), v1? $GENE_ALIAS"
+    alias_dir = tmp_path / "genes" / organism / alias
+    alias_dir.mkdir(parents=True)
+    (alias_dir / f"{alias}-goa.tsv").write_text("existing\n")
+    source_dir = tmp_path / "genes" / organism / gene
+    source_dir.mkdir(parents=True)
+    (source_dir / f"{gene}-uniprot.txt").write_text("existing\n")
+
+    tail = ["--alias", alias, "--uniprot-id", "P12345"]
+    result = _run_fetch_gene(tmp_path, fake_bin, log_path, organism, gene, *tail)
+    assert result.returncode == 0, result.stderr
+    assert f"Gene data for {organism}/{alias} already exists" in result.stdout
+    assert json.loads(log_path.read_text())[-len(tail) :] == tail
+
+    result = _run_fetch_gene(
+        tmp_path, fake_bin, log_path, organism, gene, "-a", alias, "-f"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "already exists" not in result.stdout
+
+    result = _run_fetch_gene(
+        tmp_path, fake_bin, log_path, organism, gene, f"--alias={alias}"
+    )
+    assert result.returncode == 0, result.stderr
+    assert f"Gene data for {organism}/{alias} already exists" in result.stdout
+
+    result = _run_fetch_gene(
+        tmp_path, fake_bin, log_path, organism, gene, f"-a{alias}"
+    )
+    assert result.returncode == 0, result.stderr
+    assert f"Gene data for {organism}/{alias} already exists" in result.stdout
+
+    result = _run_fetch_gene(
+        tmp_path, fake_bin, log_path, organism, gene, "-fa", alias
+    )
+    assert result.returncode == 0, result.stderr
+    assert "already exists" not in result.stdout
+
+    result = _run_fetch_gene(
+        tmp_path, fake_bin, log_path, organism, gene, f"-fa{alias}"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "already exists" not in result.stdout
+
+    result = _run_fetch_gene(
+        tmp_path, fake_bin, log_path, organism, gene, "--alias="
+    )
+    assert result.returncode == 0, result.stderr
+    assert f"Gene data for {organism}/{gene} already exists" in result.stdout


### PR DESCRIPTION
## Summary
- derive the fetch-gene preflight warning path from `--alias`/`-a`
- preserve the exact downstream argv and force behavior
- cover aliased files, source-symbol false positives, short flags, and force suppression through the public Just wrapper

## Validation
- `PYTEST_ADDOPTS='-q tests/test_fetch_gene_wrapper.py' just pytest` (3 passed)
- `just test` (1641 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Just wrapper preflight messaging and flag parsing; downstream `fetch-gene` invocation is unchanged and covered by new wrapper tests.
> 
> **Overview**
> The **`just fetch-gene`** wrapper now runs its “data already exists” preflight against the **aliased** directory and file prefix (`genes/<organism>/<alias>/…`) instead of the source gene symbol, so users with `--alias`/`-a` see warnings when the right on-disk tree would be touched.
> 
> The bash recipe **parses alias and force flags** (`--alias`, `-a`, `--alias=`, glued `-a…`, `-fa`/`-fa…`, `--force`/`-f`) only for that check; it still forwards **`"$@"` unchanged** to `ai-gene-review fetch-gene`. Empty `--alias=` falls back to the gene name. The overwrite hint is shortened to “Add **--force**” rather than repeating the full command.
> 
> **Tests** cover aliased vs source paths, short flags, combined `-fa`, force suppressing the warning, and `--uniprot-id` where alias would confuse the force-only case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2ad99ff7fa9dbcbb37f9cfb7d331c8d6404ce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->