### PR TITLE
Make NEW annotation validation qualifier-aware

### DIFF
--- a/src/ai_gene_review/validation/goa_validator.py
+++ b/src/ai_gene_review/validation/goa_validator.py
@@ -310,6 +310,15 @@ class GOAValidator:
             identity = (ann.go_id, parsed_qualifier, is_negated)
             goa_by_annotation_identity.setdefault(identity, []).append(ann)
 
+        corrected_go_ids = {
+            term.get("id", "")
+            for yaml_ann in yaml_annotations
+            if isinstance(yaml_ann, dict)
+            and isinstance((review := yaml_ann.get("review", {})), dict)
+            and review.get("action") in {"REMOVE", "MODIFY"}
+            and isinstance((term := yaml_ann.get("term", {})), dict)
+        }
+
         # Check each YAML annotation against GOA
         for yaml_ann in yaml_annotations:
             if not isinstance(yaml_ann, dict):
@@ -328,7 +337,7 @@ class GOAValidator:
                     go_id = term.get("id", "")
                     qualifier = self._parse_qualifier(yaml_ann.get("qualifier"))
                     negated = bool(yaml_ann.get("negated", False))
-                    if qualifier is None:
+                    if qualifier is None or go_id not in corrected_go_ids:
                         matching_annotations = [
                             ann
                             for ann in goa_by_go_id.get(go_id, [])
@@ -339,8 +348,10 @@ class GOAValidator:
                         matching_annotations = goa_by_annotation_identity.get(identity, [])
 
                     # Evidence/reference changes do not make an assertion novel, but
-                    # relation and negation changes do. This permits curators to replace
-                    # an incorrect `enables` assertion with `contributes_to`, for example.
+                    # relation and negation changes do when paired with an explicit
+                    # REMOVE/MODIFY correction for the same term. This permits curators
+                    # to replace an incorrect `enables` assertion with `contributes_to`
+                    # without making every relation difference look novel.
                     # Qualifier-less legacy YAML remains conservative and conflicts with
                     # any non-negated GOA assertion for the same term.
                     if matching_annotations:
@@ -357,9 +368,12 @@ class GOAValidator:
                         # This is an error - NEW annotation should not exist in GOA
                         # under any evidence/reference source, including TreeGrafter/IBA.
                         result.is_valid = False
+                        relation = qualifier or "unspecified"
+                        polarity = "negated" if negated else "positive"
                         result.error_message = (
                             f"Annotation with action=NEW exists in GOA: {go_id} "
-                            f"(GOA source(s): {source_summary})"
+                            f"(qualifier={relation}, assertion={polarity}; "
+                            f"GOA source(s): {source_summary})"
                         )
                 # Skip further validation for NEW annotations
                 continue

--- a/src/ai_gene_review/validation/goa_validator.py
+++ b/src/ai_gene_review/validation/goa_validator.py
@@ -296,13 +296,19 @@ class GOAValidator:
         goa_tuples = set()
         goa_by_tuple: Dict[Tuple[str, str, str, bool], GOAAnnotation] = {}
         goa_by_go_id: Dict[str, List[GOAAnnotation]] = {}
+        goa_by_annotation_identity: Dict[
+            Tuple[str, str, bool], List[GOAAnnotation]
+        ] = {}
         for ann in goa_annotations:
             qualifier = getattr(ann, "qualifier", "")
             is_negated = self._qualifier_is_negated(qualifier)
+            parsed_qualifier = self._parse_qualifier(qualifier) or ""
             tuple_key = (ann.go_id, ann.evidence_code, ann.reference, is_negated)
             goa_tuples.add(tuple_key)
             goa_by_tuple[tuple_key] = ann
             goa_by_go_id.setdefault(ann.go_id, []).append(ann)
+            identity = (ann.go_id, parsed_qualifier, is_negated)
+            goa_by_annotation_identity.setdefault(identity, []).append(ann)
 
         # Check each YAML annotation against GOA
         for yaml_ann in yaml_annotations:
@@ -320,13 +326,28 @@ class GOAValidator:
                 term = yaml_ann.get("term", {})
                 if isinstance(term, dict):
                     go_id = term.get("id", "")
+                    qualifier = self._parse_qualifier(yaml_ann.get("qualifier"))
+                    negated = bool(yaml_ann.get("negated", False))
+                    if qualifier is None:
+                        matching_annotations = [
+                            ann
+                            for ann in goa_by_go_id.get(go_id, [])
+                            if self._qualifier_is_negated(ann.qualifier) == negated
+                        ]
+                    else:
+                        identity = (go_id, qualifier, negated)
+                        matching_annotations = goa_by_annotation_identity.get(identity, [])
 
-                    # Check if this GO term exists in GOA under any source.
-                    if go_id in goa_by_go_id:
+                    # Evidence/reference changes do not make an assertion novel, but
+                    # relation and negation changes do. This permits curators to replace
+                    # an incorrect `enables` assertion with `contributes_to`, for example.
+                    # Qualifier-less legacy YAML remains conservative and conflicts with
+                    # any non-negated GOA assertion for the same term.
+                    if matching_annotations:
                         sources = sorted(
                             {
                                 f"{ann.evidence_code}, {ann.reference}"
-                                for ann in goa_by_go_id[go_id]
+                                for ann in matching_annotations
                             }
                         )
                         source_summary = "; ".join(sources[:3])

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -949,6 +949,52 @@ UniProtKB	Q12345	TEST	involved_in	GO:0050907	detection of chemical stimulus invo
     goa_path.unlink()
 
 
+def test_new_action_with_existing_go_id_different_qualifier_passes():
+    """A relation correction is novel even when the GO term already exists."""
+    validator = GOAValidator()
+
+    goa_content = """GENE PRODUCT DB\tGENE PRODUCT ID\tSYMBOL\tQUALIFIER\tGO TERM\tGO NAME\tGO ASPECT\tECO ID\tGO EVIDENCE CODE\tREFERENCE\tWITH/FROM\tTAXON ID\tTAXON NAME\tASSIGNED BY\tGENE NAME\tDATE
+UniProtKB\tQ12345\tTEST\tenables\tGO:0016491\toxidoreductase activity\tMF\tECO:0000256\tIEA\tGO_REF:0000002\tInterPro:IPR000001\tNCBITaxon:160488\tPseudomonas putida KT2440\tUniProt\tTest protein\t20260813"""
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".tsv", delete=False) as goa_file:
+        goa_file.write(goa_content)
+        goa_path = Path(goa_file.name)
+
+    yaml_data = {
+        "id": "Q12345",
+        "gene_symbol": "TEST",
+        "existing_annotations": [
+            {
+                "term": {"id": "GO:0016491", "label": "oxidoreductase activity"},
+                "evidence_type": "IEA",
+                "original_reference_id": "GO_REF:0000002",
+                "qualifier": "enables",
+                "review": {"summary": "The subunit does not enable the activity alone", "action": "REMOVE"},
+            },
+            {
+                "term": {"id": "GO:0016491", "label": "oxidoreductase activity"},
+                "evidence_type": "ISS",
+                "original_reference_id": "file:PSEPK/TEST/TEST-notes.md",
+                "qualifier": "contributes_to",
+                "review": {"summary": "The subunit contributes to the complex activity", "action": "NEW"},
+            },
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as yaml_file:
+        yaml.dump(yaml_data, yaml_file)
+        yaml_path = Path(yaml_file.name)
+
+    result = validator.validate_against_goa(yaml_path, goa_path)
+
+    assert result.is_valid, result.error_message
+    assert result.missing_in_yaml == []
+    assert result.missing_in_goa == []
+
+    yaml_path.unlink()
+    goa_path.unlink()
+
+
 def test_validate_gene_review_blocks_new_action_existing_in_goa():
     """Integrated best-practices validation should hard-fail NEW-vs-GOA conflicts."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -995,6 +995,48 @@ UniProtKB\tQ12345\tTEST\tenables\tGO:0016491\toxidoreductase activity\tMF\tECO:0
     goa_path.unlink()
 
 
+def test_unpaired_new_action_with_different_qualifier_fails():
+    """A relation difference alone is not enough to bypass duplicate checking."""
+    validator = GOAValidator()
+
+    goa_content = """GENE PRODUCT DB\tGENE PRODUCT ID\tSYMBOL\tQUALIFIER\tGO TERM\tGO NAME\tGO ASPECT\tECO ID\tGO EVIDENCE CODE\tREFERENCE\tWITH/FROM\tTAXON ID\tTAXON NAME\tASSIGNED BY\tGENE NAME\tDATE
+UniProtKB\tQ12345\tTEST\tinvolved_in\tGO:0050907\tdetection of chemical stimulus involved in sensory perception\tBP\tECO:0000318\tIBA\tGO_REF:0000033\tPTN000123456\tNCBITaxon:9606\tHomo sapiens\tGO_Central\tTest protein\t20260428"""
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".tsv", delete=False) as goa_file:
+        goa_file.write(goa_content)
+        goa_path = Path(goa_file.name)
+
+    yaml_data = {
+        "id": "Q12345",
+        "gene_symbol": "TEST",
+        "existing_annotations": [
+            {
+                "term": {
+                    "id": "GO:0050907",
+                    "label": "detection of chemical stimulus involved in sensory perception",
+                },
+                "evidence_type": "IDA",
+                "original_reference_id": "PMID:99999",
+                "qualifier": "acts_upstream_of_or_within",
+                "review": {"summary": "Unpaired relation change", "action": "NEW"},
+            },
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as yaml_file:
+        yaml.dump(yaml_data, yaml_file)
+        yaml_path = Path(yaml_file.name)
+
+    result = validator.validate_against_goa(yaml_path, goa_path)
+
+    assert not result.is_valid
+    assert result.error_message is not None
+    assert "qualifier=acts_upstream_of_or_within" in result.error_message
+
+    yaml_path.unlink()
+    goa_path.unlink()
+
+
 def test_validate_gene_review_blocks_new_action_existing_in_goa():
     """Integrated best-practices validation should hard-fail NEW-vs-GOA conflicts."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- match proposed NEW annotations to GOA by GO term, qualifier, and negation in strict mode
- preserve conservative behavior for legacy qualifier-less YAML
- add regression coverage for replacing `enables` with `contributes_to`

## Root cause
The validator identified annotations only by GO ID when checking `action: NEW`. That incorrectly rejected relation corrections where an existing complex subunit annotation used `enables` and the curated replacement correctly uses `contributes_to`.

## Validation
- `uv run pytest tests/test_goa_validator.py -q` (35 passed)
- `uv run ruff check src/ai_gene_review/validation/goa_validator.py tests/test_goa_validator.py`
- all eight dimethylglycine/sarcosine gene reviews from PR #2568 pass full GOA validation with this change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8d54a3ed0000cc5506f6f0aeb9d99702c849e871. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->