### PR TITLE
Normalize trailing whitespace in publication caches

### DIFF
--- a/src/ai_gene_review/etl/publication.py
+++ b/src/ai_gene_review/etl/publication.py
@@ -236,7 +236,11 @@ class Publication:
         if self.full_text:
             body_parts.append(f"\n## Full Text\n\n{self.full_text}\n")
 
-        return f"---\n{frontmatter}---\n\n{''.join(body_parts)}"
+        markdown = f"---\n{frontmatter}---\n\n{''.join(body_parts)}"
+        # PubMed's plain-text records can contain spaces before line breaks.
+        # Generated caches intentionally do not preserve Markdown hard-break
+        # whitespace; keep their content and indentation clean for Git tooling.
+        return re.sub(r"[ \t]+(?=\r?$)", "", markdown, flags=re.MULTILINE)
 
 
 def extract_pmid(pmid_str: str) -> str:

--- a/tests/test_publication_etl.py
+++ b/tests/test_publication_etl.py
@@ -1,5 +1,6 @@
 """Tests for publication ETL functionality."""
 
+import re
 import tempfile
 from pathlib import Path
 
@@ -56,6 +57,25 @@ def test_publication_to_markdown():
     assert "**DOI:** [10.1234/test](https://doi.org/10.1234/test)" in markdown
     assert "## Abstract" in markdown
     assert "This is a test abstract." in markdown
+
+
+def test_publication_to_markdown_strips_trailing_line_whitespace():
+    """Fetched PubMed text should not make generated cache files fail Git checks."""
+    pub = Publication(
+        pmid="12345",
+        title="Test Article",
+        authors=["Smith J"],
+        journal="Test Journal",
+        year="2024",
+        abstract="First abstract line.  \nSecond line.\t\n  Indented text stays indented.",
+        full_text="First full-text line. \r\nSecond full-text line.\t",
+    )
+
+    markdown = pub.to_markdown()
+
+    assert not re.search(r"[ \t]+(?=\r?\n|\r?$)", markdown)
+    assert "\n  Indented text stays indented.\n" in markdown
+    assert "First full-text line.\r\nSecond full-text line.\n" in markdown
 
 
 def test_publication_to_frontmatter_dict():


### PR DESCRIPTION
## Summary
- strip spaces and tabs immediately before line endings when serializing publication Markdown
- preserve indentation and publication content
- add regression coverage for PubMed-style trailing spaces, tabs, CRLF, and intentional leading indentation

## Why
Fresh files produced through `just fetch-pmid` can contain PubMed plain-text line-end spaces and fail `git diff --check`.

## Validation
- `just format`
- `PYTEST_ADDOPTS='-q tests/test_publication_etl.py' just pytest` (6 passed)\n- `just test` (1644 pytest passed; 132 doctests passed; mypy and Ruff clean)\n- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized output normalization in publication serialization with regression tests; no auth, data, or API behavior changes.
> 
> **Overview**
> **Publication cache files** written via `Publication.to_markdown()` no longer keep spaces or tabs immediately before line breaks (including CRLF), which PubMed plain text often includes and which triggered `git diff --check` on freshly fetched `PMID_*.md` files.
> 
> The serializer still leaves **leading indentation** on a line untouched and does not alter the substantive abstract/full-text content beyond removing that end-of-line whitespace.
> 
> A regression test covers trailing spaces, tabs, CRLF, and preserved intentional indentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de9a075a196fbafda35a3b5c0e9a48152ca8e1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->