### PR TITLE
Strip trailing whitespace from Reactome caches

### DIFF
--- a/src/ai_gene_review/etl/reactome.py
+++ b/src/ai_gene_review/etl/reactome.py
@@ -1,5 +1,6 @@
 """ETL for fetching and caching Reactome pathway information."""
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -62,7 +63,10 @@ class ReactomePathway:
         if self.summary:
             body_parts.append(f"\n## Summary\n\n{self.summary}\n")
 
-        return f"---\n{frontmatter}---\n\n{''.join(body_parts)}"
+        markdown = f"---\n{frontmatter}---\n\n{''.join(body_parts)}"
+        # Reactome summaries are API text, not authored Markdown: discard
+        # spaces/tabs before line endings while preserving indentation.
+        return re.sub(r"[ \t]+(?=\r?$)", "", markdown, flags=re.MULTILINE)
 
 
 def extract_reactome_id(reactome_str: str) -> str:

--- a/tests/test_reactome_etl.py
+++ b/tests/test_reactome_etl.py
@@ -1,0 +1,20 @@
+"""Tests for Reactome pathway cache serialization."""
+
+import re
+
+from ai_gene_review.etl.reactome import ReactomePathway
+
+
+def test_reactome_markdown_strips_trailing_line_whitespace():
+    """Reactome API text should produce Git-clean pathway cache files."""
+    pathway = ReactomePathway(
+        stable_id="R-HSA-123456",
+        display_name="Test pathway",
+        species="Homo sapiens",
+        summary="First summary line.  \nSecond line.\t\n  Indented text stays indented. \r\n",
+    )
+
+    markdown = pathway.to_markdown()
+
+    assert not re.search(r"[ \t]+(?=\r?\n|\r?$)", markdown)
+    assert "\n  Indented text stays indented.\r\n" in markdown


### PR DESCRIPTION
## Summary
- strip API-originated spaces/tabs immediately before line endings in generated Reactome Markdown
- preserve intentional indentation and CRLF line endings
- add focused serialization regression coverage

## Context
This is the separate sibling fix identified during review of #2502. No publication or gene-review files are changed.

## Validation
- `just format`
- `PYTEST_ADDOPTS='-q tests/test_reactome_etl.py' just pytest` (1 passed)\n- `just test` (1645 pytest passed; 132 doctests passed; mypy and Ruff clean)\n- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized ETL output formatting with no auth, data-model, or runtime behavior changes beyond cached markdown shape.
> 
> **Overview**
> **Reactome pathway cache files** now normalize API-sourced text so generated `.md` caches stay Git-clean.
> 
> `ReactomePathway.to_markdown()` applies a multiline regex that removes spaces and tabs immediately before each line ending (including CRLF), without stripping leading indentation on lines. A new test in `tests/test_reactome_etl.py` locks in that behavior for messy summary text from the API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fa2c58146eae1e34649d92f9e81167b9d59db20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->