### PR TITLE
Refine PSEPK aerobic nicotinate degradation module

### DIFF
--- a/genes/PSEPK/maiA/maiA-ai-review.html
+++ b/genes/PSEPK/maiA/maiA-ai-review.html
@@ -1570,6 +1570,24 @@
             </div>
         </div>
 
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the oligomeric state of purified KT2440 MaiA by size-exclusion chromatography coupled to multi-angle light scattering.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: solution-state oligomerization assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q88FY4" data-a="EXPERIMENT: Determine the oligomeric state of purified KT2440 ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
     </div>
 
 
@@ -2035,6 +2053,8 @@ suggested_questions:
 suggested_experiments:
 - description: Compare wild-type and maiA/nicE knockout strains for growth on nicotinate and maleate accumulation, with complementation by catalytic-site mutants.
   experiment_type: pathway mutant and metabolite profiling assay
+- description: Determine the oligomeric state of purified KT2440 MaiA by size-exclusion chromatography coupled to multi-angle light scattering.
+  experiment_type: solution-state oligomerization assay
 </code></pre>
             </div>
         </details>

--- a/genes/PSEPK/maiA/maiA-ai-review.html
+++ b/genes/PSEPK/maiA/maiA-ai-review.html
@@ -1083,10 +1083,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q88FY4" data-a="GO:0051289" data-r="GO_REF:0000024" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="Q88FY4" data-a="GO:0051289" data-r="GO_REF:0000024" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1094,12 +1094,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> The homotetramerization annotation is contradicted by the curated MaiA UniProt entry.
+                            <strong>Summary:</strong> The transferred homotetramerization annotation conflicts with a HAMAP-derived homodimer assignment, but neither establishes the KT2440 oligomer experimentally.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The maiA UniProt SUBUNIT annotation says Homodimer by HAMAP-Rule:MF_00943, directly contradicting the ISS-transferred homotetramerization annotation from UniProtKB:O24766; this is likely an erroneous ISS transfer.
+                            <strong>Reason:</strong> The ISS annotation and the UniProt homodimer statement are both comparative inferences. Without KT2440-specific oligomerization evidence, the homotetramerization term should not be accepted or confidently removed.
                         </div>
 
 
@@ -1959,9 +1959,9 @@ existing_annotations:
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: The homotetramerization annotation is contradicted by the curated MaiA UniProt entry.
-    action: REMOVE
-    reason: The maiA UniProt SUBUNIT annotation says Homodimer by HAMAP-Rule:MF_00943, directly contradicting the ISS-transferred homotetramerization annotation from UniProtKB:O24766; this is likely an erroneous ISS transfer.
+    summary: The transferred homotetramerization annotation conflicts with a HAMAP-derived homodimer assignment, but neither establishes the KT2440 oligomer experimentally.
+    action: UNDECIDED
+    reason: The ISS annotation and the UniProt homodimer statement are both comparative inferences. Without KT2440-specific oligomerization evidence, the homotetramerization term should not be accepted or confidently removed.
     supported_by:
     - reference_id: file:PSEPK/maiA/maiA-goa.tsv
       supporting_text: &#34;GO:0051289\tprotein homotetramerization&#34;
@@ -1972,6 +1972,7 @@ existing_annotations:
     label: nicotinate catabolic process
   evidence_type: IC
   original_reference_id: PMID:18678916
+  qualifier: involved_in
   review:
     summary: MaiA should be connected to nicotinate catabolism because it is NicE, the maleate isomerase step in the aerobic nicotinate pathway.
     action: NEW

--- a/genes/PSEPK/maiA/maiA-ai-review.yaml
+++ b/genes/PSEPK/maiA/maiA-ai-review.yaml
@@ -125,3 +125,5 @@ suggested_questions:
 suggested_experiments:
 - description: Compare wild-type and maiA/nicE knockout strains for growth on nicotinate and maleate accumulation, with complementation by catalytic-site mutants.
   experiment_type: pathway mutant and metabolite profiling assay
+- description: Determine the oligomeric state of purified KT2440 MaiA by size-exclusion chromatography coupled to multi-angle light scattering.
+  experiment_type: solution-state oligomerization assay

--- a/genes/PSEPK/maiA/maiA-ai-review.yaml
+++ b/genes/PSEPK/maiA/maiA-ai-review.yaml
@@ -49,9 +49,9 @@ existing_annotations:
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: The homotetramerization annotation is contradicted by the curated MaiA UniProt entry.
-    action: REMOVE
-    reason: The maiA UniProt SUBUNIT annotation says Homodimer by HAMAP-Rule:MF_00943, directly contradicting the ISS-transferred homotetramerization annotation from UniProtKB:O24766; this is likely an erroneous ISS transfer.
+    summary: The transferred homotetramerization annotation conflicts with a HAMAP-derived homodimer assignment, but neither establishes the KT2440 oligomer experimentally.
+    action: UNDECIDED
+    reason: The ISS annotation and the UniProt homodimer statement are both comparative inferences. Without KT2440-specific oligomerization evidence, the homotetramerization term should not be accepted or confidently removed.
     supported_by:
     - reference_id: file:PSEPK/maiA/maiA-goa.tsv
       supporting_text: "GO:0051289\tprotein homotetramerization"
@@ -62,6 +62,7 @@ existing_annotations:
     label: nicotinate catabolic process
   evidence_type: IC
   original_reference_id: PMID:18678916
+  qualifier: involved_in
   review:
     summary: MaiA should be connected to nicotinate catabolism because it is NicE, the maleate isomerase step in the aerobic nicotinate pathway.
     action: NEW

--- a/genes/PSEPK/nicA/nicA-ai-review.html
+++ b/genes/PSEPK/nicA/nicA-ai-review.html
@@ -895,7 +895,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Replace the broad term with GO:0016725 and use contributes_to because NicA is one required subunit of NicAB, not an independently active nicotinate dehydrogenase.
+                            <strong>Reason:</strong> Replace the broad term with GO:0016725; NicA&#39;s complex-level contribution is recorded in core_functions without rewriting the source GOA qualifier.
                         </div>
 
 
@@ -1312,10 +1312,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q88FX9" data-a="GO:0016725" data-r="PMID:18678916" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="Q88FX9" data-a="GO:0016725" data-r="PMID:18678916" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1323,26 +1323,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This oxidoreductase term captures the NicAB-catalyzed hydroxylation of nicotinate, but the source GOA row uses enables for a complex-subunit activity.
+                            <strong>Summary:</strong> This term captures the NicAB-catalyzed hydroxylation of nicotinate.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retain the term but change the relation to contributes_to because NicA is the iron-sulfur subunit of the assembled NicAB enzyme.
+                            <strong>Reason:</strong> Retain the source enables assertion; core_functions records that NicA contributes to the assembled NicAB molecular function.
                         </div>
 
 
-
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016725" target="_blank" class="term-link">
-                                    oxidoreductase activity, acting on CH or CH2 groups
-                                </a>
-                            </span>
-
-                        </div>
 
 
                         <div class="supported-by">
@@ -2063,11 +2052,11 @@ existing_annotations:
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
-  qualifier: contributes_to
+  qualifier: enables
   review:
     summary: Generic oxidoreductase activity is too broad and is a complex-level activity to which NicA contributes.
     action: MODIFY
-    reason: Replace the broad term with GO:0016725 and use contributes_to because NicA is one required subunit of NicAB, not an independently active nicotinate dehydrogenase.
+    reason: Replace the broad term with GO:0016725; NicA&#39;s complex-level contribution is recorded in core_functions without rewriting the source GOA qualifier.
     proposed_replacement_terms:
     - id: GO:0016725
       label: oxidoreductase activity, acting on CH or CH2 groups
@@ -2137,14 +2126,11 @@ existing_annotations:
     label: oxidoreductase activity, acting on CH or CH2 groups
   evidence_type: IDA
   original_reference_id: PMID:18678916
-  qualifier: contributes_to
+  qualifier: enables
   review:
-    summary: This oxidoreductase term captures the NicAB-catalyzed hydroxylation of nicotinate, but the source GOA row uses enables for a complex-subunit activity.
-    action: MODIFY
-    reason: Retain the term but change the relation to contributes_to because NicA is the iron-sulfur subunit of the assembled NicAB enzyme.
-    proposed_replacement_terms:
-    - id: GO:0016725
-      label: oxidoreductase activity, acting on CH or CH2 groups
+    summary: This term captures the NicAB-catalyzed hydroxylation of nicotinate.
+    action: ACCEPT
+    reason: Retain the source enables assertion; core_functions records that NicA contributes to the assembled NicAB molecular function.
     supported_by:
     - reference_id: file:PSEPK/nicA/nicA-uniprot.txt
       supporting_text: Subunit of the two-component enzyme NicAB that mediates

--- a/genes/PSEPK/nicA/nicA-ai-review.html
+++ b/genes/PSEPK/nicA/nicA-ai-review.html
@@ -879,10 +879,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88FX9" data-a="GO:0016491" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88FX9" data-a="GO:0016491" data-r="GO_REF:0000120" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -890,15 +890,26 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic oxidoreductase activity is less informative than GO:0016725 for the NicAB reaction.
+                            <strong>Summary:</strong> Generic oxidoreductase activity is too broad and is a complex-level activity to which NicA contributes.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The broader parent should not be the retained functional summary.
+                            <strong>Reason:</strong> Replace the broad term with GO:0016725 and use contributes_to because NicA is one required subunit of NicAB, not an independently active nicotinate dehydrogenase.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016725" target="_blank" class="term-link">
+                                    oxidoreductase activity, acting on CH or CH2 groups
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -1301,10 +1312,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88FX9" data-a="GO:0016725" data-r="PMID:18678916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88FX9" data-a="GO:0016725" data-r="PMID:18678916" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1312,15 +1323,26 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This oxidoreductase term captures the NicAB-catalyzed hydroxylation of nicotinate; a more specific GO term for nicotinate dehydrogenase is not present in the current GOA rows.
+                            <strong>Summary:</strong> This oxidoreductase term captures the NicAB-catalyzed hydroxylation of nicotinate, but the source GOA row uses enables for a complex-subunit activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retain the term with contributes_to because NicA is the iron-sulfur subunit of the assembled NicAB enzyme.
+                            <strong>Reason:</strong> Retain the term but change the relation to contributes_to because NicA is the iron-sulfur subunit of the assembled NicAB enzyme.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016725" target="_blank" class="term-link">
+                                    oxidoreductase activity, acting on CH or CH2 groups
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -2041,10 +2063,14 @@ existing_annotations:
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: contributes_to
   review:
-    summary: Generic oxidoreductase activity is less informative than GO:0016725 for the NicAB reaction.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: The broader parent should not be the retained functional summary.
+    summary: Generic oxidoreductase activity is too broad and is a complex-level activity to which NicA contributes.
+    action: MODIFY
+    reason: Replace the broad term with GO:0016725 and use contributes_to because NicA is one required subunit of NicAB, not an independently active nicotinate dehydrogenase.
+    proposed_replacement_terms:
+    - id: GO:0016725
+      label: oxidoreductase activity, acting on CH or CH2 groups
     supported_by:
     - reference_id: file:PSEPK/nicA/nicA-uniprot.txt
       supporting_text: Reaction=2 Fe(III)-[cytochrome] + nicotinate + H2O = 2 Fe(II)-
@@ -2113,9 +2139,12 @@ existing_annotations:
   original_reference_id: PMID:18678916
   qualifier: contributes_to
   review:
-    summary: This oxidoreductase term captures the NicAB-catalyzed hydroxylation of nicotinate; a more specific GO term for nicotinate dehydrogenase is not present in the current GOA rows.
-    action: ACCEPT
-    reason: Retain the term with contributes_to because NicA is the iron-sulfur subunit of the assembled NicAB enzyme.
+    summary: This oxidoreductase term captures the NicAB-catalyzed hydroxylation of nicotinate, but the source GOA row uses enables for a complex-subunit activity.
+    action: MODIFY
+    reason: Retain the term but change the relation to contributes_to because NicA is the iron-sulfur subunit of the assembled NicAB enzyme.
+    proposed_replacement_terms:
+    - id: GO:0016725
+      label: oxidoreductase activity, acting on CH or CH2 groups
     supported_by:
     - reference_id: file:PSEPK/nicA/nicA-uniprot.txt
       supporting_text: Subunit of the two-component enzyme NicAB that mediates

--- a/genes/PSEPK/nicA/nicA-ai-review.yaml
+++ b/genes/PSEPK/nicA/nicA-ai-review.yaml
@@ -12,10 +12,14 @@ existing_annotations:
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: contributes_to
   review:
-    summary: Generic oxidoreductase activity is less informative than GO:0016725 for the NicAB reaction.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: The broader parent should not be the retained functional summary.
+    summary: Generic oxidoreductase activity is too broad and is a complex-level activity to which NicA contributes.
+    action: MODIFY
+    reason: Replace the broad term with GO:0016725 and use contributes_to because NicA is one required subunit of NicAB, not an independently active nicotinate dehydrogenase.
+    proposed_replacement_terms:
+    - id: GO:0016725
+      label: oxidoreductase activity, acting on CH or CH2 groups
     supported_by:
     - reference_id: file:PSEPK/nicA/nicA-uniprot.txt
       supporting_text: Reaction=2 Fe(III)-[cytochrome] + nicotinate + H2O = 2 Fe(II)-
@@ -84,9 +88,12 @@ existing_annotations:
   original_reference_id: PMID:18678916
   qualifier: contributes_to
   review:
-    summary: This oxidoreductase term captures the NicAB-catalyzed hydroxylation of nicotinate; a more specific GO term for nicotinate dehydrogenase is not present in the current GOA rows.
-    action: ACCEPT
-    reason: Retain the term with contributes_to because NicA is the iron-sulfur subunit of the assembled NicAB enzyme.
+    summary: This oxidoreductase term captures the NicAB-catalyzed hydroxylation of nicotinate, but the source GOA row uses enables for a complex-subunit activity.
+    action: MODIFY
+    reason: Retain the term but change the relation to contributes_to because NicA is the iron-sulfur subunit of the assembled NicAB enzyme.
+    proposed_replacement_terms:
+    - id: GO:0016725
+      label: oxidoreductase activity, acting on CH or CH2 groups
     supported_by:
     - reference_id: file:PSEPK/nicA/nicA-uniprot.txt
       supporting_text: Subunit of the two-component enzyme NicAB that mediates

--- a/genes/PSEPK/nicA/nicA-ai-review.yaml
+++ b/genes/PSEPK/nicA/nicA-ai-review.yaml
@@ -12,11 +12,11 @@ existing_annotations:
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
-  qualifier: contributes_to
+  qualifier: enables
   review:
     summary: Generic oxidoreductase activity is too broad and is a complex-level activity to which NicA contributes.
     action: MODIFY
-    reason: Replace the broad term with GO:0016725 and use contributes_to because NicA is one required subunit of NicAB, not an independently active nicotinate dehydrogenase.
+    reason: Replace the broad term with GO:0016725; NicA's complex-level contribution is recorded in core_functions without rewriting the source GOA qualifier.
     proposed_replacement_terms:
     - id: GO:0016725
       label: oxidoreductase activity, acting on CH or CH2 groups
@@ -86,14 +86,11 @@ existing_annotations:
     label: oxidoreductase activity, acting on CH or CH2 groups
   evidence_type: IDA
   original_reference_id: PMID:18678916
-  qualifier: contributes_to
+  qualifier: enables
   review:
-    summary: This oxidoreductase term captures the NicAB-catalyzed hydroxylation of nicotinate, but the source GOA row uses enables for a complex-subunit activity.
-    action: MODIFY
-    reason: Retain the term but change the relation to contributes_to because NicA is the iron-sulfur subunit of the assembled NicAB enzyme.
-    proposed_replacement_terms:
-    - id: GO:0016725
-      label: oxidoreductase activity, acting on CH or CH2 groups
+    summary: This term captures the NicAB-catalyzed hydroxylation of nicotinate.
+    action: ACCEPT
+    reason: Retain the source enables assertion; core_functions records that NicA contributes to the assembled NicAB molecular function.
     supported_by:
     - reference_id: file:PSEPK/nicA/nicA-uniprot.txt
       supporting_text: Subunit of the two-component enzyme NicAB that mediates

--- a/genes/PSEPK/nicB/nicB-ai-review.html
+++ b/genes/PSEPK/nicB/nicB-ai-review.html
@@ -1055,7 +1055,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Replace the broad term with GO:0016725 and use contributes_to because NicB requires NicA for the assembled NicAB reaction.
+                            <strong>Reason:</strong> Replace the broad term with GO:0016725; NicB&#39;s complex-level contribution is recorded in core_functions without rewriting the source GOA qualifier.
                         </div>
 
 
@@ -1392,10 +1392,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q88FX8" data-a="GO:0016725" data-r="PMID:18678916" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="Q88FX8" data-a="GO:0016725" data-r="PMID:18678916" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1403,26 +1403,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction, but the source GOA row uses enables for a complex-subunit activity.
+                            <strong>Summary:</strong> This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retain the term but change the relation to contributes_to because NicB participates in the assembled NicAB reaction with NicA.
+                            <strong>Reason:</strong> Retain the source enables assertion; core_functions records that NicB contributes to the assembled NicAB molecular function.
                         </div>
 
 
-
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016725" target="_blank" class="term-link">
-                                    oxidoreductase activity, acting on CH or CH2 groups
-                                </a>
-                            </span>
-
-                        </div>
 
 
                         <div class="supported-by">
@@ -2251,11 +2240,11 @@ existing_annotations:
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
-  qualifier: contributes_to
+  qualifier: enables
   review:
     summary: Generic oxidoreductase activity is too broad and is a complex-level activity to which NicB contributes.
     action: MODIFY
-    reason: Replace the broad term with GO:0016725 and use contributes_to because NicB requires NicA for the assembled NicAB reaction.
+    reason: Replace the broad term with GO:0016725; NicB&#39;s complex-level contribution is recorded in core_functions without rewriting the source GOA qualifier.
     proposed_replacement_terms:
     - id: GO:0016725
       label: oxidoreductase activity, acting on CH or CH2 groups
@@ -2312,14 +2301,11 @@ existing_annotations:
     label: oxidoreductase activity, acting on CH or CH2 groups
   evidence_type: IDA
   original_reference_id: PMID:18678916
-  qualifier: contributes_to
+  qualifier: enables
   review:
-    summary: This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction, but the source GOA row uses enables for a complex-subunit activity.
-    action: MODIFY
-    reason: Retain the term but change the relation to contributes_to because NicB participates in the assembled NicAB reaction with NicA.
-    proposed_replacement_terms:
-    - id: GO:0016725
-      label: oxidoreductase activity, acting on CH or CH2 groups
+    summary: This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction.
+    action: ACCEPT
+    reason: Retain the source enables assertion; core_functions records that NicB contributes to the assembled NicAB molecular function.
     supported_by:
     - reference_id: file:PSEPK/nicB/nicB-uniprot.txt
       supporting_text: Subunit of the two-component enzyme NicAB that mediates

--- a/genes/PSEPK/nicB/nicB-ai-review.html
+++ b/genes/PSEPK/nicB/nicB-ai-review.html
@@ -1039,10 +1039,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88FX8" data-a="GO:0016491" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88FX8" data-a="GO:0016491" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1050,15 +1050,26 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic oxidoreductase activity is less informative than GO:0016725 for this enzyme complex.
+                            <strong>Summary:</strong> Generic oxidoreductase activity is too broad and is a complex-level activity to which NicB contributes.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Prefer the more specific oxidoreductase term.
+                            <strong>Reason:</strong> Replace the broad term with GO:0016725 and use contributes_to because NicB requires NicA for the assembled NicAB reaction.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016725" target="_blank" class="term-link">
+                                    oxidoreductase activity, acting on CH or CH2 groups
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -1381,10 +1392,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88FX8" data-a="GO:0016725" data-r="PMID:18678916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88FX8" data-a="GO:0016725" data-r="PMID:18678916" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1392,15 +1403,26 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction.
+                            <strong>Summary:</strong> This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction, but the source GOA row uses enables for a complex-subunit activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retain the term with contributes_to because this is the assembled NicAB reaction.
+                            <strong>Reason:</strong> Retain the term but change the relation to contributes_to because NicB participates in the assembled NicAB reaction with NicA.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016725" target="_blank" class="term-link">
+                                    oxidoreductase activity, acting on CH or CH2 groups
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -2229,10 +2251,14 @@ existing_annotations:
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: contributes_to
   review:
-    summary: Generic oxidoreductase activity is less informative than GO:0016725 for this enzyme complex.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Prefer the more specific oxidoreductase term.
+    summary: Generic oxidoreductase activity is too broad and is a complex-level activity to which NicB contributes.
+    action: MODIFY
+    reason: Replace the broad term with GO:0016725 and use contributes_to because NicB requires NicA for the assembled NicAB reaction.
+    proposed_replacement_terms:
+    - id: GO:0016725
+      label: oxidoreductase activity, acting on CH or CH2 groups
     supported_by:
     - reference_id: file:PSEPK/nicB/nicB-uniprot.txt
       supporting_text: Reaction=2 Fe(III)-[cytochrome] + nicotinate + H2O = 2 Fe(II)-
@@ -2288,9 +2314,12 @@ existing_annotations:
   original_reference_id: PMID:18678916
   qualifier: contributes_to
   review:
-    summary: This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction.
-    action: ACCEPT
-    reason: Retain the term with contributes_to because this is the assembled NicAB reaction.
+    summary: This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction, but the source GOA row uses enables for a complex-subunit activity.
+    action: MODIFY
+    reason: Retain the term but change the relation to contributes_to because NicB participates in the assembled NicAB reaction with NicA.
+    proposed_replacement_terms:
+    - id: GO:0016725
+      label: oxidoreductase activity, acting on CH or CH2 groups
     supported_by:
     - reference_id: file:PSEPK/nicB/nicB-uniprot.txt
       supporting_text: Subunit of the two-component enzyme NicAB that mediates

--- a/genes/PSEPK/nicB/nicB-ai-review.yaml
+++ b/genes/PSEPK/nicB/nicB-ai-review.yaml
@@ -40,10 +40,14 @@ existing_annotations:
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: contributes_to
   review:
-    summary: Generic oxidoreductase activity is less informative than GO:0016725 for this enzyme complex.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Prefer the more specific oxidoreductase term.
+    summary: Generic oxidoreductase activity is too broad and is a complex-level activity to which NicB contributes.
+    action: MODIFY
+    reason: Replace the broad term with GO:0016725 and use contributes_to because NicB requires NicA for the assembled NicAB reaction.
+    proposed_replacement_terms:
+    - id: GO:0016725
+      label: oxidoreductase activity, acting on CH or CH2 groups
     supported_by:
     - reference_id: file:PSEPK/nicB/nicB-uniprot.txt
       supporting_text: Reaction=2 Fe(III)-[cytochrome] + nicotinate + H2O = 2 Fe(II)-
@@ -99,9 +103,12 @@ existing_annotations:
   original_reference_id: PMID:18678916
   qualifier: contributes_to
   review:
-    summary: This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction.
-    action: ACCEPT
-    reason: Retain the term with contributes_to because this is the assembled NicAB reaction.
+    summary: This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction, but the source GOA row uses enables for a complex-subunit activity.
+    action: MODIFY
+    reason: Retain the term but change the relation to contributes_to because NicB participates in the assembled NicAB reaction with NicA.
+    proposed_replacement_terms:
+    - id: GO:0016725
+      label: oxidoreductase activity, acting on CH or CH2 groups
     supported_by:
     - reference_id: file:PSEPK/nicB/nicB-uniprot.txt
       supporting_text: Subunit of the two-component enzyme NicAB that mediates

--- a/genes/PSEPK/nicB/nicB-ai-review.yaml
+++ b/genes/PSEPK/nicB/nicB-ai-review.yaml
@@ -40,11 +40,11 @@ existing_annotations:
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
-  qualifier: contributes_to
+  qualifier: enables
   review:
     summary: Generic oxidoreductase activity is too broad and is a complex-level activity to which NicB contributes.
     action: MODIFY
-    reason: Replace the broad term with GO:0016725 and use contributes_to because NicB requires NicA for the assembled NicAB reaction.
+    reason: Replace the broad term with GO:0016725; NicB's complex-level contribution is recorded in core_functions without rewriting the source GOA qualifier.
     proposed_replacement_terms:
     - id: GO:0016725
       label: oxidoreductase activity, acting on CH or CH2 groups
@@ -101,14 +101,11 @@ existing_annotations:
     label: oxidoreductase activity, acting on CH or CH2 groups
   evidence_type: IDA
   original_reference_id: PMID:18678916
-  qualifier: contributes_to
+  qualifier: enables
   review:
-    summary: This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction, but the source GOA row uses enables for a complex-subunit activity.
-    action: MODIFY
-    reason: Retain the term but change the relation to contributes_to because NicB participates in the assembled NicAB reaction with NicA.
-    proposed_replacement_terms:
-    - id: GO:0016725
-      label: oxidoreductase activity, acting on CH or CH2 groups
+    summary: This term captures the oxidoreductase chemistry of the NicAB nicotinate hydroxylation reaction.
+    action: ACCEPT
+    reason: Retain the source enables assertion; core_functions records that NicB contributes to the assembled NicAB molecular function.
     supported_by:
     - reference_id: file:PSEPK/nicB/nicB-uniprot.txt
       supporting_text: Subunit of the two-component enzyme NicAB that mediates

--- a/genes/PSEPK/nicC/nicC-ai-review.html
+++ b/genes/PSEPK/nicC/nicC-ai-review.html
@@ -879,10 +879,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88FY2" data-a="GO:0004497" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88FY2" data-a="GO:0004497" data-r="GO_REF:0000120" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -895,10 +895,21 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Use GO:0043731 as the informative annotation.
+                            <strong>Reason:</strong> Replace the broad molecular-function term with the experimentally supported substrate-specific GO:0043731 term.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043731" target="_blank" class="term-link">
+                                    6-hydroxynicotinate 3-monooxygenase activity
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -1458,10 +1469,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88FY2" data-a="GO:0004497" data-r="PMID:18678916" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88FY2" data-a="GO:0004497" data-r="PMID:18678916" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1474,10 +1485,21 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Use GO:0043731 as the informative annotation.
+                            <strong>Reason:</strong> Replace the broad molecular-function term with the experimentally supported substrate-specific GO:0043731 term.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043731" target="_blank" class="term-link">
+                                    6-hydroxynicotinate 3-monooxygenase activity
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -2333,8 +2355,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   review:
     summary: Monooxygenase activity is correct but too broad when the specific 6-hydroxynicotinate 3-monooxygenase term is present.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Use GO:0043731 as the informative annotation.
+    action: MODIFY
+    reason: Replace the broad molecular-function term with the experimentally supported substrate-specific GO:0043731 term.
+    proposed_replacement_terms:
+    - id: GO:0043731
+      label: 6-hydroxynicotinate 3-monooxygenase activity
     supported_by:
     - &amp;id008
       reference_id: file:PSEPK/nicC/nicC-uniprot.txt
@@ -2431,8 +2456,11 @@ existing_annotations:
   original_reference_id: PMID:18678916
   review:
     summary: Monooxygenase activity is correct but too broad when the specific 6-hydroxynicotinate 3-monooxygenase term is present.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Use GO:0043731 as the informative annotation.
+    action: MODIFY
+    reason: Replace the broad molecular-function term with the experimentally supported substrate-specific GO:0043731 term.
+    proposed_replacement_terms:
+    - id: GO:0043731
+      label: 6-hydroxynicotinate 3-monooxygenase activity
     supported_by:
     - *id008
     - *id009

--- a/genes/PSEPK/nicC/nicC-ai-review.yaml
+++ b/genes/PSEPK/nicC/nicC-ai-review.yaml
@@ -14,8 +14,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   review:
     summary: Monooxygenase activity is correct but too broad when the specific 6-hydroxynicotinate 3-monooxygenase term is present.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Use GO:0043731 as the informative annotation.
+    action: MODIFY
+    reason: Replace the broad molecular-function term with the experimentally supported substrate-specific GO:0043731 term.
+    proposed_replacement_terms:
+    - id: GO:0043731
+      label: 6-hydroxynicotinate 3-monooxygenase activity
     supported_by:
     - &id008
       reference_id: file:PSEPK/nicC/nicC-uniprot.txt
@@ -112,8 +115,11 @@ existing_annotations:
   original_reference_id: PMID:18678916
   review:
     summary: Monooxygenase activity is correct but too broad when the specific 6-hydroxynicotinate 3-monooxygenase term is present.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Use GO:0043731 as the informative annotation.
+    action: MODIFY
+    reason: Replace the broad molecular-function term with the experimentally supported substrate-specific GO:0043731 term.
+    proposed_replacement_terms:
+    - id: GO:0043731
+      label: 6-hydroxynicotinate 3-monooxygenase activity
     supported_by:
     - *id008
     - *id009

--- a/modules/aerobic_nicotinate_degradation.yaml
+++ b/modules/aerobic_nicotinate_degradation.yaml
@@ -243,12 +243,12 @@ module:
                 - preferred_term: proton
               evidence:
                 - source_id: RHEA:27522
-                - source_id: InterPro:IPR058739
-                  statement: Reaction-specific NicX family support complements the exact KT2440 ortholog anchor.
                   title: 2,5-dihydroxypyridine ring-cleavage reaction
                   statement: >-
                     Rhea 27522 defines Fe(II)-dependent formation of
                     N-formylmaleamate.
+                - source_id: InterPro:IPR058739
+                  statement: Reaction-specific NicX family support complements the exact KT2440 ortholog anchor.
                 - source_id: file:PSEPK/nicX/nicX-ai-review.yaml
                   statement: >-
                     The review accepts GO:0047075 as the core function of
@@ -395,10 +395,10 @@ module:
                 - preferred_term: fumarate
               evidence:
                 - source_id: RHEA:13169
-                - source_id: InterPro:IPR028615
-                  statement: Maleate-isomerase family support complements the exact KT2440 ortholog anchor.
                   title: maleate isomerase reaction
                   statement: Rhea 13169 defines cis-trans isomerization of maleate to fumarate.
+                - source_id: InterPro:IPR028615
+                  statement: Maleate-isomerase family support complements the exact KT2440 ortholog anchor.
                 - source_id: file:PSEPK/maiA/maiA-ai-review.yaml
                   statement: >-
                     The review accepts GO:0050076 as the core function of

--- a/modules/aerobic_nicotinate_degradation.yaml
+++ b/modules/aerobic_nicotinate_degradation.yaml
@@ -113,10 +113,10 @@ module:
                           Orthologs retaining the Mo-MCD catalytic and
                           cytochrome electron-transfer architecture of NicB.
                       required_function:
-                        preferred_term: electron transfer activity
+                        preferred_term: molybdopterin cofactor binding
                         term:
-                          id: GO:0009055
-                          label: electron transfer activity
+                          id: GO:0043546
+                          label: molybdopterin cofactor binding
             function:
               preferred_term: oxidoreductase activity, acting on CH or CH2 groups
               term:
@@ -243,6 +243,8 @@ module:
                 - preferred_term: proton
               evidence:
                 - source_id: RHEA:27522
+                - source_id: InterPro:IPR058739
+                  statement: Reaction-specific NicX family support complements the exact KT2440 ortholog anchor.
                   title: 2,5-dihydroxypyridine ring-cleavage reaction
                   statement: >-
                     Rhea 27522 defines Fe(II)-dependent formation of
@@ -393,6 +395,8 @@ module:
                 - preferred_term: fumarate
               evidence:
                 - source_id: RHEA:13169
+                - source_id: InterPro:IPR028615
+                  statement: Maleate-isomerase family support complements the exact KT2440 ortholog anchor.
                   title: maleate isomerase reaction
                   statement: Rhea 13169 defines cis-trans isomerization of maleate to fumarate.
                 - source_id: file:PSEPK/maiA/maiA-ai-review.yaml

--- a/modules/aerobic_nicotinate_degradation.yaml
+++ b/modules/aerobic_nicotinate_degradation.yaml
@@ -83,34 +83,40 @@ module:
                     label: NicA iron-sulfur subunit
                     role: Relays electrons through two [2Fe-2S] clusters.
                     participant:
-                      selector_type: FAMILY
-                      family:
-                        preferred_term: NicA nicotinate dehydrogenase small-subunit family
+                      selector_type: ORTHOLOG_OF
+                      ortholog_of:
+                        preferred_term: Pseudomonas putida KT2440 NicA
                         term:
-                          id: PANTHER:PTHR44379:SF6
-                          label: BLR6046 PROTEIN
-                        representative_members:
-                          - preferred_term: NicA (Pseudomonas putida KT2440)
-                            term:
-                              id: UniProtKB:Q88FX9
-                              label: Nicotinate dehydrogenase subunit A
+                          id: UniProtKB:Q88FX9
+                          label: Nicotinate dehydrogenase subunit A
+                        description: >-
+                          Orthologs retaining the NicA small-subunit architecture
+                          and its role in a two-component NicAB enzyme.
+                      required_function:
+                        preferred_term: 2 iron, 2 sulfur cluster binding
+                        term:
+                          id: GO:0051537
+                          label: 2 iron, 2 sulfur cluster binding
                   - id: nicb_catalytic_subunit
                     label: NicB catalytic and cytochrome electron-transfer subunit
                     role: >-
                       Binds the molybdenum cofactor and heme centers required
                       for nicotinate hydroxylation and cytochrome reduction.
                     participant:
-                      selector_type: FAMILY
-                      family:
-                        preferred_term: NicB nicotinate dehydrogenase large-subunit family
+                      selector_type: ORTHOLOG_OF
+                      ortholog_of:
+                        preferred_term: Pseudomonas putida KT2440 NicB
                         term:
-                          id: InterPro:IPR052516
-                          label: N-heterocyclic hydroxylase
-                        representative_members:
-                          - preferred_term: NicB (Pseudomonas putida KT2440)
-                            term:
-                              id: UniProtKB:Q88FX8
-                              label: Nicotinate dehydrogenase subunit B
+                          id: UniProtKB:Q88FX8
+                          label: Nicotinate dehydrogenase subunit B
+                        description: >-
+                          Orthologs retaining the Mo-MCD catalytic and
+                          cytochrome electron-transfer architecture of NicB.
+                      required_function:
+                        preferred_term: electron transfer activity
+                        term:
+                          id: GO:0009055
+                          label: electron transfer activity
             function:
               preferred_term: oxidoreductase activity, acting on CH or CH2 groups
               term:
@@ -154,17 +160,21 @@ module:
           - id: nicc_activity
             label: NicC 6-hydroxynicotinate 3-monooxygenase activity
             participant:
-              selector_type: FAMILY
-              family:
-                preferred_term: NicC monooxygenase family
+              selector_type: ORTHOLOG_OF
+              ortholog_of:
+                preferred_term: Pseudomonas putida KT2440 NicC
                 term:
-                  id: PANTHER:PTHR13789:SF309
-                  label: PUTATIVE (AFU_ORTHOLOGUE AFUA_6G14510)-RELATED
-                representative_members:
-                  - preferred_term: NicC (Pseudomonas putida KT2440)
-                    term:
-                      id: UniProtKB:Q88FY2
-                      label: 6-hydroxynicotinate 3-monooxygenase
+                  id: UniProtKB:Q88FY2
+                  label: 6-hydroxynicotinate 3-monooxygenase
+                description: >-
+                  Orthologs retaining the characterized 6-hydroxynicotinate
+                  oxidative-decarboxylation reaction; the broad PANTHER
+                  monooxygenase subfamily alone is not specificity evidence.
+              required_function:
+                preferred_term: 6-hydroxynicotinate 3-monooxygenase activity
+                term:
+                  id: GO:0043731
+                  label: 6-hydroxynicotinate 3-monooxygenase activity
             function:
               preferred_term: 6-hydroxynicotinate 3-monooxygenase activity
               term:
@@ -206,17 +216,20 @@ module:
           - id: nicx_activity
             label: NicX 2,5-dihydroxypyridine dioxygenase activity
             participant:
-              selector_type: FAMILY
-              family:
-                preferred_term: NicX dioxygenase family
+              selector_type: ORTHOLOG_OF
+              ortholog_of:
+                preferred_term: Pseudomonas putida KT2440 NicX
                 term:
-                  id: InterPro:IPR058739
-                  label: NicX
-                representative_members:
-                  - preferred_term: NicX (Pseudomonas putida KT2440)
-                    term:
-                      id: UniProtKB:Q88FY1
-                      label: 2,5-dihydroxypyridine 5,6-dioxygenase
+                  id: UniProtKB:Q88FY1
+                  label: 2,5-dihydroxypyridine 5,6-dioxygenase
+                description: >-
+                  Orthologs retaining the characterized 2,5-dihydroxypyridine
+                  ring-cleavage reaction.
+              required_function:
+                preferred_term: 2,5-dihydroxypyridine 5,6-dioxygenase activity
+                term:
+                  id: GO:0047075
+                  label: 2,5-dihydroxypyridine 5,6-dioxygenase activity
             function:
               preferred_term: 2,5-dihydroxypyridine 5,6-dioxygenase activity
               term:
@@ -254,17 +267,21 @@ module:
           - id: nicd_activity
             label: NicD N-formylmaleamate deformylase activity
             participant:
-              selector_type: FAMILY
-              family:
-                preferred_term: NicD deformylase family
+              selector_type: ORTHOLOG_OF
+              ortholog_of:
+                preferred_term: Pseudomonas putida KT2440 NicD
                 term:
-                  id: PANTHER:PTHR43798:SF33
-                  label: HYDROLASE, PUTATIVE (AFU_ORTHOLOGUE AFUA_2G14860)-RELATED
-                representative_members:
-                  - preferred_term: NicD (Pseudomonas putida KT2440)
-                    term:
-                      id: UniProtKB:Q88FY3
-                      label: N-formylmaleamate deformylase
+                  id: UniProtKB:Q88FY3
+                  label: N-formylmaleamate deformylase
+                description: >-
+                  Orthologs retaining EC 3.5.1.106/Rhea 30843 activity; the
+                  broad alpha/beta-hydrolase family alone does not establish
+                  N-formylmaleamate specificity.
+              required_function:
+                preferred_term: hydrolase activity on linear amides
+                term:
+                  id: GO:0016811
+                  label: hydrolase activity, acting on carbon-nitrogen (but not peptide) bonds, in linear amides
             function:
               preferred_term: hydrolase activity, acting on carbon-nitrogen bonds in linear amides
               term:
@@ -301,17 +318,21 @@ module:
           - id: nicf_activity
             label: NicF maleamate amidohydrolase activity
             participant:
-              selector_type: FAMILY
-              family:
-                preferred_term: NicF maleamate amidohydrolase family
+              selector_type: ORTHOLOG_OF
+              ortholog_of:
+                preferred_term: Pseudomonas putida KT2440 NicF
                 term:
-                  id: PANTHER:PTHR43540:SF1
-                  label: ISOCHORISMATASE HYDROLASE
-                representative_members:
-                  - preferred_term: NicF (Pseudomonas putida KT2440)
-                    term:
-                      id: UniProtKB:Q88FY5
-                      label: Maleamate amidohydrolase
+                  id: UniProtKB:Q88FY5
+                  label: Maleamate amidohydrolase
+                description: >-
+                  Orthologs retaining EC 3.5.1.107/Rhea 27385 activity; the
+                  isochorismatase fold alone does not establish maleamate
+                  specificity.
+              required_function:
+                preferred_term: hydrolase activity on linear amides
+                term:
+                  id: GO:0016811
+                  label: hydrolase activity, acting on carbon-nitrogen (but not peptide) bonds, in linear amides
             function:
               preferred_term: hydrolase activity, acting on carbon-nitrogen bonds in linear amides
               term:
@@ -347,17 +368,20 @@ module:
           - id: maia_activity
             label: MaiA maleate isomerase activity
             participant:
-              selector_type: FAMILY
-              family:
-                preferred_term: MaiA maleate isomerase family
+              selector_type: ORTHOLOG_OF
+              ortholog_of:
+                preferred_term: Pseudomonas putida KT2440 MaiA/NicE
                 term:
-                  id: InterPro:IPR028615
+                  id: UniProtKB:Q88FY4
                   label: Maleate isomerase
-                representative_members:
-                  - preferred_term: MaiA (Pseudomonas putida KT2440)
-                    term:
-                      id: UniProtKB:Q88FY4
-                      label: Maleate isomerase
+                description: >-
+                  Orthologs retaining the maleate-to-fumarate reaction in the
+                  maleamate pathway.
+              required_function:
+                preferred_term: maleate isomerase activity
+                term:
+                  id: GO:0050076
+                  label: maleate isomerase activity
             function:
               preferred_term: maleate isomerase activity
               term:
@@ -432,12 +456,11 @@ module:
       gap_kind:
         - ONTOLOGY
     - gap_statement: >-
-        The current PANTHER selectors for NicD and NicF are broader hydrolase
-        families and do not by themselves establish N-formylmaleamate or
-        maleamate specificity.
+        Broad PANTHER and fold-level families for NicC, NicD, and NicF do not
+        by themselves establish the substrate specificity of these reactions.
       boundary: >-
-        Apply these leaves only when the family selector is accompanied by
-        pathway context, the listed P. putida exemplars, and reaction-level
-        evidence; more specific family models remain a curation need.
+        The leaves use orthology to characterized P. putida exemplars together
+        with required GO functions and exact Rhea reactions. More specific,
+        independently validated family models remain a curation need.
       gap_kind:
         - CURATION

--- a/pages/modules/aerobic_nicotinate_degradation.html
+++ b/pages/modules/aerobic_nicotinate_degradation.html
@@ -872,7 +872,7 @@
                     </div>                    <div class="slot-row">
                         <span class="slot-name">Required Function:</span>
                         <div class="descriptor">
-            <span><strong>electron transfer activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009055" target="_blank" rel="noopener">GO:0009055</a></div>
+            <span><strong>molybdopterin cofactor binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0043546" target="_blank" rel="noopener">GO:0043546</a></div>
                     </div></div>            <div class="small"><strong>Role:</strong> Binds the molybdenum cofactor and heme centers required for nicotinate hydroxylation and cytochrome reduction.</div></div>                    </div>
                 </div></div>
                     </div></div>            <h4>Function</h4>

--- a/pages/modules/aerobic_nicotinate_degradation.html
+++ b/pages/modules/aerobic_nicotinate_degradation.html
@@ -584,7 +584,8 @@
                     <p class="muted small">No <code>MODULE:aerobic_nicotinate_degradation</code> deep-research report alongside the module YAML.</p>            </div>
 
             <div class="qc-card">
-                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+                <h3>Leaf nodes lacking representative members</h3>                    <p class="small">6 leaf node(s) with no concrete protein grounding:</p>
+                    <ul class="qc-list small">                            <li><a href="#node-nicab_nicotinate_hydroxylation">NicAB-dependent 6-hydroxynicotinate formation</a> <span class="muted">PROTEIN_COMPLEX</span></li>                            <li><a href="#node-nicc_dihydroxypyridine_formation">NicC-dependent 2,5-dihydroxypyridine formation</a> <span class="muted">ORTHOLOG_OF</span></li>                            <li><a href="#node-nicx_ring_cleavage">NicX-dependent N-formylmaleamate formation</a> <span class="muted">ORTHOLOG_OF</span></li>                            <li><a href="#node-nicd_deformylation">NicD-dependent maleamate formation</a> <span class="muted">ORTHOLOG_OF</span></li>                            <li><a href="#node-nicf_maleate_formation">NicF-dependent maleate formation</a> <span class="muted">ORTHOLOG_OF</span></li>                            <li><a href="#node-maia_fumarate_formation">MaiA-dependent fumarate formation</a> <span class="muted">ORTHOLOG_OF</span></li>                    </ul>            </div>
 
             <div class="qc-card">
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
@@ -592,7 +593,7 @@
                 <h3>Gene-review completeness
                     <span class="muted small">(7/7 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        7 complete review(s) &middot;
+                        6 complete review(s) &middot;
                         7 with deep research &middot;
                         0 missing review &middot;
                         0 reviewed but lacking deep research
@@ -610,7 +611,7 @@
                                     <td>maiA
                                         <span class="muted term-id">Q88FY4</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">3/4</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                 </tr>                                <tr>
                                     <td>nicA
@@ -699,7 +700,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-nicc_activity">NicC 6-hydroxynicotinate 3-monooxygenase activity</a>
-                                <span class="tree-id">Family: NicC monooxygenase family</span>
+                                <span class="tree-id">Ortholog Of: Pseudomonas putida KT2440 NicC</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -715,7 +716,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-nicx_activity">NicX 2,5-dihydroxypyridine dioxygenase activity</a>
-                                <span class="tree-id">Family: NicX dioxygenase family</span>
+                                <span class="tree-id">Ortholog Of: Pseudomonas putida KT2440 NicX</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -731,7 +732,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-nicd_activity">NicD N-formylmaleamate deformylase activity</a>
-                                <span class="tree-id">Family: NicD deformylase family</span>
+                                <span class="tree-id">Ortholog Of: Pseudomonas putida KT2440 NicD</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -747,7 +748,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-nicf_activity">NicF maleamate amidohydrolase activity</a>
-                                <span class="tree-id">Family: NicF maleamate amidohydrolase family</span>
+                                <span class="tree-id">Ortholog Of: Pseudomonas putida KT2440 NicF</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -763,7 +764,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-maia_activity">MaiA maleate isomerase activity</a>
-                                <span class="tree-id">Family: MaiA maleate isomerase family</span>
+                                <span class="tree-id">Ortholog Of: Pseudomonas putida KT2440 MaiA/NicE</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -852,22 +853,26 @@
                     <span class="slot-name">Active units:</span>
                     <div class="active-unit-list">                            <div class="complex-unit">
         <div>
-            <strong>NicA iron-sulfur subunit</strong></div>            <div class="small"><strong>Participant:</strong> Family: NicA nicotinate dehydrogenase small-subunit family</div>
+            <strong>NicA iron-sulfur subunit</strong></div>            <div class="small"><strong>Participant:</strong> Ortholog Of: Pseudomonas putida KT2440 NicA</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Family:</span>
+                        <span class="slot-name">Ortholog Of:</span>
                         <div class="descriptor">
-            <span><strong>NicA nicotinate dehydrogenase small-subunit family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR44379%3ASF6" target="_blank" rel="noopener">PANTHER:PTHR44379:SF6</a>                    <div class="slot-row">
-                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>NicA (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FX9/entry" target="_blank" rel="noopener">UniProtKB:Q88FX9</a></span>                    </div></div>
+            <span><strong>Pseudomonas putida KT2440 NicA</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FX9/entry" target="_blank" rel="noopener">UniProtKB:Q88FX9</a>                <span class="descriptor-description">Orthologs retaining the NicA small-subunit architecture and its role in a two-component NicAB enzyme.</span></div>
+                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>2 iron, 2 sulfur cluster binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0051537" target="_blank" rel="noopener">GO:0051537</a></div>
                     </div></div>            <div class="small"><strong>Role:</strong> Relays electrons through two [2Fe-2S] clusters.</div></div>                            <div class="complex-unit">
         <div>
-            <strong>NicB catalytic and cytochrome electron-transfer subunit</strong></div>            <div class="small"><strong>Participant:</strong> Family: NicB nicotinate dehydrogenase large-subunit family</div>
+            <strong>NicB catalytic and cytochrome electron-transfer subunit</strong></div>            <div class="small"><strong>Participant:</strong> Ortholog Of: Pseudomonas putida KT2440 NicB</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Family:</span>
+                        <span class="slot-name">Ortholog Of:</span>
                         <div class="descriptor">
-            <span><strong>NicB nicotinate dehydrogenase large-subunit family</strong></span><span class="term-id">InterPro:IPR052516</span>                    <div class="slot-row">
-                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>NicB (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FX8/entry" target="_blank" rel="noopener">UniProtKB:Q88FX8</a></span>                    </div></div>
+            <span><strong>Pseudomonas putida KT2440 NicB</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FX8/entry" target="_blank" rel="noopener">UniProtKB:Q88FX8</a>                <span class="descriptor-description">Orthologs retaining the Mo-MCD catalytic and cytochrome electron-transfer architecture of NicB.</span></div>
+                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>electron transfer activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009055" target="_blank" rel="noopener">GO:0009055</a></div>
                     </div></div>            <div class="small"><strong>Role:</strong> Binds the molybdenum cofactor and heme centers required for nicotinate hydroxylation and cytochrome reduction.</div></div>                    </div>
                 </div></div>
                     </div></div>            <h4>Function</h4>
@@ -892,13 +897,15 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-nicc_activity">
         <div class="annoton-title">NicC 6-hydroxynicotinate 3-monooxygenase activity</div>
-        <div class="small muted">nicc_activity</div>            <div class="small"><strong>Participant:</strong> Family: NicC monooxygenase family</div>
+        <div class="small muted">nicc_activity</div>            <div class="small"><strong>Participant:</strong> Ortholog Of: Pseudomonas putida KT2440 NicC</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Family:</span>
+                        <span class="slot-name">Ortholog Of:</span>
                         <div class="descriptor">
-            <span><strong>NicC monooxygenase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR13789%3ASF309" target="_blank" rel="noopener">PANTHER:PTHR13789:SF309</a>                    <div class="slot-row">
-                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>NicC (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FY2/entry" target="_blank" rel="noopener">UniProtKB:Q88FY2</a></span>                    </div></div>
+            <span><strong>Pseudomonas putida KT2440 NicC</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FY2/entry" target="_blank" rel="noopener">UniProtKB:Q88FY2</a>                <span class="descriptor-description">Orthologs retaining the characterized 6-hydroxynicotinate oxidative-decarboxylation reaction; the broad PANTHER monooxygenase subfamily alone is not specificity evidence.</span></div>
+                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>6-hydroxynicotinate 3-monooxygenase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0043731" target="_blank" rel="noopener">GO:0043731</a></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>6-hydroxynicotinate 3-monooxygenase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0043731" target="_blank" rel="noopener">GO:0043731</a>                    <div class="slot-row">
@@ -923,13 +930,15 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-nicx_activity">
         <div class="annoton-title">NicX 2,5-dihydroxypyridine dioxygenase activity</div>
-        <div class="small muted">nicx_activity</div>            <div class="small"><strong>Participant:</strong> Family: NicX dioxygenase family</div>
+        <div class="small muted">nicx_activity</div>            <div class="small"><strong>Participant:</strong> Ortholog Of: Pseudomonas putida KT2440 NicX</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Family:</span>
+                        <span class="slot-name">Ortholog Of:</span>
                         <div class="descriptor">
-            <span><strong>NicX dioxygenase family</strong></span><span class="term-id">InterPro:IPR058739</span>                    <div class="slot-row">
-                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>NicX (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FY1/entry" target="_blank" rel="noopener">UniProtKB:Q88FY1</a></span>                    </div></div>
+            <span><strong>Pseudomonas putida KT2440 NicX</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FY1/entry" target="_blank" rel="noopener">UniProtKB:Q88FY1</a>                <span class="descriptor-description">Orthologs retaining the characterized 2,5-dihydroxypyridine ring-cleavage reaction.</span></div>
+                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>2,5-dihydroxypyridine 5,6-dioxygenase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047075" target="_blank" rel="noopener">GO:0047075</a></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>2,5-dihydroxypyridine 5,6-dioxygenase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047075" target="_blank" rel="noopener">GO:0047075</a>                    <div class="slot-row">
@@ -950,13 +959,15 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-nicd_activity">
         <div class="annoton-title">NicD N-formylmaleamate deformylase activity</div>
-        <div class="small muted">nicd_activity</div>            <div class="small"><strong>Participant:</strong> Family: NicD deformylase family</div>
+        <div class="small muted">nicd_activity</div>            <div class="small"><strong>Participant:</strong> Ortholog Of: Pseudomonas putida KT2440 NicD</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Family:</span>
+                        <span class="slot-name">Ortholog Of:</span>
                         <div class="descriptor">
-            <span><strong>NicD deformylase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43798%3ASF33" target="_blank" rel="noopener">PANTHER:PTHR43798:SF33</a>                    <div class="slot-row">
-                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>NicD (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FY3/entry" target="_blank" rel="noopener">UniProtKB:Q88FY3</a></span>                    </div></div>
+            <span><strong>Pseudomonas putida KT2440 NicD</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FY3/entry" target="_blank" rel="noopener">UniProtKB:Q88FY3</a>                <span class="descriptor-description">Orthologs retaining EC 3.5.1.106/Rhea 30843 activity; the broad alpha/beta-hydrolase family alone does not establish N-formylmaleamate specificity.</span></div>
+                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>hydrolase activity on linear amides</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016811" target="_blank" rel="noopener">GO:0016811</a></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>hydrolase activity, acting on carbon-nitrogen bonds in linear amides</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016811" target="_blank" rel="noopener">GO:0016811</a>                    <div class="slot-row">
@@ -978,13 +989,15 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-nicf_activity">
         <div class="annoton-title">NicF maleamate amidohydrolase activity</div>
-        <div class="small muted">nicf_activity</div>            <div class="small"><strong>Participant:</strong> Family: NicF maleamate amidohydrolase family</div>
+        <div class="small muted">nicf_activity</div>            <div class="small"><strong>Participant:</strong> Ortholog Of: Pseudomonas putida KT2440 NicF</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Family:</span>
+                        <span class="slot-name">Ortholog Of:</span>
                         <div class="descriptor">
-            <span><strong>NicF maleamate amidohydrolase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43540%3ASF1" target="_blank" rel="noopener">PANTHER:PTHR43540:SF1</a>                    <div class="slot-row">
-                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>NicF (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FY5/entry" target="_blank" rel="noopener">UniProtKB:Q88FY5</a></span>                    </div></div>
+            <span><strong>Pseudomonas putida KT2440 NicF</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FY5/entry" target="_blank" rel="noopener">UniProtKB:Q88FY5</a>                <span class="descriptor-description">Orthologs retaining EC 3.5.1.107/Rhea 27385 activity; the isochorismatase fold alone does not establish maleamate specificity.</span></div>
+                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>hydrolase activity on linear amides</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016811" target="_blank" rel="noopener">GO:0016811</a></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>hydrolase activity, acting on carbon-nitrogen bonds in linear amides</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016811" target="_blank" rel="noopener">GO:0016811</a>                    <div class="slot-row">
@@ -1005,13 +1018,15 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-maia_activity">
         <div class="annoton-title">MaiA maleate isomerase activity</div>
-        <div class="small muted">maia_activity</div>            <div class="small"><strong>Participant:</strong> Family: MaiA maleate isomerase family</div>
+        <div class="small muted">maia_activity</div>            <div class="small"><strong>Participant:</strong> Ortholog Of: Pseudomonas putida KT2440 MaiA/NicE</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Family:</span>
+                        <span class="slot-name">Ortholog Of:</span>
                         <div class="descriptor">
-            <span><strong>MaiA maleate isomerase family</strong></span><span class="term-id">InterPro:IPR028615</span>                    <div class="slot-row">
-                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>MaiA (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FY4/entry" target="_blank" rel="noopener">UniProtKB:Q88FY4</a></span>                    </div></div>
+            <span><strong>Pseudomonas putida KT2440 MaiA/NicE</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FY4/entry" target="_blank" rel="noopener">UniProtKB:Q88FY4</a>                <span class="descriptor-description">Orthologs retaining the maleate-to-fumarate reaction in the maleamate pathway.</span></div>
+                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>maleate isomerase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0050076" target="_blank" rel="noopener">GO:0050076</a></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>maleate isomerase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0050076" target="_blank" rel="noopener">GO:0050076</a>                    <div class="slot-row">

--- a/pages/projects/P_PUTIDA/batches/upa01010_aerobic_nicotinate_degradation.html
+++ b/pages/projects/P_PUTIDA/batches/upa01010_aerobic_nicotinate_degradation.html
@@ -395,14 +395,29 @@
 <li>[x] Fetch all selected genes with <code>just fetch-gene PSEPK &lt;gene&gt;</code>.</li>
 <li>[x] Review the existing Falcon deep-research reports for selected genes.</li>
 <li>[x] Curate each selected gene review.</li>
+<li>[x] Re-audit all seven selected reviews as annotation reviewer.</li>
 <li>[x] Validate module and gene reviews.</li>
 <li>[x] Open one PR for this module/pathway: <a href="https://github.com/ai4curation/ai-gene-review/pull/2325">#2325</a>.</li>
-<li>[ ] Shepherd PR through review, CI, and merge readiness.</li>
+<li>[x] Shepherd PR through review, CI, and merge readiness; PR #2325 is merged.</li>
 </ul>
 <p>2026-07-26: OpenScientist timed out after 7200s for the module + pathway +<br />
 PSEPK report; no report file was produced.</p>
 <p>2026-07-26: The generic module-level OpenScientist run also timed out after<br />
 7200s without producing a report.</p>
+<p>2026-08-13: Fresh OpenScientist retries for the seven genes, the generic<br />
+module, and the module + <code>ppu00760</code> + PSEPK combination returned no artifacts.<br />
+They were not restarted during annotation review. The existing PSEPK<br />
+<code>ppu00760</code> OpenScientist synthesis was inspected, but it models NAD+<br />
+biosynthesis/salvage and explicitly excludes nicotinate degradation; it<br />
+therefore supports separation of these boundaries rather than the chemistry of<br />
+this catabolic module.</p>
+<p>2026-08-13: Annotation re-review corrected the NicA/NicB complex-subunit<br />
+relations, replaced broad monooxygenase retention with specific-term<br />
+modifications for NicC, treated MaiA oligomerization as unresolved, and<br />
+replaced overbroad pathway selectors with reaction-constrained ortholog<br />
+selectors. The duplicate draft<br />
+<code>bacterial_aerobic_nicotinate_maleamate_catabolism</code> was consolidated into this<br />
+canonical module.</p>
 <h2 id="candidate-genes">Candidate Genes</h2>
 <table>
 <thead>

--- a/pages/projects/P_PUTIDA/batches/upa01010_aerobic_nicotinate_degradation.html
+++ b/pages/projects/P_PUTIDA/batches/upa01010_aerobic_nicotinate_degradation.html
@@ -411,13 +411,13 @@ They were not restarted during annotation review. The existing PSEPK<br />
 biosynthesis/salvage and explicitly excludes nicotinate degradation; it<br />
 therefore supports separation of these boundaries rather than the chemistry of<br />
 this catabolic module.</p>
-<p>2026-08-13: Annotation re-review corrected the NicA/NicB complex-subunit<br />
-relations, replaced broad monooxygenase retention with specific-term<br />
-modifications for NicC, treated MaiA oligomerization as unresolved, and<br />
-replaced overbroad pathway selectors with reaction-constrained ortholog<br />
-selectors. The duplicate draft<br />
-<code>bacterial_aerobic_nicotinate_maleamate_catabolism</code> was consolidated into this<br />
-canonical module.</p>
+<p>2026-08-13: Annotation re-review retained the GOA-sourced <code>enables</code> relations<br />
+for NicA and NicB while recording complex-level contribution semantics in the<br />
+core functions. It also replaced broad monooxygenase retention with<br />
+specific-term modifications for NicC, treated MaiA oligomerization as<br />
+unresolved, and replaced overbroad pathway selectors with<br />
+reaction-constrained ortholog selectors. PR #2571 records this refinement of<br />
+the canonical module.</p>
 <h2 id="candidate-genes">Candidate Genes</h2>
 <table>
 <thead>

--- a/projects/P_PUTIDA/batches/upa01010_aerobic_nicotinate_degradation.md
+++ b/projects/P_PUTIDA/batches/upa01010_aerobic_nicotinate_degradation.md
@@ -35,15 +35,32 @@ autolink_gene_symbols: false
 - [x] Fetch all selected genes with `just fetch-gene PSEPK <gene>`.
 - [x] Review the existing Falcon deep-research reports for selected genes.
 - [x] Curate each selected gene review.
+- [x] Re-audit all seven selected reviews as annotation reviewer.
 - [x] Validate module and gene reviews.
 - [x] Open one PR for this module/pathway: [#2325](https://github.com/ai4curation/ai-gene-review/pull/2325).
-- [ ] Shepherd PR through review, CI, and merge readiness.
+- [x] Shepherd PR through review, CI, and merge readiness; PR #2325 is merged.
 
 2026-07-26: OpenScientist timed out after 7200s for the module + pathway +
 PSEPK report; no report file was produced.
 
 2026-07-26: The generic module-level OpenScientist run also timed out after
 7200s without producing a report.
+
+2026-08-13: Fresh OpenScientist retries for the seven genes, the generic
+module, and the module + `ppu00760` + PSEPK combination returned no artifacts.
+They were not restarted during annotation review. The existing PSEPK
+`ppu00760` OpenScientist synthesis was inspected, but it models NAD+
+biosynthesis/salvage and explicitly excludes nicotinate degradation; it
+therefore supports separation of these boundaries rather than the chemistry of
+this catabolic module.
+
+2026-08-13: Annotation re-review corrected the NicA/NicB complex-subunit
+relations, replaced broad monooxygenase retention with specific-term
+modifications for NicC, treated MaiA oligomerization as unresolved, and
+replaced overbroad pathway selectors with reaction-constrained ortholog
+selectors. The duplicate draft
+`bacterial_aerobic_nicotinate_maleamate_catabolism` was consolidated into this
+canonical module.
 
 ## Candidate Genes
 

--- a/projects/P_PUTIDA/batches/upa01010_aerobic_nicotinate_degradation.md
+++ b/projects/P_PUTIDA/batches/upa01010_aerobic_nicotinate_degradation.md
@@ -54,13 +54,13 @@ biosynthesis/salvage and explicitly excludes nicotinate degradation; it
 therefore supports separation of these boundaries rather than the chemistry of
 this catabolic module.
 
-2026-08-13: Annotation re-review corrected the NicA/NicB complex-subunit
-relations, replaced broad monooxygenase retention with specific-term
-modifications for NicC, treated MaiA oligomerization as unresolved, and
-replaced overbroad pathway selectors with reaction-constrained ortholog
-selectors. The duplicate draft
-`bacterial_aerobic_nicotinate_maleamate_catabolism` was consolidated into this
-canonical module.
+2026-08-13: Annotation re-review retained the GOA-sourced `enables` relations
+for NicA and NicB while recording complex-level contribution semantics in the
+core functions. It also replaced broad monooxygenase retention with
+specific-term modifications for NicC, treated MaiA oligomerization as
+unresolved, and replaced overbroad pathway selectors with
+reaction-constrained ortholog selectors. PR #2571 records this refinement of
+the canonical module.
 
 ## Candidate Genes
 


### PR DESCRIPTION
## Summary
- consolidate PSEPK nicotinate work into the existing six-step aerobic nicotinate degradation module
- replace broad family selectors with reaction-constrained ortholog selectors using exact KT2440 UniProt exemplars
- model NicAB as a two-subunit complex and correct subunit MF assertions to `contributes_to`
- refine NicC to the substrate-specific monooxygenase term and leave the conflicting MaiA oligomeric state undecided
- update the pathway batch audit and rendered pages

## Evidence and scope
The pathway is grounded by six UniProt/Rhea reactions and existing Falcon gene reports. Fresh OpenScientist retries returned no artifacts; the existing ppu00760 report was checked and explicitly concerns NAD synthesis rather than this catabolic pathway.

## Validation
- strict `just validate` for nicA, nicB, nicC, nicD, nicF, nicX, and maiA
- LinkML ModuleReview validation
- semantic module validation
- gene, module, and project renders
- `git diff --check`

## Residual gaps
KT2440 MaiA oligomeric state, NicB membrane association, NicC localization, and substrate-specific GO terms for NicAB/NicD/NicF remain unresolved.