### PR TITLE
Re-review specialized yeast SSQ1 chaperone

### DIFF
--- a/genes/yeast/SSQ1/SSQ1-ai-review.html
+++ b/genes/yeast/SSQ1/SSQ1-ai-review.html
@@ -1887,7 +1887,7 @@ elsewhere in this review rather than by the uninformative protein binding.
 
 
                         <div>
-                            <strong>Reason:</strong> This IPI records the Jac1 interaction (Q03020), but generic protein binding obscures the informative cochaperone/scaffold system already captured by the ATP-dependent chaperone and Fe-S transfer annotations.
+                            <strong>Reason:</strong> This IPI records binding to the physiological Isu1 scaffold (Q03020), Ssq1&#39;s LPPVK-motif client during Fe-S cluster release. The interaction is informative, but bare protein binding obscures the substrate-specific ATP-dependent chaperone and Fe-S transfer mechanism captured elsewhere.
                         </div>
 
 
@@ -1962,12 +1962,12 @@ elsewhere in this review rather than by the uninformative protein binding.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This IPI records interaction with Jac1 (Q03020), Ssq1&#39;s dedicated J-protein cochaperone, but generic protein binding is uninformative.
+                            <strong>Summary:</strong> This IPI records interaction with the Isu1 scaffold (Q03020), Ssq1&#39;s physiological LPPVK-motif client, but generic protein binding is uninformative.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Jac1-mediated stimulation of the Ssq1 ATPase cycle is represented more meaningfully by the chaperone and ISC transfer annotations.
+                            <strong>Reason:</strong> Isu1 binding is a central part of the Ssq1 chaperone cycle, but the ATP-dependent chaperone and ISC transfer annotations represent this substrate-specific mechanism more meaningfully than bare protein binding.
                         </div>
 
 
@@ -2026,12 +2026,12 @@ elsewhere in this review rather than by the uninformative protein binding.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This high-throughput IPI records interaction with mitochondrial Hsp70 Ssc1 (P15646), but generic protein binding is uninformative.
+                            <strong>Summary:</strong> This high-throughput IPI records Nop1 (P15646), a nucleolar protein, as the partner of matrix-localized Ssq1; this is likely a non-physiological high-throughput interaction, and generic protein binding is uninformative.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The interaction does not define Ssq1&#39;s activity; ATP-dependent chaperone action on Isu during ISC transfer is the biologically informative function.
+                            <strong>Reason:</strong> The compartmentally discordant Nop1 interaction is likely high-throughput background rather than part of Ssq1 biology; Ssq1&#39;s supported activity is ATP-dependent chaperone action on Isu during ISC transfer.
                         </div>
 
 
@@ -2090,12 +2090,12 @@ elsewhere in this review rather than by the uninformative protein binding.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This chaperone-network IPI records interaction with Ssc1 (P15646), but generic protein binding is uninformative.
+                            <strong>Summary:</strong> This chaperone-network IPI records Nop1 (P15646), a nucleolar protein, as the partner of mitochondrial-matrix Ssq1; the compartment mismatch makes this likely high-throughput background.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The Ssc1 interaction is ancillary to Ssq1&#39;s specialized Isu-directed ATP-dependent chaperone activity and ISC transfer role.
+                            <strong>Reason:</strong> A Nop1-Ssq1 interaction lacks a plausible shared cellular compartment and is not supported as part of the ISC pathway, whereas Ssq1&#39;s specialized Isu-directed ATP-dependent chaperone activity is well established.
                         </div>
 
 
@@ -2154,12 +2154,12 @@ elsewhere in this review rather than by the uninformative protein binding.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This interactome IPI records Jac1 (Q03020), the dedicated J-protein cochaperone of Ssq1, but generic protein binding is uninformative.
+                            <strong>Summary:</strong> This interactome IPI records Isu1 (Q03020), the physiological scaffold client of Ssq1, but generic protein binding is uninformative.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The partner-specific cochaperone relationship is already explained by the ATPase/chaperone mechanism and Fe-S transfer annotations.
+                            <strong>Reason:</strong> The partner-specific Isu1 substrate relationship is already explained by the ATP-dependent chaperone mechanism and Fe-S transfer annotations.
                         </div>
 
 
@@ -3768,6 +3768,10 @@ this with annotations you find in gene/protein databases, but these can be outda
 <li>Core mechanism: Jac1 recruits the Isu scaffold and stimulates the Ssq1 ATPase<br />
   cycle; Mge1 promotes nucleotide exchange; Ssq1 recognizes the Isu LPPVK motif<br />
   and drives release/handoff of the newly assembled cluster to Grx5.</li>
+<li>UniProt resolves the GOA IntAct partners directly: Q03020 is the physiological<br />
+  Isu1 scaffold client, whereas P15646 is the nucleolar protein Nop1. The Isu1<br />
+  rows are biologically relevant but poorly expressed by bare protein binding;<br />
+  the Nop1 rows are likely high-throughput background for a matrix protein.</li>
 <li>Generic family terms were narrowed where a more informative child exists:<br />
   GO:0044183 and GO:0051082 are modified to GO:0140662, generic nucleotide and<br />
   hydrolase parents are over-annotated, and mitochondrial matrix is the core<br />
@@ -4066,9 +4070,10 @@ existing_annotations:
       Grx5; these are better captured by the chaperone/Fe-S transfer terms
       elsewhere in this review rather than by the uninformative protein binding.
     action: MARK_AS_OVER_ANNOTATED
-    reason: This IPI records the Jac1 interaction (Q03020), but generic protein
-      binding obscures the informative cochaperone/scaffold system already captured
-      by the ATP-dependent chaperone and Fe-S transfer annotations.
+    reason: This IPI records binding to the physiological Isu1 scaffold (Q03020),
+      Ssq1&#39;s LPPVK-motif client during Fe-S cluster release. The interaction is
+      informative, but bare protein binding obscures the substrate-specific
+      ATP-dependent chaperone and Fe-S transfer mechanism captured elsewhere.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -4081,44 +4086,49 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:12947415
   review:
-    summary: This IPI records interaction with Jac1 (Q03020), Ssq1&#39;s dedicated
-      J-protein cochaperone, but generic protein binding is uninformative.
+    summary: This IPI records interaction with the Isu1 scaffold (Q03020), Ssq1&#39;s
+      physiological LPPVK-motif client, but generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Jac1-mediated stimulation of the Ssq1 ATPase cycle is represented more
-      meaningfully by the chaperone and ISC transfer annotations.
+    reason: Isu1 binding is a central part of the Ssq1 chaperone cycle, but the
+      ATP-dependent chaperone and ISC transfer annotations represent this
+      substrate-specific mechanism more meaningfully than bare protein binding.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
   review:
-    summary: This high-throughput IPI records interaction with mitochondrial Hsp70
-      Ssc1 (P15646), but generic protein binding is uninformative.
+    summary: This high-throughput IPI records Nop1 (P15646), a nucleolar protein,
+      as the partner of matrix-localized Ssq1; this is likely a non-physiological
+      high-throughput interaction, and generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: The interaction does not define Ssq1&#39;s activity; ATP-dependent chaperone
-      action on Isu during ISC transfer is the biologically informative function.
+    reason: The compartmentally discordant Nop1 interaction is likely
+      high-throughput background rather than part of Ssq1 biology; Ssq1&#39;s supported
+      activity is ATP-dependent chaperone action on Isu during ISC transfer.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
   review:
-    summary: This chaperone-network IPI records interaction with Ssc1 (P15646), but
-      generic protein binding is uninformative.
+    summary: This chaperone-network IPI records Nop1 (P15646), a nucleolar protein,
+      as the partner of mitochondrial-matrix Ssq1; the compartment mismatch makes
+      this likely high-throughput background.
     action: MARK_AS_OVER_ANNOTATED
-    reason: The Ssc1 interaction is ancillary to Ssq1&#39;s specialized Isu-directed
-      ATP-dependent chaperone activity and ISC transfer role.
+    reason: A Nop1-Ssq1 interaction lacks a plausible shared cellular compartment
+      and is not supported as part of the ISC pathway, whereas Ssq1&#39;s specialized
+      Isu-directed ATP-dependent chaperone activity is well established.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
   review:
-    summary: This interactome IPI records Jac1 (Q03020), the dedicated J-protein
-      cochaperone of Ssq1, but generic protein binding is uninformative.
+    summary: This interactome IPI records Isu1 (Q03020), the physiological scaffold
+      client of Ssq1, but generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: The partner-specific cochaperone relationship is already explained by
-      the ATPase/chaperone mechanism and Fe-S transfer annotations.
+    reason: The partner-specific Isu1 substrate relationship is already explained
+      by the ATP-dependent chaperone mechanism and Fe-S transfer annotations.
 - term:
     id: GO:0016226
     label: iron-sulfur cluster assembly

--- a/genes/yeast/SSQ1/SSQ1-ai-review.html
+++ b/genes/yeast/SSQ1/SSQ1-ai-review.html
@@ -879,10 +879,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -890,12 +890,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> The cytoplasm IBA is a family-level localization transfer that conflicts with Ssq1&#39;s mitochondrial targeting and experimentally supported matrix location.
+                            <strong>Summary:</strong> Cytoplasm is a true but uninformatively broad ancestor of Ssq1&#39;s experimentally supported mitochondrial matrix location.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Ssq1 is imported into the mitochondrial matrix, where it performs Fe-S cluster transfer. No Ssq1-specific evidence supports cytoplasmic activity; this broad IBA reflects localization diversity elsewhere in the Hsp70 family.
+                            <strong>Reason:</strong> Ssq1 is imported into the mitochondrial matrix for Fe-S cluster transfer. GO:0005737 includes mitochondria within the cytoplasm, so it is not false, but GO:0005759 describes the functional compartment much more precisely.
                         </div>
 
 
@@ -910,7 +910,7 @@
                             <div class="propagation-row">
                                 <strong>Failure modes:</strong>
 
-                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+                                <span class="badge">GRANULARITY MISMATCH</span>
 
                             </div>
 
@@ -924,10 +924,10 @@
                                     &middot; broad Hsp70 family localization node
 
 
-                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+                                    <span class="badge">SUPPORTS TRANSFER</span>
 
 
-                                    <div class="propagation-comment">Cytoplasmic Hsp70 family members support the source node, but the mitochondrial targeting and matrix localization of Ssq1 make this transfer unsafe.</div>
+                                    <div class="propagation-comment">The broad localization is ontologically true for mitochondrial proteins, but it is much less informative than Ssq1&#39;s matrix localization.</div>
 
                                 </div>
 
@@ -1056,7 +1056,7 @@ this ATPase activity to drive productive Fe-S transfer complex formation.
 
 
                         <div>
-                            <strong>Reason:</strong> Ssq1-specific loss-of-function phenotypes place it directly in the Fe-S cluster release/transfer stage of the ISC pathway.
+                            <strong>Reason:</strong> The Hsp70-family inference is correct for Ssq1 and is independently supported by its characterized ATPase cycle and Jac1/Isu1 stimulation.
                         </div>
 
 
@@ -1300,7 +1300,7 @@ off from the Isu1/Isu2 scaffold to the carrier Grx5.
 
 
                         <div>
-                            <strong>Reason:</strong> The mutant phenotype supports Ssq1 participation in [2Fe-2S] cluster maturation, specifically downstream transfer from the Isu scaffold.
+                            <strong>Reason:</strong> Phylogenetic transfer is safe because Ssq1-specific biochemical and genetic evidence independently establishes its ISC release/handoff role.
                         </div>
 
 
@@ -1887,7 +1887,7 @@ elsewhere in this review rather than by the uninformative protein binding.
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0005759 precisely identifies the lumenal mitochondrial compartment in which Ssq1 functions, making this generic ARBA term redundant.
+                            <strong>Reason:</strong> This IPI records the Jac1 interaction (Q03020), but generic protein binding obscures the informative cochaperone/scaffold system already captured by the ATP-dependent chaperone and Fe-S transfer annotations.
                         </div>
 
 
@@ -1962,12 +1962,12 @@ elsewhere in this review rather than by the uninformative protein binding.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for SSQ1.
+                            <strong>Summary:</strong> This IPI records interaction with Jac1 (Q03020), Ssq1&#39;s dedicated J-protein cochaperone, but generic protein binding is uninformative.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Jac1-mediated stimulation of the Ssq1 ATPase cycle is represented more meaningfully by the chaperone and ISC transfer annotations.
                         </div>
 
 
@@ -2026,12 +2026,12 @@ elsewhere in this review rather than by the uninformative protein binding.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for SSQ1.
+                            <strong>Summary:</strong> This high-throughput IPI records interaction with mitochondrial Hsp70 Ssc1 (P15646), but generic protein binding is uninformative.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> The interaction does not define Ssq1&#39;s activity; ATP-dependent chaperone action on Isu during ISC transfer is the biologically informative function.
                         </div>
 
 
@@ -2090,12 +2090,12 @@ elsewhere in this review rather than by the uninformative protein binding.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for SSQ1.
+                            <strong>Summary:</strong> This chaperone-network IPI records interaction with Ssc1 (P15646), but generic protein binding is uninformative.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> The Ssc1 interaction is ancillary to Ssq1&#39;s specialized Isu-directed ATP-dependent chaperone activity and ISC transfer role.
                         </div>
 
 
@@ -2154,12 +2154,12 @@ elsewhere in this review rather than by the uninformative protein binding.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for SSQ1.
+                            <strong>Summary:</strong> This interactome IPI records Jac1 (Q03020), the dedicated J-protein cochaperone of Ssq1, but generic protein binding is uninformative.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> The partner-specific cochaperone relationship is already explained by the ATPase/chaperone mechanism and Fe-S transfer annotations.
                         </div>
 
 
@@ -2626,7 +2626,7 @@ The ATP-dependent protein folding chaperone term better represents Ssq1&#39;s bi
 
 
                         <div>
-                            <strong>Reason:</strong> Unfolded protein binding is an obsolete-style activity proxy. Ssq1 is directly characterized as an ATP-dependent Hsp70 chaperone with a specialized Isu substrate, so GO:0140662 captures both mechanism and function.
+                            <strong>Reason:</strong> Unfolded protein binding is a valid but nonspecific activity proxy. Ssq1 is directly characterized as an ATP-dependent Hsp70 chaperone with a specialized Isu substrate, so GO:0140662 captures both mechanism and function.
                         </div>
 
 
@@ -2984,6 +2984,12 @@ proteins.</h3>
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016226" target="_blank" class="term-link">
                                 iron-sulfur cluster assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044571" target="_blank" class="term-link">
+                                [2Fe-2S] cluster assembly
                             </a>
                         </span>
 
@@ -3769,9 +3775,10 @@ this with annotations you find in gene/protein databases, but these can be outda
 <li>GO:0042026 protein refolding is an unsafe general-Hsp70 IBA transfer. Ssq1 is<br />
   specialized for the Isu client and ISC transfer rather than broad stress<br />
   refolding; the propagation audit records this functional divergence.</li>
-<li>The cytoplasm IBA is removed because it conflicts with Ssq1 mitochondrial<br />
-  targeting and direct matrix localization. Intracellular iron homeostasis is<br />
-  retained as a genuine downstream phenotype, not a core direct function.</li>
+<li>The cytoplasm IBA is ontologically true because mitochondria are part of the<br />
+  GO cytoplasm, but it is marked over-annotated because matrix is the precise<br />
+  functional compartment. Intracellular iron homeostasis is retained as a<br />
+  genuine downstream phenotype, not a core direct function.</li>
 </ul>
             </div>
         </details>
@@ -3813,22 +3820,22 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: The cytoplasm IBA is a family-level localization transfer that conflicts
-      with Ssq1&#39;s mitochondrial targeting and experimentally supported matrix location.
-    action: REMOVE
-    reason: Ssq1 is imported into the mitochondrial matrix, where it performs Fe-S
-      cluster transfer. No Ssq1-specific evidence supports cytoplasmic activity; this
-      broad IBA reflects localization diversity elsewhere in the Hsp70 family.
+    summary: Cytoplasm is a true but uninformatively broad ancestor of Ssq1&#39;s
+      experimentally supported mitochondrial matrix location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Ssq1 is imported into the mitochondrial matrix for Fe-S cluster transfer.
+      GO:0005737 includes mitochondria within the cytoplasm, so it is not false, but
+      GO:0005759 describes the functional compartment much more precisely.
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
-      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      - GRANULARITY_MISMATCH
       source_entities:
       - source_id: PANTHER:PTN002321897
         source_label: broad Hsp70 family localization node
-        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
-        comment: Cytoplasmic Hsp70 family members support the source node, but the
-          mitochondrial targeting and matrix localization of Ssq1 make this transfer unsafe.
+        source_status: SUPPORTS_TRANSFER
+        comment: The broad localization is ontologically true for mitochondrial
+          proteins, but it is much less informative than Ssq1&#39;s matrix localization.
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -3856,8 +3863,8 @@ existing_annotations:
       hydrolysis to its chaperone cycle; Jac1 and Isu1 synergistically stimulate
       this ATPase activity to drive productive Fe-S transfer complex formation.
     action: ACCEPT
-    reason: Ssq1-specific loss-of-function phenotypes place it directly in the
-      Fe-S cluster release/transfer stage of the ISC pathway.
+    reason: The Hsp70-family inference is correct for Ssq1 and is independently
+      supported by its characterized ATPase cycle and Jac1/Isu1 stimulation.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3921,8 +3928,8 @@ existing_annotations:
       ATP-dependent transfer/release step, handing the nascent [2Fe-2S] cluster
       off from the Isu1/Isu2 scaffold to the carrier Grx5.
     action: ACCEPT
-    reason: The mutant phenotype supports Ssq1 participation in [2Fe-2S] cluster
-      maturation, specifically downstream transfer from the Isu scaffold.
+    reason: Phylogenetic transfer is safe because Ssq1-specific biochemical and
+      genetic evidence independently establishes its ISC release/handoff role.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -4059,8 +4066,9 @@ existing_annotations:
       Grx5; these are better captured by the chaperone/Fe-S transfer terms
       elsewhere in this review rather than by the uninformative protein binding.
     action: MARK_AS_OVER_ANNOTATED
-    reason: GO:0005759 precisely identifies the lumenal mitochondrial compartment
-      in which Ssq1 functions, making this generic ARBA term redundant.
+    reason: This IPI records the Jac1 interaction (Q03020), but generic protein
+      binding obscures the informative cochaperone/scaffold system already captured
+      by the ATP-dependent chaperone and Fe-S transfer annotations.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -4073,36 +4081,44 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:12947415
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for SSQ1.&#39;
+    summary: This IPI records interaction with Jac1 (Q03020), Ssq1&#39;s dedicated
+      J-protein cochaperone, but generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Jac1-mediated stimulation of the Ssq1 ATPase cycle is represented more
+      meaningfully by the chaperone and ISC transfer annotations.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for SSQ1.&#39;
+    summary: This high-throughput IPI records interaction with mitochondrial Hsp70
+      Ssc1 (P15646), but generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: The interaction does not define Ssq1&#39;s activity; ATP-dependent chaperone
+      action on Isu during ISC transfer is the biologically informative function.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for SSQ1.&#39;
+    summary: This chaperone-network IPI records interaction with Ssc1 (P15646), but
+      generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: The Ssc1 interaction is ancillary to Ssq1&#39;s specialized Isu-directed
+      ATP-dependent chaperone activity and ISC transfer role.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for SSQ1.&#39;
+    summary: This interactome IPI records Jac1 (Q03020), the dedicated J-protein
+      cochaperone of Ssq1, but generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: The partner-specific cochaperone relationship is already explained by
+      the ATPase/chaperone mechanism and Fe-S transfer annotations.
 - term:
     id: GO:0016226
     label: iron-sulfur cluster assembly
@@ -4208,7 +4224,7 @@ existing_annotations:
       conserved LPPVK peptide motif rather than generic unfolded proteins.
       The ATP-dependent protein folding chaperone term better represents Ssq1&#39;s biology.
     action: MODIFY
-    reason: Unfolded protein binding is an obsolete-style activity proxy. Ssq1 is
+    reason: Unfolded protein binding is a valid but nonspecific activity proxy. Ssq1 is
       directly characterized as an ATP-dependent Hsp70 chaperone with a specialized
       Isu substrate, so GO:0140662 captures both mechanism and function.
     proposed_replacement_terms:
@@ -4384,6 +4400,8 @@ core_functions:
   directly_involved_in:
   - id: GO:0016226
     label: iron-sulfur cluster assembly
+  - id: GO:0044571
+    label: &#39;[2Fe-2S] cluster assembly&#39;
   locations:
   - id: GO:0005759
     label: mitochondrial matrix

--- a/genes/yeast/SSQ1/SSQ1-ai-review.html
+++ b/genes/yeast/SSQ1/SSQ1-ai-review.html
@@ -904,7 +904,7 @@
                             <div class="propagation-title">Propagation Review</div>
                             <div class="propagation-row">
                                 <strong>Root cause:</strong>
-                                <span class="badge">PROPAGATION BAD</span>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
                             </div>
 
                             <div class="propagation-row">
@@ -3827,7 +3827,7 @@ existing_annotations:
       GO:0005737 includes mitochondria within the cytoplasm, so it is not false, but
       GO:0005759 describes the functional compartment much more precisely.
     propagation_review:
-      root_cause: PROPAGATION_BAD
+      root_cause: TERM_SCOPING_PROBLEM
       failure_modes:
       - GRANULARITY_MISMATCH
       source_entities:

--- a/genes/yeast/SSQ1/SSQ1-ai-review.html
+++ b/genes/yeast/SSQ1/SSQ1-ai-review.html
@@ -879,10 +879,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -890,14 +890,50 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm may be context-dependent or peripheral for SSQ1.
+                            <strong>Summary:</strong> The cytoplasm IBA is a family-level localization transfer that conflicts with Ssq1&#39;s mitochondrial targeting and experimentally supported matrix location.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Ssq1 is imported into the mitochondrial matrix, where it performs Fe-S cluster transfer. No Ssq1-specific evidence supports cytoplasmic activity; this broad IBA reflects localization diversity elsewhere in the Hsp70 family.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002321897</span>
+
+                                    &middot; broad Hsp70 family localization node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Cytoplasmic Hsp70 family members support the source node, but the mitochondrial targeting and matrix localization of Ssq1 make this transfer unsafe.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -932,10 +968,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -943,12 +979,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> Mitochondrion is correct but less precise than the experimentally supported mitochondrial matrix localization.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Retain the broad organelle localization as correct context; GO:0005759 captures the core site of Ssq1 activity more precisely.
                         </div>
 
 
@@ -1020,7 +1056,7 @@ this ATPase activity to drive productive Fe-S transfer complex formation.
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Ssq1-specific loss-of-function phenotypes place it directly in the Fe-S cluster release/transfer stage of the ISC pathway.
                         </div>
 
 
@@ -1073,10 +1109,10 @@ this ATPase activity to drive productive Fe-S transfer complex formation.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0031072" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0031072" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1084,12 +1120,12 @@ this ATPase activity to drive productive Fe-S transfer complex formation.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: heat shock protein binding is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> Ssq1 participates in an Hsp70 cochaperone system with Jac1 and Mge1, but this binding term is ancillary to its ATP-dependent chaperone activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The cochaperone interactions are real, but heat shock protein binding does not describe Ssq1&#39;s direct core activity in Fe-S cluster transfer.
                         </div>
 
 
@@ -1126,10 +1162,10 @@ this ATPase activity to drive productive Fe-S transfer complex formation.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0044183" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0044183" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1137,18 +1173,65 @@ this ATPase activity to drive productive Fe-S transfer complex formation.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding chaperone reflects the Hsp70 fold and
-chaperone mechanism of SSQ1. Note that Ssq1 is a highly specialized Hsp70
+                            <strong>Summary:</strong> Protein folding chaperone reflects the Hsp70 fold and chaperone mechanism
+of Ssq1. Ssq1 is a highly specialized Hsp70
 whose native client is the Fe-S scaffold Isu1 (recognized via its LPPVK
 motif), rather than a general-purpose folding chaperone like Ssc1.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The annotation is sound, but GO:0140662 specifies the experimentally established ATP-dependent Hsp70 mechanism.
                         </div>
 
 
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; Hsp70 ATPase/chaperone node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The family-level chaperone inference is correct for Ssq1; the directly characterized ATP-driven mechanism supports the more precise GO:0140662 child term.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -1217,7 +1300,7 @@ off from the Isu1/Isu2 scaffold to the carrier Grx5.
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The mutant phenotype supports Ssq1 participation in [2Fe-2S] cluster maturation, specifically downstream transfer from the Isu scaffold.
                         </div>
 
 
@@ -1300,6 +1383,44 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; general Hsp70 ATPase/chaperone node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">General Hsp70s refold stress-denatured clients, whereas Ssq1 has specialized for the Isu scaffold and Fe-S cluster transfer.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1348,10 +1469,10 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1359,12 +1480,12 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleotide binding is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> Generic nucleotide binding is true but uninformative relative to ATP binding and directly measured ATP hydrolysis.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The broad parent adds no useful specificity beyond GO:0005524 and GO:0016887, which describe the relevant nucleotide and catalytic activity.
                         </div>
 
 
@@ -1401,10 +1522,10 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005524" data-r="GO_REF:0000120" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005524" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1412,12 +1533,12 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP binding is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> ATP binding is required for Ssq1&#39;s Hsp70 chaperone cycle.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Correct mechanistic activity, retained as non-core because the directly measured ATP hydrolysis term is more informative.
                         </div>
 
 
@@ -1454,10 +1575,10 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005739" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005739" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1465,12 +1586,12 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> Mitochondrion is correct but less precise than mitochondrial matrix.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Retain as a correct broad localization while using GO:0005759 for the core site of activity.
                         </div>
 
 
@@ -1518,12 +1639,12 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrial matrix is the correct subcellular location of SSQ1, where it performs Fe-S cluster transfer.
+                            <strong>Summary:</strong> Mitochondrial matrix is the precise site of Ssq1-mediated Fe-S cluster transfer.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The mitochondrial targeting sequence and localization evidence agree with the compartment in which the ISC machinery operates.
                         </div>
 
 
@@ -1576,10 +1697,10 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0016787" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0016787" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1587,12 +1708,12 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: hydrolase activity is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> Generic hydrolase activity is an over-broad parent of Ssq1&#39;s ATP hydrolysis activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> GO:0016887 gives the experimentally established catalytic activity; retaining the generic hydrolase parent as core would obscure that specificity.
                         </div>
 
 
@@ -1640,12 +1761,12 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP hydrolysis activity is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> Ssq1 is an Hsp70 ATPase whose catalytic cycle drives Isu engagement and Fe-S cluster release.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The InterPro transfer is independently supported by direct biochemical measurement of Ssq1 ATPase activity.
                         </div>
 
 
@@ -1682,10 +1803,10 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0070013" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0070013" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1693,12 +1814,12 @@ over-annotation since more specific terms capture Ssq1&#39;s biology.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: intracellular organelle lumen is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> Intracellular organelle lumen is a very broad parent of the mitochondrial matrix localization.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> GO:0005759 precisely identifies the lumenal mitochondrial compartment in which Ssq1 functions, making this generic ARBA term redundant.
                         </div>
 
 
@@ -1766,7 +1887,7 @@ elsewhere in this review rather than by the uninformative protein binding.
 
 
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> GO:0005759 precisely identifies the lumenal mitochondrial compartment in which Ssq1 functions, making this generic ARBA term redundant.
                         </div>
 
 
@@ -2107,7 +2228,7 @@ transfer step rather than de novo synthesis.
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Ssq1-specific loss-of-function phenotypes place it directly in the Fe-S cluster release/transfer stage of the ISC pathway.
                         </div>
 
 
@@ -2190,7 +2311,7 @@ this cluster to the downstream carrier Grx5.
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The mutant phenotype supports Ssq1 participation in [2Fe-2S] cluster maturation, specifically downstream transfer from the Isu scaffold.
                         </div>
 
 
@@ -2254,10 +2375,10 @@ this cluster to the downstream carrier Grx5.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005739" data-r="PMID:11273703" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005739" data-r="PMID:11273703" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2265,12 +2386,12 @@ this cluster to the downstream carrier Grx5.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> The mitochondrial phenotype is consistent with Ssq1&#39;s matrix-localized role, but mitochondrion is less precise than the matrix term.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Retain this broad localization context while using GO:0005759 for the core compartment.
                         </div>
 
 
@@ -2338,7 +2459,7 @@ primary defect in Fe-S cluster maturation. Kept as non-core.
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Mitochondrial iron accumulation is a well-supported downstream consequence of impaired Fe-S cluster maturation, not Ssq1&#39;s direct activity.
                         </div>
 
 
@@ -2421,7 +2542,7 @@ Mge1 acting as the nucleotide exchange factor that resets the cycle.
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Biochemical assays directly establish the ATPase cycle that drives Ssq1 substrate engagement and release.
                         </div>
 
 
@@ -2500,12 +2621,12 @@ Mge1 acting as the nucleotide exchange factor that resets the cycle.
 substrate-binding behavior, but for this specialized chaperone the
 physiological client is the folded Isu1 scaffold recognized via its
 conserved LPPVK peptide motif rather than generic unfolded proteins.
-The protein folding chaperone term better represents Ssq1&#39;s biology.
+The ATP-dependent protein folding chaperone term better represents Ssq1&#39;s biology.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Unfolded protein binding is an obsolete-style activity proxy. Ssq1 is directly characterized as an ATP-dependent Hsp70 chaperone with a specialized Isu substrate, so GO:0140662 captures both mechanism and function.
                         </div>
 
 
@@ -2514,8 +2635,8 @@ The protein folding chaperone term better represents Ssq1&#39;s biology.
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
 
@@ -2580,10 +2701,10 @@ The protein folding chaperone term better represents Ssq1&#39;s biology.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005739" data-r="PMID:24769239" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005739" data-r="PMID:24769239" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2591,12 +2712,12 @@ The protein folding chaperone term better represents Ssq1&#39;s biology.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> Mitochondrial proteomics supports the organelle assignment but not a more specific function than the matrix-localized ISC role.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Correct broad localization; mitochondrial matrix is the core location.
                         </div>
 
 
@@ -2644,10 +2765,10 @@ The protein folding chaperone term better represents Ssq1&#39;s biology.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005739" data-r="PMID:16823961" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q05931" data-a="GO:0005739" data-r="PMID:16823961" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2655,12 +2776,12 @@ The protein folding chaperone term better represents Ssq1&#39;s biology.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> Mitochondrial proteomics supports the organelle assignment but not a more specific function than the matrix-localized ISC role.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Correct broad localization; mitochondrial matrix is the core location.
                         </div>
 
 
@@ -2719,12 +2840,12 @@ The protein folding chaperone term better represents Ssq1&#39;s biology.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrial matrix is consistent with known biology of SSQ1.
+                            <strong>Summary:</strong> Direct localization places Ssq1 in the mitochondrial matrix, the site of its Fe-S cluster transfer activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct experimental localization supports the precise core compartment.
                         </div>
 
 
@@ -2791,7 +2912,7 @@ driving the ATP-dependent Fe-S transfer step from Isu1 to Grx5.
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Independent mutant evidence supports Ssq1 as a core ISC transfer chaperone required for maturation of Fe-S proteins.
                         </div>
 
 
@@ -2848,8 +2969,8 @@ proteins.</h3>
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                            protein folding chaperone
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                            ATP-dependent protein folding chaperone
                         </a>
                     </span>
                 </div>
@@ -3614,6 +3735,49 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SSQ1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q05931" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ssq1-review-notes">SSQ1 review notes</h1>
+<h2 id="2026-08-12-re-review">2026-08-12 re-review</h2>
+<ul>
+<li>Identity verified as <em>Saccharomyces cerevisiae</em> SSQ1/YLR369W, UniProt Q05931,<br />
+  the mitochondrial Ssq-type Hsp70 dedicated to iron-sulfur cluster biogenesis.</li>
+<li>The existing Falcon report is correctly scoped to Q05931. An OpenScientist<br />
+  run was launched through <code>just deep-research-openscientist yeast SSQ1</code>; after<br />
+  extended silent polling without a returned artifact it was interrupted. No<br />
+  unreturned result was treated as evidence.</li>
+<li>Core mechanism: Jac1 recruits the Isu scaffold and stimulates the Ssq1 ATPase<br />
+  cycle; Mge1 promotes nucleotide exchange; Ssq1 recognizes the Isu LPPVK motif<br />
+  and drives release/handoff of the newly assembled cluster to Grx5.</li>
+<li>Generic family terms were narrowed where a more informative child exists:<br />
+  GO:0044183 and GO:0051082 are modified to GO:0140662, generic nucleotide and<br />
+  hydrolase parents are over-annotated, and mitochondrial matrix is the core<br />
+  location rather than its broad organelle/lumen parents.</li>
+<li>GO:0042026 protein refolding is an unsafe general-Hsp70 IBA transfer. Ssq1 is<br />
+  specialized for the Isu client and ISC transfer rather than broad stress<br />
+  refolding; the propagation audit records this functional divergence.</li>
+<li>The cytoplasm IBA is removed because it conflicts with Ssq1 mitochondrial<br />
+  targeting and direct matrix localization. Intracellular iron homeostasis is<br />
+  retained as a genuine downstream phenotype, not a core direct function.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3649,18 +3813,33 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: cytoplasm may be context-dependent or peripheral for SSQ1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: The cytoplasm IBA is a family-level localization transfer that conflicts
+      with Ssq1&#39;s mitochondrial targeting and experimentally supported matrix location.
+    action: REMOVE
+    reason: Ssq1 is imported into the mitochondrial matrix, where it performs Fe-S
+      cluster transfer. No Ssq1-specific evidence supports cytoplasmic activity; this
+      broad IBA reflects localization diversity elsewhere in the Hsp70 family.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN002321897
+        source_label: broad Hsp70 family localization node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Cytoplasmic Hsp70 family members support the source node, but the
+          mitochondrial targeting and matrix localization of Ssq1 make this transfer unsafe.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: mitochondrion is consistent with known biology of SSQ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Mitochondrion is correct but less precise than the experimentally supported
+      mitochondrial matrix localization.
+    action: KEEP_AS_NON_CORE
+    reason: Retain the broad organelle localization as correct context; GO:0005759
+      captures the core site of Ssq1 activity more precisely.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3677,7 +3856,8 @@ existing_annotations:
       hydrolysis to its chaperone cycle; Jac1 and Isu1 synergistically stimulate
       this ATPase activity to drive productive Fe-S transfer complex formation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Ssq1-specific loss-of-function phenotypes place it directly in the
+      Fe-S cluster release/transfer stage of the ISC pathway.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3690,9 +3870,11 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: heat shock protein binding is consistent with known biology of SSQ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Ssq1 participates in an Hsp70 cochaperone system with Jac1 and Mge1,
+      but this binding term is ancillary to its ATP-dependent chaperone activity.
+    action: KEEP_AS_NON_CORE
+    reason: The cochaperone interactions are real, but heat shock protein binding does
+      not describe Ssq1&#39;s direct core activity in Fe-S cluster transfer.
 - term:
     id: GO:0044183
     label: protein folding chaperone
@@ -3700,18 +3882,33 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: |-
-      Manual review: protein folding chaperone reflects the Hsp70 fold and
-      chaperone mechanism of SSQ1. Note that Ssq1 is a highly specialized Hsp70
+      Protein folding chaperone reflects the Hsp70 fold and chaperone mechanism
+      of Ssq1. Ssq1 is a highly specialized Hsp70
       whose native client is the Fe-S scaffold Isu1 (recognized via its LPPVK
       motif), rather than a general-purpose folding chaperone like Ssc1.
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    action: MODIFY
+    reason: The annotation is sound, but GO:0140662 specifies the experimentally
+      established ATP-dependent Hsp70 mechanism.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: Ssq1 recognizes the scaffold **Isu1** through the conserved
         **LPPVK** motif (a peptide loop) that engages the Hsp70 substrate-binding
         site
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: Hsp70 ATPase/chaperone node
+        source_status: SUPPORTS_TRANSFER
+        comment: The family-level chaperone inference is correct for Ssq1; the
+          directly characterized ATP-driven mechanism supports the more precise
+          GO:0140662 child term.
 - term:
     id: GO:0016226
     label: iron-sulfur cluster assembly
@@ -3724,7 +3921,8 @@ existing_annotations:
       ATP-dependent transfer/release step, handing the nascent [2Fe-2S] cluster
       off from the Isu1/Isu2 scaffold to the carrier Grx5.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The mutant phenotype supports Ssq1 participation in [2Fe-2S] cluster
+      maturation, specifically downstream transfer from the Isu scaffold.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3758,42 +3956,59 @@ existing_annotations:
         system with a narrowly defined native client (the ISC scaffold Isu)**, supporting
         the view that Ssq1’s primary function is to catalyze a specific Fe–S transfer
         step rather than general mitochondrial proteostasis
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: general Hsp70 ATPase/chaperone node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: General Hsp70s refold stress-denatured clients, whereas Ssq1 has
+          specialized for the Isu scaffold and Fe-S cluster transfer.
 - term:
     id: GO:0000166
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: &#39;Manual review: nucleotide binding is consistent with known biology of SSQ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Generic nucleotide binding is true but uninformative relative to ATP
+      binding and directly measured ATP hydrolysis.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The broad parent adds no useful specificity beyond GO:0005524 and
+      GO:0016887, which describe the relevant nucleotide and catalytic activity.
 - term:
     id: GO:0005524
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: ATP binding is consistent with known biology of SSQ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: ATP binding is required for Ssq1&#39;s Hsp70 chaperone cycle.
+    action: KEEP_AS_NON_CORE
+    reason: Correct mechanistic activity, retained as non-core because the directly
+      measured ATP hydrolysis term is more informative.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;Manual review: mitochondrion is consistent with known biology of SSQ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Mitochondrion is correct but less precise than mitochondrial matrix.
+    action: KEEP_AS_NON_CORE
+    reason: Retain as a correct broad localization while using GO:0005759 for the
+      core site of activity.
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Manual review: mitochondrial matrix is the correct subcellular location of SSQ1, where it performs Fe-S cluster transfer.&#39;
+    summary: Mitochondrial matrix is the precise site of Ssq1-mediated Fe-S
+      cluster transfer.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The mitochondrial targeting sequence and localization evidence agree
+      with the compartment in which the ISC machinery operates.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3804,27 +4019,33 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: &#39;Manual review: hydrolase activity is consistent with known biology of SSQ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Generic hydrolase activity is an over-broad parent of Ssq1&#39;s ATP
+      hydrolysis activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: GO:0016887 gives the experimentally established catalytic activity;
+      retaining the generic hydrolase parent as core would obscure that specificity.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: &#39;Manual review: ATP hydrolysis activity is consistent with known biology of SSQ1.&#39;
+    summary: Ssq1 is an Hsp70 ATPase whose catalytic cycle drives Isu engagement
+      and Fe-S cluster release.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The InterPro transfer is independently supported by direct biochemical
+      measurement of Ssq1 ATPase activity.
 - term:
     id: GO:0070013
     label: intracellular organelle lumen
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;Manual review: intracellular organelle lumen is consistent with known biology of SSQ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Intracellular organelle lumen is a very broad parent of the mitochondrial
+      matrix localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: GO:0005759 precisely identifies the lumenal mitochondrial compartment in
+      which Ssq1 functions, making this generic ARBA term redundant.
 - term:
     id: GO:0005515
     label: protein binding
@@ -3838,7 +4059,8 @@ existing_annotations:
       Grx5; these are better captured by the chaperone/Fe-S transfer terms
       elsewhere in this review rather than by the uninformative protein binding.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: GO:0005759 precisely identifies the lumenal mitochondrial compartment
+      in which Ssq1 functions, making this generic ARBA term redundant.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3895,7 +4117,8 @@ existing_annotations:
       Fe-S clusters accumulate on the Isu1 scaffold, indicating a block in the
       transfer step rather than de novo synthesis.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Ssq1-specific loss-of-function phenotypes place it directly in the
+      Fe-S cluster release/transfer stage of the ISC pathway.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3913,7 +4136,8 @@ existing_annotations:
       scaffold, and Ssq1 (with Jac1 and Mge1) mediates the release/transfer of
       this cluster to the downstream carrier Grx5.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The mutant phenotype supports Ssq1 participation in [2Fe-2S] cluster
+      maturation, specifically downstream transfer from the Isu scaffold.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3927,9 +4151,11 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:11273703
   review:
-    summary: &#39;Manual review: mitochondrion is consistent with known biology of SSQ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: The mitochondrial phenotype is consistent with Ssq1&#39;s matrix-localized
+      role, but mitochondrion is less precise than the matrix term.
+    action: KEEP_AS_NON_CORE
+    reason: Retain this broad localization context while using GO:0005759 for the
+      core compartment.
 - term:
     id: GO:0006879
     label: intracellular iron ion homeostasis
@@ -3943,7 +4169,8 @@ existing_annotations:
       mitochondrial iron, but this iron dysregulation is secondary to the
       primary defect in Fe-S cluster maturation. Kept as non-core.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Mitochondrial iron accumulation is a well-supported downstream
+      consequence of impaired Fe-S cluster maturation, not Ssq1&#39;s direct activity.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3960,7 +4187,8 @@ existing_annotations:
       stimulated by the J-protein Jac1 together with the Isu1 substrate, with
       Mge1 acting as the nucleotide exchange factor that resets the cycle.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Biochemical assays directly establish the ATPase cycle that drives
+      Ssq1 substrate engagement and release.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3978,12 +4206,14 @@ existing_annotations:
       substrate-binding behavior, but for this specialized chaperone the
       physiological client is the folded Isu1 scaffold recognized via its
       conserved LPPVK peptide motif rather than generic unfolded proteins.
-      The protein folding chaperone term better represents Ssq1&#39;s biology.
+      The ATP-dependent protein folding chaperone term better represents Ssq1&#39;s biology.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Unfolded protein binding is an obsolete-style activity proxy. Ssq1 is
+      directly characterized as an ATP-dependent Hsp70 chaperone with a specialized
+      Isu substrate, so GO:0140662 captures both mechanism and function.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -3996,27 +4226,30 @@ existing_annotations:
   evidence_type: HDA
   original_reference_id: PMID:24769239
   review:
-    summary: &#39;Manual review: mitochondrion is consistent with known biology of SSQ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Mitochondrial proteomics supports the organelle assignment but not a
+      more specific function than the matrix-localized ISC role.
+    action: KEEP_AS_NON_CORE
+    reason: Correct broad localization; mitochondrial matrix is the core location.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HDA
   original_reference_id: PMID:16823961
   review:
-    summary: &#39;Manual review: mitochondrion is consistent with known biology of SSQ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Mitochondrial proteomics supports the organelle assignment but not a
+      more specific function than the matrix-localized ISC role.
+    action: KEEP_AS_NON_CORE
+    reason: Correct broad localization; mitochondrial matrix is the core location.
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: IDA
   original_reference_id: PMID:8707841
   review:
-    summary: &#39;Manual review: mitochondrial matrix is consistent with known biology of SSQ1.&#39;
+    summary: Direct localization places Ssq1 in the mitochondrial matrix, the site
+      of its Fe-S cluster transfer activity.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct experimental localization supports the precise core compartment.
 - term:
     id: GO:0016226
     label: iron-sulfur cluster assembly
@@ -4029,7 +4262,8 @@ existing_annotations:
       assembly, consistent with its established role as the specialized Hsp70
       driving the ATP-dependent Fe-S transfer step from Isu1 to Grx5.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Independent mutant evidence supports Ssq1 as a core ISC transfer
+      chaperone required for maturation of Fe-S proteins.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -4145,8 +4379,8 @@ core_functions:
     and its handoff to the carrier Grx5, enabling maturation of cellular Fe-S
     proteins.
   molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
   directly_involved_in:
   - id: GO:0016226
     label: iron-sulfur cluster assembly

--- a/genes/yeast/SSQ1/SSQ1-ai-review.yaml
+++ b/genes/yeast/SSQ1/SSQ1-ai-review.yaml
@@ -271,9 +271,10 @@ existing_annotations:
       Grx5; these are better captured by the chaperone/Fe-S transfer terms
       elsewhere in this review rather than by the uninformative protein binding.
     action: MARK_AS_OVER_ANNOTATED
-    reason: This IPI records the Jac1 interaction (Q03020), but generic protein
-      binding obscures the informative cochaperone/scaffold system already captured
-      by the ATP-dependent chaperone and Fe-S transfer annotations.
+    reason: This IPI records binding to the physiological Isu1 scaffold (Q03020),
+      Ssq1's LPPVK-motif client during Fe-S cluster release. The interaction is
+      informative, but bare protein binding obscures the substrate-specific
+      ATP-dependent chaperone and Fe-S transfer mechanism captured elsewhere.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -286,44 +287,49 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:12947415
   review:
-    summary: This IPI records interaction with Jac1 (Q03020), Ssq1's dedicated
-      J-protein cochaperone, but generic protein binding is uninformative.
+    summary: This IPI records interaction with the Isu1 scaffold (Q03020), Ssq1's
+      physiological LPPVK-motif client, but generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Jac1-mediated stimulation of the Ssq1 ATPase cycle is represented more
-      meaningfully by the chaperone and ISC transfer annotations.
+    reason: Isu1 binding is a central part of the Ssq1 chaperone cycle, but the
+      ATP-dependent chaperone and ISC transfer annotations represent this
+      substrate-specific mechanism more meaningfully than bare protein binding.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
   review:
-    summary: This high-throughput IPI records interaction with mitochondrial Hsp70
-      Ssc1 (P15646), but generic protein binding is uninformative.
+    summary: This high-throughput IPI records Nop1 (P15646), a nucleolar protein,
+      as the partner of matrix-localized Ssq1; this is likely a non-physiological
+      high-throughput interaction, and generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: The interaction does not define Ssq1's activity; ATP-dependent chaperone
-      action on Isu during ISC transfer is the biologically informative function.
+    reason: The compartmentally discordant Nop1 interaction is likely
+      high-throughput background rather than part of Ssq1 biology; Ssq1's supported
+      activity is ATP-dependent chaperone action on Isu during ISC transfer.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
   review:
-    summary: This chaperone-network IPI records interaction with Ssc1 (P15646), but
-      generic protein binding is uninformative.
+    summary: This chaperone-network IPI records Nop1 (P15646), a nucleolar protein,
+      as the partner of mitochondrial-matrix Ssq1; the compartment mismatch makes
+      this likely high-throughput background.
     action: MARK_AS_OVER_ANNOTATED
-    reason: The Ssc1 interaction is ancillary to Ssq1's specialized Isu-directed
-      ATP-dependent chaperone activity and ISC transfer role.
+    reason: A Nop1-Ssq1 interaction lacks a plausible shared cellular compartment
+      and is not supported as part of the ISC pathway, whereas Ssq1's specialized
+      Isu-directed ATP-dependent chaperone activity is well established.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
   review:
-    summary: This interactome IPI records Jac1 (Q03020), the dedicated J-protein
-      cochaperone of Ssq1, but generic protein binding is uninformative.
+    summary: This interactome IPI records Isu1 (Q03020), the physiological scaffold
+      client of Ssq1, but generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: The partner-specific cochaperone relationship is already explained by
-      the ATPase/chaperone mechanism and Fe-S transfer annotations.
+    reason: The partner-specific Isu1 substrate relationship is already explained
+      by the ATP-dependent chaperone mechanism and Fe-S transfer annotations.
 - term:
     id: GO:0016226
     label: iron-sulfur cluster assembly

--- a/genes/yeast/SSQ1/SSQ1-ai-review.yaml
+++ b/genes/yeast/SSQ1/SSQ1-ai-review.yaml
@@ -25,22 +25,22 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: The cytoplasm IBA is a family-level localization transfer that conflicts
-      with Ssq1's mitochondrial targeting and experimentally supported matrix location.
-    action: REMOVE
-    reason: Ssq1 is imported into the mitochondrial matrix, where it performs Fe-S
-      cluster transfer. No Ssq1-specific evidence supports cytoplasmic activity; this
-      broad IBA reflects localization diversity elsewhere in the Hsp70 family.
+    summary: Cytoplasm is a true but uninformatively broad ancestor of Ssq1's
+      experimentally supported mitochondrial matrix location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Ssq1 is imported into the mitochondrial matrix for Fe-S cluster transfer.
+      GO:0005737 includes mitochondria within the cytoplasm, so it is not false, but
+      GO:0005759 describes the functional compartment much more precisely.
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
-      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      - GRANULARITY_MISMATCH
       source_entities:
       - source_id: PANTHER:PTN002321897
         source_label: broad Hsp70 family localization node
-        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
-        comment: Cytoplasmic Hsp70 family members support the source node, but the
-          mitochondrial targeting and matrix localization of Ssq1 make this transfer unsafe.
+        source_status: SUPPORTS_TRANSFER
+        comment: The broad localization is ontologically true for mitochondrial
+          proteins, but it is much less informative than Ssq1's matrix localization.
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -68,8 +68,8 @@ existing_annotations:
       hydrolysis to its chaperone cycle; Jac1 and Isu1 synergistically stimulate
       this ATPase activity to drive productive Fe-S transfer complex formation.
     action: ACCEPT
-    reason: Ssq1-specific loss-of-function phenotypes place it directly in the
-      Fe-S cluster release/transfer stage of the ISC pathway.
+    reason: The Hsp70-family inference is correct for Ssq1 and is independently
+      supported by its characterized ATPase cycle and Jac1/Isu1 stimulation.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -133,8 +133,8 @@ existing_annotations:
       ATP-dependent transfer/release step, handing the nascent [2Fe-2S] cluster
       off from the Isu1/Isu2 scaffold to the carrier Grx5.
     action: ACCEPT
-    reason: The mutant phenotype supports Ssq1 participation in [2Fe-2S] cluster
-      maturation, specifically downstream transfer from the Isu scaffold.
+    reason: Phylogenetic transfer is safe because Ssq1-specific biochemical and
+      genetic evidence independently establishes its ISC release/handoff role.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -271,8 +271,9 @@ existing_annotations:
       Grx5; these are better captured by the chaperone/Fe-S transfer terms
       elsewhere in this review rather than by the uninformative protein binding.
     action: MARK_AS_OVER_ANNOTATED
-    reason: GO:0005759 precisely identifies the lumenal mitochondrial compartment
-      in which Ssq1 functions, making this generic ARBA term redundant.
+    reason: This IPI records the Jac1 interaction (Q03020), but generic protein
+      binding obscures the informative cochaperone/scaffold system already captured
+      by the ATP-dependent chaperone and Fe-S transfer annotations.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -285,36 +286,44 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:12947415
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for SSQ1.'
+    summary: This IPI records interaction with Jac1 (Q03020), Ssq1's dedicated
+      J-protein cochaperone, but generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Jac1-mediated stimulation of the Ssq1 ATPase cycle is represented more
+      meaningfully by the chaperone and ISC transfer annotations.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for SSQ1.'
+    summary: This high-throughput IPI records interaction with mitochondrial Hsp70
+      Ssc1 (P15646), but generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: The interaction does not define Ssq1's activity; ATP-dependent chaperone
+      action on Isu during ISC transfer is the biologically informative function.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for SSQ1.'
+    summary: This chaperone-network IPI records interaction with Ssc1 (P15646), but
+      generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: The Ssc1 interaction is ancillary to Ssq1's specialized Isu-directed
+      ATP-dependent chaperone activity and ISC transfer role.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for SSQ1.'
+    summary: This interactome IPI records Jac1 (Q03020), the dedicated J-protein
+      cochaperone of Ssq1, but generic protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: The partner-specific cochaperone relationship is already explained by
+      the ATPase/chaperone mechanism and Fe-S transfer annotations.
 - term:
     id: GO:0016226
     label: iron-sulfur cluster assembly
@@ -420,7 +429,7 @@ existing_annotations:
       conserved LPPVK peptide motif rather than generic unfolded proteins.
       The ATP-dependent protein folding chaperone term better represents Ssq1's biology.
     action: MODIFY
-    reason: Unfolded protein binding is an obsolete-style activity proxy. Ssq1 is
+    reason: Unfolded protein binding is a valid but nonspecific activity proxy. Ssq1 is
       directly characterized as an ATP-dependent Hsp70 chaperone with a specialized
       Isu substrate, so GO:0140662 captures both mechanism and function.
     proposed_replacement_terms:
@@ -596,6 +605,8 @@ core_functions:
   directly_involved_in:
   - id: GO:0016226
     label: iron-sulfur cluster assembly
+  - id: GO:0044571
+    label: '[2Fe-2S] cluster assembly'
   locations:
   - id: GO:0005759
     label: mitochondrial matrix

--- a/genes/yeast/SSQ1/SSQ1-ai-review.yaml
+++ b/genes/yeast/SSQ1/SSQ1-ai-review.yaml
@@ -25,18 +25,33 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: cytoplasm may be context-dependent or peripheral for SSQ1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: The cytoplasm IBA is a family-level localization transfer that conflicts
+      with Ssq1's mitochondrial targeting and experimentally supported matrix location.
+    action: REMOVE
+    reason: Ssq1 is imported into the mitochondrial matrix, where it performs Fe-S
+      cluster transfer. No Ssq1-specific evidence supports cytoplasmic activity; this
+      broad IBA reflects localization diversity elsewhere in the Hsp70 family.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN002321897
+        source_label: broad Hsp70 family localization node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Cytoplasmic Hsp70 family members support the source node, but the
+          mitochondrial targeting and matrix localization of Ssq1 make this transfer unsafe.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: mitochondrion is consistent with known biology of SSQ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Mitochondrion is correct but less precise than the experimentally supported
+      mitochondrial matrix localization.
+    action: KEEP_AS_NON_CORE
+    reason: Retain the broad organelle localization as correct context; GO:0005759
+      captures the core site of Ssq1 activity more precisely.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -53,7 +68,8 @@ existing_annotations:
       hydrolysis to its chaperone cycle; Jac1 and Isu1 synergistically stimulate
       this ATPase activity to drive productive Fe-S transfer complex formation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Ssq1-specific loss-of-function phenotypes place it directly in the
+      Fe-S cluster release/transfer stage of the ISC pathway.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -66,9 +82,11 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: heat shock protein binding is consistent with known biology of SSQ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Ssq1 participates in an Hsp70 cochaperone system with Jac1 and Mge1,
+      but this binding term is ancillary to its ATP-dependent chaperone activity.
+    action: KEEP_AS_NON_CORE
+    reason: The cochaperone interactions are real, but heat shock protein binding does
+      not describe Ssq1's direct core activity in Fe-S cluster transfer.
 - term:
     id: GO:0044183
     label: protein folding chaperone
@@ -76,18 +94,33 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: |-
-      Manual review: protein folding chaperone reflects the Hsp70 fold and
-      chaperone mechanism of SSQ1. Note that Ssq1 is a highly specialized Hsp70
+      Protein folding chaperone reflects the Hsp70 fold and chaperone mechanism
+      of Ssq1. Ssq1 is a highly specialized Hsp70
       whose native client is the Fe-S scaffold Isu1 (recognized via its LPPVK
       motif), rather than a general-purpose folding chaperone like Ssc1.
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    action: MODIFY
+    reason: The annotation is sound, but GO:0140662 specifies the experimentally
+      established ATP-dependent Hsp70 mechanism.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: Ssq1 recognizes the scaffold **Isu1** through the conserved
         **LPPVK** motif (a peptide loop) that engages the Hsp70 substrate-binding
         site
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: Hsp70 ATPase/chaperone node
+        source_status: SUPPORTS_TRANSFER
+        comment: The family-level chaperone inference is correct for Ssq1; the
+          directly characterized ATP-driven mechanism supports the more precise
+          GO:0140662 child term.
 - term:
     id: GO:0016226
     label: iron-sulfur cluster assembly
@@ -100,7 +133,8 @@ existing_annotations:
       ATP-dependent transfer/release step, handing the nascent [2Fe-2S] cluster
       off from the Isu1/Isu2 scaffold to the carrier Grx5.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The mutant phenotype supports Ssq1 participation in [2Fe-2S] cluster
+      maturation, specifically downstream transfer from the Isu scaffold.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -134,42 +168,59 @@ existing_annotations:
         system with a narrowly defined native client (the ISC scaffold Isu)**, supporting
         the view that Ssq1’s primary function is to catalyze a specific Fe–S transfer
         step rather than general mitochondrial proteostasis
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: general Hsp70 ATPase/chaperone node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: General Hsp70s refold stress-denatured clients, whereas Ssq1 has
+          specialized for the Isu scaffold and Fe-S cluster transfer.
 - term:
     id: GO:0000166
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: 'Manual review: nucleotide binding is consistent with known biology of SSQ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Generic nucleotide binding is true but uninformative relative to ATP
+      binding and directly measured ATP hydrolysis.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The broad parent adds no useful specificity beyond GO:0005524 and
+      GO:0016887, which describe the relevant nucleotide and catalytic activity.
 - term:
     id: GO:0005524
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: ATP binding is consistent with known biology of SSQ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: ATP binding is required for Ssq1's Hsp70 chaperone cycle.
+    action: KEEP_AS_NON_CORE
+    reason: Correct mechanistic activity, retained as non-core because the directly
+      measured ATP hydrolysis term is more informative.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'Manual review: mitochondrion is consistent with known biology of SSQ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Mitochondrion is correct but less precise than mitochondrial matrix.
+    action: KEEP_AS_NON_CORE
+    reason: Retain as a correct broad localization while using GO:0005759 for the
+      core site of activity.
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Manual review: mitochondrial matrix is the correct subcellular location of SSQ1, where it performs Fe-S cluster transfer.'
+    summary: Mitochondrial matrix is the precise site of Ssq1-mediated Fe-S
+      cluster transfer.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The mitochondrial targeting sequence and localization evidence agree
+      with the compartment in which the ISC machinery operates.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -180,27 +231,33 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: 'Manual review: hydrolase activity is consistent with known biology of SSQ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Generic hydrolase activity is an over-broad parent of Ssq1's ATP
+      hydrolysis activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: GO:0016887 gives the experimentally established catalytic activity;
+      retaining the generic hydrolase parent as core would obscure that specificity.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'Manual review: ATP hydrolysis activity is consistent with known biology of SSQ1.'
+    summary: Ssq1 is an Hsp70 ATPase whose catalytic cycle drives Isu engagement
+      and Fe-S cluster release.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The InterPro transfer is independently supported by direct biochemical
+      measurement of Ssq1 ATPase activity.
 - term:
     id: GO:0070013
     label: intracellular organelle lumen
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'Manual review: intracellular organelle lumen is consistent with known biology of SSQ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Intracellular organelle lumen is a very broad parent of the mitochondrial
+      matrix localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: GO:0005759 precisely identifies the lumenal mitochondrial compartment in
+      which Ssq1 functions, making this generic ARBA term redundant.
 - term:
     id: GO:0005515
     label: protein binding
@@ -214,7 +271,8 @@ existing_annotations:
       Grx5; these are better captured by the chaperone/Fe-S transfer terms
       elsewhere in this review rather than by the uninformative protein binding.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: GO:0005759 precisely identifies the lumenal mitochondrial compartment
+      in which Ssq1 functions, making this generic ARBA term redundant.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -271,7 +329,8 @@ existing_annotations:
       Fe-S clusters accumulate on the Isu1 scaffold, indicating a block in the
       transfer step rather than de novo synthesis.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Ssq1-specific loss-of-function phenotypes place it directly in the
+      Fe-S cluster release/transfer stage of the ISC pathway.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -289,7 +348,8 @@ existing_annotations:
       scaffold, and Ssq1 (with Jac1 and Mge1) mediates the release/transfer of
       this cluster to the downstream carrier Grx5.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The mutant phenotype supports Ssq1 participation in [2Fe-2S] cluster
+      maturation, specifically downstream transfer from the Isu scaffold.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -303,9 +363,11 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:11273703
   review:
-    summary: 'Manual review: mitochondrion is consistent with known biology of SSQ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: The mitochondrial phenotype is consistent with Ssq1's matrix-localized
+      role, but mitochondrion is less precise than the matrix term.
+    action: KEEP_AS_NON_CORE
+    reason: Retain this broad localization context while using GO:0005759 for the
+      core compartment.
 - term:
     id: GO:0006879
     label: intracellular iron ion homeostasis
@@ -319,7 +381,8 @@ existing_annotations:
       mitochondrial iron, but this iron dysregulation is secondary to the
       primary defect in Fe-S cluster maturation. Kept as non-core.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Mitochondrial iron accumulation is a well-supported downstream
+      consequence of impaired Fe-S cluster maturation, not Ssq1's direct activity.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -336,7 +399,8 @@ existing_annotations:
       stimulated by the J-protein Jac1 together with the Isu1 substrate, with
       Mge1 acting as the nucleotide exchange factor that resets the cycle.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Biochemical assays directly establish the ATPase cycle that drives
+      Ssq1 substrate engagement and release.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -354,12 +418,14 @@ existing_annotations:
       substrate-binding behavior, but for this specialized chaperone the
       physiological client is the folded Isu1 scaffold recognized via its
       conserved LPPVK peptide motif rather than generic unfolded proteins.
-      The protein folding chaperone term better represents Ssq1's biology.
+      The ATP-dependent protein folding chaperone term better represents Ssq1's biology.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Unfolded protein binding is an obsolete-style activity proxy. Ssq1 is
+      directly characterized as an ATP-dependent Hsp70 chaperone with a specialized
+      Isu substrate, so GO:0140662 captures both mechanism and function.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -372,27 +438,30 @@ existing_annotations:
   evidence_type: HDA
   original_reference_id: PMID:24769239
   review:
-    summary: 'Manual review: mitochondrion is consistent with known biology of SSQ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Mitochondrial proteomics supports the organelle assignment but not a
+      more specific function than the matrix-localized ISC role.
+    action: KEEP_AS_NON_CORE
+    reason: Correct broad localization; mitochondrial matrix is the core location.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HDA
   original_reference_id: PMID:16823961
   review:
-    summary: 'Manual review: mitochondrion is consistent with known biology of SSQ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Mitochondrial proteomics supports the organelle assignment but not a
+      more specific function than the matrix-localized ISC role.
+    action: KEEP_AS_NON_CORE
+    reason: Correct broad localization; mitochondrial matrix is the core location.
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: IDA
   original_reference_id: PMID:8707841
   review:
-    summary: 'Manual review: mitochondrial matrix is consistent with known biology of SSQ1.'
+    summary: Direct localization places Ssq1 in the mitochondrial matrix, the site
+      of its Fe-S cluster transfer activity.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct experimental localization supports the precise core compartment.
 - term:
     id: GO:0016226
     label: iron-sulfur cluster assembly
@@ -405,7 +474,8 @@ existing_annotations:
       assembly, consistent with its established role as the specialized Hsp70
       driving the ATP-dependent Fe-S transfer step from Isu1 to Grx5.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Independent mutant evidence supports Ssq1 as a core ISC transfer
+      chaperone required for maturation of Fe-S proteins.
     supported_by:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
@@ -521,8 +591,8 @@ core_functions:
     and its handoff to the carrier Grx5, enabling maturation of cellular Fe-S
     proteins.
   molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
   directly_involved_in:
   - id: GO:0016226
     label: iron-sulfur cluster assembly

--- a/genes/yeast/SSQ1/SSQ1-ai-review.yaml
+++ b/genes/yeast/SSQ1/SSQ1-ai-review.yaml
@@ -32,7 +32,7 @@ existing_annotations:
       GO:0005737 includes mitochondria within the cytoplasm, so it is not false, but
       GO:0005759 describes the functional compartment much more precisely.
     propagation_review:
-      root_cause: PROPAGATION_BAD
+      root_cause: TERM_SCOPING_PROBLEM
       failure_modes:
       - GRANULARITY_MISMATCH
       source_entities:

--- a/genes/yeast/SSQ1/SSQ1-notes.md
+++ b/genes/yeast/SSQ1/SSQ1-notes.md
@@ -1,0 +1,23 @@
+# SSQ1 review notes
+
+## 2026-08-12 re-review
+
+- Identity verified as *Saccharomyces cerevisiae* SSQ1/YLR369W, UniProt Q05931,
+  the mitochondrial Ssq-type Hsp70 dedicated to iron-sulfur cluster biogenesis.
+- The existing Falcon report is correctly scoped to Q05931. An OpenScientist
+  run was launched through `just deep-research-openscientist yeast SSQ1`; after
+  extended silent polling without a returned artifact it was interrupted. No
+  unreturned result was treated as evidence.
+- Core mechanism: Jac1 recruits the Isu scaffold and stimulates the Ssq1 ATPase
+  cycle; Mge1 promotes nucleotide exchange; Ssq1 recognizes the Isu LPPVK motif
+  and drives release/handoff of the newly assembled cluster to Grx5.
+- Generic family terms were narrowed where a more informative child exists:
+  GO:0044183 and GO:0051082 are modified to GO:0140662, generic nucleotide and
+  hydrolase parents are over-annotated, and mitochondrial matrix is the core
+  location rather than its broad organelle/lumen parents.
+- GO:0042026 protein refolding is an unsafe general-Hsp70 IBA transfer. Ssq1 is
+  specialized for the Isu client and ISC transfer rather than broad stress
+  refolding; the propagation audit records this functional divergence.
+- The cytoplasm IBA is removed because it conflicts with Ssq1 mitochondrial
+  targeting and direct matrix localization. Intracellular iron homeostasis is
+  retained as a genuine downstream phenotype, not a core direct function.

--- a/genes/yeast/SSQ1/SSQ1-notes.md
+++ b/genes/yeast/SSQ1/SSQ1-notes.md
@@ -18,6 +18,7 @@
 - GO:0042026 protein refolding is an unsafe general-Hsp70 IBA transfer. Ssq1 is
   specialized for the Isu client and ISC transfer rather than broad stress
   refolding; the propagation audit records this functional divergence.
-- The cytoplasm IBA is removed because it conflicts with Ssq1 mitochondrial
-  targeting and direct matrix localization. Intracellular iron homeostasis is
-  retained as a genuine downstream phenotype, not a core direct function.
+- The cytoplasm IBA is ontologically true because mitochondria are part of the
+  GO cytoplasm, but it is marked over-annotated because matrix is the precise
+  functional compartment. Intracellular iron homeostasis is retained as a
+  genuine downstream phenotype, not a core direct function.

--- a/genes/yeast/SSQ1/SSQ1-notes.md
+++ b/genes/yeast/SSQ1/SSQ1-notes.md
@@ -11,6 +11,10 @@
 - Core mechanism: Jac1 recruits the Isu scaffold and stimulates the Ssq1 ATPase
   cycle; Mge1 promotes nucleotide exchange; Ssq1 recognizes the Isu LPPVK motif
   and drives release/handoff of the newly assembled cluster to Grx5.
+- UniProt resolves the GOA IntAct partners directly: Q03020 is the physiological
+  Isu1 scaffold client, whereas P15646 is the nucleolar protein Nop1. The Isu1
+  rows are biologically relevant but poorly expressed by bare protein binding;
+  the Nop1 rows are likely high-throughput background for a matrix protein.
 - Generic family terms were narrowed where a more informative child exists:
   GO:0044183 and GO:0051082 are modified to GO:0140662, generic nucleotide and
   hydrolase parents are over-annotated, and mitochondrial matrix is the core

--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -2081,8 +2081,8 @@ established:</p>
 <td><em>S. cerevisiae</em></td>
 <td>Q05931</td>
 <td>29</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>Mito HSP70</td>
+<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140662">GO:0140662</a></td>
+<td>Specialized mitochondrial HSP70 for ATP-driven Fe-S cluster transfer from Isu to Grx5</td>
 </tr>
 <tr>
 <td><a href="../../genes/yeast/SSZ1/SSZ1-ai-review.html">SSZ1</a></td>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -564,7 +564,7 @@ established:
 | SSA4 | *S. cerevisiae* | P22202 | 25 | MODIFY → GO:0044183 | HSP70 |
 | SSB1 | *S. cerevisiae* | P11484 | 36 | MODIFY → GO:0140662 | Ribosome-associated HSP70; ATP-driven nascent-chain folding at the tunnel exit |
 | SSB2 | *S. cerevisiae* | P40150 | 39 | MODIFY → GO:0044183 | Ribosome-associated HSP70 paralog of SSB1 |
-| SSQ1 | *S. cerevisiae* | Q05931 | 29 | MODIFY → GO:0044183 | Mito HSP70 |
+| SSQ1 | *S. cerevisiae* | Q05931 | 29 | MODIFY → GO:0140662 | Specialized mitochondrial HSP70 for ATP-driven Fe-S cluster transfer from Isu to Grx5 |
 | SSZ1 | *S. cerevisiae* | P38788 | 30 | MODIFY → GO:0044183 | RAC HSP70 |
 | SYO1 | *S. cerevisiae* | Q07395 | 12 | MODIFY | Ribosome assembly |
 | TCP1 | *S. cerevisiae* | P12612 | 23 | MODIFY → GO:0044183 | TRiC subunit |


### PR DESCRIPTION
## Summary
- re-review canonical yeast SSQ1/Q05931 as the specialized mitochondrial Hsp70 for ISC cluster transfer
- refine generic chaperone/unfolded-binding terms to GO:0140662 and distinguish core matrix/ATPase/Fe-S functions from broad parents and downstream phenotypes
- add structured propagation audits for unsafe cytoplasm/refolding transfers and update the UPB project row
- record OpenScientist wrapper provenance; the identity-correct job remained in silent polling and was interrupted without treating any unreturned artifact as evidence

## Validation
- `just validate yeast SSQ1` (zero warnings)
- `just render yeast SSQ1`
- `just render-project UNFOLDED_PROTEIN_BINDING`
- `just deploy-browser`
- `just test` (1,648 pytest; 132 doctests; mypy and Ruff clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9ab2593ae36384b70eab8e477e307bae862619ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->