### PR TITLE
Run the project-frontmatter check when projects/ changes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,6 +54,12 @@ jobs:
               - 'tests/**'
               - 'pyproject.toml'
               - 'uv.lock'
+              # projects/ is here because tests/test_project_frontmatter.py
+              # validates it. Without this the check can only ever fire on a PR
+              # that also touches src/, which project-doc PRs do not -- so it
+              # was structurally unable to catch what it exists to catch, and a
+              # doc with four out-of-vocabulary tags merged green.
+              - 'projects/**'
             # The agentic-automation surface: workflow definitions, the central
             # agent config, the composite actions, and the deterministic guard
             # scripts. Cheap to check, and not otherwise covered when a PR only

--- a/projects/PANCRUSTACEA_METAMORPHOSIS.md
+++ b/projects/PANCRUSTACEA_METAMORPHOSIS.md
@@ -1,7 +1,7 @@
 ---
 title: "Pancrustacea Metamorphosis Gene Families"
 maturity: IN_PROGRESS
-tags: [LITERATURE, ARTHROPOD, DEVELOPMENT, CANDIDATE_GENES]
+tags: [BIOLOGY_DOMAIN]
 species: [DROME]
 genes: [kni, hairy, klg, trn, caps, kek1, krz, insc]
 ---


### PR DESCRIPTION
## The gap

`tests/test_project_frontmatter.py` validates `projects/*.md` frontmatter, but `just test` is gated on the `src` path filter — `src/`, `tests/`, `pyproject.toml`, `uv.lock`. A PR that only touches `projects/` never runs it.

So the check could only ever fire on a PR that *also* changed `src/` — which project-doc PRs, by definition, do not. It was structurally unable to catch what it exists to catch.

## What got through

`PANCRUSTACEA_METAMORPHOSIS.md` (from #2614) carries `[LITERATURE, ARTHROPOD, DEVELOPMENT, CANDIDATE_GENES]` — none in the controlled vocabulary (`BIOLOGY_DOMAIN`, `EVALUATION`, `FLAGSHIP`, `ML_PREDICTIONS`, `OBSOLETION`, `PIPELINE`).

**Main is red on a clean checkout while CI reports green**, because the test never ran there:

```
$ git worktree add --detach /tmp/wt origin/main && cd /tmp/wt
$ uv run pytest tests/test_project_frontmatter.py -q
FAILED tests/test_project_frontmatter.py::test_project_tags_are_controlled[PANCRUSTACEA_METAMORPHOSIS.md]
1 failed, 591 passed
```

Retagged `BIOLOGY_DOMAIN`, which is what the vocabulary offers for a gene-family biology page.

## Scope

Only that one doc is affected — the other 147 pass. This closes the gap before it widens rather than cleaning up after it.

Found while merging main into #2616: that PR touches `src/`, so it runs the full suite and inherits this failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)