### PR TITLE
Review human LRP2BP annotations and core function

### DIFF
--- a/genes/human/LRP2BP/LRP2BP-ai-review.yaml
+++ b/genes/human/LRP2BP/LRP2BP-ai-review.yaml
@@ -1,0 +1,488 @@
+id: Q9P2M1
+gene_symbol: LRP2BP
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: >-
+  LRP2BP is a 347-residue cytoplasmic repeat protein containing one TPR and six
+  Sel1-like repeats. It associates with a proline-rich region near the N terminus
+  of the cytoplasmic tail of the multiligand receptor LRP2/megalin and has been
+  proposed to recruit regulatory proteins to that tail. LRP2BP shows vesicular
+  staining near the plasma membrane and throughout the cytoplasm. Its association
+  with LRP2 did not block receptor endocytosis in the reported assay, and the
+  downstream consequences for LRP2 trafficking or transcription remain unresolved.
+  Two closely related splice isoforms are curated; isoform 2 carries a two-residue
+  insertion after residue 35, but no isoform-specific function has been established.
+alternative_products:
+- name: '1'
+  id: Q9P2M1-1
+- name: '2'
+  id: Q9P2M1-2
+  sequence_note: VSP_030664
+existing_annotations:
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  supporting_entities:
+  - UniProtKB-SubCell:SL-0086
+  review:
+    summary: >-
+      UniProtKB subcellular-location vocabulary mapping places LRP2BP in the
+      cytoplasm.
+    action: ACCEPT
+    reason: >-
+      Cytoplasmic localization is consistent with LRP2BP acting as an
+      intracellular receptor-tail adaptor and with the reviewed UniProtKB
+      localization record. The broad compartment is appropriate and represents
+      a core location.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: UniProtKB-SubCell:SL-0086
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  supporting_entities:
+  - UniProtKB:P30711
+  review:
+    summary: >-
+      A BioPlex 2.0 affinity-purification mass-spectrometry screen reports an
+      LRP2BP association with GSTT1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The curated IPI preserves a candidate co-association from a systematic
+      proteome-scale screen, but generic protein binding does not describe a
+      mechanistic molecular function of LRP2BP. The association should remain
+      available as interaction provenance rather than be treated as a core GO
+      function.
+    supported_by:
+    - reference_id: PMID:28514442
+      supporting_text: With more than 56,000 candidate interactions
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  supporting_entities:
+  - UniProtKB:P09211
+  - UniProtKB:P31273
+  - UniProtKB:P38936
+  - UniProtKB:P55040
+  - UniProtKB:Q14088
+  - UniProtKB:Q6NZ36-4
+  - UniProtKB:Q7Z4N8
+  - UniProtKB:Q86UW9
+  - UniProtKB:Q86YD7
+  - UniProtKB:Q8IVW4
+  - UniProtKB:Q8N4L8
+  - UniProtKB:Q8NHY3
+  - UniProtKB:Q92917
+  - UniProtKB:Q92922
+  - UniProtKB:Q96BZ8
+  - UniProtKB:Q96SQ5
+  - UniProtKB:Q9BV19
+  - UniProtKB:Q9BWG6
+  review:
+    summary: >-
+      The HuRI systematic binary-interactome screen reports LRP2BP interactions
+      with eighteen human protein partners.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These curator-assigned IPI records are retained as evidence for the
+      reported binary pairs, including the specifically tested Q6NZ36-4
+      proteoform. They do not establish a shared mechanism for LRP2BP, so
+      collapsing the screen into generic protein binding is functionally
+      uninformative and should not be treated as core function.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: reference interactome map of human binary protein interactions
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  supporting_entities:
+  - UniProtKB:P30711
+  review:
+    summary: >-
+      A BioPlex 3.0 affinity-purification mass-spectrometry screen reports an
+      LRP2BP association with GSTT1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Recurrence of the LRP2BP-GSTT1 association in BioPlex 2.0 and 3.0 lends
+      confidence to the reported co-association, but neither generic protein
+      binding nor this screen result defines a mechanistic molecular function
+      of LRP2BP. Preserve the interaction provenance as non-core screen evidence.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: mass spectrometry, we have created two proteome-scale, cell-line-specific
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12508107
+  qualifier: enables
+  supporting_entities:
+  - UniProtKB:Q7Z5C0
+  review:
+    summary: >-
+      Yeast two-hybrid experiments identify LRP2BP/MegBP as a TPR-containing
+      scaffold that binds the cytoplasmic tail of LRP2/megalin and additional
+      protein partners.
+    action: MODIFY
+    reason: >-
+      Direct binding to LRP2 is well supported, but generic protein binding is
+      uninformative. The accessible evidence identifies LRP2BP as a scaffold and
+      suggests that it recruits other proteins to the receptor tail, which is
+      better represented by protein-macromolecule adaptor activity; the proposed
+      downstream transcriptional model remains tentative.
+    proposed_replacement_terms:
+    - id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    supported_by:
+    - reference_id: PMID:12508107
+      supporting_text: scaffold protein with tetratrico peptide repeats, the megalin-binding protein
+    - reference_id: PMID:12508107
+      supporting_text: |-
+        identified proteins that bound to MegBP and thus might be recruited to the
+        megalin tail. MegBP-interacting partners included several transcriptional
+references:
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      Current GO reference for electronic mapping of the reviewed UniProt
+      subcellular-location vocabulary. It explains the cytoplasm annotation provenance but is not
+      primary biological evidence.
+- id: PMID:12508107
+  title: Functional interaction of megalin with the megalinbinding protein (MegBP),
+    a novel tetratrico peptide repeat-containing adaptor molecule.
+  findings:
+  - statement: A targeted yeast two-hybrid study identified the TPR-containing MegBP as an LRP2/megalin-associated scaffold and mapped binding to a proline-rich region near the N terminus of the receptor tail.
+    supporting_text: |-
+      Using yeast two-hybrid screens, we identified a novel
+      scaffold protein with tetratrico peptide repeats, the megalin-binding protein
+      (MegBP) that associates with the receptor. The binding site of MegBP was mapped
+      to an N-terminal region on the receptor tail harboring a proline-rich peptide
+      element.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+  - statement: MegBP association did not inhibit megalin endocytosis in the reported assay, whereas MegBP overexpression caused cellular lethality.
+    supporting_text: |-
+      MegBP binding did not block the endocytic activity of the receptor;
+      however, overexpression resulted in cellular lethality.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+  - statement: Additional screens recovered transcriptional regulators as candidate MegBP partners, motivating—but not establishing—a model connecting the megalin tail to transcriptional regulation.
+    supporting_text: |-
+      MegBP-interacting partners included several transcriptional
+      regulators such as the SKI-interacting protein (SKIP), a co-activator of the
+      vitamin D receptor. These finding suggest a model whereby megalin directly
+      participates in transcriptional regulation through controlled sequestration or
+      release of transcription factors via MegBP.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed title and abstract were verified. This is the sole targeted mechanistic
+      source among the seeded papers and supports MegBP-LRP2 association plus
+      receptor-tail binding-site mapping. The cache is abstract-only and does not state the
+      tested MegBP species or splice isoform; human Q9P2M1 assignment comes from the
+      reviewed UniProt record. The transcriptional-regulation mechanism remains an
+      author-proposed model.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings:
+  - statement: BioPlex 2.0 reports candidate protein co-associations from affinity-purification mass spectrometry rather than necessarily direct binary interactions.
+    supporting_text: With more than 56,000 candidate interactions
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed identity and full text were verified. GOA/IntAct attributes an
+      LRP2BP-GSTT1 co-association to this proteome-scale AP-MS resource, but LRP2BP and the
+      pair are not named in the cached article body. It is screen evidence without
+      targeted functional follow-up.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings:
+  - statement: HuRI interactions arose from repeated proteome-scale yeast two-hybrid screening with pairwise retesting and sequence confirmation.
+    supporting_text: To map the reference interactome, we performed nine screens of Space III, followed by pairwise verification by quadruplicate retesting and sequence confirmation.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed identity and full text were verified. GOA/IntAct links LRP2BP to 18
+      partners from this HuRI binary-interaction screen. None is named with LRP2BP in
+      the cached article body, and no result establishes an adaptor mechanism, stable
+      complex, or physiological role. These are human screen-level
+      physical-interaction leads.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings:
+  - statement: BioPlex 3.0 and a second HCT116 network were designed as cell-line-specific AP-MS interaction maps, so individual associations remain context-dependent candidates.
+    supporting_text: The first, BioPlex 3.0, results from affinity purification
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed identity and full text were verified. GOA/IntAct again reports the
+      LRP2BP-GSTT1 co-association, but the pair is absent from the cached article body.
+      Recurrence across BioPlex releases supports reproducibility in the screen system,
+      not an LRP2BP-specific mechanism or a constitutive interaction across tissues.
+- id: file:human/LRP2BP/LRP2BP-uniprot.txt
+  title: UniProtKB/Swiss-Prot record for human LRP2BP (Q9P2M1)
+  findings:
+  - statement: The reviewed human record treats LRP2BP as a candidate adapter for LRP2 and records a direct LRP2 interaction from PMID:12508107.
+    supporting_text: |-
+      CC   -!- FUNCTION: May act as an adapter that regulates LRP2 function.
+      CC   -!- SUBUNIT: Interacts with LRP2. {ECO:0000269|PubMed:12508107}.
+    reference_section_type: DATABASE_ENTRY
+  - statement: Human LRP2BP is recorded in the cytoplasm with vesicular staining near the plasma membrane and throughout the cytoplasm.
+    supporting_text: |-
+      CC   -!- SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:12508107}.
+      CC       Note=Detected in a vesicular staining pattern close to the plasma
+      CC       membrane and throughout the cytoplasm.
+    reference_section_type: DATABASE_ENTRY
+  - statement: The reviewed record contains two named splice isoforms; isoform 2 differs by the small VSP_030664 insertion at residue 35.
+    supporting_text: |-
+      CC   -!- ALTERNATIVE PRODUCTS:
+      CC       Event=Alternative splicing; Named isoforms=2;
+      CC       Name=1;
+      CC         IsoId=Q9P2M1-1; Sequence=Displayed;
+      CC       Name=2;
+      CC         IsoId=Q9P2M1-2; Sequence=VSP_030664;
+    reference_section_type: DATABASE_ENTRY
+  - statement: The 347-residue canonical protein contains one annotated TPR followed by six annotated Sel1-like repeats.
+    supporting_text: |-
+      FT   REPEAT          59..92
+      FT                   /note="TPR"
+      FT   REPEAT          93..125
+      FT                   /note="Sel1-like 1"
+      FT   REPEAT          133..168
+      FT                   /note="Sel1-like 2"
+      FT   REPEAT          173..206
+      FT                   /note="Sel1-like 3"
+      FT   REPEAT          207..242
+      FT                   /note="Sel1-like 4"
+      FT   REPEAT          243..277
+      FT                   /note="Sel1-like 5"
+      FT   REPEAT          297..332
+      FT                   /note="Sel1-like 6"
+    reference_section_type: DATABASE_ENTRY
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Reviewed source for human identity, 347-residue canonical sequence, two named
+      splice isoforms, repeat architecture, cytoplasmic localization, and the curated
+      LRP2 interaction. It contains AlphaFoldDB/SMR predictions but no PDB
+      cross-reference; therefore no experimental LRP2BP structure or mapped MegBP-side
+      interaction interface is established.
+- id: file:interpro/panther/PTHR44554/PTHR44554-entries.csv
+  title: PANTHER PTHR44554 LRP2-binding protein family entries
+  findings:
+  - statement: The fetched PANTHER member table places human LRP2BP in the LRP2-binding protein subfamily PTHR44554:SF1.
+    supporting_text: Q9P2M1,LRP2-binding protein,protein,9606,Homo sapiens,Homo sapiens (Human),LRP2BP,347,PTHR44554:SF1,LRP2-BINDING PROTEIN,True
+    reference_section_type: DATABASE_ENTRY
+  - statement: Mouse Lrp2bp is assigned to the same PTHR44554:SF1 subfamily, supporting an exact vertebrate orthology boundary rather than paralog transfer.
+    supporting_text: Q9D4C6,LRP2-binding protein,protein,10090,Mus musculus,Mus musculus (Mouse),Lrp2bp,346,PTHR44554:SF1,LRP2-BINDING PROTEIN,True
+    reference_section_type: DATABASE_ENTRY
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      Generated member table directly confirms the sampled vertebrate ortholog set
+      and human placement in exact subfamily SF1. Family membership supports conserved
+      architecture/orthology only; it does not independently demonstrate LRP2 binding,
+      adaptor activity, subcellular localization, or isoform-specific function.
+core_functions:
+- description: >-
+    LRP2BP acts as a repeat-containing protein-macromolecule adaptor associated
+    with the cytoplasmic tail of LRP2/megalin. A targeted interaction study mapped
+    the LRP2-side binding site to a proline-rich N-terminal region of the receptor
+    tail and recovered additional candidate LRP2BP partners that could be recruited
+    to the receptor. This supports a cytoplasmic scaffold/adaptor role, while the
+    accessible evidence does not establish a stable ternary complex, a specific
+    downstream transcriptional pathway, or a requirement for LRP2 endocytosis.
+  molecular_function:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:12508107
+    supporting_text: |-
+      Using yeast two-hybrid screens, we identified a novel
+      scaffold protein with tetratrico peptide repeats, the megalin-binding protein
+      (MegBP) that associates with the receptor. The binding site of MegBP was mapped
+      to an N-terminal region on the receptor tail harboring a proline-rich peptide
+      element.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:12508107
+    supporting_text: |-
+      MegBP-interacting partners included several transcriptional
+      regulators such as the SKI-interacting protein (SKIP), a co-activator of the
+      vitamin D receptor. These finding suggest a model whereby megalin directly
+      participates in transcriptional regulation through controlled sequestration or
+      release of transcription factors via MegBP.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:12508107
+    supporting_text: |-
+      MegBP binding did not block the endocytic activity of the receptor;
+      however, overexpression resulted in cellular lethality.
+    reference_section_type: ABSTRACT
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Which surface of human LRP2BP binds the proline-rich LRP2 tail, and does the
+    interaction require a particular TPR or Sel1-like repeat?
+- question: >-
+    Which candidate LRP2BP partners form an endogenous complex with LRP2BP and LRP2,
+    and can any partner bind simultaneously with the receptor tail?
+- question: >-
+    Does endogenous LRP2BP regulate cargo-specific LRP2 trafficking, receptor
+    recycling, proteolysis, or transcriptional signaling in LRP2-expressing epithelia?
+- question: >-
+    Does the two-residue insertion in LRP2BP isoform 2 alter repeat packing,
+    localization, partner choice, or LRP2 association?
+suggested_experiments:
+- description: >-
+    Reconstitute binding with purified human LRP2BP repeat fragments and the LRP2
+    cytoplasmic tail, then combine quantitative affinity measurements, systematic
+    repeat mutagenesis, and structural analysis of the minimal complex.
+  hypothesis: >-
+    A defined subset of LRP2BP TPR/Sel1-like repeats recognizes the proline-rich
+    N-terminal region of the LRP2 cytoplasmic tail.
+  experiment_type: quantitative interaction mapping and structural analysis
+- description: >-
+    Endogenously tag LRP2BP and LRP2 in a human proximal-tubule or choroid-plexus
+    epithelial model and use proximity labeling, reciprocal co-immunoprecipitation,
+    and size-resolved native complex analysis before and after cargo uptake.
+  hypothesis: >-
+    LRP2BP assembles a regulated receptor-tail complex whose composition changes
+    during the LRP2 endocytic cycle.
+  experiment_type: endogenous receptor-complex proteomics
+- description: >-
+    Generate LRP2BP-null epithelial cells and rescue them with wild-type or
+    LRP2-binding-defective LRP2BP, then quantify LRP2 surface abundance, cargo uptake,
+    endosomal recycling, ectodomain shedding, and receptor-tail-dependent transcription.
+  hypothesis: >-
+    LRP2BP controls a subset of LRP2 trafficking or signaling outputs without being
+    required for bulk receptor endocytosis.
+  experiment_type: separation-of-function receptor trafficking analysis
+- description: >-
+    Express each LRP2BP isoform from the endogenous locus in otherwise isogenic cells
+    and compare localization, LRP2-tail affinity, partner proteomes, and receptor
+    functional outputs.
+  hypothesis: >-
+    The small isoform-2 insertion produces a measurable but context-dependent change
+    in LRP2BP interaction specificity rather than a wholly distinct biological role.
+  experiment_type: isoform-resolved endogenous complementation
+knowledge_gaps:
+- gap_statement: >-
+    The endogenous molecular consequence of the LRP2BP-LRP2 association is unknown.
+  boundary: >-
+    Targeted evidence establishes association with the LRP2 tail, but the reported
+    interaction did not block receptor endocytosis, and the proposed transcriptional
+    mechanism was not directly demonstrated.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Without a demonstrated output, no specific LRP2 trafficking or transcriptional
+    biological-process term can be assigned to LRP2BP.
+  resolution: >-
+    Disrupt endogenous LRP2BP or its LRP2-binding interface in a physiological human
+    epithelial model and measure cargo-specific receptor trafficking together with
+    receptor-tail-dependent transcriptional outputs.
+  provenance:
+  - reference_id: PMID:12508107
+    supporting_text: |-
+      MegBP binding did not block the endocytic activity of the receptor;
+      however, overexpression resulted in cellular lethality.
+    reference_section_type: ABSTRACT
+- gap_statement: >-
+    The LRP2BP-side interaction interface and endogenous complex composition are
+    unresolved.
+  boundary: >-
+    The study mapped a proline-rich binding region on LRP2 and recovered candidate
+    LRP2BP partners, but no LRP2BP interface, stoichiometry, simultaneous ternary
+    binding, or experimental structure has been established.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    Defining the interface and complex is required to distinguish a physical
+    receptor-tail scaffold from a broader constitutive adaptor mechanism.
+  resolution: >-
+    Map the minimal human LRP2BP-LRP2 interface structurally and determine endogenous
+    complex composition and stoichiometry with orthogonal interaction assays.
+  provenance:
+  - reference_id: PMID:12508107
+    supporting_text: |-
+      Using yeast two-hybrid screens, we identified a novel
+      scaffold protein with tetratrico peptide repeats, the megalin-binding protein
+      (MegBP) that associates with the receptor. The binding site of MegBP was mapped
+      to an N-terminal region on the receptor tail harboring a proline-rich peptide
+      element.
+    reference_section_type: ABSTRACT
+- gap_statement: >-
+    The identity and dynamics of the LRP2BP-positive cytoplasmic vesicles are unknown.
+  boundary: >-
+    The reviewed human record reports vesicular staining near the plasma membrane
+    and throughout the cytoplasm, but no endosomal subtype, cargo state, or direct
+    colocalization with LRP2 is resolved in the accessible evidence.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    Compartment-resolved localization is needed before assigning a specific vesicle
+    or endosomal cellular-component term.
+  resolution: >-
+    Endogenously tag LRP2BP and compare its dynamics with LRP2 and established
+    endosomal markers during synchronized cargo uptake and receptor recycling.
+- gap_statement: >-
+    The biological significance of LRP2BP isoform 2 is unknown.
+  boundary: >-
+    UniProt curates a two-residue insertion after residue 35, but the targeted paper
+    and interaction screens do not resolve which isoform was tested or establish an
+    isoform-specific phenotype.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Isoform-resolved evidence is required before transferring canonical localization
+    or adaptor function to a specific proteoform.
+  resolution: >-
+    Compare the two endogenous human isoforms in isogenic cells using quantitative
+    localization, interaction, and LRP2 functional assays.

--- a/genes/human/LRP2BP/LRP2BP-goa.tsv
+++ b/genes/human/LRP2BP/LRP2BP-goa.tsv
@@ -1,0 +1,23 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	Q9P2M1	LRP2BP	located_in	GO:0005737	cytoplasm	cellular_component	ECO:0007322	IEA	GO_REF:0000044	UniProtKB-SubCell:SL-0086	9606	Homo sapiens	UniProt	LRP2-binding protein	20260727
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:28514442	UniProtKB:P30711	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P09211	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P31273	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P38936	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:P55040	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q14088	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q6NZ36-4	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q7Z4N8	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q86UW9	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q86YD7	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8IVW4	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8N4L8	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8NHY3	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q92917	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q92922	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q96BZ8	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q96SQ5	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9BV19	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q9BWG6	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:33961781	UniProtKB:P30711	9606	Homo sapiens	IntAct	LRP2-binding protein	20260725
+UniProtKB	Q9P2M1	LRP2BP	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:12508107	UniProtKB:Q7Z5C0	9606	Homo sapiens	HGNC-UCL	LRP2-binding protein	20050222

--- a/genes/human/LRP2BP/LRP2BP-notes.md
+++ b/genes/human/LRP2BP/LRP2BP-notes.md
@@ -1,0 +1,32 @@
+# LRP2BP literature and evidence notes
+
+## Evidence hierarchy
+
+The literature base is sparse. PMID:12508107 is the only seeded targeted study of MegBP/LRP2BP. It identifies MegBP as a TPR-containing scaffold associated with megalin/LRP2 and maps the receptor-side binding site to a proline-rich N-terminal region of the LRP2 cytoplasmic tail [PMID:12508107 "scaffold protein with tetratrico peptide repeats, the megalin-binding protein"] [PMID:12508107 "The binding site of MegBP was mapped"]. The cache is abstract-only and does not state the tested MegBP species or splice isoform. The reviewed human UniProt record maps this evidence to Q9P2M1, but that database assignment should not be mistaken for study-level proteoform resolution [file:human/LRP2BP/LRP2BP-uniprot.txt "CC   -!- SUBUNIT: Interacts with LRP2. {ECO:0000269|PubMed:12508107}."].
+
+The interaction did not block receptor endocytosis in the reported experiment [PMID:12508107 "MegBP binding did not block the endocytic activity of the receptor;"] and MegBP overexpression caused cellular lethality [PMID:12508107 "however, overexpression resulted in cellular lethality."]. The proposed connection between megalin and transcriptional regulation is explicitly a model based on additional interaction-screen partners, including SKIP, rather than a demonstrated transcriptional activity of LRP2BP [PMID:12508107 "These finding suggest a model whereby megalin directly"] [PMID:12508107 "release of transcription factors via MegBP."].
+
+## Screen-only interactions
+
+PMID:28514442 is BioPlex 2.0 AP-MS; GOA/IntAct assigns an LRP2BP-GSTT1 co-association to it, but the pair is not named in the cached article body. The paper itself calls the network edges candidate interactions [PMID:28514442 "With more than 56,000 candidate interactions"]. PMID:33961781 reports BioPlex 3.0 and a second cell-line-specific network; GOA/IntAct again assigns LRP2BP-GSTT1, providing screen-system recurrence but not targeted mechanistic validation [PMID:33961781 "The first, BioPlex 3.0, results from affinity purification"].
+
+PMID:32296183 is the HuRI proteome-scale binary yeast-two-hybrid map. GOA/IntAct attributes 18 LRP2BP partners to this source, but none is named with LRP2BP in the cached article body. The screen used repeated search-space screens and pairwise verification [PMID:32296183 "To map the reference interactome, we performed nine screens of Space III, followed by pairwise verification by quadruplicate retesting and sequence confirmation."]. These pairs are human binary-interaction leads; without targeted follow-up they do not establish stable complexes, shared pathways, localization, or adapter function.
+
+## Human protein, isoforms, architecture, and structure
+
+Reviewed Q9P2M1 is a 347-residue cytoplasmic protein. UniProt records vesicular staining near the plasma membrane and throughout the cytoplasm [file:human/LRP2BP/LRP2BP-uniprot.txt "CC       Note=Detected in a vesicular staining pattern close to the plasma"]. Its architecture is repeat-rich: one annotated TPR at residues 59–92 and six Sel1-like repeats extending through residues 297–332 [file:human/LRP2BP/LRP2BP-uniprot.txt "FT   REPEAT          59..92"] [file:human/LRP2BP/LRP2BP-uniprot.txt "FT                   /note=\"Sel1-like 6\""]. These repeats are compatible with a protein-interaction scaffold, but the paper maps the binding site on LRP2, not an interface on LRP2BP.
+
+UniProt names two splice isoforms [file:human/LRP2BP/LRP2BP-uniprot.txt "CC       Event=Alternative splicing; Named isoforms=2;"]. Isoform 2 carries the small VSP_030664 change at residue 35, recorded as T to TKS [file:human/LRP2BP/LRP2BP-uniprot.txt "FT                   /note=\"T -> TKS (in isoform 2)\""]. No cited functional experiment is isoform-resolved, so the LRP2 interaction, localization, and screen results must not be assigned specifically to isoform 1 or 2.
+
+The reviewed record has AlphaFoldDB and SMR cross-references but no PDB cross-reference [file:human/LRP2BP/LRP2BP-uniprot.txt "DR   AlphaFoldDB; Q9P2M1; -."]. Thus there is a predicted structural model, but no curated experimental structure and no experimentally resolved LRP2BP-LRP2 interface.
+
+## Orthology and paralog boundaries
+
+The fetched PANTHER table places human Q9P2M1 with mouse Q9D4C6, rat Q569C2, macaque Q4R3N2, zebrafish A5PLI4, and Xenopus Q6IND7 in exact subfamily PTHR44554:SF1 [file:interpro/panther/PTHR44554/PTHR44554-entries.csv "Q9P2M1,LRP2-binding protein,protein,9606,Homo sapiens,Homo sapiens (Human),LRP2BP,347,PTHR44554:SF1,LRP2-BINDING PROTEIN,True"]. This supports a conserved vertebrate ortholog group and similar protein lengths, not automatic transfer of LRP2 binding or the proposed transcriptional model. No distinct human paralog is present in the fetched representative table; this does not prove that paralogs are absent from every broader database classification.
+
+## Curation boundaries
+
+- Direct targeted evidence supports physical association with LRP2 and mapping of the binding site on the LRP2 tail.
+- The adapter/regulatory role is plausible but remains qualified as “may act” in the reviewed record [file:human/LRP2BP/LRP2BP-uniprot.txt "CC   -!- FUNCTION: May act as an adapter that regulates LRP2 function."].
+- Screen partners should remain screen-level associations unless independently validated and functionally connected to LRP2BP.
+- No evidence here licenses catalytic activity, autonomous receptor activity, a stable transcriptional complex, isoform-specific function, or an experimentally solved structure.

--- a/genes/human/LRP2BP/LRP2BP-uniprot.txt
+++ b/genes/human/LRP2BP/LRP2BP-uniprot.txt
@@ -1,0 +1,271 @@
+ID   LR2BP_HUMAN             Reviewed;         347 AA.
+AC   Q9P2M1; A6NJR7; A7E219; B3KX83; Q9NSN6;
+DT   15-JAN-2008, integrated into UniProtKB/Swiss-Prot.
+DT   15-JAN-2008, sequence version 2.
+DT   10-JUN-2026, entry version 159.
+DE   RecName: Full=LRP2-binding protein;
+DE   AltName: Full=Megalin-binding protein;
+DE            Short=MegBP;
+GN   Name=LRP2BP; Synonyms=KIAA1325;
+OS   Homo sapiens (Human).
+OC   Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia;
+OC   Eutheria; Euarchontoglires; Primates; Haplorrhini; Catarrhini; Hominidae;
+OC   Homo.
+OX   NCBI_TaxID=9606;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA] (ISOFORM 1).
+RC   TISSUE=Brain;
+RX   PubMed=10718198; DOI=10.1093/dnares/7.1.65;
+RA   Nagase T., Kikuno R., Ishikawa K., Hirosawa M., Ohara O.;
+RT   "Prediction of the coding sequences of unidentified human genes. XVI. The
+RT   complete sequences of 150 new cDNA clones from brain which code for large
+RT   proteins in vitro.";
+RL   DNA Res. 7:65-73(2000).
+RN   [2]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA] (ISOFORM 1).
+RC   TISSUE=Brain;
+RX   PubMed=14702039; DOI=10.1038/ng1285;
+RA   Ota T., Suzuki Y., Nishikawa T., Otsuki T., Sugiyama T., Irie R.,
+RA   Wakamatsu A., Hayashi K., Sato H., Nagai K., Kimura K., Makita H.,
+RA   Sekine M., Obayashi M., Nishi T., Shibahara T., Tanaka T., Ishii S.,
+RA   Yamamoto J., Saito K., Kawai Y., Isono Y., Nakamura Y., Nagahari K.,
+RA   Murakami K., Yasuda T., Iwayanagi T., Wagatsuma M., Shiratori A., Sudo H.,
+RA   Hosoiri T., Kaku Y., Kodaira H., Kondo H., Sugawara M., Takahashi M.,
+RA   Kanda K., Yokoi T., Furuya T., Kikkawa E., Omura Y., Abe K., Kamihara K.,
+RA   Katsuta N., Sato K., Tanikawa M., Yamazaki M., Ninomiya K., Ishibashi T.,
+RA   Yamashita H., Murakawa K., Fujimori K., Tanai H., Kimata M., Watanabe M.,
+RA   Hiraoka S., Chiba Y., Ishida S., Ono Y., Takiguchi S., Watanabe S.,
+RA   Yosida M., Hotuta T., Kusano J., Kanehori K., Takahashi-Fujii A., Hara H.,
+RA   Tanase T.-O., Nomura Y., Togiya S., Komai F., Hara R., Takeuchi K.,
+RA   Arita M., Imose N., Musashino K., Yuuki H., Oshima A., Sasaki N.,
+RA   Aotsuka S., Yoshikawa Y., Matsunawa H., Ichihara T., Shiohata N., Sano S.,
+RA   Moriya S., Momiyama H., Satoh N., Takami S., Terashima Y., Suzuki O.,
+RA   Nakagawa S., Senoh A., Mizoguchi H., Goto Y., Shimizu F., Wakebe H.,
+RA   Hishigaki H., Watanabe T., Sugiyama A., Takemoto M., Kawakami B.,
+RA   Yamazaki M., Watanabe K., Kumagai A., Itakura S., Fukuzumi Y., Fujimori Y.,
+RA   Komiyama M., Tashiro H., Tanigami A., Fujiwara T., Ono T., Yamada K.,
+RA   Fujii Y., Ozaki K., Hirao M., Ohmori Y., Kawabata A., Hikiji T.,
+RA   Kobatake N., Inagaki H., Ikema Y., Okamoto S., Okitani R., Kawakami T.,
+RA   Noguchi S., Itoh T., Shigeta K., Senba T., Matsumura K., Nakajima Y.,
+RA   Mizuno T., Morinaga M., Sasaki M., Togashi T., Oyama M., Hata H.,
+RA   Watanabe M., Komatsu T., Mizushima-Sugano J., Satoh T., Shirai Y.,
+RA   Takahashi Y., Nakagawa K., Okumura K., Nagase T., Nomura N., Kikuchi H.,
+RA   Masuho Y., Yamashita R., Nakai K., Yada T., Nakamura Y., Ohara O.,
+RA   Isogai T., Sugano S.;
+RT   "Complete sequencing and characterization of 21,243 full-length human
+RT   cDNAs.";
+RL   Nat. Genet. 36:40-45(2004).
+RN   [3]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA] (ISOFORM 2).
+RC   TISSUE=Amygdala;
+RX   PubMed=17974005; DOI=10.1186/1471-2164-8-399;
+RA   Bechtel S., Rosenfelder H., Duda A., Schmidt C.P., Ernst U.,
+RA   Wellenreuther R., Mehrle A., Schuster C., Bahr A., Bloecker H., Heubner D.,
+RA   Hoerlein A., Michel G., Wedler H., Koehrer K., Ottenwaelder B., Poustka A.,
+RA   Wiemann S., Schupp I.;
+RT   "The full-ORF clone resource of the German cDNA consortium.";
+RL   BMC Genomics 8:399-399(2007).
+RN   [4]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RX   PubMed=15815621; DOI=10.1038/nature03466;
+RA   Hillier L.W., Graves T.A., Fulton R.S., Fulton L.A., Pepin K.H., Minx P.,
+RA   Wagner-McPherson C., Layman D., Wylie K., Sekhon M., Becker M.C.,
+RA   Fewell G.A., Delehaunty K.D., Miner T.L., Nash W.E., Kremitzki C., Oddy L.,
+RA   Du H., Sun H., Bradshaw-Cordum H., Ali J., Carter J., Cordes M., Harris A.,
+RA   Isak A., van Brunt A., Nguyen C., Du F., Courtney L., Kalicki J.,
+RA   Ozersky P., Abbott S., Armstrong J., Belter E.A., Caruso L., Cedroni M.,
+RA   Cotton M., Davidson T., Desai A., Elliott G., Erb T., Fronick C., Gaige T.,
+RA   Haakenson W., Haglund K., Holmes A., Harkins R., Kim K., Kruchowski S.S.,
+RA   Strong C.M., Grewal N., Goyea E., Hou S., Levy A., Martinka S., Mead K.,
+RA   McLellan M.D., Meyer R., Randall-Maher J., Tomlinson C.,
+RA   Dauphin-Kohlberg S., Kozlowicz-Reilly A., Shah N., Swearengen-Shahid S.,
+RA   Snider J., Strong J.T., Thompson J., Yoakum M., Leonard S., Pearman C.,
+RA   Trani L., Radionenko M., Waligorski J.E., Wang C., Rock S.M.,
+RA   Tin-Wollam A.-M., Maupin R., Latreille P., Wendl M.C., Yang S.-P., Pohl C.,
+RA   Wallis J.W., Spieth J., Bieri T.A., Berkowicz N., Nelson J.O., Osborne J.,
+RA   Ding L., Meyer R., Sabo A., Shotland Y., Sinha P., Wohldmann P.E.,
+RA   Cook L.L., Hickenbotham M.T., Eldred J., Williams D., Jones T.A., She X.,
+RA   Ciccarelli F.D., Izaurralde E., Taylor J., Schmutz J., Myers R.M.,
+RA   Cox D.R., Huang X., McPherson J.D., Mardis E.R., Clifton S.W., Warren W.C.,
+RA   Chinwalla A.T., Eddy S.R., Marra M.A., Ovcharenko I., Furey T.S.,
+RA   Miller W., Eichler E.E., Bork P., Suyama M., Torrents D., Waterston R.H.,
+RA   Wilson R.K.;
+RT   "Generation and annotation of the DNA sequences of human chromosomes 2 and
+RT   4.";
+RL   Nature 434:724-731(2005).
+RN   [5]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RA   Mural R.J., Istrail S., Sutton G.G., Florea L., Halpern A.L., Mobarry C.M.,
+RA   Lippert R., Walenz B., Shatkay H., Dew I., Miller J.R., Flanigan M.J.,
+RA   Edwards N.J., Bolanos R., Fasulo D., Halldorsson B.V., Hannenhalli S.,
+RA   Turner R., Yooseph S., Lu F., Nusskern D.R., Shue B.C., Zheng X.H.,
+RA   Zhong F., Delcher A.L., Huson D.H., Kravitz S.A., Mouchard L., Reinert K.,
+RA   Remington K.A., Clark A.G., Waterman M.S., Eichler E.E., Adams M.D.,
+RA   Hunkapiller M.W., Myers E.W., Venter J.C.;
+RL   Submitted (SEP-2005) to the EMBL/GenBank/DDBJ databases.
+RN   [6]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA] (ISOFORM 1).
+RX   PubMed=15489334; DOI=10.1101/gr.2596504;
+RG   The MGC Project Team;
+RT   "The status, quality, and expansion of the NIH full-length cDNA project:
+RT   the Mammalian Gene Collection (MGC).";
+RL   Genome Res. 14:2121-2127(2004).
+RN   [7]
+RP   SUBCELLULAR LOCATION, AND INTERACTION WITH LRP2.
+RX   PubMed=12508107; DOI=10.1242/jcs.00243;
+RA   Petersen H.H., Hilpert J., Militz D., Zandler V., Jacobsen C.,
+RA   Roebroek A.J.M., Willnow T.E.;
+RT   "Functional interaction of megalin with the megalin-binding protein
+RT   (MegBP), a novel tetratrico peptide repeat-containing adaptor molecule.";
+RL   J. Cell Sci. 116:453-461(2003).
+CC   -!- FUNCTION: May act as an adapter that regulates LRP2 function.
+CC   -!- SUBUNIT: Interacts with LRP2. {ECO:0000269|PubMed:12508107}.
+CC   -!- INTERACTION:
+CC       Q9P2M1; Q9BV19: C1orf50; NbExp=3; IntAct=EBI-18273118, EBI-2874661;
+CC       Q9P2M1; Q8N4L8: CCDC24; NbExp=3; IntAct=EBI-18273118, EBI-1104933;
+CC       Q9P2M1; Q8IVW4: CDKL3; NbExp=3; IntAct=EBI-18273118, EBI-3919850;
+CC       Q9P2M1; P38936: CDKN1A; NbExp=3; IntAct=EBI-18273118, EBI-375077;
+CC       Q9P2M1; Q86UW9: DTX2; NbExp=3; IntAct=EBI-18273118, EBI-740376;
+CC       Q9P2M1; Q6NZ36-4: FAAP20; NbExp=3; IntAct=EBI-18273118, EBI-12013806;
+CC       Q9P2M1; Q86YD7: FAM90A1; NbExp=3; IntAct=EBI-18273118, EBI-6658203;
+CC       Q9P2M1; Q8NHY3: GAS2L2; NbExp=3; IntAct=EBI-18273118, EBI-7960826;
+CC       Q9P2M1; P55040: GEM; NbExp=3; IntAct=EBI-18273118, EBI-744104;
+CC       Q9P2M1; Q92917: GPKOW; NbExp=3; IntAct=EBI-18273118, EBI-746309;
+CC       Q9P2M1; P09211: GSTP1; NbExp=3; IntAct=EBI-18273118, EBI-353467;
+CC       Q9P2M1; P30711: GSTT1; NbExp=2; IntAct=EBI-18273118, EBI-8770084;
+CC       Q9P2M1; P31273: HOXC8; NbExp=3; IntAct=EBI-18273118, EBI-1752118;
+CC       Q9P2M1; Q96BZ8: LENG1; NbExp=3; IntAct=EBI-18273118, EBI-726510;
+CC       Q9P2M1; Q7Z4N8: P4HA3; NbExp=3; IntAct=EBI-18273118, EBI-10181968;
+CC       Q9P2M1; Q14088: RAB33A; NbExp=3; IntAct=EBI-18273118, EBI-744685;
+CC       Q9P2M1; Q9BWG6: SCNM1; NbExp=3; IntAct=EBI-18273118, EBI-748391;
+CC       Q9P2M1; Q92922: SMARCC1; NbExp=3; IntAct=EBI-18273118, EBI-355653;
+CC       Q9P2M1; Q96SQ5: ZNF587; NbExp=3; IntAct=EBI-18273118, EBI-6427977;
+CC   -!- SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:12508107}.
+CC       Note=Detected in a vesicular staining pattern close to the plasma
+CC       membrane and throughout the cytoplasm.
+CC   -!- ALTERNATIVE PRODUCTS:
+CC       Event=Alternative splicing; Named isoforms=2;
+CC       Name=1;
+CC         IsoId=Q9P2M1-1; Sequence=Displayed;
+CC       Name=2;
+CC         IsoId=Q9P2M1-2; Sequence=VSP_030664;
+CC   -!- SEQUENCE CAUTION:
+CC       Sequence=BAA92563.1; Type=Erroneous initiation; Evidence={ECO:0000305};
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; AB037746; BAA92563.1; ALT_INIT; mRNA.
+DR   EMBL; AK126913; BAG54395.1; -; mRNA.
+DR   EMBL; AL161975; CAB82313.2; -; mRNA.
+DR   EMBL; AC106897; -; NOT_ANNOTATED_CDS; Genomic_DNA.
+DR   EMBL; CH471056; EAX04650.1; -; Genomic_DNA.
+DR   EMBL; BC150161; AAI50162.1; -; mRNA.
+DR   EMBL; BC152444; AAI52445.1; -; mRNA.
+DR   CCDS; CCDS3840.1; -. [Q9P2M1-1]
+DR   PIR; T47138; T47138.
+DR   RefSeq; NP_001364369.1; NM_001377440.1. [Q9P2M1-1]
+DR   RefSeq; NP_001372530.1; NM_001385601.1. [Q9P2M1-1]
+DR   RefSeq; NP_060879.2; NM_018409.3. [Q9P2M1-1]
+DR   RefSeq; XP_016863899.1; XM_017008410.3. [Q9P2M1-1]
+DR   RefSeq; XP_024309902.1; XM_024454134.2. [Q9P2M1-1]
+DR   RefSeq; XP_024309903.1; XM_024454135.2. [Q9P2M1-1]
+DR   AlphaFoldDB; Q9P2M1; -.
+DR   SMR; Q9P2M1; -.
+DR   BioGRID; 120916; 23.
+DR   FunCoup; Q9P2M1; 62.
+DR   IntAct; Q9P2M1; 20.
+DR   STRING; 9606.ENSP00000332681; -.
+DR   iPTMnet; Q9P2M1; -.
+DR   PhosphoSitePlus; Q9P2M1; -.
+DR   BioMuta; LRP2BP; -.
+DR   DMDM; 166199159; -.
+DR   MassIVE; Q9P2M1; -.
+DR   PaxDb; 9606-ENSP00000332681; -.
+DR   PeptideAtlas; Q9P2M1; -.
+DR   ProteomicsDB; 83845; -. [Q9P2M1-1]
+DR   ProteomicsDB; 83846; -. [Q9P2M1-2]
+DR   Antibodypedia; 28937; 61 antibodies from 17 providers.
+DR   DNASU; 55805; -.
+DR   Ensembl; ENST00000328559.11; ENSP00000332681.7; ENSG00000109771.17. [Q9P2M1-1]
+DR   Ensembl; ENST00000505916.6; ENSP00000426203.1; ENSG00000109771.17. [Q9P2M1-1]
+DR   Ensembl; ENST00000927575.1; ENSP00000597634.1; ENSG00000109771.17. [Q9P2M1-1]
+DR   Ensembl; ENST00000943162.1; ENSP00000613221.1; ENSG00000109771.17. [Q9P2M1-1]
+DR   Ensembl; ENST00000943163.1; ENSP00000613222.1; ENSG00000109771.17. [Q9P2M1-1]
+DR   GeneID; 55805; -.
+DR   KEGG; hsa:55805; -.
+DR   MANE-Select; ENST00000505916.6; ENSP00000426203.1; NM_001377440.1; NP_001364369.1.
+DR   UCSC; uc003ixj.3; human. [Q9P2M1-1]
+DR   AGR; HGNC:25434; -.
+DR   ClinPGx; PA142671538; -.
+DR   CTD; 55805; -.
+DR   DisGeNET; 55805; -.
+DR   GeneCards; LRP2BP; -.
+DR   HGNC; HGNC:25434; LRP2BP.
+DR   HPA; ENSG00000109771; Tissue enhanced (pituitary gland, retina).
+DR   MIM; 619020; gene.
+DR   OpenTargets; ENSG00000109771; -.
+DR   VEuPathDB; HostDB:ENSG00000109771; -.
+DR   eggNOG; KOG1550; Eukaryota.
+DR   GeneTree; ENSGT00390000013490; -.
+DR   InParanoid; Q9P2M1; -.
+DR   OMA; TDHYTHA; -.
+DR   OrthoDB; 2384430at2759; -.
+DR   PAN-GO; Q9P2M1; 0 GO annotations based on evolutionary models.
+DR   PhylomeDB; Q9P2M1; -.
+DR   PathwayCommons; Q9P2M1; -.
+DR   SignaLink; Q9P2M1; -.
+DR   Agora; ENSG00000109771; -.
+DR   BioGRID-ORCS; 55805; 7 hits in 1144 CRISPR screens.
+DR   GenomeRNAi; 55805; -.
+DR   Pharos; Q9P2M1; Tbio.
+DR   PRO; PR:Q9P2M1; -.
+DR   Proteomes; UP000005640; Chromosome 4.
+DR   RNAct; Q9P2M1; protein.
+DR   Bgee; ENSG00000109771; Expressed in sperm and 107 other cell types or tissues.
+DR   ExpressionAtlas; Q9P2M1; baseline and differential.
+DR   GO; GO:0005737; C:cytoplasm; IEA:UniProtKB-SubCell.
+DR   Gene3D; 1.25.40.10; Tetratricopeptide repeat domain; 1.
+DR   InterPro; IPR052323; LRP2-binding.
+DR   InterPro; IPR006597; Sel1-like.
+DR   InterPro; IPR011990; TPR-like_helical_dom_sf.
+DR   InterPro; IPR019734; TPR_rpt.
+DR   PANTHER; PTHR44554; LRP2-BINDING PROTEIN; 1.
+DR   PANTHER; PTHR44554:SF1; LRP2-BINDING PROTEIN; 1.
+DR   Pfam; PF08238; Sel1; 5.
+DR   SMART; SM00671; SEL1; 5.
+DR   SUPFAM; SSF81901; HCP-like; 1.
+DR   PROSITE; PS50005; TPR; 1.
+DR   PROSITE; PS50293; TPR_REGION; 1.
+PE   1: Evidence at protein level;
+KW   Alternative splicing; Cytoplasm; Proteomics identification;
+KW   Reference proteome; Repeat; TPR repeat.
+FT   CHAIN           1..347
+FT                   /note="LRP2-binding protein"
+FT                   /id="PRO_0000315707"
+FT   REPEAT          59..92
+FT                   /note="TPR"
+FT   REPEAT          93..125
+FT                   /note="Sel1-like 1"
+FT   REPEAT          133..168
+FT                   /note="Sel1-like 2"
+FT   REPEAT          173..206
+FT                   /note="Sel1-like 3"
+FT   REPEAT          207..242
+FT                   /note="Sel1-like 4"
+FT   REPEAT          243..277
+FT                   /note="Sel1-like 5"
+FT   REPEAT          297..332
+FT                   /note="Sel1-like 6"
+FT   VAR_SEQ         35
+FT                   /note="T -> TKS (in isoform 2)"
+FT                   /evidence="ECO:0000303|PubMed:17974005"
+FT                   /id="VSP_030664"
+SQ   SEQUENCE   347 AA;  39780 MW;  6BC7C6E758A63F33 CRC64;
+     MKLTSEKLPK NPFYASVSQY AAKNQKFFQW KKEKTDYTHA NLVDKALQLL KERILKGDTL
+     AYFLRGQLYF EEGWYEEALE QFEEIKEKDH QATYQLGVMY YDGLGTTLDA EKGVDYMKKI
+     LDSPCPKARH LKFAAAYNLG RAYYEGKGVK RSNEEAERLW LIAADNGNPK ASVKAQSMLG
+     LYYSTKEPKE LEKAFYWHSE ACGNGNLESQ GALGLMYLYG QGIRQDTEAA LQCLREAAER
+     GNVYAQGNLV EYYYKMKFFT KCVAFSKRIA DYDEVHDIPM IAQVTDCLPE FIGRGMAMAS
+     FYHARCLQLG LGITRDETTA KHYYSKACRL NPALADELHS LLIRQRI
+//

--- a/interpro/panther/PTHR44554/PTHR44554-entries.csv
+++ b/interpro/panther/PTHR44554/PTHR44554-entries.csv
@@ -1,0 +1,7 @@
+id,name,entry_type,source_tax_id,source_tax_name,full_tax_name,gene,length,subfamily,subfamily_name,in_alphafold
+A5PLI4,LRP2-binding protein,protein,7955,Danio rerio,Danio rerio (Zebrafish),lrp2bp,343,PTHR44554:SF1,LRP2-BINDING PROTEIN,True
+Q4R3N2,LRP2-binding protein,protein,9541,Macaca fascicularis,Macaca fascicularis (Crab-eating macaque),LRP2BP,348,PTHR44554:SF1,LRP2-BINDING PROTEIN,True
+Q569C2,LRP2-binding protein,protein,10116,Rattus norvegicus,Rattus norvegicus (Rat),Lrp2bp,346,PTHR44554:SF1,LRP2-BINDING PROTEIN,True
+Q6IND7,LRP2-binding protein,protein,8355,Xenopus laevis,Xenopus laevis (African clawed frog),lrp2bp,341,PTHR44554:SF1,LRP2-BINDING PROTEIN,True
+Q9D4C6,LRP2-binding protein,protein,10090,Mus musculus,Mus musculus (Mouse),Lrp2bp,346,PTHR44554:SF1,LRP2-BINDING PROTEIN,True
+Q9P2M1,LRP2-binding protein,protein,9606,Homo sapiens,Homo sapiens (Human),LRP2BP,347,PTHR44554:SF1,LRP2-BINDING PROTEIN,True

--- a/interpro/panther/PTHR44554/PTHR44554-metadata.yaml
+++ b/interpro/panther/PTHR44554/PTHR44554-metadata.yaml
@@ -1,0 +1,54 @@
+metadata:
+  accession: PTHR44554
+  entry_id: null
+  type: family
+  go_terms: null
+  source_database: panther
+  member_databases: null
+  integrated: IPR052323
+  hierarchy: null
+  name:
+    name: LRP2-binding protein
+    short: LRP2-binding
+  description:
+  - text: This family of proteins may be involved in the regulation of LRP2, a multi-ligand
+      receptor protein that plays a critical role in cellular uptake and signaling.
+      The members of this family are thought to serve as adapter molecules that influence
+      the function of LRP2, potentially affecting its interactions with various ligands
+      or modulating its activity within different signaling pathways. The precise
+      mechanisms by which these proteins regulate LRP2 function remain to be fully
+      elucidated, but their conserved role across different species suggests a fundamental
+      importance in cellular physiology related to LRP2-mediated processes.
+    llm: true
+    checked: false
+    updated: false
+  wikipedia: null
+  literature: null
+  set_info: null
+  overlaps_with: null
+  counters:
+    subfamilies: 1
+    domain_architectures: 0
+    interactions: 0
+    matches: 913
+    pathways: 0
+    proteins: 913
+    proteomes: 712
+    sets: 0
+    structural_models:
+      alphafold: 828
+    structures: 1
+    taxa: 2275
+  entry_annotations:
+    hmm: 0
+    logo: 0
+  cross_references: {}
+  is_llm: true
+  is_reviewed_llm: false
+  is_updated_llm: false
+  representative_structure: null
+_fetch_info:
+  fetched_date: '2026-08-18T20:39:32.860884'
+  api_endpoint: https://www.ebi.ac.uk/interpro/api/entry/panther/PTHR44554/
+  database: panther
+  family_id: PTHR44554

--- a/publications/PMID_12508107.md
+++ b/publications/PMID_12508107.md
@@ -1,0 +1,61 @@
+---
+pmid: '12508107'
+title: Functional interaction of megalin with the megalinbinding protein (MegBP),
+  a novel tetratrico peptide repeat-containing adaptor molecule.
+authors:
+- Petersen HH
+- Hilpert J
+- Militz D
+- Zandler V
+- Jacobsen C
+- Roebroek AJ
+- Willnow TE
+journal: J Cell Sci
+year: '2003'
+full_text_available: false
+doi: 10.1242/jcs.00243
+pubmed_publication_types:
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Functional interaction of megalin with the megalinbinding protein (MegBP), a novel tetratrico peptide repeat-containing adaptor molecule.
+**Authors:** Petersen HH, Hilpert J, Militz D, Zandler V, Jacobsen C, Roebroek AJ, Willnow TE
+**Journal:** J Cell Sci (2003)
+**DOI:** [10.1242/jcs.00243](https://doi.org/10.1242/jcs.00243)
+
+## Abstract
+
+1. J Cell Sci. 2003 Feb 1;116(Pt 3):453-61. doi: 10.1242/jcs.00243.
+
+Functional interaction of megalin with the megalinbinding protein (MegBP), a
+novel tetratrico peptide repeat-containing adaptor molecule.
+
+Petersen HH(1), Hilpert J, Militz D, Zandler V, Jacobsen C, Roebroek AJ, Willnow
+TE.
+
+Author information:
+(1)Max-Delbrueck-Center for Molecular Medicine and Medical Faculty of the Free
+University of Berlin, Germany.
+
+Megalin is a member of the LDL receptor gene family that plays an important role
+in forebrain development and in cellular vitamin D metabolism through endocytic
+uptake of vitamin D metabolites. Similar to other receptors in this gene family,
+megalin is believed to functionally interact with intracellular proteins through
+adaptors that bind to the receptor tail and regulate its endocytic and signal
+transducing activities. Using yeast two-hybrid screens, we identified a novel
+scaffold protein with tetratrico peptide repeats, the megalin-binding protein
+(MegBP) that associates with the receptor. The binding site of MegBP was mapped
+to an N-terminal region on the receptor tail harboring a proline-rich peptide
+element. MegBP binding did not block the endocytic activity of the receptor;
+however, overexpression resulted in cellular lethality. In further screens, we
+identified proteins that bound to MegBP and thus might be recruited to the
+megalin tail. MegBP-interacting partners included several transcriptional
+regulators such as the SKI-interacting protein (SKIP), a co-activator of the
+vitamin D receptor. These finding suggest a model whereby megalin directly
+participates in transcriptional regulation through controlled sequestration or
+release of transcription factors via MegBP.
+
+DOI: 10.1242/jcs.00243
+PMID: 12508107 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- reconcile 22 live LRP2BP assertions into five provenance-exact source records
- replace generic binding with a bounded protein-macromolecule adaptor interpretation for the targeted LRP2-tail study
- synthesize one cytoplasmic adaptor core while explicitly bounding downstream trafficking, transcription, isoform, structure, and screen-only evidence gaps

## Validation
- `just validate human LRP2BP`
- `just validate-goa human LRP2BP`
- reference, raw-quote, duplicate-key, and diff hygiene audits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 27795fee41bad24b4383eaa0316b3ec8a55b77f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->