### PR TITLE
Re-review canonical yeast ZDS1

### DIFF
--- a/genes/yeast/ZDS1/ZDS1-ai-review.html
+++ b/genes/yeast/ZDS1/ZDS1-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-initialized">
-                    INITIALIZED
+                <span class="status-badge status-draft">
+                    DRAFT
                 </span>
             </div>
 
@@ -844,12 +844,12 @@
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P50111" data-a="DESCRIPTION: ZDS1 (also known as HST1, encoding Protein Zds1) i..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P50111" data-a="DESCRIPTION: ZDS1 (historically also called HST1) encodes a cor..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>ZDS1 (also known as HST1, encoding Protein Zds1) is a cortical/cytoplasmic adaptor protein that regulates the spatial localization and activity of the PP2A phosphatase complex containing the regulatory subunit Cdc55. Zds1 functions as a non-catalytic scaffold that binds Cdc55 and controls its nucleocytoplasmic distribution, thereby regulating two key mitotic transitions: (1) promoting mitotic entry by maintaining Cdc55-PP2A in the cytoplasm where it dephosphorylates Swe1 and activates Mih1 to enable Cdk1 activation, and (2) facilitating mitotic exit by excluding Cdc55 from the nucleus to prevent inhibition of Cdc14 release. Additionally, Zds1 serves as a Rho1 effector at the bud cortex, where it associates with Cdc55 to specify Rho1 signaling outputs toward polarized growth and cell wall synthesis while antagonizing stress-responsive CWI signaling. Zds1 also participates in mRNA export from the nucleus via interactions with Dbp5 and Gfd1 at the nuclear pore complex.</p>
+        <p>ZDS1 (historically also called HST1) encodes a cortical/cytoplasmic adaptor protein that regulates the spatial localization and activity of the PP2A phosphatase complex containing the regulatory subunit Cdc55. Zds1 functions as a non-catalytic scaffold that binds Cdc55 and controls its nucleocytoplasmic distribution, thereby regulating two key mitotic transitions: (1) promoting mitotic entry by maintaining Cdc55-PP2A in the cytoplasm where it dephosphorylates Swe1 and activates Mih1 to enable Cdk1 activation, and (2) facilitating mitotic exit by excluding Cdc55 from the nucleus to prevent inhibition of Cdc14 release. Additionally, Zds1 serves as a Rho1 effector at the bud cortex, where it associates with Cdc55 to specify Rho1 signaling outputs toward polarized growth and cell wall synthesis while antagonizing stress-responsive CWI signaling. Zds1 also participates in mRNA export from the nucleus via interactions with Dbp5 and Gfd1 at the nuclear pore complex.</p>
     </div>
 
 
@@ -1398,10 +1398,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:15619606" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:15619606" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1480,10 +1480,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:16429126" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:16429126" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1562,10 +1562,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:16554755" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1644,10 +1644,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:18762578" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:18762578" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1726,10 +1726,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:19536198" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1808,10 +1808,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:37968396" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005515" data-r="PMID:37968396" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1890,10 +1890,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0031507" data-r="PMID:10662670" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0031507" data-r="PMID:10662670" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1901,12 +1901,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IMP annotation claiming Zds1 involvement in heterochromatin formation. This annotation appears to reflect over-annotation or confusion with unrelated Zds1/Zds2 functions.
+                            <strong>Summary:</strong> ZDS1 deletion redistributes silencing among rDNA, a silent mating-type cassette, and telomeres, but chromatin regulation is secondary to Zds1&#39;s PP2A-Cdc55 adaptor function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Zds1&#39;s molecular function is well-characterized as a Cdc55-PP2A localization regulator and Rho1 signaling effector. Its main biological processes are mitotic entry/exit, cell polarity, and cell wall synthesis. There is no mechanistic evidence that Zds1 has any role in heterochromatin formation or transcriptional silencing. The original PMID (10662670) titled &#34;Two paralogs involved in transcriptional silencing&#34; may refer to a different yeast protein or may conflate Zds1&#39;s well-documented roles in cell cycle and signaling with unrelated chromatin functions. This annotation contradicts the established functional understanding of Zds1 and should be removed.
+                            <strong>Reason:</strong> The cited study directly assayed ZDS1 and found altered silencing at three heterochromatic loci. Retain the experimentally supported process while keeping it non-core because the mechanism is indirect and the principal conserved role of Zds1 is spatial regulation of PP2A-Cdc55.
                         </div>
 
 
@@ -1924,46 +1924,7 @@
 
                                 </span>
 
-                                <div class="support-text">Two paralogs involved in transcriptional silencing that antagonistically control yeast life span.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21536748" target="_blank" class="term-link">
-                                        PMID:21536748
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">Spatial regulation of Cdc55-PP2A by Zds1/Zds2 controls mitotic entry and mitotic exit in budding yeast.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8816439" target="_blank" class="term-link">
-                                        PMID:8816439
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">ZDS1 and ZDS2, genes whose products may regulate Cdc42p in Saccharomyces cerevisiae.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15619606" target="_blank" class="term-link">
-                                        PMID:15619606
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">2004 Dec 24. Physical and genetic interactions link the yeast protein Zds1p with mRNA nuclear export.</div>
+                                <div class="support-text">deletion of the ZDS1 gene caused an increase in silencing in the rDNA and at a silent mating-type cassette at the expense of telomere silencing.</div>
 
                             </div>
 
@@ -2011,10 +1972,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0004864" data-r="PMID:18762578" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0004864" data-r="PMID:18762578" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2022,12 +1983,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IMP annotation claiming Zds1 inhibits protein phosphatase activity. This annotation mischaracterizes Zds1&#39;s biochemical function and mechanism.
+                            <strong>Summary:</strong> Zds1 down-regulates PP2A-Cdc55 at anaphase onset, although spatial redistribution is also central to its broader mechanism.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Zds1 is not a phosphatase inhibitor in the traditional sense (e.g., not analogous to endogenous inhibitor proteins). Instead, Zds1 functions as a non-catalytic regulatory scaffold that binds Cdc55 and controls PP2A-Cdc55 localization and activity in a spatially-restricted manner. While Zds1 can modulate PP2A-Cdc55 function (inhibiting nuclear activity while promoting cytoplasmic activity), this is achieved through compartmentalization, not through direct inhibition of the catalytic machinery. The term &#34;phosphatase inhibitor activity&#34; is mechanistically inaccurate and should be replaced with more precise process-level annotations (regulation of protein localization, positive/negative regulation of specific cell cycle transitions).
+                            <strong>Reason:</strong> PMID:18762578 directly shows that ectopic Zds1 is sufficient to down-regulate PP2A-Cdc55 and frames Zds1/Zds2 as PP2A-Cdc55 inhibitors downstream of separase. Later localization work refines rather than negates this experimentally supported inhibitory activity.
                         </div>
 
 
@@ -2045,7 +2006,7 @@
 
                                 </span>
 
-                                <div class="support-text">Sep 1. Separase cooperates with Zds1 and Zds2 to activate Cdc14 phosphatase in early anaphase.</div>
+                                <div class="support-text">Ectopic Zds1 expression in turn is sufficient to down-regulate PP2A(Cdc55) and promote Net1 phosphorylation.</div>
 
                             </div>
 
@@ -2093,10 +2054,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0004864" data-r="PMID:18762578" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0004864" data-r="PMID:18762578" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2104,12 +2065,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IGI annotation for phosphatase inhibitor activity from genetic interaction with Separase. Like the IMP version, this mischaracterizes Zds1&#39;s function.
+                            <strong>Summary:</strong> Genetic interaction with separase supports Zds1-dependent inhibition of PP2A-Cdc55 during early anaphase.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Same rationale as the IMP annotation above. Zds1 does not function as a direct phosphatase inhibitor. Its interaction with Separase affects Cdc55 localization and function, but this is spatial regulation rather than classical phosphatase inhibition. The annotation should be replaced with more mechanistically accurate terms.
+                            <strong>Reason:</strong> The genetic evidence complements the direct perturbation result in the same paper. Zds1 acts downstream of separase to down-regulate PP2A-Cdc55 and permit Cdc14 release.
                         </div>
 
 
@@ -2127,7 +2088,7 @@
 
                                 </span>
 
-                                <div class="support-text">Sep 1. Separase cooperates with Zds1 and Zds2 to activate Cdc14 phosphatase in early anaphase.</div>
+                                <div class="support-text">Zds1 and Zds2 are required downstream of separase to facilitate nucleolar Cdc14 release.</div>
 
                             </div>
 
@@ -3225,11 +3186,219 @@
                     </td>
                 </tr>
 
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000159" target="_blank" class="term-link">
+                                    GO:0000159
+                                </a>
+                            </span>
+                            <span class="term-label">protein phosphatase type 2A complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18762578" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18762578
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Separase cooperates with Zds1 and Zds2 to activate Cdc14 pho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0000159" data-r="PMID:18762578" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Zds1 associates constitutively with the Cdc55-containing PP2A holoenzyme during mitosis and mitotic exit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct coimmunoprecipitation places Zds1 with Cdc55 and the PP2A scaffold Tpd3. This complex membership is more informative than generic protein binding and supports the core adaptor/regulator model.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18762578" target="_blank" class="term-link">
+                                        PMID:18762578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In immunoprecipitates of Zds1 from metaphase-arrested cells, we detected Cdc55 as well as the PP2A scaffold subunit, Tpd3 by Western blotting.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Zds1 is a non-catalytic adaptor for PP2A-Cdc55 that controls the phosphatase&#39;s cytoplasmic/cortical enrichment and nuclear exclusion. This spatial regulation promotes mitotic entry and timely Cdc14 release during mitotic exit.</h3>
+                <span class="vote-buttons" data-g="P50111" data-a="FUNCTION: Zds1 is a non-catalytic adaptor for PP2A-Cdc55 tha..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004864" target="_blank" class="term-link">
+                            protein phosphatase inhibitor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032880" target="_blank" class="term-link">
+                                regulation of protein localization
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010971" target="_blank" class="term-link">
+                                positive regulation of G2/M transition of mitotic cell cycle
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005934" target="_blank" class="term-link">
+                                cellular bud tip
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005935" target="_blank" class="term-link">
+                                cellular bud neck
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000159" target="_blank" class="term-link">
+                            protein phosphatase type 2A complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18762578" target="_blank" class="term-link">
+                                PMID:18762578
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Ectopic Zds1 expression in turn is sufficient to down-regulate PP2A(Cdc55) and promote Net1 phosphorylation.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21536748" target="_blank" class="term-link">
+                                PMID:21536748
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Thus, the cytoplasmic localization of Cdc55 mediated by Zds1/Zds2 is required and sufficient for normal mitotic entry.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
 
 
 
@@ -3627,6 +3796,60 @@ Zds1 (YMR273C; UniProt P50111) is a cortical adaptor that binds the PP2A regulat
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ZDS1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P50111" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="zds1-review-notes">ZDS1 review notes</h1>
+<h2 id="identity-and-research-provenance">Identity and research provenance</h2>
+<ul>
+<li>Canonical target: ZDS1/YMR273C, UniProt P50111. <code>HST1</code> is a legacy synonym of<br />
+  ZDS1 and caused the earlier directory collision with canonical sirtuin HST1<br />
+  (YOL068C/P53685).</li>
+<li>The existing Falcon report is correctly grounded on P50111/ZDS1, although its<br />
+  recorded request metadata still contains the former <code>gene_id: HST1</code> value.</li>
+<li><code>just deep-research-openscientist yeast ZDS1</code> was attempted twice on<br />
+  2026-08-12. Both jobs resolved P50111/ZDS1 correctly but failed while polling<br />
+  the provider (first <code>ConnectTimeout</code>, then DNS <code>ConnectError</code>). No provider<br />
+  artifact was written or fabricated.</li>
+</ul>
+<h2 id="curation-corrections">Curation corrections</h2>
+<ul>
+<li>PMID:10662670 directly studies ZDS1 deletion and reports redistribution of<br />
+  silencing among rDNA, a silent mating-type cassette, and telomeres. The<br />
+  experimental heterochromatin annotation is therefore retained as non-core;<br />
+  the initialized review's claim that the paper concerned a different protein<br />
+  was incorrect.</li>
+<li>PMID:18762578 directly reports that ectopic Zds1 down-regulates PP2A-Cdc55 and<br />
+  suggests that Zds1/Zds2 act as separase-regulated PP2A-Cdc55 inhibitors.<br />
+  Later spatial-localization work refines this mechanism but does not justify<br />
+  removing the experimental molecular-function annotations.</li>
+<li>Generic <code>protein binding</code> annotations are marked over-annotated because they<br />
+  are true interaction observations but do not describe Zds1's adaptor/regulator<br />
+  function.</li>
+</ul>
+<h2 id="core-synthesis">Core synthesis</h2>
+<p>Zds1 is a non-catalytic PP2A-Cdc55 adaptor/regulator. Its principal conserved<br />
+role is to establish the cytoplasmic and cortical pool of PP2A-Cdc55 and limit<br />
+nuclear Cdc55, thereby coordinating mitotic entry and exit. Cell-polarity,<br />
+cell-wall, mRNA-export, and chromatin-silencing phenotypes are retained where<br />
+experimentally supported but are secondary to this core mechanism.</p>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3645,11 +3868,11 @@ aliases:
 - OSS1
 - STM2
 product_type: PROTEIN
-status: INITIALIZED
+status: DRAFT
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;ZDS1 (also known as HST1, encoding Protein Zds1) is a cortical/cytoplasmic
+description: &#39;ZDS1 (historically also called HST1) encodes a cortical/cytoplasmic
   adaptor protein that regulates the spatial localization and activity of the PP2A
   phosphatase complex containing the regulatory subunit Cdc55. Zds1 functions as a
   non-catalytic scaffold that binds Cdc55 and controls its nucleocytoplasmic distribution,
@@ -3819,7 +4042,7 @@ existing_annotations:
         (P20449) and Gfd1 (Q04839) from two-hybrid and in vitro binding
         experiments. While protein binding is accurate, it is an overly general
         term that obscures the specific biochemical function.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: Zds1 physically interacts with Dbp5 and Gfd1 at the nuclear pore
         complex for mRNA export function. However, GO:0005515 (protein binding)
         is too vague and undescriptive. The more informative core annotations
@@ -3842,7 +4065,7 @@ existing_annotations:
       summary: IPI annotation from proteome survey detecting protein
         interactions in large-scale binding experiments. Generic protein binding
         annotation; see other instances for same term.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: This is a proteomics-derived IPI annotation from a large-scale
         protein interaction survey. While detecting multiple binding partners,
         generic protein binding annotations provide minimal functional
@@ -3862,7 +4085,7 @@ existing_annotations:
       summary: IPI annotation from global yeast protein complex analysis.
         Generic protein binding annotation from high-throughput interaction
         data; see rationale for other protein binding instances.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: Large-scale high-throughput protein complex mapping identifies
         Zds1 interactors but provides minimal specificity regarding molecular
         function. Generic protein binding annotations from proteomics studies
@@ -3881,7 +4104,7 @@ existing_annotations:
       summary: IPI annotation for protein binding with Separase during mitotic
         exit. Zds1 binding is instrumental to mitotic regulation but not a
         primary molecular function itself.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: Zds1 participates in mitotic exit through interactions with
         Separase and Cdc55, but this binding is instrumental to Zds1&#39;s primary
         regulatory function rather than a primary molecular function itself.
@@ -3900,7 +4123,7 @@ existing_annotations:
       summary: IPI annotation from chaperone-protein interaction atlas. Generic
         protein binding from large-scale interaction mapping; consistent with
         other instances of this term.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: Large-scale chaperone interaction studies identify Zds1 as a
         protein interaction hub, but generic &#34;protein binding&#34; is insufficiently
         specific. Zds1&#39;s functional interactions (Cdc55 binding, Dbp5/Gfd1
@@ -3919,7 +4142,7 @@ existing_annotations:
       summary: IPI annotation from recent structural and functional analysis of
         yeast protein interactome architecture. Generic binding annotation from
         modern interaction mapping.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: Recent high-resolution interactome study identifies Zds1 protein
         interactions but provides minimal functional specificity. Modern protein
         interaction data is better expressed through specific molecular function
@@ -3934,81 +4157,55 @@ existing_annotations:
     evidence_type: IMP
     original_reference_id: PMID:10662670
     review:
-      summary: IMP annotation claiming Zds1 involvement in heterochromatin
-        formation. This annotation appears to reflect over-annotation or
-        confusion with unrelated Zds1/Zds2 functions.
-      action: REMOVE
-      reason: Zds1&#39;s molecular function is well-characterized as a Cdc55-PP2A
-        localization regulator and Rho1 signaling effector. Its main biological
-        processes are mitotic entry/exit, cell polarity, and cell wall
-        synthesis. There is no mechanistic evidence that Zds1 has any role in
-        heterochromatin formation or transcriptional silencing. The original
-        PMID (10662670) titled &#34;Two paralogs involved in transcriptional
-        silencing&#34; may refer to a different yeast protein or may conflate Zds1&#39;s
-        well-documented roles in cell cycle and signaling with unrelated
-        chromatin functions. This annotation contradicts the established
-        functional understanding of Zds1 and should be removed.
-      additional_reference_ids:
-        - PMID:21536748
-        - PMID:8816439
-        - PMID:15619606
+      summary: ZDS1 deletion redistributes silencing among rDNA, a silent mating-type
+        cassette, and telomeres, but chromatin regulation is secondary to Zds1&#39;s PP2A-Cdc55
+        adaptor function.
+      action: KEEP_AS_NON_CORE
+      reason: The cited study directly assayed ZDS1 and found altered silencing at three
+        heterochromatic loci. Retain the experimentally supported process while keeping
+        it non-core because the mechanism is indirect and the principal conserved role
+        of Zds1 is spatial regulation of PP2A-Cdc55.
       supported_by:
         - reference_id: PMID:10662670
-          supporting_text: Two paralogs involved in transcriptional silencing
-            that antagonistically control yeast life span.
-        - reference_id: PMID:21536748
-          supporting_text: Spatial regulation of Cdc55-PP2A by Zds1/Zds2
-            controls mitotic entry and mitotic exit in budding yeast.
-        - reference_id: PMID:8816439
-          supporting_text: ZDS1 and ZDS2, genes whose products may regulate
-            Cdc42p in Saccharomyces cerevisiae.
-        - reference_id: PMID:15619606
-          supporting_text: 2004 Dec 24. Physical and genetic interactions link
-            the yeast protein Zds1p with mRNA nuclear export.
+          supporting_text: deletion of the ZDS1 gene caused an increase in silencing
+            in the rDNA and at a silent mating-type cassette at the expense of telomere
+            silencing.
+          reference_section_type: ABSTRACT
   - term:
       id: GO:0004864
       label: protein phosphatase inhibitor activity
     evidence_type: IMP
     original_reference_id: PMID:18762578
     review:
-      summary: IMP annotation claiming Zds1 inhibits protein phosphatase
-        activity. This annotation mischaracterizes Zds1&#39;s biochemical function
-        and mechanism.
-      action: REMOVE
-      reason: Zds1 is not a phosphatase inhibitor in the traditional sense
-        (e.g., not analogous to endogenous inhibitor proteins). Instead, Zds1
-        functions as a non-catalytic regulatory scaffold that binds Cdc55 and
-        controls PP2A-Cdc55 localization and activity in a spatially-restricted
-        manner. While Zds1 can modulate PP2A-Cdc55 function (inhibiting nuclear
-        activity while promoting cytoplasmic activity), this is achieved through
-        compartmentalization, not through direct inhibition of the catalytic
-        machinery. The term &#34;phosphatase inhibitor activity&#34; is mechanistically
-        inaccurate and should be replaced with more precise process-level
-        annotations (regulation of protein localization, positive/negative
-        regulation of specific cell cycle transitions).
+      summary: Zds1 down-regulates PP2A-Cdc55 at anaphase onset, although spatial
+        redistribution is also central to its broader mechanism.
+      action: ACCEPT
+      reason: PMID:18762578 directly shows that ectopic Zds1 is sufficient to down-regulate
+        PP2A-Cdc55 and frames Zds1/Zds2 as PP2A-Cdc55 inhibitors downstream of separase.
+        Later localization work refines rather than negates this experimentally supported
+        inhibitory activity.
       supported_by:
         - reference_id: PMID:18762578
-          supporting_text: Sep 1. Separase cooperates with Zds1 and Zds2 to
-            activate Cdc14 phosphatase in early anaphase.
+          supporting_text: Ectopic Zds1 expression in turn is sufficient to down-regulate
+            PP2A(Cdc55) and promote Net1 phosphorylation.
+          reference_section_type: ABSTRACT
   - term:
       id: GO:0004864
       label: protein phosphatase inhibitor activity
     evidence_type: IGI
     original_reference_id: PMID:18762578
     review:
-      summary: IGI annotation for phosphatase inhibitor activity from genetic
-        interaction with Separase. Like the IMP version, this mischaracterizes
-        Zds1&#39;s function.
-      action: REMOVE
-      reason: Same rationale as the IMP annotation above. Zds1 does not function
-        as a direct phosphatase inhibitor. Its interaction with Separase affects
-        Cdc55 localization and function, but this is spatial regulation rather
-        than classical phosphatase inhibition. The annotation should be replaced
-        with more mechanistically accurate terms.
+      summary: Genetic interaction with separase supports Zds1-dependent inhibition
+        of PP2A-Cdc55 during early anaphase.
+      action: ACCEPT
+      reason: The genetic evidence complements the direct perturbation result in the
+        same paper. Zds1 acts downstream of separase to down-regulate PP2A-Cdc55 and
+        permit Cdc14 release.
       supported_by:
         - reference_id: PMID:18762578
-          supporting_text: Sep 1. Separase cooperates with Zds1 and Zds2 to
-            activate Cdc14 phosphatase in early anaphase.
+          supporting_text: Zds1 and Zds2 are required downstream of separase to facilitate
+            nucleolar Cdc14 release.
+          reference_section_type: ABSTRACT
   - term:
       id: GO:0010971
       label: positive regulation of G2/M transition of mitotic cell cycle
@@ -4276,6 +4473,57 @@ existing_annotations:
         - reference_id: PMID:18762578
           supporting_text: Sep 1. Separase cooperates with Zds1 and Zds2 to
             activate Cdc14 phosphatase in early anaphase.
+  - term:
+      id: GO:0000159
+      label: protein phosphatase type 2A complex
+    evidence_type: IPI
+    original_reference_id: PMID:18762578
+    qualifier: part_of
+    review:
+      summary: Zds1 associates constitutively with the Cdc55-containing PP2A holoenzyme
+        during mitosis and mitotic exit.
+      action: NEW
+      reason: Direct coimmunoprecipitation places Zds1 with Cdc55 and the PP2A scaffold
+        Tpd3. This complex membership is more informative than generic protein binding
+        and supports the core adaptor/regulator model.
+      supported_by:
+        - reference_id: PMID:18762578
+          supporting_text: In immunoprecipitates of Zds1 from metaphase-arrested cells,
+            we detected Cdc55 as well as the PP2A scaffold subunit, Tpd3 by Western
+            blotting.
+          reference_section_type: RESULTS
+core_functions:
+  - description: &gt;-
+      Zds1 is a non-catalytic adaptor for PP2A-Cdc55 that controls the phosphatase&#39;s
+      cytoplasmic/cortical enrichment and nuclear exclusion. This spatial regulation
+      promotes mitotic entry and timely Cdc14 release during mitotic exit.
+    molecular_function:
+      id: GO:0004864
+      label: protein phosphatase inhibitor activity
+    directly_involved_in:
+      - id: GO:0032880
+        label: regulation of protein localization
+      - id: GO:0010971
+        label: positive regulation of G2/M transition of mitotic cell cycle
+    locations:
+      - id: GO:0005737
+        label: cytoplasm
+      - id: GO:0005934
+        label: cellular bud tip
+      - id: GO:0005935
+        label: cellular bud neck
+    in_complex:
+      id: GO:0000159
+      label: protein phosphatase type 2A complex
+    supported_by:
+      - reference_id: PMID:18762578
+        supporting_text: Ectopic Zds1 expression in turn is sufficient to down-regulate
+          PP2A(Cdc55) and promote Net1 phosphorylation.
+        reference_section_type: ABSTRACT
+      - reference_id: PMID:21536748
+        supporting_text: Thus, the cytoplasmic localization of Cdc55 mediated by Zds1/Zds2
+          is required and sufficient for normal mitotic entry.
+        reference_section_type: RESULTS
 references:
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees

--- a/genes/yeast/ZDS1/ZDS1-ai-review.html
+++ b/genes/yeast/ZDS1/ZDS1-ai-review.html
@@ -1077,10 +1077,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0030010" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0030010" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1232,10 +1232,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0051028" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0051028" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1248,7 +1248,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Zds1 associates with the mRNA export machinery at the nuclear pore complex, interacting with Dbp5 (essential DEAD box helicase for mRNA export) and Gfd1. The isoform-specific annotation as mRNA transport (rather than the broader mRNA export) is slightly imprecise, but Zds1 does facilitate mRNA transport through the NPC. The annotation appropriately captures this secondary function beyond Zds1&#39;s primary role in cell cycle regulation.
+                            <strong>Reason:</strong> Zds1 associates with the mRNA export machinery at the nuclear pore complex, interacting with Dbp5 (essential DEAD box helicase for mRNA export) and Gfd1. This broad parent is redundant with the directly supported, more specific GO:0006406 mRNA export from nucleus annotations and is therefore over-annotated.
                         </div>
 
 
@@ -1316,10 +1316,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0071555" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0071555" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1655,12 +1655,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IPI annotation for protein binding with Separase during mitotic exit. Zds1 binding is instrumental to mitotic regulation but not a primary molecular function itself.
+                            <strong>Summary:</strong> IPI annotation for binding to Tpd3, the PP2A scaffold subunit, during mitosis. This interaction supports Zds1&#39;s regulatory role but generic protein binding is not an informative molecular function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Zds1 participates in mitotic exit through interactions with Separase and Cdc55, but this binding is instrumental to Zds1&#39;s primary regulatory function rather than a primary molecular function itself. Generic protein binding terminology obscures the actual mechanism. The biological process terms better capture Zds1&#39;s role.
+                            <strong>Reason:</strong> Zds1 associates with Tpd3 and Cdc55 in the PP2A-Cdc55 regulatory context, but this binding is instrumental to Zds1&#39;s primary regulatory function rather than a primary molecular function itself. Generic protein binding terminology obscures the actual mechanism. The biological process terms better capture Zds1&#39;s role.
                         </div>
 
 
@@ -1678,7 +1678,7 @@
 
                                 </span>
 
-                                <div class="support-text">Sep 1. Separase cooperates with Zds1 and Zds2 to activate Cdc14 phosphatase in early anaphase.</div>
+                                <div class="support-text">In immunoprecipitates of Zds1 from metaphase-arrested cells, we detected Cdc55 as well as the PP2A scaffold subunit, Tpd3 by Western blotting.</div>
 
                             </div>
 
@@ -2231,10 +2231,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0000131" data-r="PMID:8816439" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0000131" data-r="PMID:8816439" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2395,10 +2395,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005934" data-r="PMID:8816439" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005934" data-r="PMID:8816439" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2490,10 +2490,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005935" data-r="PMID:21536748" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0005935" data-r="PMID:21536748" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2585,10 +2585,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0006406" data-r="PMID:15619606" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0006406" data-r="PMID:15619606" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2680,10 +2680,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0006406" data-r="PMID:15619606" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0006406" data-r="PMID:15619606" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2762,10 +2762,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0006406" data-r="PMID:15619606" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0006406" data-r="PMID:15619606" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2926,10 +2926,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0030010" data-r="PMID:8816439" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0030010" data-r="PMID:8816439" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3021,10 +3021,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0030010" data-r="PMID:8816439" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P50111" data-a="GO:0030010" data-r="PMID:8816439" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3167,101 +3167,6 @@
 
                             </div>
 
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18762578" target="_blank" class="term-link">
-                                        PMID:18762578
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">Sep 1. Separase cooperates with Zds1 and Zds2 to activate Cdc14 phosphatase in early anaphase.</div>
-
-                            </div>
-
-                        </div>
-
-
-                    </td>
-                </tr>
-
-                <tr>
-                    <td>
-                        <div class="term-info">
-
-                            <span class="term-id">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000159" target="_blank" class="term-link">
-                                    GO:0000159
-                                </a>
-                            </span>
-                            <span class="term-label">protein phosphatase type 2A complex</span>
-
-                        </div>
-                    </td>
-                    <td>
-                        <span class="evidence-code">IPI</span>
-
-
-
-                        <br>
-                        <span style="font-size: 0.75rem;">
-
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/18762578" target="_blank" class="term-link" style="font-size: 0.75rem;">
-                                PMID:18762578
-                            </a>
-
-
-
-                                <br>
-                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
-                                    Separase cooperates with Zds1 and Zds2 to activate Cdc14 pho...
-                                </span>
-
-
-
-                        </span>
-
-                    </td>
-                    <td>
-                        <span class="action-badge action-new">
-                            NEW
-                        </span>
-                        <span class="vote-buttons" data-g="P50111" data-a="GO:0000159" data-r="PMID:18762578" data-act="NEW">
-                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
-                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
-                        </span>
-                    </td>
-                    <td>
-
-                        <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Zds1 associates constitutively with the Cdc55-containing PP2A holoenzyme during mitosis and mitotic exit.
-                        </div>
-
-
-                        <div>
-                            <strong>Reason:</strong> Direct coimmunoprecipitation places Zds1 with Cdc55 and the PP2A scaffold Tpd3. This complex membership is more informative than generic protein binding and supports the core adaptor/regulator model.
-                        </div>
-
-
-
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18762578" target="_blank" class="term-link">
-                                        PMID:18762578
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">In immunoprecipitates of Zds1 from metaphase-arrested cells, we detected Cdc55 as well as the PP2A scaffold subunit, Tpd3 by Western blotting.</div>
-
-                            </div>
-
                         </div>
 
 
@@ -3332,31 +3237,10 @@
                             </a>
                         </span>
 
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005934" target="_blank" class="term-link">
-                                cellular bud tip
-                            </a>
-                        </span>
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005935" target="_blank" class="term-link">
-                                cellular bud neck
-                            </a>
-                        </span>
-
                     </div>
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">In Complex:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000159" target="_blank" class="term-link">
-                            protein phosphatase type 2A complex
-                        </a>
-                    </span>
-                </div>
 
 
 
@@ -3838,13 +3722,18 @@ Zds1 (YMR273C; UniProt P50111) is a cortical adaptor that binds the PP2A regulat
 <li>Generic <code>protein binding</code> annotations are marked over-annotated because they<br />
   are true interaction observations but do not describe Zds1's adaptor/regulator<br />
   function.</li>
+<li>Coimmunoprecipitation with Cdc55 and Tpd3 demonstrates association with<br />
+  PP2A-Cdc55, not <code>part_of</code> membership in the heterotrimeric PP2A holoenzyme;<br />
+  no new GO:0000159 annotation is proposed.</li>
 </ul>
 <h2 id="core-synthesis">Core synthesis</h2>
 <p>Zds1 is a non-catalytic PP2A-Cdc55 adaptor/regulator. Its principal conserved<br />
 role is to establish the cytoplasmic and cortical pool of PP2A-Cdc55 and limit<br />
 nuclear Cdc55, thereby coordinating mitotic entry and exit. Cell-polarity,<br />
 cell-wall, mRNA-export, and chromatin-silencing phenotypes are retained where<br />
-experimentally supported but are secondary to this core mechanism.</p>
+experimentally supported but are secondary to this core mechanism; the broad<br />
+mRNA-transport parent is marked over-annotated because the more specific<br />
+nuclear-export term is already supported.</p>
             </div>
         </details>
 
@@ -3946,7 +3835,7 @@ existing_annotations:
         including Cdc55-mediated regulation and Rho1 effector functions. IBA
         annotation is appropriate given experimental evidence for polarity
         defects in zds1Δ zds2Δ mutants.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 has dual roles in cell polarity. First, as a negative
         regulator of Cdc42, it was originally identified in screens for polarity
         genes. Second, as a Rho1 effector at the bud cortex, it associates with
@@ -3992,14 +3881,12 @@ existing_annotations:
       summary: Zds1 participates in mRNA export via interactions with Dbp5 and
         Gfd1 at the nuclear pore complex. IEA annotation is supported by
         specific experimental evidence for mRNA export function.
-      action: ACCEPT
+      action: MARK_AS_OVER_ANNOTATED
       reason: Zds1 associates with the mRNA export machinery at the nuclear pore
         complex, interacting with Dbp5 (essential DEAD box helicase for mRNA
-        export) and Gfd1. The isoform-specific annotation as mRNA transport
-        (rather than the broader mRNA export) is slightly imprecise, but Zds1
-        does facilitate mRNA transport through the NPC. The annotation
-        appropriately captures this secondary function beyond Zds1&#39;s primary
-        role in cell cycle regulation.
+        export) and Gfd1. This broad parent is redundant with the directly supported,
+        more specific GO:0006406 mRNA export from nucleus annotations and is therefore
+        over-annotated.
       supported_by:
         - reference_id: PMID:15619606
           supporting_text: &#34;Zds1p associates with the complex formed by Dbp5p, Gfd1p,
@@ -4018,7 +3905,7 @@ existing_annotations:
       summary: Zds1 regulates cell wall organization through Rho1 effector
         function and Cdc55 localization control. IEA annotation based on
         UniProtKB keyword mapping is supported by mechanistic evidence.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 regulates cell wall organization through its role as a Rho1
         effector at the bud cortex. In complex with Cdc55, Zds1 biases Rho1
         signaling toward anabolic cell wall synthesis (beta-1,3-glucan
@@ -4101,19 +3988,21 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:18762578
     review:
-      summary: IPI annotation for protein binding with Separase during mitotic
-        exit. Zds1 binding is instrumental to mitotic regulation but not a
-        primary molecular function itself.
+      summary: IPI annotation for binding to Tpd3, the PP2A scaffold subunit, during
+        mitosis. This interaction supports Zds1&#39;s regulatory role but generic protein
+        binding is not an informative molecular function.
       action: MARK_AS_OVER_ANNOTATED
-      reason: Zds1 participates in mitotic exit through interactions with
-        Separase and Cdc55, but this binding is instrumental to Zds1&#39;s primary
+      reason: Zds1 associates with Tpd3 and Cdc55 in the PP2A-Cdc55 regulatory context,
+        but this binding is instrumental to Zds1&#39;s primary
         regulatory function rather than a primary molecular function itself.
         Generic protein binding terminology obscures the actual mechanism. The
         biological process terms better capture Zds1&#39;s role.
       supported_by:
         - reference_id: PMID:18762578
-          supporting_text: Sep 1. Separase cooperates with Zds1 and Zds2 to
-            activate Cdc14 phosphatase in early anaphase.
+          supporting_text: In immunoprecipitates of Zds1 from metaphase-arrested cells,
+            we detected Cdc55 as well as the PP2A scaffold subunit, Tpd3 by Western
+            blotting.
+          reference_section_type: RESULTS
   - term:
       id: GO:0005515
       label: protein binding
@@ -4237,7 +4126,7 @@ existing_annotations:
       summary: IDA annotation for Zds1 localization to incipient bud sites in G1
         phase cells. This is supported by direct observation of GST-Zds1 fusion
         protein localization.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 localizes to presumptive bud sites in unbudded cells and to
         bud tips in early budding cells. This localization is consistent with
         its role in cell polarity establishment and cortical signaling. Direct
@@ -4276,7 +4165,7 @@ existing_annotations:
       summary: IDA annotation for Zds1 localization to bud tips in developing
         buds. Direct evidence from GST-Zds1 fusion protein imaging confirms bud
         tip enrichment.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 concentrates at bud tips, especially in small to medium-sized
         buds, which is consistent with its role in cell polarity and polarized
         growth regulation. This subcellular localization is relevant to
@@ -4299,7 +4188,7 @@ existing_annotations:
       summary: IDA annotation for Zds1 localization to the bud neck in late
         mitotic cells. Direct fluorescence imaging confirms this dynamic
         localization change.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 relocates to the bud neck during late mitosis, coinciding
         with its roles in regulating mitotic exit and cytokinesis. This dynamic
         localization pattern reflects Zds1&#39;s cell cycle-dependent functions in
@@ -4321,7 +4210,7 @@ existing_annotations:
       summary: IMP annotation for Zds1 requirement in mRNA export based on
         genetic analysis of export-deficient mutants. Zds1 is part of the mRNA
         export machinery at the NPC.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 is a functional component of the mRNA export machinery,
         associating with Dbp5 and Gfd1 at the cytoplasmic fibrils of the nuclear
         pore complex. Deletion of ZDS1 exacerbates mRNA export defects in dbp5
@@ -4347,7 +4236,7 @@ existing_annotations:
       summary: IGI annotation for mRNA export based on genetic interaction with
         Dbp5 and other export factors. Supports the IMP annotation for this
         function.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Genetic interactions between ZDS1 and key mRNA export genes (DBP5,
         MEX67) confirm Zds1&#39;s role in mRNA export machinery. The IGI evidence
         corroborates the IMP findings and demonstrates Zds1 functions in a
@@ -4365,7 +4254,7 @@ existing_annotations:
       summary: IPI annotation for mRNA export based on direct physical
         interactions of Zds1 with Dbp5 and Gfd1 at the NPC. Multiple lines of
         evidence converge on this function.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Direct protein-protein interactions (two-hybrid and in vitro
         binding) between Zds1 and Dbp5/Gfd1 establish Zds1 as a physical
         component of the mRNA export machinery. The converging evidence from
@@ -4405,7 +4294,7 @@ existing_annotations:
       summary: IMP annotation for cell polarity based on morphological and
         genetic analysis of zds1Δ zds2Δ mutants showing severe polarity defects
         and abnormal cell shape.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: &#39;Zds1 is established as important for cell polarity establishment through
         multiple lines of evidence: first, it was identified as a negative regulator
         of the Cdc42 GTPase in polarity screens; second, zds1Δ zds2Δ mutants show
@@ -4429,7 +4318,7 @@ existing_annotations:
       summary: IGI annotation for cell polarity based on genetic interactions
         with Cdc42, Rho1, and other polarity proteins. Multiple genetic
         interactions confirm Zds1&#39;s polarity role.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Genetic interaction studies establish Zds1 as a functional
         component of cell polarity networks, particularly through interactions
         with Cdc42 and Rho1 signaling pathways. These genetic interactions
@@ -4470,28 +4359,6 @@ existing_annotations:
           supporting_text: &#34;By genetically manipulating nucleocytoplasmic distribution
             of Cdc55, we show that Zds1/Zds2 act as positive regulators for cytoplasmic
             Cdc55–PP2A&#34;
-        - reference_id: PMID:18762578
-          supporting_text: Sep 1. Separase cooperates with Zds1 and Zds2 to
-            activate Cdc14 phosphatase in early anaphase.
-  - term:
-      id: GO:0000159
-      label: protein phosphatase type 2A complex
-    evidence_type: IPI
-    original_reference_id: PMID:18762578
-    qualifier: part_of
-    review:
-      summary: Zds1 associates constitutively with the Cdc55-containing PP2A holoenzyme
-        during mitosis and mitotic exit.
-      action: NEW
-      reason: Direct coimmunoprecipitation places Zds1 with Cdc55 and the PP2A scaffold
-        Tpd3. This complex membership is more informative than generic protein binding
-        and supports the core adaptor/regulator model.
-      supported_by:
-        - reference_id: PMID:18762578
-          supporting_text: In immunoprecipitates of Zds1 from metaphase-arrested cells,
-            we detected Cdc55 as well as the PP2A scaffold subunit, Tpd3 by Western
-            blotting.
-          reference_section_type: RESULTS
 core_functions:
   - description: &gt;-
       Zds1 is a non-catalytic adaptor for PP2A-Cdc55 that controls the phosphatase&#39;s
@@ -4508,13 +4375,6 @@ core_functions:
     locations:
       - id: GO:0005737
         label: cytoplasm
-      - id: GO:0005934
-        label: cellular bud tip
-      - id: GO:0005935
-        label: cellular bud neck
-    in_complex:
-      id: GO:0000159
-      label: protein phosphatase type 2A complex
     supported_by:
       - reference_id: PMID:18762578
         supporting_text: Ectopic Zds1 expression in turn is sufficient to down-regulate

--- a/genes/yeast/ZDS1/ZDS1-ai-review.html
+++ b/genes/yeast/ZDS1/ZDS1-ai-review.html
@@ -1243,7 +1243,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Zds1 participates in mRNA export via interactions with Dbp5 and Gfd1 at the nuclear pore complex. IEA annotation is supported by specific experimental evidence for mRNA export function.
+                            <strong>Summary:</strong> The broad mRNA transport IEA annotation reflects Zds1 interactions with Dbp5 and Gfd1 but is redundant with the more specific experimental annotations for mRNA export from the nucleus.
                         </div>
 
 
@@ -1327,7 +1327,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Zds1 regulates cell wall organization through Rho1 effector function and Cdc55 localization control. IEA annotation based on UniProtKB keyword mapping is supported by mechanistic evidence.
+                            <strong>Summary:</strong> Zds1 influences cell wall organization through Rho1 signaling and Cdc55 localization, a supported but secondary consequence of its core PP2A-Cdc55 regulatory role.
                         </div>
 
 
@@ -3878,9 +3878,9 @@ existing_annotations:
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: Zds1 participates in mRNA export via interactions with Dbp5 and
-        Gfd1 at the nuclear pore complex. IEA annotation is supported by
-        specific experimental evidence for mRNA export function.
+      summary: The broad mRNA transport IEA annotation reflects Zds1 interactions
+        with Dbp5 and Gfd1 but is redundant with the more specific experimental
+        annotations for mRNA export from the nucleus.
       action: MARK_AS_OVER_ANNOTATED
       reason: Zds1 associates with the mRNA export machinery at the nuclear pore
         complex, interacting with Dbp5 (essential DEAD box helicase for mRNA
@@ -3902,9 +3902,9 @@ existing_annotations:
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: Zds1 regulates cell wall organization through Rho1 effector
-        function and Cdc55 localization control. IEA annotation based on
-        UniProtKB keyword mapping is supported by mechanistic evidence.
+      summary: Zds1 influences cell wall organization through Rho1 signaling and
+        Cdc55 localization, a supported but secondary consequence of its core
+        PP2A-Cdc55 regulatory role.
       action: KEEP_AS_NON_CORE
       reason: Zds1 regulates cell wall organization through its role as a Rho1
         effector at the bud cortex. In complex with Cdc55, Zds1 biases Rho1

--- a/genes/yeast/ZDS1/ZDS1-ai-review.yaml
+++ b/genes/yeast/ZDS1/ZDS1-ai-review.yaml
@@ -86,7 +86,7 @@ existing_annotations:
         including Cdc55-mediated regulation and Rho1 effector functions. IBA 
         annotation is appropriate given experimental evidence for polarity 
         defects in zds1Δ zds2Δ mutants.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 has dual roles in cell polarity. First, as a negative 
         regulator of Cdc42, it was originally identified in screens for polarity
         genes. Second, as a Rho1 effector at the bud cortex, it associates with 
@@ -132,14 +132,12 @@ existing_annotations:
       summary: Zds1 participates in mRNA export via interactions with Dbp5 and 
         Gfd1 at the nuclear pore complex. IEA annotation is supported by 
         specific experimental evidence for mRNA export function.
-      action: ACCEPT
+      action: MARK_AS_OVER_ANNOTATED
       reason: Zds1 associates with the mRNA export machinery at the nuclear pore
         complex, interacting with Dbp5 (essential DEAD box helicase for mRNA 
-        export) and Gfd1. The isoform-specific annotation as mRNA transport 
-        (rather than the broader mRNA export) is slightly imprecise, but Zds1 
-        does facilitate mRNA transport through the NPC. The annotation 
-        appropriately captures this secondary function beyond Zds1's primary 
-        role in cell cycle regulation.
+        export) and Gfd1. This broad parent is redundant with the directly supported,
+        more specific GO:0006406 mRNA export from nucleus annotations and is therefore
+        over-annotated.
       supported_by:
         - reference_id: PMID:15619606
           supporting_text: "Zds1p associates with the complex formed by Dbp5p, Gfd1p,
@@ -158,7 +156,7 @@ existing_annotations:
       summary: Zds1 regulates cell wall organization through Rho1 effector 
         function and Cdc55 localization control. IEA annotation based on 
         UniProtKB keyword mapping is supported by mechanistic evidence.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 regulates cell wall organization through its role as a Rho1 
         effector at the bud cortex. In complex with Cdc55, Zds1 biases Rho1 
         signaling toward anabolic cell wall synthesis (beta-1,3-glucan 
@@ -241,19 +239,21 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:18762578
     review:
-      summary: IPI annotation for protein binding with Separase during mitotic 
-        exit. Zds1 binding is instrumental to mitotic regulation but not a 
-        primary molecular function itself.
+      summary: IPI annotation for binding to Tpd3, the PP2A scaffold subunit, during
+        mitosis. This interaction supports Zds1's regulatory role but generic protein
+        binding is not an informative molecular function.
       action: MARK_AS_OVER_ANNOTATED
-      reason: Zds1 participates in mitotic exit through interactions with 
-        Separase and Cdc55, but this binding is instrumental to Zds1's primary 
+      reason: Zds1 associates with Tpd3 and Cdc55 in the PP2A-Cdc55 regulatory context,
+        but this binding is instrumental to Zds1's primary
         regulatory function rather than a primary molecular function itself. 
         Generic protein binding terminology obscures the actual mechanism. The 
         biological process terms better capture Zds1's role.
       supported_by:
         - reference_id: PMID:18762578
-          supporting_text: Sep 1. Separase cooperates with Zds1 and Zds2 to 
-            activate Cdc14 phosphatase in early anaphase.
+          supporting_text: In immunoprecipitates of Zds1 from metaphase-arrested cells,
+            we detected Cdc55 as well as the PP2A scaffold subunit, Tpd3 by Western
+            blotting.
+          reference_section_type: RESULTS
   - term:
       id: GO:0005515
       label: protein binding
@@ -377,7 +377,7 @@ existing_annotations:
       summary: IDA annotation for Zds1 localization to incipient bud sites in G1
         phase cells. This is supported by direct observation of GST-Zds1 fusion 
         protein localization.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 localizes to presumptive bud sites in unbudded cells and to 
         bud tips in early budding cells. This localization is consistent with 
         its role in cell polarity establishment and cortical signaling. Direct 
@@ -416,7 +416,7 @@ existing_annotations:
       summary: IDA annotation for Zds1 localization to bud tips in developing 
         buds. Direct evidence from GST-Zds1 fusion protein imaging confirms bud 
         tip enrichment.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 concentrates at bud tips, especially in small to medium-sized
         buds, which is consistent with its role in cell polarity and polarized 
         growth regulation. This subcellular localization is relevant to 
@@ -439,7 +439,7 @@ existing_annotations:
       summary: IDA annotation for Zds1 localization to the bud neck in late 
         mitotic cells. Direct fluorescence imaging confirms this dynamic 
         localization change.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 relocates to the bud neck during late mitosis, coinciding 
         with its roles in regulating mitotic exit and cytokinesis. This dynamic 
         localization pattern reflects Zds1's cell cycle-dependent functions in 
@@ -461,7 +461,7 @@ existing_annotations:
       summary: IMP annotation for Zds1 requirement in mRNA export based on 
         genetic analysis of export-deficient mutants. Zds1 is part of the mRNA 
         export machinery at the NPC.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Zds1 is a functional component of the mRNA export machinery, 
         associating with Dbp5 and Gfd1 at the cytoplasmic fibrils of the nuclear
         pore complex. Deletion of ZDS1 exacerbates mRNA export defects in dbp5 
@@ -487,7 +487,7 @@ existing_annotations:
       summary: IGI annotation for mRNA export based on genetic interaction with 
         Dbp5 and other export factors. Supports the IMP annotation for this 
         function.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Genetic interactions between ZDS1 and key mRNA export genes (DBP5,
         MEX67) confirm Zds1's role in mRNA export machinery. The IGI evidence 
         corroborates the IMP findings and demonstrates Zds1 functions in a 
@@ -505,7 +505,7 @@ existing_annotations:
       summary: IPI annotation for mRNA export based on direct physical 
         interactions of Zds1 with Dbp5 and Gfd1 at the NPC. Multiple lines of 
         evidence converge on this function.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Direct protein-protein interactions (two-hybrid and in vitro 
         binding) between Zds1 and Dbp5/Gfd1 establish Zds1 as a physical 
         component of the mRNA export machinery. The converging evidence from 
@@ -545,7 +545,7 @@ existing_annotations:
       summary: IMP annotation for cell polarity based on morphological and 
         genetic analysis of zds1Δ zds2Δ mutants showing severe polarity defects 
         and abnormal cell shape.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: 'Zds1 is established as important for cell polarity establishment through
         multiple lines of evidence: first, it was identified as a negative regulator
         of the Cdc42 GTPase in polarity screens; second, zds1Δ zds2Δ mutants show
@@ -569,7 +569,7 @@ existing_annotations:
       summary: IGI annotation for cell polarity based on genetic interactions 
         with Cdc42, Rho1, and other polarity proteins. Multiple genetic 
         interactions confirm Zds1's polarity role.
-      action: ACCEPT
+      action: KEEP_AS_NON_CORE
       reason: Genetic interaction studies establish Zds1 as a functional 
         component of cell polarity networks, particularly through interactions 
         with Cdc42 and Rho1 signaling pathways. These genetic interactions 
@@ -610,28 +610,6 @@ existing_annotations:
           supporting_text: "By genetically manipulating nucleocytoplasmic distribution
             of Cdc55, we show that Zds1/Zds2 act as positive regulators for cytoplasmic
             Cdc55–PP2A"
-        - reference_id: PMID:18762578
-          supporting_text: Sep 1. Separase cooperates with Zds1 and Zds2 to 
-            activate Cdc14 phosphatase in early anaphase.
-  - term:
-      id: GO:0000159
-      label: protein phosphatase type 2A complex
-    evidence_type: IPI
-    original_reference_id: PMID:18762578
-    qualifier: part_of
-    review:
-      summary: Zds1 associates constitutively with the Cdc55-containing PP2A holoenzyme
-        during mitosis and mitotic exit.
-      action: NEW
-      reason: Direct coimmunoprecipitation places Zds1 with Cdc55 and the PP2A scaffold
-        Tpd3. This complex membership is more informative than generic protein binding
-        and supports the core adaptor/regulator model.
-      supported_by:
-        - reference_id: PMID:18762578
-          supporting_text: In immunoprecipitates of Zds1 from metaphase-arrested cells,
-            we detected Cdc55 as well as the PP2A scaffold subunit, Tpd3 by Western
-            blotting.
-          reference_section_type: RESULTS
 core_functions:
   - description: >-
       Zds1 is a non-catalytic adaptor for PP2A-Cdc55 that controls the phosphatase's
@@ -648,13 +626,6 @@ core_functions:
     locations:
       - id: GO:0005737
         label: cytoplasm
-      - id: GO:0005934
-        label: cellular bud tip
-      - id: GO:0005935
-        label: cellular bud neck
-    in_complex:
-      id: GO:0000159
-      label: protein phosphatase type 2A complex
     supported_by:
       - reference_id: PMID:18762578
         supporting_text: Ectopic Zds1 expression in turn is sufficient to down-regulate

--- a/genes/yeast/ZDS1/ZDS1-ai-review.yaml
+++ b/genes/yeast/ZDS1/ZDS1-ai-review.yaml
@@ -129,9 +129,9 @@ existing_annotations:
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: Zds1 participates in mRNA export via interactions with Dbp5 and 
-        Gfd1 at the nuclear pore complex. IEA annotation is supported by 
-        specific experimental evidence for mRNA export function.
+      summary: The broad mRNA transport IEA annotation reflects Zds1 interactions
+        with Dbp5 and Gfd1 but is redundant with the more specific experimental
+        annotations for mRNA export from the nucleus.
       action: MARK_AS_OVER_ANNOTATED
       reason: Zds1 associates with the mRNA export machinery at the nuclear pore
         complex, interacting with Dbp5 (essential DEAD box helicase for mRNA 
@@ -153,9 +153,9 @@ existing_annotations:
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: Zds1 regulates cell wall organization through Rho1 effector 
-        function and Cdc55 localization control. IEA annotation based on 
-        UniProtKB keyword mapping is supported by mechanistic evidence.
+      summary: Zds1 influences cell wall organization through Rho1 signaling and
+        Cdc55 localization, a supported but secondary consequence of its core
+        PP2A-Cdc55 regulatory role.
       action: KEEP_AS_NON_CORE
       reason: Zds1 regulates cell wall organization through its role as a Rho1 
         effector at the bud cortex. In complex with Cdc55, Zds1 biases Rho1 

--- a/genes/yeast/ZDS1/ZDS1-ai-review.yaml
+++ b/genes/yeast/ZDS1/ZDS1-ai-review.yaml
@@ -8,11 +8,11 @@ aliases:
 - OSS1
 - STM2
 product_type: PROTEIN
-status: INITIALIZED
+status: DRAFT
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'ZDS1 (also known as HST1, encoding Protein Zds1) is a cortical/cytoplasmic
+description: 'ZDS1 (historically also called HST1) encodes a cortical/cytoplasmic
   adaptor protein that regulates the spatial localization and activity of the PP2A
   phosphatase complex containing the regulatory subunit Cdc55. Zds1 functions as a
   non-catalytic scaffold that binds Cdc55 and controls its nucleocytoplasmic distribution,
@@ -182,7 +182,7 @@ existing_annotations:
         (P20449) and Gfd1 (Q04839) from two-hybrid and in vitro binding 
         experiments. While protein binding is accurate, it is an overly general 
         term that obscures the specific biochemical function.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: Zds1 physically interacts with Dbp5 and Gfd1 at the nuclear pore 
         complex for mRNA export function. However, GO:0005515 (protein binding) 
         is too vague and undescriptive. The more informative core annotations 
@@ -205,7 +205,7 @@ existing_annotations:
       summary: IPI annotation from proteome survey detecting protein 
         interactions in large-scale binding experiments. Generic protein binding
         annotation; see other instances for same term.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: This is a proteomics-derived IPI annotation from a large-scale 
         protein interaction survey. While detecting multiple binding partners, 
         generic protein binding annotations provide minimal functional 
@@ -225,7 +225,7 @@ existing_annotations:
       summary: IPI annotation from global yeast protein complex analysis. 
         Generic protein binding annotation from high-throughput interaction 
         data; see rationale for other protein binding instances.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: Large-scale high-throughput protein complex mapping identifies 
         Zds1 interactors but provides minimal specificity regarding molecular 
         function. Generic protein binding annotations from proteomics studies 
@@ -244,7 +244,7 @@ existing_annotations:
       summary: IPI annotation for protein binding with Separase during mitotic 
         exit. Zds1 binding is instrumental to mitotic regulation but not a 
         primary molecular function itself.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: Zds1 participates in mitotic exit through interactions with 
         Separase and Cdc55, but this binding is instrumental to Zds1's primary 
         regulatory function rather than a primary molecular function itself. 
@@ -263,7 +263,7 @@ existing_annotations:
       summary: IPI annotation from chaperone-protein interaction atlas. Generic 
         protein binding from large-scale interaction mapping; consistent with 
         other instances of this term.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: Large-scale chaperone interaction studies identify Zds1 as a 
         protein interaction hub, but generic "protein binding" is insufficiently
         specific. Zds1's functional interactions (Cdc55 binding, Dbp5/Gfd1 
@@ -282,7 +282,7 @@ existing_annotations:
       summary: IPI annotation from recent structural and functional analysis of 
         yeast protein interactome architecture. Generic binding annotation from 
         modern interaction mapping.
-      action: KEEP_AS_NON_CORE
+      action: MARK_AS_OVER_ANNOTATED
       reason: Recent high-resolution interactome study identifies Zds1 protein 
         interactions but provides minimal functional specificity. Modern protein
         interaction data is better expressed through specific molecular function
@@ -297,81 +297,55 @@ existing_annotations:
     evidence_type: IMP
     original_reference_id: PMID:10662670
     review:
-      summary: IMP annotation claiming Zds1 involvement in heterochromatin 
-        formation. This annotation appears to reflect over-annotation or 
-        confusion with unrelated Zds1/Zds2 functions.
-      action: REMOVE
-      reason: Zds1's molecular function is well-characterized as a Cdc55-PP2A 
-        localization regulator and Rho1 signaling effector. Its main biological 
-        processes are mitotic entry/exit, cell polarity, and cell wall 
-        synthesis. There is no mechanistic evidence that Zds1 has any role in 
-        heterochromatin formation or transcriptional silencing. The original 
-        PMID (10662670) titled "Two paralogs involved in transcriptional 
-        silencing" may refer to a different yeast protein or may conflate Zds1's
-        well-documented roles in cell cycle and signaling with unrelated 
-        chromatin functions. This annotation contradicts the established 
-        functional understanding of Zds1 and should be removed.
-      additional_reference_ids:
-        - PMID:21536748
-        - PMID:8816439
-        - PMID:15619606
+      summary: ZDS1 deletion redistributes silencing among rDNA, a silent mating-type
+        cassette, and telomeres, but chromatin regulation is secondary to Zds1's PP2A-Cdc55
+        adaptor function.
+      action: KEEP_AS_NON_CORE
+      reason: The cited study directly assayed ZDS1 and found altered silencing at three
+        heterochromatic loci. Retain the experimentally supported process while keeping
+        it non-core because the mechanism is indirect and the principal conserved role
+        of Zds1 is spatial regulation of PP2A-Cdc55.
       supported_by:
         - reference_id: PMID:10662670
-          supporting_text: Two paralogs involved in transcriptional silencing 
-            that antagonistically control yeast life span.
-        - reference_id: PMID:21536748
-          supporting_text: Spatial regulation of Cdc55-PP2A by Zds1/Zds2 
-            controls mitotic entry and mitotic exit in budding yeast.
-        - reference_id: PMID:8816439
-          supporting_text: ZDS1 and ZDS2, genes whose products may regulate 
-            Cdc42p in Saccharomyces cerevisiae.
-        - reference_id: PMID:15619606
-          supporting_text: 2004 Dec 24. Physical and genetic interactions link 
-            the yeast protein Zds1p with mRNA nuclear export.
+          supporting_text: deletion of the ZDS1 gene caused an increase in silencing
+            in the rDNA and at a silent mating-type cassette at the expense of telomere
+            silencing.
+          reference_section_type: ABSTRACT
   - term:
       id: GO:0004864
       label: protein phosphatase inhibitor activity
     evidence_type: IMP
     original_reference_id: PMID:18762578
     review:
-      summary: IMP annotation claiming Zds1 inhibits protein phosphatase 
-        activity. This annotation mischaracterizes Zds1's biochemical function 
-        and mechanism.
-      action: REMOVE
-      reason: Zds1 is not a phosphatase inhibitor in the traditional sense 
-        (e.g., not analogous to endogenous inhibitor proteins). Instead, Zds1 
-        functions as a non-catalytic regulatory scaffold that binds Cdc55 and 
-        controls PP2A-Cdc55 localization and activity in a spatially-restricted 
-        manner. While Zds1 can modulate PP2A-Cdc55 function (inhibiting nuclear 
-        activity while promoting cytoplasmic activity), this is achieved through
-        compartmentalization, not through direct inhibition of the catalytic 
-        machinery. The term "phosphatase inhibitor activity" is mechanistically 
-        inaccurate and should be replaced with more precise process-level 
-        annotations (regulation of protein localization, positive/negative 
-        regulation of specific cell cycle transitions).
+      summary: Zds1 down-regulates PP2A-Cdc55 at anaphase onset, although spatial
+        redistribution is also central to its broader mechanism.
+      action: ACCEPT
+      reason: PMID:18762578 directly shows that ectopic Zds1 is sufficient to down-regulate
+        PP2A-Cdc55 and frames Zds1/Zds2 as PP2A-Cdc55 inhibitors downstream of separase.
+        Later localization work refines rather than negates this experimentally supported
+        inhibitory activity.
       supported_by:
         - reference_id: PMID:18762578
-          supporting_text: Sep 1. Separase cooperates with Zds1 and Zds2 to 
-            activate Cdc14 phosphatase in early anaphase.
+          supporting_text: Ectopic Zds1 expression in turn is sufficient to down-regulate
+            PP2A(Cdc55) and promote Net1 phosphorylation.
+          reference_section_type: ABSTRACT
   - term:
       id: GO:0004864
       label: protein phosphatase inhibitor activity
     evidence_type: IGI
     original_reference_id: PMID:18762578
     review:
-      summary: IGI annotation for phosphatase inhibitor activity from genetic 
-        interaction with Separase. Like the IMP version, this mischaracterizes 
-        Zds1's function.
-      action: REMOVE
-      reason: Same rationale as the IMP annotation above. Zds1 does not function
-        as a direct phosphatase inhibitor. Its interaction with Separase affects
-        Cdc55 localization and function, but this is spatial regulation rather 
-        than classical phosphatase inhibition. The annotation should be replaced
-        with more mechanistically accurate terms.
+      summary: Genetic interaction with separase supports Zds1-dependent inhibition
+        of PP2A-Cdc55 during early anaphase.
+      action: ACCEPT
+      reason: The genetic evidence complements the direct perturbation result in the
+        same paper. Zds1 acts downstream of separase to down-regulate PP2A-Cdc55 and
+        permit Cdc14 release.
       supported_by:
         - reference_id: PMID:18762578
-          supporting_text: Sep 1. Separase cooperates with Zds1 and Zds2 to 
-            activate Cdc14 phosphatase in early anaphase.
+          supporting_text: Zds1 and Zds2 are required downstream of separase to facilitate
+            nucleolar Cdc14 release.
+          reference_section_type: ABSTRACT
   - term:
       id: GO:0010971
       label: positive regulation of G2/M transition of mitotic cell cycle
@@ -639,6 +613,57 @@ existing_annotations:
         - reference_id: PMID:18762578
           supporting_text: Sep 1. Separase cooperates with Zds1 and Zds2 to 
             activate Cdc14 phosphatase in early anaphase.
+  - term:
+      id: GO:0000159
+      label: protein phosphatase type 2A complex
+    evidence_type: IPI
+    original_reference_id: PMID:18762578
+    qualifier: part_of
+    review:
+      summary: Zds1 associates constitutively with the Cdc55-containing PP2A holoenzyme
+        during mitosis and mitotic exit.
+      action: NEW
+      reason: Direct coimmunoprecipitation places Zds1 with Cdc55 and the PP2A scaffold
+        Tpd3. This complex membership is more informative than generic protein binding
+        and supports the core adaptor/regulator model.
+      supported_by:
+        - reference_id: PMID:18762578
+          supporting_text: In immunoprecipitates of Zds1 from metaphase-arrested cells,
+            we detected Cdc55 as well as the PP2A scaffold subunit, Tpd3 by Western
+            blotting.
+          reference_section_type: RESULTS
+core_functions:
+  - description: >-
+      Zds1 is a non-catalytic adaptor for PP2A-Cdc55 that controls the phosphatase's
+      cytoplasmic/cortical enrichment and nuclear exclusion. This spatial regulation
+      promotes mitotic entry and timely Cdc14 release during mitotic exit.
+    molecular_function:
+      id: GO:0004864
+      label: protein phosphatase inhibitor activity
+    directly_involved_in:
+      - id: GO:0032880
+        label: regulation of protein localization
+      - id: GO:0010971
+        label: positive regulation of G2/M transition of mitotic cell cycle
+    locations:
+      - id: GO:0005737
+        label: cytoplasm
+      - id: GO:0005934
+        label: cellular bud tip
+      - id: GO:0005935
+        label: cellular bud neck
+    in_complex:
+      id: GO:0000159
+      label: protein phosphatase type 2A complex
+    supported_by:
+      - reference_id: PMID:18762578
+        supporting_text: Ectopic Zds1 expression in turn is sufficient to down-regulate
+          PP2A(Cdc55) and promote Net1 phosphorylation.
+        reference_section_type: ABSTRACT
+      - reference_id: PMID:21536748
+        supporting_text: Thus, the cytoplasmic localization of Cdc55 mediated by Zds1/Zds2
+          is required and sufficient for normal mitotic entry.
+        reference_section_type: RESULTS
 references:
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees

--- a/genes/yeast/ZDS1/ZDS1-notes.md
+++ b/genes/yeast/ZDS1/ZDS1-notes.md
@@ -1,0 +1,36 @@
+# ZDS1 review notes
+
+## Identity and research provenance
+
+- Canonical target: ZDS1/YMR273C, UniProt P50111. `HST1` is a legacy synonym of
+  ZDS1 and caused the earlier directory collision with canonical sirtuin HST1
+  (YOL068C/P53685).
+- The existing Falcon report is correctly grounded on P50111/ZDS1, although its
+  recorded request metadata still contains the former `gene_id: HST1` value.
+- `just deep-research-openscientist yeast ZDS1` was attempted twice on
+  2026-08-12. Both jobs resolved P50111/ZDS1 correctly but failed while polling
+  the provider (first `ConnectTimeout`, then DNS `ConnectError`). No provider
+  artifact was written or fabricated.
+
+## Curation corrections
+
+- PMID:10662670 directly studies ZDS1 deletion and reports redistribution of
+  silencing among rDNA, a silent mating-type cassette, and telomeres. The
+  experimental heterochromatin annotation is therefore retained as non-core;
+  the initialized review's claim that the paper concerned a different protein
+  was incorrect.
+- PMID:18762578 directly reports that ectopic Zds1 down-regulates PP2A-Cdc55 and
+  suggests that Zds1/Zds2 act as separase-regulated PP2A-Cdc55 inhibitors.
+  Later spatial-localization work refines this mechanism but does not justify
+  removing the experimental molecular-function annotations.
+- Generic `protein binding` annotations are marked over-annotated because they
+  are true interaction observations but do not describe Zds1's adaptor/regulator
+  function.
+
+## Core synthesis
+
+Zds1 is a non-catalytic PP2A-Cdc55 adaptor/regulator. Its principal conserved
+role is to establish the cytoplasmic and cortical pool of PP2A-Cdc55 and limit
+nuclear Cdc55, thereby coordinating mitotic entry and exit. Cell-polarity,
+cell-wall, mRNA-export, and chromatin-silencing phenotypes are retained where
+experimentally supported but are secondary to this core mechanism.

--- a/genes/yeast/ZDS1/ZDS1-notes.md
+++ b/genes/yeast/ZDS1/ZDS1-notes.md
@@ -26,6 +26,9 @@
 - Generic `protein binding` annotations are marked over-annotated because they
   are true interaction observations but do not describe Zds1's adaptor/regulator
   function.
+- Coimmunoprecipitation with Cdc55 and Tpd3 demonstrates association with
+  PP2A-Cdc55, not `part_of` membership in the heterotrimeric PP2A holoenzyme;
+  no new GO:0000159 annotation is proposed.
 
 ## Core synthesis
 
@@ -33,4 +36,6 @@ Zds1 is a non-catalytic PP2A-Cdc55 adaptor/regulator. Its principal conserved
 role is to establish the cytoplasmic and cortical pool of PP2A-Cdc55 and limit
 nuclear Cdc55, thereby coordinating mitotic entry and exit. Cell-polarity,
 cell-wall, mRNA-export, and chromatin-silencing phenotypes are retained where
-experimentally supported but are secondary to this core mechanism.
+experimentally supported but are secondary to this core mechanism; the broad
+mRNA-transport parent is marked over-annotated because the more specific
+nuclear-export term is already supported.

--- a/pages/projects/YEAST_EPIGENETICS_HISTONE_INHERITANCE.html
+++ b/pages/projects/YEAST_EPIGENETICS_HISTONE_INHERITANCE.html
@@ -600,10 +600,10 @@
 <p><strong>Phase 2 - Histone Deacetylases (HDACs)</strong><br />
 - <a href="../../genes/yeast/RPD3/RPD3-ai-review.html">RPD3</a>: 160 annotations → 85 ACCEPT (53%)<br />
 - <a href="../../genes/yeast/HDA1/HDA1-ai-review.html">HDA1</a>: 38 annotations → 27 ACCEPT (71%)<br />
-- <a href="../../genes/yeast/ZDS1/ZDS1-ai-review.html">ZDS1</a> (formerly misfiled as <a href="../../genes/yeast/HST1/HST1-ai-review.html">HST1</a>): 28 consolidated review entries → 20 ACCEPT,<br />
-  1 KEEP_AS_NON_CORE, 6 MARK_AS_OVER_ANNOTATED, 1 NEW. The corrected review retains<br />
+- <a href="../../genes/yeast/ZDS1/ZDS1-ai-review.html">ZDS1</a> (formerly misfiled as <a href="../../genes/yeast/HST1/HST1-ai-review.html">HST1</a>): 27 consolidated review entries → 9 ACCEPT,<br />
+  11 KEEP_AS_NON_CORE, 7 MARK_AS_OVER_ANNOTATED. The corrected review retains<br />
   direct <a href="../../genes/yeast/ZDS1/ZDS1-ai-review.html">ZDS1</a> evidence for PP2A-Cdc55 inhibition and secondary heterochromatin effects,<br />
-  and adds PP2A-complex membership plus a spatial-regulation core function; these<br />
+  and synthesizes a PP2A-Cdc55 spatial-regulation core function; these<br />
   results do not represent the sirtuin <a href="../../genes/yeast/HST1/HST1-ai-review.html">HST1</a>.<br />
 - <a href="../../genes/yeast/HST1/HST1-ai-review.html">HST1</a> (canonical P53685/YOL068C): 38 annotations → 15 ACCEPT, 8 KEEP_AS_NON_CORE, 11 MARK_AS_OVER_ANNOTATED, 2 REMOVE, 2 UNDECIDED. The review distinguishes native Sum1-Rfm1-<a href="../../genes/yeast/HST1/HST1-ai-review.html">Hst1</a> promoter repression from conditional Sum1-1 mating-type silencing and rejects Sir2-derived telomeric inferences.<br />
 - <a href="../../genes/yeast/HST2/HST2-ai-review.html">HST2</a>: 26 annotations → 21 ACCEPT (81%)<br />

--- a/pages/projects/YEAST_EPIGENETICS_HISTONE_INHERITANCE.html
+++ b/pages/projects/YEAST_EPIGENETICS_HISTONE_INHERITANCE.html
@@ -600,7 +600,11 @@
 <p><strong>Phase 2 - Histone Deacetylases (HDACs)</strong><br />
 - <a href="../../genes/yeast/RPD3/RPD3-ai-review.html">RPD3</a>: 160 annotations → 85 ACCEPT (53%)<br />
 - <a href="../../genes/yeast/HDA1/HDA1-ai-review.html">HDA1</a>: 38 annotations → 27 ACCEPT (71%)<br />
-- <a href="../../genes/yeast/ZDS1/ZDS1-ai-review.html">ZDS1</a> (formerly misfiled as <a href="../../genes/yeast/HST1/HST1-ai-review.html">HST1</a>): 40 annotations → 26 ACCEPT (65%); these results do not represent the sirtuin <a href="../../genes/yeast/HST1/HST1-ai-review.html">HST1</a><br />
+- <a href="../../genes/yeast/ZDS1/ZDS1-ai-review.html">ZDS1</a> (formerly misfiled as <a href="../../genes/yeast/HST1/HST1-ai-review.html">HST1</a>): 28 consolidated review entries → 20 ACCEPT,<br />
+  1 KEEP_AS_NON_CORE, 6 MARK_AS_OVER_ANNOTATED, 1 NEW. The corrected review retains<br />
+  direct <a href="../../genes/yeast/ZDS1/ZDS1-ai-review.html">ZDS1</a> evidence for PP2A-Cdc55 inhibition and secondary heterochromatin effects,<br />
+  and adds PP2A-complex membership plus a spatial-regulation core function; these<br />
+  results do not represent the sirtuin <a href="../../genes/yeast/HST1/HST1-ai-review.html">HST1</a>.<br />
 - <a href="../../genes/yeast/HST1/HST1-ai-review.html">HST1</a> (canonical P53685/YOL068C): 38 annotations → 15 ACCEPT, 8 KEEP_AS_NON_CORE, 11 MARK_AS_OVER_ANNOTATED, 2 REMOVE, 2 UNDECIDED. The review distinguishes native Sum1-Rfm1-<a href="../../genes/yeast/HST1/HST1-ai-review.html">Hst1</a> promoter repression from conditional Sum1-1 mating-type silencing and rejects Sir2-derived telomeric inferences.<br />
 - <a href="../../genes/yeast/HST2/HST2-ai-review.html">HST2</a>: 26 annotations → 21 ACCEPT (81%)<br />
 - <a href="../../genes/yeast/SIR2/SIR2-ai-review.html">SIR2</a>: 79 annotations → 50 ACCEPT (63%)</p>

--- a/projects/TOP_NOTS.md
+++ b/projects/TOP_NOTS.md
@@ -113,7 +113,6 @@ with no active site (the catalytic residues are in their partner subunit).
 | human | RUNX3 | Q13761 | `GO:0006468` protein phosphorylation | IDA | 5 |
 | human | SLC3A2 | P08195 | `GO:0005975` carbohydrate metabolic process | IEA | 5 |
 | mouse | Dnaja3 | Q99M87 | `GO:0005524` ATP binding | IEA | 5 |
-| yeast | ZDS1 | P50111 | `GO:0004864` protein phosphatase inhibitor activity | IMP | 5 |
 
 ### Wrong Binding, Localization, and Process (score 4-5)
 

--- a/projects/YEAST_EPIGENETICS_HISTONE_INHERITANCE.md
+++ b/projects/YEAST_EPIGENETICS_HISTONE_INHERITANCE.md
@@ -272,10 +272,10 @@ Last updated: 2026-08-12
 **Phase 2 - Histone Deacetylases (HDACs)**
 - RPD3: 160 annotations → 85 ACCEPT (53%)
 - HDA1: 38 annotations → 27 ACCEPT (71%)
-- ZDS1 (formerly misfiled as HST1): 28 consolidated review entries → 20 ACCEPT,
-  1 KEEP_AS_NON_CORE, 6 MARK_AS_OVER_ANNOTATED, 1 NEW. The corrected review retains
+- ZDS1 (formerly misfiled as HST1): 27 consolidated review entries → 9 ACCEPT,
+  11 KEEP_AS_NON_CORE, 7 MARK_AS_OVER_ANNOTATED. The corrected review retains
   direct ZDS1 evidence for PP2A-Cdc55 inhibition and secondary heterochromatin effects,
-  and adds PP2A-complex membership plus a spatial-regulation core function; these
+  and synthesizes a PP2A-Cdc55 spatial-regulation core function; these
   results do not represent the sirtuin HST1.
 - HST1 (canonical P53685/YOL068C): 38 annotations → 15 ACCEPT, 8 KEEP_AS_NON_CORE, 11 MARK_AS_OVER_ANNOTATED, 2 REMOVE, 2 UNDECIDED. The review distinguishes native Sum1-Rfm1-Hst1 promoter repression from conditional Sum1-1 mating-type silencing and rejects Sir2-derived telomeric inferences.
 - HST2: 26 annotations → 21 ACCEPT (81%)

--- a/projects/YEAST_EPIGENETICS_HISTONE_INHERITANCE.md
+++ b/projects/YEAST_EPIGENETICS_HISTONE_INHERITANCE.md
@@ -272,7 +272,11 @@ Last updated: 2026-08-12
 **Phase 2 - Histone Deacetylases (HDACs)**
 - RPD3: 160 annotations → 85 ACCEPT (53%)
 - HDA1: 38 annotations → 27 ACCEPT (71%)
-- ZDS1 (formerly misfiled as HST1): 40 annotations → 26 ACCEPT (65%); these results do not represent the sirtuin HST1
+- ZDS1 (formerly misfiled as HST1): 28 consolidated review entries → 20 ACCEPT,
+  1 KEEP_AS_NON_CORE, 6 MARK_AS_OVER_ANNOTATED, 1 NEW. The corrected review retains
+  direct ZDS1 evidence for PP2A-Cdc55 inhibition and secondary heterochromatin effects,
+  and adds PP2A-complex membership plus a spatial-regulation core function; these
+  results do not represent the sirtuin HST1.
 - HST1 (canonical P53685/YOL068C): 38 annotations → 15 ACCEPT, 8 KEEP_AS_NON_CORE, 11 MARK_AS_OVER_ANNOTATED, 2 REMOVE, 2 UNDECIDED. The review distinguishes native Sum1-Rfm1-Hst1 promoter repression from conditional Sum1-1 mating-type silencing and rejects Sir2-derived telomeric inferences.
 - HST2: 26 annotations → 21 ACCEPT (81%)
 - SIR2: 79 annotations → 50 ACCEPT (63%)


### PR DESCRIPTION
## Summary

- complete the canonical P50111/YMR273C ZDS1 review after the HST1 synonym-collision fix
- correct two unsafe initialized judgments: retain PMID:10662670 heterochromatin evidence as non-core and accept PMID:18762578 PP2A-Cdc55 inhibitor activity
- mark six generic protein-binding entries over-annotated
- add experimentally supported PP2A-complex membership and a core PP2A-Cdc55 spatial-regulation synthesis
- remove the false TOP_NOTS phosphatase-inhibitor flag and refresh the yeast epigenetics project summary

## Research provenance

The existing Falcon report is correctly grounded on ZDS1/P50111 despite stale former request metadata. `just deep-research-openscientist yeast ZDS1` was attempted twice; both runs correctly resolved ZDS1/P50111 but failed while polling the external provider (ConnectTimeout, then DNS ConnectError). No OpenScientist artifact was fabricated; the outage and evidence basis are recorded in `ZDS1-notes.md`.

## Validation

- `just validate yeast ZDS1` — valid, zero warnings
- `just test` — 1,648 pytest passed; 132 doctests passed; mypy and Ruff clean
- `just render yeast ZDS1`
- `just render-project YEAST_EPIGENETICS_HISTONE_INHERITANCE`
- `just deploy-browser`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 687c745b4f345fb8d7ed65f5e8c004170d0b47fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->