### PR TITLE
Fix Pancrustacea project tags

### DIFF
--- a/pages/projects/PANCRUSTACEA_METAMORPHOSIS.html
+++ b/pages/projects/PANCRUSTACEA_METAMORPHOSIS.html
@@ -352,7 +352,7 @@
 
         <p class="project-meta">
             <span class="badge m-IN_PROGRESS">IN_PROGRESS</span>
-            <span class="badge tag t-LITERATURE">LITERATURE</span><span class="badge tag t-ARTHROPOD">ARTHROPOD</span><span class="badge tag t-DEVELOPMENT">DEVELOPMENT</span><span class="badge tag t-CANDIDATE_GENES">CANDIDATE_GENES</span>
+            <span class="badge tag t-BIOLOGY_DOMAIN">BIOLOGY_DOMAIN</span>
         </p>
 
 

--- a/projects/PANCRUSTACEA_METAMORPHOSIS.md
+++ b/projects/PANCRUSTACEA_METAMORPHOSIS.md
@@ -1,7 +1,7 @@
 ---
 title: "Pancrustacea Metamorphosis Gene Families"
 maturity: IN_PROGRESS
-tags: [LITERATURE, ARTHROPOD, DEVELOPMENT, CANDIDATE_GENES]
+tags: [BIOLOGY_DOMAIN]
 species: [DROME]
 genes: [kni, hairy, klg, trn, caps, kek1, krz, insc]
 ---


### PR DESCRIPTION
## Summary
- replace unsupported free-form Pancrustacea project tags with the controlled `BIOLOGY_DOMAIN` tag
- regenerate the project HTML

## Validation
- `PYTEST_ADDOPTS="-k project_tags_are_controlled" just pytest`
- `just render-project PANCRUSTACEA_METAMORPHOSIS`
- `just test`