### PR TITLE
Clarify hypothesis citation sidecar status

### DIFF
--- a/scripts/gene_hypothesis_deep_research.py
+++ b/scripts/gene_hypothesis_deep_research.py
@@ -1534,6 +1534,13 @@ def print_run_result(result: RunResult) -> None:
     )
     print(f"output={result.output_file}")
     print(f"citations={result.citations_file}")
+    if result.status == "DRY_RUN":
+        citations_status = "planned"
+    elif result.citations_file.exists() and result.citations_file.stat().st_size > 0:
+        citations_status = "present"
+    else:
+        citations_status = "missing"
+    print(f"citations_status={citations_status}")
     print(f"command={shell_join(result.command)}")
     if result.detail:
         print(f"detail={result.detail}")

--- a/tests/test_gene_hypothesis_deep_research.py
+++ b/tests/test_gene_hypothesis_deep_research.py
@@ -457,6 +457,47 @@ def test_dry_run_does_not_create_output_directory(tmp_path: Path) -> None:
     assert not result.output_file.parent.exists()
 
 
+@pytest.mark.parametrize(
+    ("run_status", "citations_text", "expected_status"),
+    [
+        ("DRY_RUN", None, "planned"),
+        ("OK", None, "missing"),
+        ("OK", "citation list\n", "present"),
+    ],
+)
+def test_print_run_result_reports_citations_status(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    run_status: str,
+    citations_text: str | None,
+    expected_status: str,
+) -> None:
+    genes_root = make_gene_workspace(tmp_path)
+    record = ghr.candidate_records(genes_root, "human", "TEST")[0]
+    output_file = tmp_path / "output.md"
+    citations_file = Path(f"{output_file}.citations.md")
+    if citations_text is not None:
+        citations_file.write_text(citations_text, encoding="utf-8")
+
+    result = ghr.RunResult(
+        record=record,
+        provider="openscientist",
+        status=run_status,
+        returncode=0,
+        duration_seconds=1.0,
+        output_file=output_file,
+        citations_file=citations_file,
+        command=["deep-research-client", "research"],
+        detail="",
+    )
+
+    ghr.print_run_result(result)
+
+    output = capsys.readouterr().out
+    assert f"citations={citations_file}\n" in output
+    assert f"citations_status={expected_status}\n" in output
+
+
 def test_just_wrapper_preserves_quoted_free_text_arguments(tmp_path: Path) -> None:
     """The public Just wrapper must not flatten quoted variadic arguments."""
     genes_root = make_gene_workspace(tmp_path / "workspace with spaces")


### PR DESCRIPTION
## Summary
- keep reporting the planned citations sidecar path for compatibility
- explicitly report whether the sidecar is planned, present, or missing
- cover dry-run, missing, and non-empty sidecar outcomes

## Validation
- `PYTEST_ADDOPTS="-k print_run_result_reports_citations_status" just pytest` (3 passed)
- `just format`
- `just test` (1648 pytest, 132 doctests, mypy and Ruff clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 973e88b73a00fa6ae77a8d65ca3fc25cb69640ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->