### PR TITLE
Preserve ncRNA fetch wrapper arguments

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -144,12 +144,24 @@ fetch-gene organism gene *args:
 # Example: just fetch-ncrna human SNORD3A
 # Example: just fetch-ncrna human XIST --alias lncRNA-XIST
 # Example: just fetch-ncrna human U1 --rnacentral-id URS000012345_9606
-fetch-ncrna organism gene *args="":
-    uv run ai-gene-review fetch-ncrna {{organism}} {{gene}} --output-dir . {{args}}
+[positional-arguments]
+fetch-ncrna organism gene *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    organism="$1"
+    gene="$2"
+    shift 2
+    uv run ai-gene-review fetch-ncrna "$organism" "$gene" --output-dir . "$@"
 
 # Fetch ncRNA gene data from RNAcentral (alias for consistency)
-fetch-rna-gene organism gene *args="":
-    uv run ai-gene-review fetch-ncrna {{organism}} {{gene}} --output-dir . {{args}}
+[positional-arguments]
+fetch-rna-gene organism gene *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    organism="$1"
+    gene="$2"
+    shift 2
+    uv run ai-gene-review fetch-ncrna "$organism" "$gene" --output-dir . "$@"
 
 # Fetch gene descriptions from external sources (Alliance_Imported, Alliance_Automated, UniProt, RefSeq)
 # Example: just fetch-descriptions yeast CAT2

--- a/tests/test_fetch_ncrna_wrapper.py
+++ b/tests/test_fetch_ncrna_wrapper.py
@@ -1,0 +1,92 @@
+"""Argument-boundary tests for the public ncRNA-fetch wrappers."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_fake_uv(tmp_path: Path) -> tuple[Path, Path]:
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["FETCH_NCRNA_ARGV_LOG"], "w") as handle:
+    json.dump(sys.argv[1:], handle)
+"""
+    )
+    fake_uv.chmod(0o755)
+    return fake_bin, tmp_path / "argv log.json"
+
+
+def _run_wrapper(
+    tmp_path: Path, fake_bin: Path, log_path: Path, recipe: str, *args: str
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["FETCH_NCRNA_ARGV_LOG"] = str(log_path)
+    return subprocess.run(
+        [
+            "just",
+            "--justfile",
+            str(REPO_ROOT / "justfile"),
+            "--working-directory",
+            str(tmp_path),
+            recipe,
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize("recipe", ["fetch-ncrna", "fetch-rna-gene"])
+def test_fetch_ncrna_wrappers_preserve_exact_argument_boundaries(
+    tmp_path: Path, recipe: str
+) -> None:
+    fake_bin, log_path = _write_fake_uv(tmp_path)
+    organism = "TEST ORG"
+    gene = "ncRNA (draft), v1? $GENE"
+    fixed = [
+        "run",
+        "ai-gene-review",
+        "fetch-ncrna",
+        organism,
+        gene,
+        "--output-dir",
+        ".",
+    ]
+
+    result = _run_wrapper(tmp_path, fake_bin, log_path, recipe, organism, gene)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == fixed
+
+    tail = [
+        "--alias",
+        "Alias (draft), v1? $NCRNA_ALIAS",
+        "--rnacentral-id",
+        "URS000012345_9606",
+        "--no-seed",
+        "--force",
+    ]
+    result = _run_wrapper(
+        tmp_path, fake_bin, log_path, recipe, organism, gene, *tail
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == [*fixed, *tail]


### PR DESCRIPTION
## Summary
- forward `fetch-ncrna` variadic arguments through exact Bash positional parameters
- apply the same fix to the `fetch-rna-gene` alias recipe
- cover zero tails and spaced/metacharacter option values through the public root Justfile

## Validation
- `PYTEST_ADDOPTS='-q tests/test_fetch_ncrna_wrapper.py' just pytest` (2 passed)
- `just test` (1643 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-tooling only (Just recipes + tests); no runtime app or data-path changes beyond how CLI args are passed to the existing fetch-ncrna command.
> 
> **Overview**
> **`fetch-ncrna` and `fetch-rna-gene`** no longer inline `{{organism}}`, `{{gene}}`, and `{{args}}` into a single `just` recipe. Both now use **`[positional-arguments]`** plus a small Bash script (same pattern as **`fetch-gene`**) that binds `$1`/`$2` and forwards `"$@"` to `uv run ai-gene-review fetch-ncrna … --output-dir .`.
> 
> That fixes cases where variadic Just interpolation could **split or mishandle** extra flags and values with spaces or shell-sensitive characters (e.g. `--alias` values with punctuation).
> 
> Adds **`tests/test_fetch_ncrna_wrapper.py`**, which runs the root Justfile with a fake `uv` on `PATH` and checks the logged argv for both recipes with no tail args and with a full option tail (`--alias`, `--rnacentral-id`, `--no-seed`, `--force`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359d3b730ca61a0422d51e6e0ca86be707a295f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->