### PR TITLE
Keep no-hit UniProt resolver test offline

### DIFF
--- a/tests/test_organism_codes.py
+++ b/tests/test_organism_codes.py
@@ -430,14 +430,24 @@ class TestResolveGeneToUniprotPrimarySymbolPreference:
         # Must not have consulted TrEMBL for human
         assert mock_lookup.call_count == 1
 
+    @patch(
+        "ai_gene_review.etl.gene.fetch_uniprot_data",
+        side_effect=ValueError("not a real accession"),
+    )
     @patch("ai_gene_review.etl.gene.uniprot_by_gene_taxon")
-    def test_worm_no_hits_anywhere_raises(self, mock_lookup):
-        """Non-human gene with no Swiss-Prot or TrEMBL hits at all must raise."""
+    def test_worm_no_hits_anywhere_raises(self, mock_lookup, mock_fetch):
+        """Non-human gene with no Swiss-Prot or TrEMBL hits at all must raise.
+
+        ``nonexistent-gene`` matches the accession-like syntax checked before
+        gene-name lookup, so mock that preliminary fetch to keep this unit test
+        hermetic when UniProt DNS or network access is unavailable.
+        """
         mock_lookup.return_value = []
 
         with pytest.raises(ValueError):
             resolve_gene_to_uniprot("nonexistent-gene", "worm")
 
+        mock_fetch.assert_called_once_with("nonexistent-gene")
         # Should have tried both Swiss-Prot and TrEMBL
         assert mock_lookup.call_count == 2
 


### PR DESCRIPTION
## Summary

- mock the preliminary accession fetch in the non-human no-hit resolver unit test
- assert that the accession-like probe still occurs exactly once
- keep the test hermetic when `rest.uniprot.org` DNS/network is unavailable

The fixture gene `nonexistent-gene` matches the resolver's accession-like syntax, so mocking only `uniprot_by_gene_taxon` allowed an unexpected live request before the intended gene-name lookup assertions. The adjacent human synonym regression already uses this same isolation pattern.

## Validation

- `PYTEST_ADDOPTS='-q tests/test_organism_codes.py -k worm_no_hits_anywhere_raises' just pytest` — 1 passed
- `just test` — 1,648 pytest + 132 doctests passed; mypy and Ruff clean
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e85e2576198dd6a701a3ed9006ae76acb3fa97f6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->