### PR TITLE
Re-review yeast SSB2 ribosome-associated Hsp70

### DIFF
--- a/genes/yeast/SSB2/SSB2-ai-review.html
+++ b/genes/yeast/SSB2/SSB2-ai-review.html
@@ -833,14 +833,7 @@
         <p>SSB2 (YNL209W, UniProt P40150) encodes one of the two nearly identical
 ribosome-associated cytosolic Hsp70 chaperones of Saccharomyces cerevisiae;
 its paralog SSB1 (P11484) differs by only ~4 residues, and the two are almost
-always studied together as &#34;Ssb&#34;. GENE-IDENTITY NOTE: this is the genuine
-ribosome-associated Hsp70 paralog (Ssb-type Hsp70 subfamily), NOT to be
-confused with the unrelated sibling-symbol collision elsewhere in this dataset
-where &#34;SSB1&#34; resolved to Sbp1p/P10080, an RGG/RRM RNA-binding protein. Both
-the UniProt accession (P40150, &#34;Ribosome-associated molecular chaperone SSB2&#34;,
-EC 3.6.4.10, heat shock protein 70 family / Ssb-type subfamily) and the falcon
-deep research report independently confirm the ribosome-associated Hsp70
-identity. Ssb2 is a canonical Hsp70 with an N-terminal nucleotide-binding/ATPase
+always studied together as &#34;Ssb&#34;. Ssb2 is a canonical Hsp70 with an N-terminal nucleotide-binding/ATPase
 domain (NBD) and a C-terminal substrate-binding domain (SBD); it uses an
 ATP-driven conformational cycle to bind short hydrophobic segments of nascent
 polypeptides as they emerge from the ribosomal tunnel exit. Its core function
@@ -1072,6 +1065,42 @@ over-annotation from high-throughput localization datasets.
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002500132</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Plasma-membrane localization may apply to other family members, but Ssb2 is a soluble cytosolic ribosome-associated Hsp70.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1262,10 +1291,10 @@ interactions that constitute the ribosome-associated Hsp70 chaperone system.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0044183" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0044183" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1280,12 +1309,58 @@ ATP-dependent protein folding chaperone (GO:0140662).
 
 
                         <div>
-                            <strong>Reason:</strong> Core molecular function. Accepted; a more specific child term
-(ATP-dependent protein folding chaperone, GO:0140662) is captured in
-core_functions to reflect the ATP-dependent Hsp70 mechanism.
+                            <strong>Reason:</strong> The family-level term is correct but less precise than the experimentally
+supported ATP-dependent Hsp70 mechanism; replace it with GO:0140662.
                         </div>
 
 
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The family transfer correctly identifies chaperone activity in Ssb2, but GO:0140662 captures its ATP-dependent mechanism more precisely.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -3693,7 +3768,39 @@ J-protein Zuo1) to promote de novo cotranslational protein folding.</h3>
 
 
 
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
 
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051083" target="_blank" class="term-link">
+                                &#39;de novo&#39; cotranslational protein folding
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006450" target="_blank" class="term-link">
+                                regulation of translational fidelity
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
 
 
 
@@ -3727,75 +3834,6 @@ J-protein Zuo1) to promote de novo cotranslational protein folding.</h3>
                         </span>
 
                         <div class="finding-text">Ssb to function as a chaperone on the ribosome, preventing the misfolding of</div>
-
-                    </li>
-
-                </ul>
-            </div>
-
-        </div>
-
-        <div class="core-function-card">
-
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Cotranslational chaperone acting on cytosolic translating 80S ribosomes near
-the 60S tunnel exit, directly engaging nascent chains as part of the
-RAC-Ssb system to support de novo folding of a large fraction of the nascent
-proteome.</h3>
-                <span class="vote-buttons" data-g="P40150" data-a="FUNCTION: Cotranslational chaperone acting on cytosolic tran..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-
-
-            <div class="core-function-terms">
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
-                            ATP-dependent protein folding chaperone
-                        </a>
-                    </span>
-                </div>
-
-
-
-
-
-
-
-
-
-            </div>
-
-
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-
-                    <li class="finding-item">
-                        <span class="reference-id">
-
-                            file:yeast/SSB2/SSB2-deep-research-falcon.md
-
-                        </span>
-
-                        <div class="finding-text">Ssb proteins (Ssb1/Ssb2) are **cytosolic** and **ribosome-associated**, positioned at the **60S tunnel exit**</div>
-
-                    </li>
-
-                    <li class="finding-item">
-                        <span class="reference-id">
-
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/23332755" target="_blank" class="term-link">
-                                PMID:23332755
-                            </a>
-
-                        </span>
-
-                        <div class="finding-text">define the cotranslational substrate</div>
 
                     </li>
 
@@ -4697,6 +4735,45 @@ These values imply Ssb2 participates in folding/biogenesis decisions for a large
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SSB2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40150" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ssb2-review-notes">SSB2 review notes</h1>
+<h2 id="2026-08-12-re-review">2026-08-12 re-review</h2>
+<ul>
+<li>Identity verified as <em>Saccharomyces cerevisiae</em> SSB2/YNL209W, UniProt P40150,<br />
+  the canonical ribosome-associated Ssb-type Hsp70 paralog of SSB1/P11484.</li>
+<li>Ssb2 directly binds nascent chains at the cytosolic 60S tunnel exit. RAC's<br />
+  Zuo1 J-domain stimulates Ssb ATP hydrolysis, driving the NBD/SBD cycle used for<br />
+  ATP-dependent cotranslational folding.</li>
+<li>GO:0044183 is modified to the more specific GO:0140662, consistent with the<br />
+  existing unfolded-protein-binding annotations and SSB1 project decision.</li>
+<li>ATP binding and hydrolysis are genuine core biochemical activities. Broad<br />
+  nucleotide-binding and hydrolase parents are over-annotated, while protein<br />
+  refolding is retained only as a plausible non-core general Hsp70 capability.</li>
+<li>Plasma-membrane localization is unsupported for this soluble cytosolic Hsp70;<br />
+  the IBA transfer is audited against its PANTHER family node. Cytoplasm is true<br />
+  but less specific than the core cytosolic ribosome localization.</li>
+<li>The consolidated core function combines GO:0140662 with de novo<br />
+  cotranslational folding, translational fidelity, and cytosolic localization.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4716,14 +4793,7 @@ description: |-
   SSB2 (YNL209W, UniProt P40150) encodes one of the two nearly identical
   ribosome-associated cytosolic Hsp70 chaperones of Saccharomyces cerevisiae;
   its paralog SSB1 (P11484) differs by only ~4 residues, and the two are almost
-  always studied together as &#34;Ssb&#34;. GENE-IDENTITY NOTE: this is the genuine
-  ribosome-associated Hsp70 paralog (Ssb-type Hsp70 subfamily), NOT to be
-  confused with the unrelated sibling-symbol collision elsewhere in this dataset
-  where &#34;SSB1&#34; resolved to Sbp1p/P10080, an RGG/RRM RNA-binding protein. Both
-  the UniProt accession (P40150, &#34;Ribosome-associated molecular chaperone SSB2&#34;,
-  EC 3.6.4.10, heat shock protein 70 family / Ssb-type subfamily) and the falcon
-  deep research report independently confirm the ribosome-associated Hsp70
-  identity. Ssb2 is a canonical Hsp70 with an N-terminal nucleotide-binding/ATPase
+  always studied together as &#34;Ssb&#34;. Ssb2 is a canonical Hsp70 with an N-terminal nucleotide-binding/ATPase
   domain (NBD) and a C-terminal substrate-binding domain (SBD); it uses an
   ATP-driven conformational cycle to bind short hydrophobic segments of nascent
   polypeptides as they emerge from the ribosomal tunnel exit. Its core function
@@ -4794,6 +4864,16 @@ existing_annotations:
       falcon report and UniProt localize Ssb to the cytosol and ribosome; a
       plasma membrane assignment for this abundant cytosolic Hsp70 is an
       over-annotation from high-throughput localization datasets.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN002500132
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Plasma-membrane localization may apply to other family members,
+          but Ssb2 is a soluble cytosolic ribosome-associated Hsp70.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -4848,11 +4928,23 @@ existing_annotations:
       Ssb2 is a protein folding chaperone that assists cotranslational folding of
       nascent chains. The more precise MF for this ATP-driven Hsp70 is
       ATP-dependent protein folding chaperone (GO:0140662).
-    action: ACCEPT
+    action: MODIFY
     reason: |-
-      Core molecular function. Accepted; a more specific child term
-      (ATP-dependent protein folding chaperone, GO:0140662) is captured in
-      core_functions to reflect the ATP-dependent Hsp70 mechanism.
+      The family-level term is correct but less precise than the experimentally
+      supported ATP-dependent Hsp70 mechanism; replace it with GO:0140662.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The family transfer correctly identifies chaperone activity in
+          Ssb2, but GO:0140662 captures its ATP-dependent mechanism more precisely.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -5406,27 +5498,20 @@ core_functions:
   molecular_function:
     id: GO:0140662
     label: ATP-dependent protein folding chaperone
+  directly_involved_in:
+  - id: GO:0051083
+    label: &#39;&#39;&#39;de novo&#39;&#39; cotranslational protein folding&#39;
+  - id: GO:0006450
+    label: regulation of translational fidelity
+  locations:
+  - id: GO:0005829
+    label: cytosol
   supported_by:
   - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
     supporting_text: Ssb1/2 (including Ssb2) act as the **direct nascent-chain binders** during co-translational folding in yeast
     reference_section_type: OTHER
   - reference_id: PMID:9670014
     supporting_text: Ssb to function as a chaperone on the ribosome, preventing the misfolding of
-    reference_section_type: ABSTRACT
-- description: |-
-    Cotranslational chaperone acting on cytosolic translating 80S ribosomes near
-    the 60S tunnel exit, directly engaging nascent chains as part of the
-    RAC-Ssb system to support de novo folding of a large fraction of the nascent
-    proteome.
-  molecular_function:
-    id: GO:0140662
-    label: ATP-dependent protein folding chaperone
-  supported_by:
-  - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
-    supporting_text: Ssb proteins (Ssb1/Ssb2) are **cytosolic** and **ribosome-associated**, positioned at the **60S tunnel exit**
-    reference_section_type: OTHER
-  - reference_id: PMID:23332755
-    supporting_text: define the cotranslational substrate
     reference_section_type: ABSTRACT
 references:
 - id: GO_REF:0000033

--- a/genes/yeast/SSB2/SSB2-ai-review.html
+++ b/genes/yeast/SSB2/SSB2-ai-review.html
@@ -1959,10 +1959,10 @@ translational fidelity, with the principal defect in translation termination.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0006452" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0006452" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2898,10 +2898,10 @@ ribosome-associated Hsp70 with no functional role at the plasma membrane.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0006452" data-r="PMID:16607023" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0006452" data-r="PMID:16607023" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3479,10 +3479,10 @@ activity underlying its Hsp70 chaperone cycle.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0042149" data-r="PMID:19723765" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0042149" data-r="PMID:19723765" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3775,12 +3775,6 @@ J-protein Zuo1) to promote de novo cotranslational protein folding.</h3>
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051083" target="_blank" class="term-link">
                                 &#39;de novo&#39; cotranslational protein folding
-                            </a>
-                        </span>
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006450" target="_blank" class="term-link">
-                                regulation of translational fidelity
                             </a>
                         </span>
 
@@ -4757,17 +4751,25 @@ These values imply Ssb2 participates in folding/biogenesis decisions for a large
   the canonical ribosome-associated Ssb-type Hsp70 paralog of SSB1/P11484.</li>
 <li>Ssb2 directly binds nascent chains at the cytosolic 60S tunnel exit. RAC's<br />
   Zuo1 J-domain stimulates Ssb ATP hydrolysis, driving the NBD/SBD cycle used for<br />
-  ATP-dependent cotranslational folding.</li>
+  ATP-dependent cotranslational folding. <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" title="Ssb to function as a   chaperone on the ribosome, preventing the misfolding of">PMID:9670014</a></li>
 <li>GO:0044183 is modified to the more specific GO:0140662, consistent with the<br />
   existing unfolded-protein-binding annotations and SSB1 project decision.</li>
 <li>ATP binding and hydrolysis are genuine core biochemical activities. Broad<br />
   nucleotide-binding and hydrolase parents are over-annotated, while protein<br />
-  refolding is retained only as a plausible non-core general Hsp70 capability.</li>
+  refolding is retained only as a plausible non-core general Hsp70 capability.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9860955" title="Here we report that the ATPase activities of these two classes   of Hsp70s exhibit different kinetic properties.">PMID:9860955</a></li>
 <li>Plasma-membrane localization is unsupported for this soluble cytosolic Hsp70;<br />
   the IBA transfer is audited against its PANTHER family node. Cytoplasm is true<br />
   but less specific than the core cytosolic ribosome localization.</li>
 <li>The consolidated core function combines GO:0140662 with de novo<br />
-  cotranslational folding, translational fidelity, and cytosolic localization.</li>
+  cotranslational folding and cytosolic localization. Translational fidelity,<br />
+  frameshifting, and glucose-starvation responses remain supported annotations<br />
+  but are not modeled as processes directly carried out by the chaperone MF;<br />
+  PMID:15456889 describes fidelity as extending beyond the nascent-chain<br />
+  chaperone role.</li>
+<li>Roughly half of cellular Ssb is ribosome-associated, but this is dynamic rather<br />
+  than stable complex membership, so the core function uses cytosol as location<br />
+  and describes the 60S tunnel-exit position in prose instead of <code>in_complex</code>.</li>
 </ul>
             </div>
         </details>
@@ -5103,7 +5105,7 @@ existing_annotations:
     summary: |-
       Deletion of Ssb1/2 (or RAC) specifically inhibits -1 programmed ribosomal
       frameshifting and impairs Killer virus maintenance.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
       Supported experimentally (PMID:16607023). Note the effect is specific to -1
       PRF (no effect on +1 PRF), a downstream consequence of Ssb&#39;s role at the
@@ -5309,7 +5311,7 @@ existing_annotations:
       Deletion of Ssb1p/Ssb2p (or RAC) specifically inhibits -1 programmed
       ribosomal frameshifting and impairs Killer virus maintenance, with no effect
       on +1 PRF.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
       Strong direct IMP evidence (PMID:16607023). A genuine, specific downstream
       consequence of Ssb function at the translating ribosome.
@@ -5433,7 +5435,7 @@ existing_annotations:
       Ssb is required for glucose sensing via the SNF1 kinase network: the
       chaperone keeps SNF1 in the nonphosphorylated state in the presence of
       glucose, and Deltassb1 Deltassb2 cells resemble glucose-repression mutants.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
       Supported by genetic interaction (PMID:19723765). A genuine downstream
       physiological role connecting Ssb chaperone function to glucose/SNF1
@@ -5501,8 +5503,6 @@ core_functions:
   directly_involved_in:
   - id: GO:0051083
     label: &#39;&#39;&#39;de novo&#39;&#39; cotranslational protein folding&#39;
-  - id: GO:0006450
-    label: regulation of translational fidelity
   locations:
   - id: GO:0005829
     label: cytosol

--- a/genes/yeast/SSB2/SSB2-ai-review.yaml
+++ b/genes/yeast/SSB2/SSB2-ai-review.yaml
@@ -319,7 +319,7 @@ existing_annotations:
     summary: |-
       Deletion of Ssb1/2 (or RAC) specifically inhibits -1 programmed ribosomal
       frameshifting and impairs Killer virus maintenance.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
       Supported experimentally (PMID:16607023). Note the effect is specific to -1
       PRF (no effect on +1 PRF), a downstream consequence of Ssb's role at the
@@ -525,7 +525,7 @@ existing_annotations:
       Deletion of Ssb1p/Ssb2p (or RAC) specifically inhibits -1 programmed
       ribosomal frameshifting and impairs Killer virus maintenance, with no effect
       on +1 PRF.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
       Strong direct IMP evidence (PMID:16607023). A genuine, specific downstream
       consequence of Ssb function at the translating ribosome.
@@ -649,7 +649,7 @@ existing_annotations:
       Ssb is required for glucose sensing via the SNF1 kinase network: the
       chaperone keeps SNF1 in the nonphosphorylated state in the presence of
       glucose, and Deltassb1 Deltassb2 cells resemble glucose-repression mutants.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
       Supported by genetic interaction (PMID:19723765). A genuine downstream
       physiological role connecting Ssb chaperone function to glucose/SNF1
@@ -717,8 +717,6 @@ core_functions:
   directly_involved_in:
   - id: GO:0051083
     label: '''de novo'' cotranslational protein folding'
-  - id: GO:0006450
-    label: regulation of translational fidelity
   locations:
   - id: GO:0005829
     label: cytosol

--- a/genes/yeast/SSB2/SSB2-ai-review.yaml
+++ b/genes/yeast/SSB2/SSB2-ai-review.yaml
@@ -9,14 +9,7 @@ description: |-
   SSB2 (YNL209W, UniProt P40150) encodes one of the two nearly identical
   ribosome-associated cytosolic Hsp70 chaperones of Saccharomyces cerevisiae;
   its paralog SSB1 (P11484) differs by only ~4 residues, and the two are almost
-  always studied together as "Ssb". GENE-IDENTITY NOTE: this is the genuine
-  ribosome-associated Hsp70 paralog (Ssb-type Hsp70 subfamily), NOT to be
-  confused with the unrelated sibling-symbol collision elsewhere in this dataset
-  where "SSB1" resolved to Sbp1p/P10080, an RGG/RRM RNA-binding protein. Both
-  the UniProt accession (P40150, "Ribosome-associated molecular chaperone SSB2",
-  EC 3.6.4.10, heat shock protein 70 family / Ssb-type subfamily) and the falcon
-  deep research report independently confirm the ribosome-associated Hsp70
-  identity. Ssb2 is a canonical Hsp70 with an N-terminal nucleotide-binding/ATPase
+  always studied together as "Ssb". Ssb2 is a canonical Hsp70 with an N-terminal nucleotide-binding/ATPase
   domain (NBD) and a C-terminal substrate-binding domain (SBD); it uses an
   ATP-driven conformational cycle to bind short hydrophobic segments of nascent
   polypeptides as they emerge from the ribosomal tunnel exit. Its core function
@@ -87,6 +80,16 @@ existing_annotations:
       falcon report and UniProt localize Ssb to the cytosol and ribosome; a
       plasma membrane assignment for this abundant cytosolic Hsp70 is an
       over-annotation from high-throughput localization datasets.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN002500132
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Plasma-membrane localization may apply to other family members,
+          but Ssb2 is a soluble cytosolic ribosome-associated Hsp70.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -141,11 +144,23 @@ existing_annotations:
       Ssb2 is a protein folding chaperone that assists cotranslational folding of
       nascent chains. The more precise MF for this ATP-driven Hsp70 is
       ATP-dependent protein folding chaperone (GO:0140662).
-    action: ACCEPT
+    action: MODIFY
     reason: |-
-      Core molecular function. Accepted; a more specific child term
-      (ATP-dependent protein folding chaperone, GO:0140662) is captured in
-      core_functions to reflect the ATP-dependent Hsp70 mechanism.
+      The family-level term is correct but less precise than the experimentally
+      supported ATP-dependent Hsp70 mechanism; replace it with GO:0140662.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The family transfer correctly identifies chaperone activity in
+          Ssb2, but GO:0140662 captures its ATP-dependent mechanism more precisely.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -699,27 +714,20 @@ core_functions:
   molecular_function:
     id: GO:0140662
     label: ATP-dependent protein folding chaperone
+  directly_involved_in:
+  - id: GO:0051083
+    label: '''de novo'' cotranslational protein folding'
+  - id: GO:0006450
+    label: regulation of translational fidelity
+  locations:
+  - id: GO:0005829
+    label: cytosol
   supported_by:
   - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
     supporting_text: Ssb1/2 (including Ssb2) act as the **direct nascent-chain binders** during co-translational folding in yeast
     reference_section_type: OTHER
   - reference_id: PMID:9670014
     supporting_text: Ssb to function as a chaperone on the ribosome, preventing the misfolding of
-    reference_section_type: ABSTRACT
-- description: |-
-    Cotranslational chaperone acting on cytosolic translating 80S ribosomes near
-    the 60S tunnel exit, directly engaging nascent chains as part of the
-    RAC-Ssb system to support de novo folding of a large fraction of the nascent
-    proteome.
-  molecular_function:
-    id: GO:0140662
-    label: ATP-dependent protein folding chaperone
-  supported_by:
-  - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
-    supporting_text: Ssb proteins (Ssb1/Ssb2) are **cytosolic** and **ribosome-associated**, positioned at the **60S tunnel exit**
-    reference_section_type: OTHER
-  - reference_id: PMID:23332755
-    supporting_text: define the cotranslational substrate
     reference_section_type: ABSTRACT
 references:
 - id: GO_REF:0000033

--- a/genes/yeast/SSB2/SSB2-notes.md
+++ b/genes/yeast/SSB2/SSB2-notes.md
@@ -6,14 +6,24 @@
   the canonical ribosome-associated Ssb-type Hsp70 paralog of SSB1/P11484.
 - Ssb2 directly binds nascent chains at the cytosolic 60S tunnel exit. RAC's
   Zuo1 J-domain stimulates Ssb ATP hydrolysis, driving the NBD/SBD cycle used for
-  ATP-dependent cotranslational folding.
+  ATP-dependent cotranslational folding. [PMID:9670014 "Ssb to function as a
+  chaperone on the ribosome, preventing the misfolding of"]
 - GO:0044183 is modified to the more specific GO:0140662, consistent with the
   existing unfolded-protein-binding annotations and SSB1 project decision.
 - ATP binding and hydrolysis are genuine core biochemical activities. Broad
   nucleotide-binding and hydrolase parents are over-annotated, while protein
   refolding is retained only as a plausible non-core general Hsp70 capability.
+  [PMID:9860955 "Here we report that the ATPase activities of these two classes
+  of Hsp70s exhibit different kinetic properties."]
 - Plasma-membrane localization is unsupported for this soluble cytosolic Hsp70;
   the IBA transfer is audited against its PANTHER family node. Cytoplasm is true
   but less specific than the core cytosolic ribosome localization.
 - The consolidated core function combines GO:0140662 with de novo
-  cotranslational folding, translational fidelity, and cytosolic localization.
+  cotranslational folding and cytosolic localization. Translational fidelity,
+  frameshifting, and glucose-starvation responses remain supported annotations
+  but are not modeled as processes directly carried out by the chaperone MF;
+  PMID:15456889 describes fidelity as extending beyond the nascent-chain
+  chaperone role.
+- Roughly half of cellular Ssb is ribosome-associated, but this is dynamic rather
+  than stable complex membership, so the core function uses cytosol as location
+  and describes the 60S tunnel-exit position in prose instead of `in_complex`.

--- a/genes/yeast/SSB2/SSB2-notes.md
+++ b/genes/yeast/SSB2/SSB2-notes.md
@@ -1,0 +1,19 @@
+# SSB2 review notes
+
+## 2026-08-12 re-review
+
+- Identity verified as *Saccharomyces cerevisiae* SSB2/YNL209W, UniProt P40150,
+  the canonical ribosome-associated Ssb-type Hsp70 paralog of SSB1/P11484.
+- Ssb2 directly binds nascent chains at the cytosolic 60S tunnel exit. RAC's
+  Zuo1 J-domain stimulates Ssb ATP hydrolysis, driving the NBD/SBD cycle used for
+  ATP-dependent cotranslational folding.
+- GO:0044183 is modified to the more specific GO:0140662, consistent with the
+  existing unfolded-protein-binding annotations and SSB1 project decision.
+- ATP binding and hydrolysis are genuine core biochemical activities. Broad
+  nucleotide-binding and hydrolase parents are over-annotated, while protein
+  refolding is retained only as a plausible non-core general Hsp70 capability.
+- Plasma-membrane localization is unsupported for this soluble cytosolic Hsp70;
+  the IBA transfer is audited against its PANTHER family node. Cytoplasm is true
+  but less specific than the core cytosolic ribosome localization.
+- The consolidated core function combines GO:0140662 with de novo
+  cotranslational folding, translational fidelity, and cytosolic localization.

--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -2073,8 +2073,8 @@ established:</p>
 <td><em>S. cerevisiae</em></td>
 <td>P40150</td>
 <td>39</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>Ribosome-associated HSP70 paralog of <a href="../../genes/yeast/SSB1/SSB1-ai-review.html">SSB1</a></td>
+<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140662">GO:0140662</a></td>
+<td>Ribosome-associated HSP70 paralog of <a href="../../genes/yeast/SSB1/SSB1-ai-review.html">SSB1</a>; ATP-driven nascent-chain folding</td>
 </tr>
 <tr>
 <td><a href="../../genes/yeast/SSQ1/SSQ1-ai-review.html">SSQ1</a></td>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -563,7 +563,7 @@ established:
 | SSA3 | *S. cerevisiae* | P09435 | 26 | MODIFY → GO:0044183 | HSP70 |
 | SSA4 | *S. cerevisiae* | P22202 | 25 | MODIFY → GO:0044183 | HSP70 |
 | SSB1 | *S. cerevisiae* | P11484 | 36 | MODIFY → GO:0140662 | Ribosome-associated HSP70; ATP-driven nascent-chain folding at the tunnel exit |
-| SSB2 | *S. cerevisiae* | P40150 | 39 | MODIFY → GO:0044183 | Ribosome-associated HSP70 paralog of SSB1 |
+| SSB2 | *S. cerevisiae* | P40150 | 39 | MODIFY → GO:0140662 | Ribosome-associated HSP70 paralog of SSB1; ATP-driven nascent-chain folding |
 | SSQ1 | *S. cerevisiae* | Q05931 | 29 | MODIFY → GO:0140662 | Specialized mitochondrial HSP70 for ATP-driven Fe-S cluster transfer from Isu to Grx5 |
 | SSZ1 | *S. cerevisiae* | P38788 | 30 | ACCEPT GO:0044183 | Atypical RAC HSP70-like regulator; pragmatic co-chaperone term, not an ATPase claim |
 | SYO1 | *S. cerevisiae* | Q07395 | 12 | MODIFY | Ribosome assembly |


### PR DESCRIPTION
## Summary
- verify canonical SSB2/P40150 identity and remove workflow commentary from the biological description
- refine the broad chaperone MF to GO:0140662 and consolidate the core ATP-driven cotranslational-folding model
- add structured propagation audits for unsafe plasma-membrane localization and the GO:0044183 specificity change
- align the unfolded-protein-binding project and generated gene/project/browser artifacts

## Validation
- `just validate yeast SSB2` (valid, zero warnings)
- `just render yeast SSB2`
- `just render-project UNFOLDED_PROTEIN_BINDING`
- `just deploy-browser`
- `just test` (1648 pytest passed; 132 doctests passed; mypy and Ruff clean)
- `git diff --check`