### PR TITLE
Complete SSA3 annotation row audit

### DIFF
--- a/genes/yeast/SSA3/SSA3-ai-review.html
+++ b/genes/yeast/SSA3/SSA3-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -830,7 +830,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>SSA3 (YBL075C) encodes Ssa3, one of the four cytosolic Hsp70-Ssa molecular chaperones of budding yeast. It is an ATP-dependent chaperone of the Hsp70 family with an N-terminal nucleotide-binding/ATPase domain and a C-terminal substrate-binding domain that binds exposed hydrophobic segments of non-native polypeptides to prevent aggregation and promote folding/refolding and protein quality control. Unlike constitutively expressed Ssa1/Ssa2, Ssa3 and Ssa4 are stress/heat-inducible: Ssa3 has very low basal expression and is strongly induced by heat shock and other proteotoxic stress through Hsf1/heat shock element promoter architecture, and SSA3-HSE reporters are widely used as readouts of Hsf1 activity. Ssa3 functions predominantly in cytosolic and nuclear protein-homeostasis systems, works with Hsp40 co-chaperones and Hsp110 nucleotide-exchange factors, and contributes to cotranslational folding, post-translational protein translocation, refolding of denatured substrates, and prion propagation. Although the Ssa paralogs are partly redundant, Ssa3 shows measurable functional specialization. SSA3 has a paralog, SSA4, that arose from whole-genome duplication.</p>
+        <p>SSA3 (YBL075C) encodes Ssa3, one of the four cytosolic Hsp70-Ssa molecular chaperones of budding yeast. It is an ATP-dependent chaperone of the Hsp70 family with an N-terminal nucleotide-binding/ATPase domain and a C-terminal substrate-binding domain that binds exposed hydrophobic segments of non-native polypeptides to prevent aggregation and promote folding/refolding and protein quality control. Unlike constitutively expressed Ssa1/Ssa2, Ssa3 and Ssa4 are stress/heat-inducible: Ssa3 has very low basal expression and is strongly induced by heat shock and other proteotoxic stress through Hsf1/heat shock element promoter architecture, and SSA3-HSE reporters are widely used as readouts of Hsf1 activity. Ssa3 functions predominantly in the cytosol, with a context-dependent nuclear pool, works with Hsp40 co-chaperones and Hsp110 nucleotide-exchange factors, and contributes to cotranslational folding, post-translational protein translocation, refolding of denatured substrates, and prion propagation. Although the Ssa paralogs are partly redundant, Ssa3 shows measurable functional specialization. SSA3 has a paralog, SSA4, that arose from whole-genome duplication.</p>
     </div>
 
 
@@ -1043,9 +1043,10 @@ SSA3-focused literature review supports a plasma-membrane pool.
 
 
                         <div>
-                            <strong>Reason:</strong> This family-level IBA conflicts with the established cytosolic localization
-of Ssa3 and lacks target-specific evidence. It is therefore treated as a
-compartment-mismatched propagation rather than a peripheral localization.
+                            <strong>Reason:</strong> The pinned 2025 GOA row points to PAINT node PTN002500132, but the current
+local PTHR19375 PAINT snapshot retains nucleus and cytosol at that node and
+no longer carries GO:0005886. The stale inference also lacks target-specific
+corroboration: Ssa3 is independently supported as a cytosolic Hsp70.
                         </div>
 
 
@@ -1054,14 +1055,7 @@ compartment-mismatched propagation rather than a peripheral localization.
                             <div class="propagation-title">Propagation Review</div>
                             <div class="propagation-row">
                                 <strong>Root cause:</strong>
-                                <span class="badge">PROPAGATION BAD</span>
-                            </div>
-
-                            <div class="propagation-row">
-                                <strong>Failure modes:</strong>
-
-                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
-
+                                <span class="badge">SOURCE STALE OR MISSING</span>
                             </div>
 
 
@@ -1074,10 +1068,10 @@ compartment-mismatched propagation rather than a peripheral localization.
                                     &middot; PAINT Hsp70 family node
 
 
-                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
 
 
-                                    <div class="propagation-comment">Plasma-membrane localization may apply to another Hsp70 family member, but Ssa3 is a cytosolic Ssa chaperone.</div>
+                                    <div class="propagation-comment">The current PTHR19375 PAINT snapshot has nucleus and cytosol IBD rows at this node but no plasma-membrane IBD row; the pinned GOA transfer is stale.</div>
 
                                 </div>
 
@@ -1565,10 +1559,10 @@ denatured substrates, supporting protein refolding as a core process.
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P09435" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1582,11 +1576,22 @@ activity; Ssa3 has an N-terminal nucleotide-binding (ATPase) domain.
 
 
                         <div>
-                            <strong>Reason:</strong> The annotation is not false, but it is redundant and substantially less
-informative than the existing ATP-binding and ATP-hydrolysis annotations.
+                            <strong>Reason:</strong> Nucleotide binding is correct but too broad for the Hsp70 nucleotide-binding
+domain; replace it with the existing, mechanistically specific ATP-binding term.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    ATP binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -1982,32 +1987,43 @@ driving the substrate-affinity cycle.
                         <div class="term-info">
 
                             <span class="term-id">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
-                                    GO:0051082
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
                                 </a>
                             </span>
-                            <span class="term-label">unfolded protein binding</span>
+                            <span class="term-label">protein folding</span>
 
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">IEA</span>
+                        <span class="evidence-code">IGI</span>
 
 
 
                         <br>
                         <span style="font-size: 0.75rem;">
 
-                            GO_REF:0000117
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9789005
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Folding in vivo of a newly translated yeast cytosolic enzyme...
+                                </span>
+
+
 
                         </span>
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P09435" data-a="GO:0051082" data-r="GO_REF:0000117" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0006457" data-r="PMID:9789005" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2015,32 +2031,15 @@ driving the substrate-affinity cycle.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Ssa3 binds non-native/unfolded proteins, but as an ATP-dependent Hsp70 the
-more precise molecular function is ATP-dependent protein folding chaperone
-activity (GO:0140662), which is also the term InterPro assigns in UniProt.
+                            <strong>Summary:</strong> This separate genetic-interaction row is linked to SSA4 (WITH/FROM SGD:S000000905). Kim et al. support SSA-class cytosolic Hsp70 function in folding newly translated proteins; the partner records the tested genetic context rather than an isoform-specific mechanism.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Falcon emphasizes that Ssa3 is an ATP-dependent chaperone whose
-substrate binding is coupled to the ATPase cycle; the ATP-dependent
-protein folding chaperone term (GO:0140662) captures this more precisely
-than the generic unfolded protein binding. This matches the InterPro IEA
-annotation in UniProt (GO:0140662).
+                            <strong>Reason:</strong> Protein folding is a core Ssa3 process supported at the SSA-family level; retain this partner-specific IGI row.
                         </div>
 
 
-
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
-                                    ATP-dependent protein folding chaperone
-                                </a>
-                            </span>
-
-                        </div>
 
 
                         <div class="supported-by">
@@ -2049,11 +2048,13 @@ annotation in UniProt (GO:0140662).
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:yeast/SSA3/SSA3-deep-research-falcon.md
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link">
+                                        PMID:9789005
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">ATP binding and hydrolysis drive switching between low-affinity/high-exchange and high-affinity/slow-exchange substrate states; co-chaperones (notably J-domain proteins/Hsp40s) stimulate ATP hydrolysis and nucleotide-exchange factors reset the cycle.</div>
+                                <div class="support-text">yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.</div>
 
                             </div>
 
@@ -2112,17 +2113,12 @@ annotation in UniProt (GO:0140662).
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic protein binding from a high-throughput protein-complex mass
-spectrometry study; uninformative about Ssa3&#39;s molecular function, which
-is better captured by its chaperone/co-chaperone interaction terms.
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–MTC5 association (WITH/FROM UniProtKB:Q03897) from a high-throughput protein-complex mass-spectrometry study. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Per curation guidance, protein binding (GO:0005515) is uninformative.
-More specific terms (heat shock protein binding, protein folding
-chaperone) capture the biology; this generic HTP annotation is
-over-annotated.
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
                         </div>
 
 
@@ -2181,14 +2177,780 @@ over-annotated.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic protein binding from a high-throughput protein-complex study;
-uninformative about molecular function.
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–HEM13 association (WITH/FROM UniProtKB:P11353) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative; more specific chaperone
-terms apply. Over-annotated.
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–RAD50 association (WITH/FROM UniProtKB:P12753) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–YCR043C association (WITH/FROM UniProtKB:P25361) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–RAD23 association (WITH/FROM UniProtKB:P32628) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–PMT1 association (WITH/FROM UniProtKB:P33775) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–SIS2 association (WITH/FROM UniProtKB:P36024) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–ENP1 association (WITH/FROM UniProtKB:P38333) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–MSB3 association (WITH/FROM UniProtKB:P48566) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–RPL38 association (WITH/FROM UniProtKB:P49167) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–PKR1 association (WITH/FROM UniProtKB:Q03880) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–MTC5 association (WITH/FROM UniProtKB:Q03897) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–MMS22 association (WITH/FROM UniProtKB:Q06164) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16554755
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Global landscape of protein complexes in the yeast Saccharom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:16554755" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–GTT2 association (WITH/FROM UniProtKB:Q12390) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
                         </div>
 
 
@@ -2247,14 +3009,855 @@ terms apply. Over-annotated.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic protein binding from a chaperone-interaction atlas; the
-chaperone-substrate/co-chaperone biology is better represented by specific
-terms such as heat shock protein binding and protein folding chaperone.
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–HEM13 association (WITH/FROM UniProtKB:P11353) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative. Over-annotated.
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–RAD50 association (WITH/FROM UniProtKB:P12753) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–SSA4 association (WITH/FROM UniProtKB:P22202) from the TAP-tag chaperone-interaction atlas. Because SSA4 is another Hsp70 paralog, the partner class supports a more informative Hsp70-protein-binding replacement; the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding with GO:0030544 Hsp70 protein binding. The curator-supplied partner identity establishes that the bound partner is an Hsp70, which licenses the partner-class refinement even though the affinity-capture dataset does not establish direct binary contact.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
+                                    Hsp70 protein binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–YCR043C association (WITH/FROM UniProtKB:P25361) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–RAD23 association (WITH/FROM UniProtKB:P32628) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–PMT1 association (WITH/FROM UniProtKB:P33775) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–SIS2 association (WITH/FROM UniProtKB:P36024) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–ENP1 association (WITH/FROM UniProtKB:P38333) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–MSB3 association (WITH/FROM UniProtKB:P48566) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–RPL38 association (WITH/FROM UniProtKB:P49167) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–PKR1 association (WITH/FROM UniProtKB:Q03880) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–MTC5 association (WITH/FROM UniProtKB:Q03897) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–MMS22 association (WITH/FROM UniProtKB:Q06164) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19536198
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An atlas of chaperone-protein interactions in Saccharomyces ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–GTT2 association (WITH/FROM UniProtKB:Q12390) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
                         </div>
 
 
@@ -2313,13 +3916,12 @@ terms such as heat shock protein binding and protein folding chaperone.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic protein binding from an inter-species interaction network;
-uninformative about Ssa3&#39;s molecular function.
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–human HSPBP1 association (WITH/FROM UniProtKB:Q9NZL4) from an inter-species interaction network. The generic term does not identify an enabled molecular function and the dataset does not by itself establish direct binary contact.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative. Over-annotated.
+                            <strong>Reason:</strong> Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
                         </div>
 
 
@@ -2367,10 +3969,10 @@ uninformative about Ssa3&#39;s molecular function.
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:31454312" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0005515" data-r="PMID:31454312" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2378,16 +3980,26 @@ uninformative about Ssa3&#39;s molecular function.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic protein binding from a study of paralog heteromer retention;
-uninformative about molecular function.
+                            <strong>Summary:</strong> This separate GOA row records a dataset-level Ssa3–SSA4 association (WITH/FROM UniProtKB:P22202) from a paralog-heteromer retention study. Because SSA4 is another Hsp70 paralog, the partner class supports a more informative Hsp70-protein-binding replacement; the dataset does not by itself establish direct binary contact.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative. Over-annotated.
+                            <strong>Reason:</strong> Replace generic protein binding with GO:0030544 Hsp70 protein binding. The curator-supplied partner identity establishes that the bound partner is an Hsp70, which licenses the partner-class refinement even though the study does not establish direct binary contact for this pair.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
+                                    Hsp70 protein binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -2444,16 +4056,19 @@ uninformative about molecular function.
 
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Ssa3, as a cytosolic Hsp70, contributes to protein quality control of
-misfolded/non-native proteins. This is a genuine part of the proteostasis
-role but is captured at a level peripheral to the core chaperone
-molecular function; kept as non-core.
+misfolded/non-native proteins. The cached PMID:24855027 record is
+abstract-only and Mca1-focused and does not expose the SSA3-specific IMP
+experiment, so this curator annotation is retained by deference as a
+genuine but non-core proteostasis process.
                         </div>
 
 
                         <div>
                             <strong>Reason:</strong> Falcon supports the general role of cytosolic Hsp70-Ssa proteins in
 proteostasis and quality control (degradation/refolding of non-native
-substrates), but this term is retained as a non-core process annotation.
+substrates). Because the cached paper is abstract-only and does not show
+the SSA3-specific experiment available to the curator, retain the IMP by
+deference and keep the process annotation non-core.
                         </div>
 
 
@@ -2628,15 +4243,12 @@ curator rather than overclaiming what the abstract shows.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Genetic evidence that the SSA class of cytosolic Hsp70 mediates folding in
-vivo of newly translated yeast proteins. Core biological process for Ssa3.
+                            <strong>Summary:</strong> This separate genetic-interaction row is linked to SSA1 (WITH/FROM SGD:S000000004). Kim et al. support SSA-class cytosolic Hsp70 function in folding newly translated proteins; the partner records the tested genetic context rather than an isoform-specific mechanism.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Consistent with falcon: Hsp70-Ssa proteins bind non-native proteins and
-assist folding; PMID:9789005 demonstrates the SSA class mediates folding
-of newly translated cytosolic proteins.
+                            <strong>Reason:</strong> Protein folding is a core Ssa3 process supported at the SSA-family level; retain this partner-specific IGI row.
                         </div>
 
 
@@ -2658,14 +4270,364 @@ of newly translated cytosolic proteins.
 
                             </div>
 
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                                    GO:0051082
+                                </a>
+                            </span>
+                            <span class="term-label">unfolded protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9789005
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Folding in vivo of a newly translated yeast cytosolic enzyme...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0051082" data-r="PMID:9789005" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate genetic-interaction row is linked to SSA1 (WITH/FROM SGD:S000000004). Binding non-native clients is real, but the productive, ATP-coupled chaperone activity is more precisely represented by GO:0140662.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic unfolded-protein binding with ATP-dependent protein folding chaperone activity while retaining this partner-specific IGI provenance.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:yeast/SSA3/SSA3-deep-research-falcon.md
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link">
+                                        PMID:9789005
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">Hsp70-Ssa proteins bind exposed hydrophobic regions on unfolded proteins, assist folding/refolding, and support proteostasis</div>
+                                <div class="support-text">yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                                    GO:0051082
+                                </a>
+                            </span>
+                            <span class="term-label">unfolded protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9789005
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Folding in vivo of a newly translated yeast cytosolic enzyme...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0051082" data-r="PMID:9789005" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate genetic-interaction row is linked to SSA4 (WITH/FROM SGD:S000000905). Binding non-native clients is real, but the productive, ATP-coupled chaperone activity is more precisely represented by GO:0140662.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic unfolded-protein binding with ATP-dependent protein folding chaperone activity while retaining this partner-specific IGI provenance.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link">
+                                        PMID:9789005
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                                    GO:0051082
+                                </a>
+                            </span>
+                            <span class="term-label">unfolded protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9789005
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Folding in vivo of a newly translated yeast cytosolic enzyme...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0051082" data-r="PMID:9789005" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate genetic-interaction row is linked to SSA2 (WITH/FROM SGD:S000003947). Binding non-native clients is real, but the productive, ATP-coupled chaperone activity is more precisely represented by GO:0140662.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic unfolded-protein binding with ATP-dependent protein folding chaperone activity while retaining this partner-specific IGI provenance.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link">
+                                        PMID:9789005
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9789005
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Folding in vivo of a newly translated yeast cytosolic enzyme...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0006457" data-r="PMID:9789005" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This separate genetic-interaction row is linked to SSA2 (WITH/FROM SGD:S000003947). Kim et al. support SSA-class cytosolic Hsp70 function in folding newly translated proteins; the partner records the tested genetic context rather than an isoform-specific mechanism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein folding is a core Ssa3 process supported at the SSA-family level; retain this partner-specific IGI row.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link">
+                                        PMID:9789005
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.</div>
 
                             </div>
 
@@ -2765,7 +4727,9 @@ ER-scoped replacement.
 
                                 </span>
 
-                                <div class="support-text">These results are consistent with SSA proteins and Ydj1p acting together in the translocation process.</div>
+                                <div class="support-text">prepro-alpha-factor was inhibited within 2 min of the shift to 37 degrees C,
+suggesting a direct effect of the hsp70 defect on translocation. More than 50%
+of radiolabeled alpha-factor accumulated in the precursor form</div>
 
                             </div>
 
@@ -2835,15 +4799,19 @@ ER-scoped replacement.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Genetic interactions within the essential SSA subfamily are consistent
-with the ATP-dependent (ATPase) Hsp70 chaperone activity. Core catalytic
-function; same conclusion as the other ATP hydrolysis annotations.
+                            <strong>Summary:</strong> The GOA row records an SSA3–SSA1 genetic interaction (WITH/FROM
+SGD:S000000004). Genetic interactions within the essential SSA subfamily
+are consistent with ATP-dependent Hsp70 chaperone activity; the ATPase
+claim is accepted on established Hsp70 family mechanism rather than as a
+direct biochemical assay in this paper.
                         </div>
 
 
                         <div>
                             <strong>Reason:</strong> Falcon establishes ATP-dependent operation of the Ssa chaperones with ATP
-hydrolysis driving the substrate-affinity cycle.
+hydrolysis driving the substrate-affinity cycle. PMID:3302682 supplies the
+SSA1 genetic-interaction context, while the biochemical ATPase conclusion
+rests on the independently established Hsp70 family mechanism.
                         </div>
 
 
@@ -2883,25 +4851,14 @@ hydrolysis driving the substrate-affinity cycle.
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">IGI</span>
+                        <span class="evidence-code">IEA</span>
 
 
 
                         <br>
                         <span style="font-size: 0.75rem;">
 
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/9789005" target="_blank" class="term-link" style="font-size: 0.75rem;">
-                                PMID:9789005
-                            </a>
-
-
-
-                                <br>
-                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
-                                    Folding in vivo of a newly translated yeast cytosolic enzyme...
-                                </span>
-
-
+                            GO_REF:0000117
 
                         </span>
 
@@ -2910,7 +4867,7 @@ hydrolysis driving the substrate-affinity cycle.
                         <span class="action-badge action-modify">
                             MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P09435" data-a="GO:0051082" data-r="PMID:9789005" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P09435" data-a="GO:0051082" data-r="GO_REF:0000117" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2920,8 +4877,7 @@ hydrolysis driving the substrate-affinity cycle.
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Ssa3 binds non-native/unfolded proteins, but as an ATP-dependent Hsp70 the
 more precise molecular function is ATP-dependent protein folding chaperone
-activity (GO:0140662). Same conclusion as the IEA unfolded protein binding
-annotation above.
+activity (GO:0140662), which is also the term InterPro assigns in UniProt.
                         </div>
 
 
@@ -2983,7 +4939,9 @@ ATP-dependent protein folding chaperone: its N-terminal nucleotide-binding
 (ATPase) domain binds and hydrolyzes ATP to drive cycles of high- and
 low-affinity binding of exposed hydrophobic segments on non-native
 polypeptides, preventing aggregation and promoting productive
-folding/refolding in the cytosol.</h3>
+folding/refolding in the cytosol. Partner-class annotations also place Ssa3
+in the Hsp70/Hsp40/Hsp110 co-chaperone network, while SSA-family experiments
+support an additional role in post-translational precursor translocation.</h3>
                 <span class="vote-buttons" data-g="P09435" data-a="FUNCTION: Ssa3 is a stress-inducible cytosolic Hsp70 (Ssa su..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -3017,6 +4975,12 @@ folding/refolding in the cytosol.</h3>
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                 protein refolding
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031204" target="_blank" class="term-link">
+                                post-translational protein targeting to membrane, translocation
                             </a>
                         </span>
 
@@ -3191,6 +5155,20 @@ folding/refolding in the cytosol.</h3>
                 <div class="reference-title">Systematic identification of protein complexes in Saccharomyces cerevisiae by mass spectrometry.</div>
 
 
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The source reports high-throughput mass-spectrometric identification of protein complexes rather than targeted binary tests for every edge.</div>
+
+                        <div class="finding-text">"Here we report,
+using the budding yeast Saccharomyces cerevisiae as a test case, an example of
+this approach, which we term high-throughput mass spectrometric protein complex
+identification (HMS-PCI)."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
 
             <div class="reference-item">
@@ -3207,6 +5185,20 @@ folding/refolding in the cytosol.</h3>
                 <div class="reference-title">Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.</div>
 
 
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The interaction map is based on tandem affinity purification and mass spectrometry of thousands of tagged yeast proteins.</div>
+
+                        <div class="finding-text">"We used tandem affinity purification to process 4,562 different
+tagged proteins of the yeast Saccharomyces cerevisiae. Each preparation was
+analysed by both matrix-assisted laser desorption/ionization-time of flight mass
+spectrometry and liquid chromatography tandem mass spectrometry"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
 
             <div class="reference-item">
@@ -3222,6 +5214,17 @@ folding/refolding in the cytosol.</h3>
 
                 <div class="reference-title">An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.</div>
 
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The chaperone-atlas associations are indirect TAP-tag complex interactions rather than proof of direct binary binding.</div>
+
+                        <div class="finding-text">"It should be emphasized that the interactions presented are indirect TAP-tag based interactions and not direct binary interactions."</div>
+
+                    </li>
+
+                </ul>
 
             </div>
 
@@ -3270,6 +5273,19 @@ folding/refolding in the cytosol.</h3>
 
                 <div class="reference-title">The role of structural pleiotropy and regulatory evolution in the retention of heteromers of paralogs.</div>
 
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The study finds that heteromerization is frequent among duplicated yeast homomers and correlates with paralog functional similarity.</div>
+
+                        <div class="finding-text">"Using yeast as a model, we find that heteromerization is
+frequent among duplicated homomers and correlates with functional similarity
+between paralogs."</div>
+
+                    </li>
+
+                </ul>
 
             </div>
 
@@ -3459,6 +5475,29 @@ proficient isoform for [PSI+] prion propagation/maintenance.
 </div>
 
                         <div class="finding-text">"Ssa3 was reported as the most proficient isoform for [PSI+] propagation/maintenance"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:interpro/panther/PTHR19375/PTHR19375-paint.tsv
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Current PANTHER PTHR19375 PAINT annotation snapshot</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PTN002500132 currently carries nucleus and cytosol IBD assertions but no plasma-membrane assertion, showing that the pinned 2025 GOA transfer is stale.</div>
 
                     </li>
 
@@ -4247,9 +6286,12 @@ this with annotations you find in gene/protein databases, but these can be outda
   replacement therefore uses the ER-scoped post-translational sibling<br />
   GO:0031204, not the existing SRP-dependent cotranslational label; the separate<br />
   mitochondrial phenotype is not encoded by that replacement. <a href="https://pubmed.ncbi.nlm.nih.gov/8754838" title="These results are   consistent with SSA proteins and Ydj1p acting together in the translocation   process.">PMID:8754838</a></li>
-<li>The plasma-membrane IBA is removed as a compartment-mismatched family<br />
-  propagation. UniProt and the SSA3-focused literature consistently identify<br />
-  Ssa3 as cytosolic; no target-specific plasma-membrane evidence was found. A<br />
+<li>The plasma-membrane IBA is removed as a stale PAINT transfer. The pinned 2025<br />
+  GOA row points to PTN002500132, but the current local PTHR19375 PAINT snapshot<br />
+  carries nucleus and cytosol at that node and no longer carries GO:0005886.<br />
+  This is a current-node comparison, not an inference from donor count. UniProt<br />
+  and the SSA3-focused literature consistently identify Ssa3 as cytosolic; no<br />
+  target-specific plasma-membrane evidence was found. A<br />
   targeted OpenScientist hypothesis run independently preferred <code>REMOVE</code> because<br />
   it found no SSA3-specific experimental support. Its live QuickGO claims that<br />
   the P09435 IBA had been retired and that Ssa4 lacked the same IBA conflict with<br />
@@ -4263,6 +6305,14 @@ this with annotations you find in gene/protein databases, but these can be outda
   had access to more evidence than the cached abstract.</li>
 <li>The UNFOLDED_PROTEIN_BINDING project row now uses GO:0140662 for SSA3, aligning<br />
   the project decision with the review's ATP-dependent Hsp70 mechanism.</li>
+</ul>
+<h2 id="2026-08-27-row-completeness-follow-up">2026-08-27 row-completeness follow-up</h2>
+<ul>
+<li>The review was promoted from <code>DRAFT</code> to <code>COMPLETE</code> after restoring one review<br />
+  record for every one of the 55 pinned GOA rows. Repeated IPI and IGI rows are retained<br />
+  separately by reference and <code>WITH/FROM</code> partner rather than collapsed.</li>
+<li>Generic nucleotide binding is now <code>MODIFY</code> to the existing specific ATP-binding<br />
+  term GO:0005524, matching the treatment of the same parent term in SSA4.</li>
 </ul>
             </div>
         </details>
@@ -4280,7 +6330,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P09435
 gene_symbol: SSA3
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -4292,8 +6342,8 @@ description: &gt;-
   and protein quality control. Unlike constitutively expressed Ssa1/Ssa2, Ssa3 and Ssa4 are
   stress/heat-inducible: Ssa3 has very low basal expression and is strongly induced by heat shock and
   other proteotoxic stress through Hsf1/heat shock element promoter architecture, and SSA3-HSE
-  reporters are widely used as readouts of Hsf1 activity. Ssa3 functions predominantly in cytosolic
-  and nuclear protein-homeostasis systems, works with Hsp40 co-chaperones and Hsp110
+  reporters are widely used as readouts of Hsf1 activity. Ssa3 functions predominantly in the
+  cytosol, with a context-dependent nuclear pool, works with Hsp40 co-chaperones and Hsp110
   nucleotide-exchange factors, and contributes to cotranslational folding, post-translational protein
   translocation, refolding of denatured substrates, and prion propagation. Although the Ssa paralogs
   are partly redundant, Ssa3 shows measurable functional specialization. SSA3 has a paralog, SSA4,
@@ -4349,20 +6399,21 @@ existing_annotations:
       SSA3-focused literature review supports a plasma-membrane pool.
     action: REMOVE
     reason: |-
-      This family-level IBA conflicts with the established cytosolic localization
-      of Ssa3 and lacks target-specific evidence. It is therefore treated as a
-      compartment-mismatched propagation rather than a peripheral localization.
+      The pinned 2025 GOA row points to PAINT node PTN002500132, but the current
+      local PTHR19375 PAINT snapshot retains nucleus and cytosol at that node and
+      no longer carries GO:0005886. The stale inference also lacks target-specific
+      corroboration: Ssa3 is independently supported as a cytosolic Hsp70.
     propagation_review:
-      root_cause: PROPAGATION_BAD
-      failure_modes:
-      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      root_cause: SOURCE_STALE_OR_MISSING
       source_entities:
       - source_id: PANTHER:PTN002500132
         source_label: PAINT Hsp70 family node
-        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
-        comment: Plasma-membrane localization may apply to another Hsp70 family
-          member, but Ssa3 is a cytosolic Ssa chaperone.
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          The current PTHR19375 PAINT snapshot has nucleus and cytosol IBD rows at
+          this node but no plasma-membrane IBD row; the pinned GOA transfer is stale.
     additional_reference_ids:
+    - file:interpro/panther/PTHR19375/PTHR19375-paint.tsv
     - file:yeast/SSA3/SSA3-hypotheses/existing-go-0005886-keep-as-non-core/openscientist.md
     supported_by:
     - reference_id: file:yeast/SSA3/SSA3-hypotheses/existing-go-0005886-keep-as-non-core/openscientist.md
@@ -4492,10 +6543,13 @@ existing_annotations:
     summary: |-
       Nucleotide binding is a generic parent of the more informative ATP binding
       activity; Ssa3 has an N-terminal nucleotide-binding (ATPase) domain.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: |-
-      The annotation is not false, but it is redundant and substantially less
-      informative than the existing ATP-binding and ATP-hydrolysis annotations.
+      Nucleotide binding is correct but too broad for the Hsp70 nucleotide-binding
+      domain; replace it with the existing, mechanistically specific ATP-binding term.
+    proposed_replacement_terms:
+    - id: GO:0005524
+      label: ATP binding
     supported_by:
     - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
       supporting_text: |-
@@ -4594,96 +6648,399 @@ existing_annotations:
         ATP binding and hydrolysis drive switching between low-affinity/high-exchange and high-affinity/slow-exchange substrate states; co-chaperones (notably J-domain proteins/Hsp40s) stimulate ATP hydrolysis and nucleotide-exchange factors reset the cycle.
       reference_section_type: OTHER
 - term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000117
+    id: GO:0006457
+    label: protein folding
+  evidence_type: IGI
+  original_reference_id: PMID:9789005
   review:
-    summary: |-
-      Ssa3 binds non-native/unfolded proteins, but as an ATP-dependent Hsp70 the
-      more precise molecular function is ATP-dependent protein folding chaperone
-      activity (GO:0140662), which is also the term InterPro assigns in UniProt.
-    action: MODIFY
-    reason: |-
-      Falcon emphasizes that Ssa3 is an ATP-dependent chaperone whose
-      substrate binding is coupled to the ATPase cycle; the ATP-dependent
-      protein folding chaperone term (GO:0140662) captures this more precisely
-      than the generic unfolded protein binding. This matches the InterPro IEA
-      annotation in UniProt (GO:0140662).
-    proposed_replacement_terms:
-    - id: GO:0140662
-      label: ATP-dependent protein folding chaperone
+    summary: &gt;-
+      This separate genetic-interaction row is linked to SSA4
+      (WITH/FROM SGD:S000000905). Kim et al. support SSA-class cytosolic Hsp70 function
+      in folding newly translated proteins; the partner records the tested
+      genetic context rather than an isoform-specific mechanism.
+    action: ACCEPT
+    reason: Protein folding is a core Ssa3 process supported at the SSA-family level; retain this partner-specific IGI row.
     supported_by:
-    - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
+    - reference_id: PMID:9789005
       supporting_text: |-
-        ATP binding and hydrolysis drive switching between low-affinity/high-exchange and high-affinity/slow-exchange substrate states; co-chaperones (notably J-domain proteins/Hsp40s) stimulate ATP hydrolysis and nucleotide-exchange factors reset the cycle.
-      reference_section_type: OTHER
+        yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:11805837
   review:
-    summary: |-
-      Generic protein binding from a high-throughput protein-complex mass
-      spectrometry study; uninformative about Ssa3&#39;s molecular function, which
-      is better captured by its chaperone/co-chaperone interaction terms.
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–MTC5 association
+      (WITH/FROM UniProtKB:Q03897) from a high-throughput protein-complex mass-spectrometry study. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
     action: MARK_AS_OVER_ANNOTATED
-    reason: |-
-      Per curation guidance, protein binding (GO:0005515) is uninformative.
-      More specific terms (heat shock protein binding, protein folding
-      chaperone) capture the biology; this generic HTP annotation is
-      over-annotated.
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
   review:
-    summary: |-
-      Generic protein binding from a high-throughput protein-complex study;
-      uninformative about molecular function.
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–HEM13 association
+      (WITH/FROM UniProtKB:P11353) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
     action: MARK_AS_OVER_ANNOTATED
-    reason: |-
-      Protein binding (GO:0005515) is uninformative; more specific chaperone
-      terms apply. Over-annotated.
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–RAD50 association
+      (WITH/FROM UniProtKB:P12753) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–YCR043C association
+      (WITH/FROM UniProtKB:P25361) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–RAD23 association
+      (WITH/FROM UniProtKB:P32628) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–PMT1 association
+      (WITH/FROM UniProtKB:P33775) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–SIS2 association
+      (WITH/FROM UniProtKB:P36024) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–ENP1 association
+      (WITH/FROM UniProtKB:P38333) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–MSB3 association
+      (WITH/FROM UniProtKB:P48566) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–RPL38 association
+      (WITH/FROM UniProtKB:P49167) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–PKR1 association
+      (WITH/FROM UniProtKB:Q03880) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–MTC5 association
+      (WITH/FROM UniProtKB:Q03897) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–MMS22 association
+      (WITH/FROM UniProtKB:Q06164) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–GTT2 association
+      (WITH/FROM UniProtKB:Q12390) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
   review:
-    summary: |-
-      Generic protein binding from a chaperone-interaction atlas; the
-      chaperone-substrate/co-chaperone biology is better represented by specific
-      terms such as heat shock protein binding and protein folding chaperone.
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–HEM13 association
+      (WITH/FROM UniProtKB:P11353) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
     action: MARK_AS_OVER_ANNOTATED
-    reason: |-
-      Protein binding (GO:0005515) is uninformative. Over-annotated.
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–RAD50 association
+      (WITH/FROM UniProtKB:P12753) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–SSA4 association
+      (WITH/FROM UniProtKB:P22202) from the TAP-tag chaperone-interaction atlas. Because SSA4 is another Hsp70 paralog, the partner class supports a more
+      informative Hsp70-protein-binding replacement; the dataset does not by itself
+      establish direct binary contact.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic protein binding with GO:0030544 Hsp70 protein binding. The
+      curator-supplied partner identity establishes that the bound partner is an
+      Hsp70, which licenses the partner-class refinement even though the
+      affinity-capture dataset does not establish direct binary contact.
+    proposed_replacement_terms:
+    - id: GO:0030544
+      label: Hsp70 protein binding
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–YCR043C association
+      (WITH/FROM UniProtKB:P25361) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–RAD23 association
+      (WITH/FROM UniProtKB:P32628) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–PMT1 association
+      (WITH/FROM UniProtKB:P33775) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–SIS2 association
+      (WITH/FROM UniProtKB:P36024) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–ENP1 association
+      (WITH/FROM UniProtKB:P38333) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–MSB3 association
+      (WITH/FROM UniProtKB:P48566) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–RPL38 association
+      (WITH/FROM UniProtKB:P49167) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–PKR1 association
+      (WITH/FROM UniProtKB:Q03880) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–MTC5 association
+      (WITH/FROM UniProtKB:Q03897) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–MMS22 association
+      (WITH/FROM UniProtKB:Q06164) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–GTT2 association
+      (WITH/FROM UniProtKB:Q12390) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:27107014
   review:
-    summary: |-
-      Generic protein binding from an inter-species interaction network;
-      uninformative about Ssa3&#39;s molecular function.
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–human HSPBP1 association
+      (WITH/FROM UniProtKB:Q9NZL4) from an inter-species interaction network. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
     action: MARK_AS_OVER_ANNOTATED
-    reason: |-
-      Protein binding (GO:0005515) is uninformative. Over-annotated.
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:31454312
   review:
-    summary: |-
-      Generic protein binding from a study of paralog heteromer retention;
-      uninformative about molecular function.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: |-
-      Protein binding (GO:0005515) is uninformative. Over-annotated.
+    summary: &gt;-
+      This separate GOA row records a dataset-level Ssa3–SSA4 association
+      (WITH/FROM UniProtKB:P22202) from a paralog-heteromer retention study. Because SSA4 is another Hsp70 paralog, the partner class supports a more
+      informative Hsp70-protein-binding replacement; the dataset does not by itself
+      establish direct binary contact.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic protein binding with GO:0030544 Hsp70 protein binding. The
+      curator-supplied partner identity establishes that the bound partner is an
+      Hsp70, which licenses the partner-class refinement even though the study
+      does not establish direct binary contact for this pair.
+    proposed_replacement_terms:
+    - id: GO:0030544
+      label: Hsp70 protein binding
 - term:
     id: GO:0006515
     label: protein quality control for misfolded or incompletely synthesized proteins
@@ -4692,14 +7049,17 @@ existing_annotations:
   review:
     summary: |-
       Ssa3, as a cytosolic Hsp70, contributes to protein quality control of
-      misfolded/non-native proteins. This is a genuine part of the proteostasis
-      role but is captured at a level peripheral to the core chaperone
-      molecular function; kept as non-core.
+      misfolded/non-native proteins. The cached PMID:24855027 record is
+      abstract-only and Mca1-focused and does not expose the SSA3-specific IMP
+      experiment, so this curator annotation is retained by deference as a
+      genuine but non-core proteostasis process.
     action: KEEP_AS_NON_CORE
     reason: |-
       Falcon supports the general role of cytosolic Hsp70-Ssa proteins in
       proteostasis and quality control (degradation/refolding of non-native
-      substrates), but this term is retained as a non-core process annotation.
+      substrates). Because the cached paper is abstract-only and does not show
+      the SSA3-specific experiment available to the curator, retain the IMP by
+      deference and keep the process annotation non-core.
     supported_by:
     - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
       supporting_text: Ssa proteins promote folding, translocation, degradation, and refolding of denatured substrates
@@ -4736,22 +7096,96 @@ existing_annotations:
   evidence_type: IGI
   original_reference_id: PMID:9789005
   review:
-    summary: |-
-      Genetic evidence that the SSA class of cytosolic Hsp70 mediates folding in
-      vivo of newly translated yeast proteins. Core biological process for Ssa3.
+    summary: &gt;-
+      This separate genetic-interaction row is linked to SSA1
+      (WITH/FROM SGD:S000000004). Kim et al. support SSA-class cytosolic Hsp70 function
+      in folding newly translated proteins; the partner records the tested
+      genetic context rather than an isoform-specific mechanism.
     action: ACCEPT
-    reason: |-
-      Consistent with falcon: Hsp70-Ssa proteins bind non-native proteins and
-      assist folding; PMID:9789005 demonstrates the SSA class mediates folding
-      of newly translated cytosolic proteins.
+    reason: Protein folding is a core Ssa3 process supported at the SSA-family level; retain this partner-specific IGI row.
     supported_by:
     - reference_id: PMID:9789005
       supporting_text: |-
         yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
       reference_section_type: ABSTRACT
-    - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
-      supporting_text: Hsp70-Ssa proteins bind exposed hydrophobic regions on unfolded proteins, assist folding/refolding, and support proteostasis
-      reference_section_type: OTHER
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  evidence_type: IGI
+  original_reference_id: PMID:9789005
+  review:
+    summary: &gt;-
+      This separate genetic-interaction row is linked to SSA1
+      (WITH/FROM SGD:S000000004). Binding non-native clients is real, but the productive,
+      ATP-coupled chaperone activity is more precisely represented by GO:0140662.
+    action: MODIFY
+    reason: Replace generic unfolded-protein binding with ATP-dependent protein folding chaperone activity while retaining this partner-specific IGI provenance.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:9789005
+      supporting_text: |-
+        yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  evidence_type: IGI
+  original_reference_id: PMID:9789005
+  review:
+    summary: &gt;-
+      This separate genetic-interaction row is linked to SSA4
+      (WITH/FROM SGD:S000000905). Binding non-native clients is real, but the productive,
+      ATP-coupled chaperone activity is more precisely represented by GO:0140662.
+    action: MODIFY
+    reason: Replace generic unfolded-protein binding with ATP-dependent protein folding chaperone activity while retaining this partner-specific IGI provenance.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:9789005
+      supporting_text: |-
+        yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  evidence_type: IGI
+  original_reference_id: PMID:9789005
+  review:
+    summary: &gt;-
+      This separate genetic-interaction row is linked to SSA2
+      (WITH/FROM SGD:S000003947). Binding non-native clients is real, but the productive,
+      ATP-coupled chaperone activity is more precisely represented by GO:0140662.
+    action: MODIFY
+    reason: Replace generic unfolded-protein binding with ATP-dependent protein folding chaperone activity while retaining this partner-specific IGI provenance.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:9789005
+      supporting_text: |-
+        yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0006457
+    label: protein folding
+  evidence_type: IGI
+  original_reference_id: PMID:9789005
+  review:
+    summary: &gt;-
+      This separate genetic-interaction row is linked to SSA2
+      (WITH/FROM SGD:S000003947). Kim et al. support SSA-class cytosolic Hsp70 function
+      in folding newly translated proteins; the partner records the tested
+      genetic context rather than an isoform-specific mechanism.
+    action: ACCEPT
+    reason: Protein folding is a core Ssa3 process supported at the SSA-family level; retain this partner-specific IGI row.
+    supported_by:
+    - reference_id: PMID:9789005
+      supporting_text: |-
+        yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0006616
     label: SRP-dependent cotranslational protein targeting to membrane, translocation
@@ -4776,7 +7210,9 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:8754838
       supporting_text: |-
-        These results are consistent with SSA proteins and Ydj1p acting together in the translocation process.
+        prepro-alpha-factor was inhibited within 2 min of the shift to 37 degrees C,
+        suggesting a direct effect of the hsp70 defect on translocation. More than 50%
+        of radiolabeled alpha-factor accumulated in the precursor form
       reference_section_type: ABSTRACT
     - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
       supporting_text: Ssa proteins promote folding, translocation, degradation, and refolding of denatured substrates
@@ -4788,13 +7224,17 @@ existing_annotations:
   original_reference_id: PMID:3302682
   review:
     summary: |-
-      Genetic interactions within the essential SSA subfamily are consistent
-      with the ATP-dependent (ATPase) Hsp70 chaperone activity. Core catalytic
-      function; same conclusion as the other ATP hydrolysis annotations.
+      The GOA row records an SSA3–SSA1 genetic interaction (WITH/FROM
+      SGD:S000000004). Genetic interactions within the essential SSA subfamily
+      are consistent with ATP-dependent Hsp70 chaperone activity; the ATPase
+      claim is accepted on established Hsp70 family mechanism rather than as a
+      direct biochemical assay in this paper.
     action: ACCEPT
     reason: |-
       Falcon establishes ATP-dependent operation of the Ssa chaperones with ATP
-      hydrolysis driving the substrate-affinity cycle.
+      hydrolysis driving the substrate-affinity cycle. PMID:3302682 supplies the
+      SSA1 genetic-interaction context, while the biochemical ATPase conclusion
+      rests on the independently established Hsp70 family mechanism.
     supported_by:
     - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
       supporting_text: |-
@@ -4803,14 +7243,13 @@ existing_annotations:
 - term:
     id: GO:0051082
     label: unfolded protein binding
-  evidence_type: IGI
-  original_reference_id: PMID:9789005
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
   review:
     summary: |-
       Ssa3 binds non-native/unfolded proteins, but as an ATP-dependent Hsp70 the
       more precise molecular function is ATP-dependent protein folding chaperone
-      activity (GO:0140662). Same conclusion as the IEA unfolded protein binding
-      annotation above.
+      activity (GO:0140662), which is also the term InterPro assigns in UniProt.
     action: MODIFY
     reason: |-
       Falcon emphasizes ATP-dependent, ATPase-cycle-coupled substrate binding;
@@ -4832,7 +7271,9 @@ core_functions:
     (ATPase) domain binds and hydrolyzes ATP to drive cycles of high- and
     low-affinity binding of exposed hydrophobic segments on non-native
     polypeptides, preventing aggregation and promoting productive
-    folding/refolding in the cytosol.
+    folding/refolding in the cytosol. Partner-class annotations also place Ssa3
+    in the Hsp70/Hsp40/Hsp110 co-chaperone network, while SSA-family experiments
+    support an additional role in post-translational precursor translocation.
   molecular_function:
     id: GO:0140662
     label: ATP-dependent protein folding chaperone
@@ -4841,6 +7282,8 @@ core_functions:
     label: protein folding
   - id: GO:0042026
     label: protein refolding
+  - id: GO:0031204
+    label: post-translational protein targeting to membrane, translocation
   locations:
   - id: GO:0005829
     label: cytosol
@@ -4879,22 +7322,80 @@ references:
     reference_section_type: ABSTRACT
 - id: PMID:11805837
   title: Systematic identification of protein complexes in Saccharomyces cerevisiae by mass spectrometry.
-  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      The cached abstract verifies a proteome-scale mass-spectrometric complex map. The specific Ssa3-Mtc5 edge is not narrated, so its partner identity is retained from GOA without treating the row as a direct binary assay.
+  findings:
+  - statement: The source reports high-throughput mass-spectrometric identification of protein complexes rather than targeted binary tests for every edge.
+    supporting_text: |-
+      Here we report,
+      using the budding yeast Saccharomyces cerevisiae as a test case, an example of
+      this approach, which we term high-throughput mass spectrometric protein complex
+      identification (HMS-PCI).
+    reference_section_type: ABSTRACT
 - id: PMID:16554755
   title: Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.
-  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      Full text verifies a global tandem-affinity-purification/mass-spectrometry complex map. The 13 Ssa3 partner rows are dataset-level records and are not individually narrated as direct binary interactions.
+  findings:
+  - statement: The interaction map is based on tandem affinity purification and mass spectrometry of thousands of tagged yeast proteins.
+    supporting_text: |-
+      We used tandem affinity purification to process 4,562 different
+      tagged proteins of the yeast Saccharomyces cerevisiae. Each preparation was
+      analysed by both matrix-assisted laser desorption/ionization-time of flight mass
+      spectrometry and liquid chromatography tandem mass spectrometry
+    reference_section_type: ABSTRACT
 - id: PMID:19536198
   title: &#39;An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.&#39;
-  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PMC full text checked. The atlas explicitly identifies Ssa3 as a promiscuous chaperone, but its TAP-tag associations usually reflect protein complexes rather than direct binary contact; partner-specific GOA rows are therefore retained with that caveat.
+  findings:
+  - statement: The chaperone-atlas associations are indirect TAP-tag complex interactions rather than proof of direct binary binding.
+    supporting_text: &gt;-
+      It should be emphasized that the interactions presented are indirect TAP-tag based
+      interactions and not direct binary interactions.
+    reference_section_type: RESULTS
 - id: PMID:24855027
   title: Life-span extension by a metacaspase in the yeast Saccharomyces cerevisiae.
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      The cached record is abstract-only and focused on Mca1; it does not mention
+      SSA3 or expose the SSA3-specific IMP experiment available to the curator.
+      The biologically consistent annotation is therefore retained by deference
+      rather than treated as directly verified from the cached text.
   findings: []
 - id: PMID:27107014
   title: An inter-species protein-protein interaction network across vast evolutionary distance.
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      The paper reports a large inter-species interaction network. The Ssa3-human-HSPBP1 edge is retained from the curator-supplied GOA row, but the main cached text does not provide enough edge-specific detail to treat it as a targeted functional assay.
   findings: []
 - id: PMID:31454312
   title: The role of structural pleiotropy and regulatory evolution in the retention of heteromers of paralogs.
-  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      Full text verifies an experimental/computational study of paralog heteromer retention. The Ssa3-Ssa4 row is retained from GOA, but the main narrative does not individually discuss this pair, so the direct edge remains unverified here.
+  findings:
+  - statement: The study finds that heteromerization is frequent among duplicated yeast homomers and correlates with paralog functional similarity.
+    supporting_text: |-
+      Using yeast as a model, we find that heteromerization is
+      frequent among duplicated homomers and correlates with functional similarity
+      between paralogs.
+    reference_section_type: ABSTRACT
 - id: PMID:3302682
   title: Complex interactions among members of an essential subfamily of hsp70 genes in Saccharomyces cerevisiae.
   reference_review:
@@ -4998,6 +7499,12 @@ references:
     supporting_text: |-
       Ssa3 was reported as the most proficient isoform for [PSI+] propagation/maintenance
     reference_section_type: OTHER
+- id: file:interpro/panther/PTHR19375/PTHR19375-paint.tsv
+  title: Current PANTHER PTHR19375 PAINT annotation snapshot
+  findings:
+  - statement: &gt;-
+      PTN002500132 currently carries nucleus and cytosol IBD assertions but no
+      plasma-membrane assertion, showing that the pinned 2025 GOA transfer is stale.
 - id: file:yeast/SSA3/SSA3-hypotheses/existing-go-0005886-keep-as-non-core/openscientist.md
   title: OpenScientist review of the SSA3 plasma-membrane IBA annotation
   reference_review:

--- a/genes/yeast/SSA3/SSA3-ai-review.yaml
+++ b/genes/yeast/SSA3/SSA3-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P09435
 gene_symbol: SSA3
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -13,8 +13,8 @@ description: >-
   and protein quality control. Unlike constitutively expressed Ssa1/Ssa2, Ssa3 and Ssa4 are
   stress/heat-inducible: Ssa3 has very low basal expression and is strongly induced by heat shock and
   other proteotoxic stress through Hsf1/heat shock element promoter architecture, and SSA3-HSE
-  reporters are widely used as readouts of Hsf1 activity. Ssa3 functions predominantly in cytosolic
-  and nuclear protein-homeostasis systems, works with Hsp40 co-chaperones and Hsp110
+  reporters are widely used as readouts of Hsf1 activity. Ssa3 functions predominantly in the
+  cytosol, with a context-dependent nuclear pool, works with Hsp40 co-chaperones and Hsp110
   nucleotide-exchange factors, and contributes to cotranslational folding, post-translational protein
   translocation, refolding of denatured substrates, and prion propagation. Although the Ssa paralogs
   are partly redundant, Ssa3 shows measurable functional specialization. SSA3 has a paralog, SSA4,
@@ -70,20 +70,21 @@ existing_annotations:
       SSA3-focused literature review supports a plasma-membrane pool.
     action: REMOVE
     reason: |-
-      This family-level IBA conflicts with the established cytosolic localization
-      of Ssa3 and lacks target-specific evidence. It is therefore treated as a
-      compartment-mismatched propagation rather than a peripheral localization.
+      The pinned 2025 GOA row points to PAINT node PTN002500132, but the current
+      local PTHR19375 PAINT snapshot retains nucleus and cytosol at that node and
+      no longer carries GO:0005886. The stale inference also lacks target-specific
+      corroboration: Ssa3 is independently supported as a cytosolic Hsp70.
     propagation_review:
-      root_cause: PROPAGATION_BAD
-      failure_modes:
-      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      root_cause: SOURCE_STALE_OR_MISSING
       source_entities:
       - source_id: PANTHER:PTN002500132
         source_label: PAINT Hsp70 family node
-        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
-        comment: Plasma-membrane localization may apply to another Hsp70 family
-          member, but Ssa3 is a cytosolic Ssa chaperone.
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          The current PTHR19375 PAINT snapshot has nucleus and cytosol IBD rows at
+          this node but no plasma-membrane IBD row; the pinned GOA transfer is stale.
     additional_reference_ids:
+    - file:interpro/panther/PTHR19375/PTHR19375-paint.tsv
     - file:yeast/SSA3/SSA3-hypotheses/existing-go-0005886-keep-as-non-core/openscientist.md
     supported_by:
     - reference_id: file:yeast/SSA3/SSA3-hypotheses/existing-go-0005886-keep-as-non-core/openscientist.md
@@ -213,10 +214,13 @@ existing_annotations:
     summary: |-
       Nucleotide binding is a generic parent of the more informative ATP binding
       activity; Ssa3 has an N-terminal nucleotide-binding (ATPase) domain.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: |-
-      The annotation is not false, but it is redundant and substantially less
-      informative than the existing ATP-binding and ATP-hydrolysis annotations.
+      Nucleotide binding is correct but too broad for the Hsp70 nucleotide-binding
+      domain; replace it with the existing, mechanistically specific ATP-binding term.
+    proposed_replacement_terms:
+    - id: GO:0005524
+      label: ATP binding
     supported_by:
     - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
       supporting_text: |-
@@ -315,96 +319,399 @@ existing_annotations:
         ATP binding and hydrolysis drive switching between low-affinity/high-exchange and high-affinity/slow-exchange substrate states; co-chaperones (notably J-domain proteins/Hsp40s) stimulate ATP hydrolysis and nucleotide-exchange factors reset the cycle.
       reference_section_type: OTHER
 - term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000117
+    id: GO:0006457
+    label: protein folding
+  evidence_type: IGI
+  original_reference_id: PMID:9789005
   review:
-    summary: |-
-      Ssa3 binds non-native/unfolded proteins, but as an ATP-dependent Hsp70 the
-      more precise molecular function is ATP-dependent protein folding chaperone
-      activity (GO:0140662), which is also the term InterPro assigns in UniProt.
-    action: MODIFY
-    reason: |-
-      Falcon emphasizes that Ssa3 is an ATP-dependent chaperone whose
-      substrate binding is coupled to the ATPase cycle; the ATP-dependent
-      protein folding chaperone term (GO:0140662) captures this more precisely
-      than the generic unfolded protein binding. This matches the InterPro IEA
-      annotation in UniProt (GO:0140662).
-    proposed_replacement_terms:
-    - id: GO:0140662
-      label: ATP-dependent protein folding chaperone
+    summary: >-
+      This separate genetic-interaction row is linked to SSA4
+      (WITH/FROM SGD:S000000905). Kim et al. support SSA-class cytosolic Hsp70 function
+      in folding newly translated proteins; the partner records the tested
+      genetic context rather than an isoform-specific mechanism.
+    action: ACCEPT
+    reason: Protein folding is a core Ssa3 process supported at the SSA-family level; retain this partner-specific IGI row.
     supported_by:
-    - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
+    - reference_id: PMID:9789005
       supporting_text: |-
-        ATP binding and hydrolysis drive switching between low-affinity/high-exchange and high-affinity/slow-exchange substrate states; co-chaperones (notably J-domain proteins/Hsp40s) stimulate ATP hydrolysis and nucleotide-exchange factors reset the cycle.
-      reference_section_type: OTHER
+        yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:11805837
   review:
-    summary: |-
-      Generic protein binding from a high-throughput protein-complex mass
-      spectrometry study; uninformative about Ssa3's molecular function, which
-      is better captured by its chaperone/co-chaperone interaction terms.
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–MTC5 association
+      (WITH/FROM UniProtKB:Q03897) from a high-throughput protein-complex mass-spectrometry study. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
     action: MARK_AS_OVER_ANNOTATED
-    reason: |-
-      Per curation guidance, protein binding (GO:0005515) is uninformative.
-      More specific terms (heat shock protein binding, protein folding
-      chaperone) capture the biology; this generic HTP annotation is
-      over-annotated.
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
   review:
-    summary: |-
-      Generic protein binding from a high-throughput protein-complex study;
-      uninformative about molecular function.
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–HEM13 association
+      (WITH/FROM UniProtKB:P11353) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
     action: MARK_AS_OVER_ANNOTATED
-    reason: |-
-      Protein binding (GO:0005515) is uninformative; more specific chaperone
-      terms apply. Over-annotated.
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–RAD50 association
+      (WITH/FROM UniProtKB:P12753) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–YCR043C association
+      (WITH/FROM UniProtKB:P25361) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–RAD23 association
+      (WITH/FROM UniProtKB:P32628) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–PMT1 association
+      (WITH/FROM UniProtKB:P33775) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–SIS2 association
+      (WITH/FROM UniProtKB:P36024) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–ENP1 association
+      (WITH/FROM UniProtKB:P38333) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–MSB3 association
+      (WITH/FROM UniProtKB:P48566) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–RPL38 association
+      (WITH/FROM UniProtKB:P49167) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–PKR1 association
+      (WITH/FROM UniProtKB:Q03880) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–MTC5 association
+      (WITH/FROM UniProtKB:Q03897) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–MMS22 association
+      (WITH/FROM UniProtKB:Q06164) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–GTT2 association
+      (WITH/FROM UniProtKB:Q12390) from a global affinity-purification protein-complex map. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
   review:
-    summary: |-
-      Generic protein binding from a chaperone-interaction atlas; the
-      chaperone-substrate/co-chaperone biology is better represented by specific
-      terms such as heat shock protein binding and protein folding chaperone.
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–HEM13 association
+      (WITH/FROM UniProtKB:P11353) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
     action: MARK_AS_OVER_ANNOTATED
-    reason: |-
-      Protein binding (GO:0005515) is uninformative. Over-annotated.
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–RAD50 association
+      (WITH/FROM UniProtKB:P12753) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–SSA4 association
+      (WITH/FROM UniProtKB:P22202) from the TAP-tag chaperone-interaction atlas. Because SSA4 is another Hsp70 paralog, the partner class supports a more
+      informative Hsp70-protein-binding replacement; the dataset does not by itself
+      establish direct binary contact.
+    action: MODIFY
+    reason: >-
+      Replace generic protein binding with GO:0030544 Hsp70 protein binding. The
+      curator-supplied partner identity establishes that the bound partner is an
+      Hsp70, which licenses the partner-class refinement even though the
+      affinity-capture dataset does not establish direct binary contact.
+    proposed_replacement_terms:
+    - id: GO:0030544
+      label: Hsp70 protein binding
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–YCR043C association
+      (WITH/FROM UniProtKB:P25361) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–RAD23 association
+      (WITH/FROM UniProtKB:P32628) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–PMT1 association
+      (WITH/FROM UniProtKB:P33775) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–SIS2 association
+      (WITH/FROM UniProtKB:P36024) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–ENP1 association
+      (WITH/FROM UniProtKB:P38333) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–MSB3 association
+      (WITH/FROM UniProtKB:P48566) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–RPL38 association
+      (WITH/FROM UniProtKB:P49167) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–PKR1 association
+      (WITH/FROM UniProtKB:Q03880) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–MTC5 association
+      (WITH/FROM UniProtKB:Q03897) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–MMS22 association
+      (WITH/FROM UniProtKB:Q06164) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  review:
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–GTT2 association
+      (WITH/FROM UniProtKB:Q12390) from the TAP-tag chaperone-interaction atlas. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:27107014
   review:
-    summary: |-
-      Generic protein binding from an inter-species interaction network;
-      uninformative about Ssa3's molecular function.
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–human HSPBP1 association
+      (WITH/FROM UniProtKB:Q9NZL4) from an inter-species interaction network. The generic term does not identify an enabled molecular function and the
+      dataset does not by itself establish direct binary contact.
     action: MARK_AS_OVER_ANNOTATED
-    reason: |-
-      Protein binding (GO:0005515) is uninformative. Over-annotated.
+    reason: Protein binding is uninformative; retain the partner provenance in the review but do not use this generic term as a functional assertion.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:31454312
   review:
-    summary: |-
-      Generic protein binding from a study of paralog heteromer retention;
-      uninformative about molecular function.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: |-
-      Protein binding (GO:0005515) is uninformative. Over-annotated.
+    summary: >-
+      This separate GOA row records a dataset-level Ssa3–SSA4 association
+      (WITH/FROM UniProtKB:P22202) from a paralog-heteromer retention study. Because SSA4 is another Hsp70 paralog, the partner class supports a more
+      informative Hsp70-protein-binding replacement; the dataset does not by itself
+      establish direct binary contact.
+    action: MODIFY
+    reason: >-
+      Replace generic protein binding with GO:0030544 Hsp70 protein binding. The
+      curator-supplied partner identity establishes that the bound partner is an
+      Hsp70, which licenses the partner-class refinement even though the study
+      does not establish direct binary contact for this pair.
+    proposed_replacement_terms:
+    - id: GO:0030544
+      label: Hsp70 protein binding
 - term:
     id: GO:0006515
     label: protein quality control for misfolded or incompletely synthesized proteins
@@ -413,14 +720,17 @@ existing_annotations:
   review:
     summary: |-
       Ssa3, as a cytosolic Hsp70, contributes to protein quality control of
-      misfolded/non-native proteins. This is a genuine part of the proteostasis
-      role but is captured at a level peripheral to the core chaperone
-      molecular function; kept as non-core.
+      misfolded/non-native proteins. The cached PMID:24855027 record is
+      abstract-only and Mca1-focused and does not expose the SSA3-specific IMP
+      experiment, so this curator annotation is retained by deference as a
+      genuine but non-core proteostasis process.
     action: KEEP_AS_NON_CORE
     reason: |-
       Falcon supports the general role of cytosolic Hsp70-Ssa proteins in
       proteostasis and quality control (degradation/refolding of non-native
-      substrates), but this term is retained as a non-core process annotation.
+      substrates). Because the cached paper is abstract-only and does not show
+      the SSA3-specific experiment available to the curator, retain the IMP by
+      deference and keep the process annotation non-core.
     supported_by:
     - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
       supporting_text: Ssa proteins promote folding, translocation, degradation, and refolding of denatured substrates
@@ -457,22 +767,96 @@ existing_annotations:
   evidence_type: IGI
   original_reference_id: PMID:9789005
   review:
-    summary: |-
-      Genetic evidence that the SSA class of cytosolic Hsp70 mediates folding in
-      vivo of newly translated yeast proteins. Core biological process for Ssa3.
+    summary: >-
+      This separate genetic-interaction row is linked to SSA1
+      (WITH/FROM SGD:S000000004). Kim et al. support SSA-class cytosolic Hsp70 function
+      in folding newly translated proteins; the partner records the tested
+      genetic context rather than an isoform-specific mechanism.
     action: ACCEPT
-    reason: |-
-      Consistent with falcon: Hsp70-Ssa proteins bind non-native proteins and
-      assist folding; PMID:9789005 demonstrates the SSA class mediates folding
-      of newly translated cytosolic proteins.
+    reason: Protein folding is a core Ssa3 process supported at the SSA-family level; retain this partner-specific IGI row.
     supported_by:
     - reference_id: PMID:9789005
       supporting_text: |-
         yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
       reference_section_type: ABSTRACT
-    - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
-      supporting_text: Hsp70-Ssa proteins bind exposed hydrophobic regions on unfolded proteins, assist folding/refolding, and support proteostasis
-      reference_section_type: OTHER
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  evidence_type: IGI
+  original_reference_id: PMID:9789005
+  review:
+    summary: >-
+      This separate genetic-interaction row is linked to SSA1
+      (WITH/FROM SGD:S000000004). Binding non-native clients is real, but the productive,
+      ATP-coupled chaperone activity is more precisely represented by GO:0140662.
+    action: MODIFY
+    reason: Replace generic unfolded-protein binding with ATP-dependent protein folding chaperone activity while retaining this partner-specific IGI provenance.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:9789005
+      supporting_text: |-
+        yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  evidence_type: IGI
+  original_reference_id: PMID:9789005
+  review:
+    summary: >-
+      This separate genetic-interaction row is linked to SSA4
+      (WITH/FROM SGD:S000000905). Binding non-native clients is real, but the productive,
+      ATP-coupled chaperone activity is more precisely represented by GO:0140662.
+    action: MODIFY
+    reason: Replace generic unfolded-protein binding with ATP-dependent protein folding chaperone activity while retaining this partner-specific IGI provenance.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:9789005
+      supporting_text: |-
+        yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  evidence_type: IGI
+  original_reference_id: PMID:9789005
+  review:
+    summary: >-
+      This separate genetic-interaction row is linked to SSA2
+      (WITH/FROM SGD:S000003947). Binding non-native clients is real, but the productive,
+      ATP-coupled chaperone activity is more precisely represented by GO:0140662.
+    action: MODIFY
+    reason: Replace generic unfolded-protein binding with ATP-dependent protein folding chaperone activity while retaining this partner-specific IGI provenance.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:9789005
+      supporting_text: |-
+        yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0006457
+    label: protein folding
+  evidence_type: IGI
+  original_reference_id: PMID:9789005
+  review:
+    summary: >-
+      This separate genetic-interaction row is linked to SSA2
+      (WITH/FROM SGD:S000003947). Kim et al. support SSA-class cytosolic Hsp70 function
+      in folding newly translated proteins; the partner records the tested
+      genetic context rather than an isoform-specific mechanism.
+    action: ACCEPT
+    reason: Protein folding is a core Ssa3 process supported at the SSA-family level; retain this partner-specific IGI row.
+    supported_by:
+    - reference_id: PMID:9789005
+      supporting_text: |-
+        yeast cytosolic OTC is assisted to its native state by the SSA class of yeast cytosolic Hsp70 proteins.
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0006616
     label: SRP-dependent cotranslational protein targeting to membrane, translocation
@@ -497,7 +881,9 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:8754838
       supporting_text: |-
-        These results are consistent with SSA proteins and Ydj1p acting together in the translocation process.
+        prepro-alpha-factor was inhibited within 2 min of the shift to 37 degrees C,
+        suggesting a direct effect of the hsp70 defect on translocation. More than 50%
+        of radiolabeled alpha-factor accumulated in the precursor form
       reference_section_type: ABSTRACT
     - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
       supporting_text: Ssa proteins promote folding, translocation, degradation, and refolding of denatured substrates
@@ -509,13 +895,17 @@ existing_annotations:
   original_reference_id: PMID:3302682
   review:
     summary: |-
-      Genetic interactions within the essential SSA subfamily are consistent
-      with the ATP-dependent (ATPase) Hsp70 chaperone activity. Core catalytic
-      function; same conclusion as the other ATP hydrolysis annotations.
+      The GOA row records an SSA3–SSA1 genetic interaction (WITH/FROM
+      SGD:S000000004). Genetic interactions within the essential SSA subfamily
+      are consistent with ATP-dependent Hsp70 chaperone activity; the ATPase
+      claim is accepted on established Hsp70 family mechanism rather than as a
+      direct biochemical assay in this paper.
     action: ACCEPT
     reason: |-
       Falcon establishes ATP-dependent operation of the Ssa chaperones with ATP
-      hydrolysis driving the substrate-affinity cycle.
+      hydrolysis driving the substrate-affinity cycle. PMID:3302682 supplies the
+      SSA1 genetic-interaction context, while the biochemical ATPase conclusion
+      rests on the independently established Hsp70 family mechanism.
     supported_by:
     - reference_id: file:yeast/SSA3/SSA3-deep-research-falcon.md
       supporting_text: |-
@@ -524,14 +914,13 @@ existing_annotations:
 - term:
     id: GO:0051082
     label: unfolded protein binding
-  evidence_type: IGI
-  original_reference_id: PMID:9789005
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
   review:
     summary: |-
       Ssa3 binds non-native/unfolded proteins, but as an ATP-dependent Hsp70 the
       more precise molecular function is ATP-dependent protein folding chaperone
-      activity (GO:0140662). Same conclusion as the IEA unfolded protein binding
-      annotation above.
+      activity (GO:0140662), which is also the term InterPro assigns in UniProt.
     action: MODIFY
     reason: |-
       Falcon emphasizes ATP-dependent, ATPase-cycle-coupled substrate binding;
@@ -553,7 +942,9 @@ core_functions:
     (ATPase) domain binds and hydrolyzes ATP to drive cycles of high- and
     low-affinity binding of exposed hydrophobic segments on non-native
     polypeptides, preventing aggregation and promoting productive
-    folding/refolding in the cytosol.
+    folding/refolding in the cytosol. Partner-class annotations also place Ssa3
+    in the Hsp70/Hsp40/Hsp110 co-chaperone network, while SSA-family experiments
+    support an additional role in post-translational precursor translocation.
   molecular_function:
     id: GO:0140662
     label: ATP-dependent protein folding chaperone
@@ -562,6 +953,8 @@ core_functions:
     label: protein folding
   - id: GO:0042026
     label: protein refolding
+  - id: GO:0031204
+    label: post-translational protein targeting to membrane, translocation
   locations:
   - id: GO:0005829
     label: cytosol
@@ -600,22 +993,80 @@ references:
     reference_section_type: ABSTRACT
 - id: PMID:11805837
   title: Systematic identification of protein complexes in Saccharomyces cerevisiae by mass spectrometry.
-  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: >-
+      The cached abstract verifies a proteome-scale mass-spectrometric complex map. The specific Ssa3-Mtc5 edge is not narrated, so its partner identity is retained from GOA without treating the row as a direct binary assay.
+  findings:
+  - statement: The source reports high-throughput mass-spectrometric identification of protein complexes rather than targeted binary tests for every edge.
+    supporting_text: |-
+      Here we report,
+      using the budding yeast Saccharomyces cerevisiae as a test case, an example of
+      this approach, which we term high-throughput mass spectrometric protein complex
+      identification (HMS-PCI).
+    reference_section_type: ABSTRACT
 - id: PMID:16554755
   title: Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.
-  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: >-
+      Full text verifies a global tandem-affinity-purification/mass-spectrometry complex map. The 13 Ssa3 partner rows are dataset-level records and are not individually narrated as direct binary interactions.
+  findings:
+  - statement: The interaction map is based on tandem affinity purification and mass spectrometry of thousands of tagged yeast proteins.
+    supporting_text: |-
+      We used tandem affinity purification to process 4,562 different
+      tagged proteins of the yeast Saccharomyces cerevisiae. Each preparation was
+      analysed by both matrix-assisted laser desorption/ionization-time of flight mass
+      spectrometry and liquid chromatography tandem mass spectrometry
+    reference_section_type: ABSTRACT
 - id: PMID:19536198
   title: 'An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.'
-  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      PMC full text checked. The atlas explicitly identifies Ssa3 as a promiscuous chaperone, but its TAP-tag associations usually reflect protein complexes rather than direct binary contact; partner-specific GOA rows are therefore retained with that caveat.
+  findings:
+  - statement: The chaperone-atlas associations are indirect TAP-tag complex interactions rather than proof of direct binary binding.
+    supporting_text: >-
+      It should be emphasized that the interactions presented are indirect TAP-tag based
+      interactions and not direct binary interactions.
+    reference_section_type: RESULTS
 - id: PMID:24855027
   title: Life-span extension by a metacaspase in the yeast Saccharomyces cerevisiae.
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: >-
+      The cached record is abstract-only and focused on Mca1; it does not mention
+      SSA3 or expose the SSA3-specific IMP experiment available to the curator.
+      The biologically consistent annotation is therefore retained by deference
+      rather than treated as directly verified from the cached text.
   findings: []
 - id: PMID:27107014
   title: An inter-species protein-protein interaction network across vast evolutionary distance.
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: >-
+      The paper reports a large inter-species interaction network. The Ssa3-human-HSPBP1 edge is retained from the curator-supplied GOA row, but the main cached text does not provide enough edge-specific detail to treat it as a targeted functional assay.
   findings: []
 - id: PMID:31454312
   title: The role of structural pleiotropy and regulatory evolution in the retention of heteromers of paralogs.
-  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: >-
+      Full text verifies an experimental/computational study of paralog heteromer retention. The Ssa3-Ssa4 row is retained from GOA, but the main narrative does not individually discuss this pair, so the direct edge remains unverified here.
+  findings:
+  - statement: The study finds that heteromerization is frequent among duplicated yeast homomers and correlates with paralog functional similarity.
+    supporting_text: |-
+      Using yeast as a model, we find that heteromerization is
+      frequent among duplicated homomers and correlates with functional similarity
+      between paralogs.
+    reference_section_type: ABSTRACT
 - id: PMID:3302682
   title: Complex interactions among members of an essential subfamily of hsp70 genes in Saccharomyces cerevisiae.
   reference_review:
@@ -719,6 +1170,12 @@ references:
     supporting_text: |-
       Ssa3 was reported as the most proficient isoform for [PSI+] propagation/maintenance
     reference_section_type: OTHER
+- id: file:interpro/panther/PTHR19375/PTHR19375-paint.tsv
+  title: Current PANTHER PTHR19375 PAINT annotation snapshot
+  findings:
+  - statement: >-
+      PTN002500132 currently carries nucleus and cytosol IBD assertions but no
+      plasma-membrane assertion, showing that the pinned 2025 GOA transfer is stale.
 - id: file:yeast/SSA3/SSA3-hypotheses/existing-go-0005886-keep-as-non-core/openscientist.md
   title: OpenScientist review of the SSA3 plasma-membrane IBA annotation
   reference_review:

--- a/genes/yeast/SSA3/SSA3-notes.md
+++ b/genes/yeast/SSA3/SSA3-notes.md
@@ -30,9 +30,12 @@ The YAML `description` field was revised to keep it as a standalone biological s
   mitochondrial phenotype is not encoded by that replacement. [PMID:8754838 "These results are
   consistent with SSA proteins and Ydj1p acting together in the translocation
   process."]
-- The plasma-membrane IBA is removed as a compartment-mismatched family
-  propagation. UniProt and the SSA3-focused literature consistently identify
-  Ssa3 as cytosolic; no target-specific plasma-membrane evidence was found. A
+- The plasma-membrane IBA is removed as a stale PAINT transfer. The pinned 2025
+  GOA row points to PTN002500132, but the current local PTHR19375 PAINT snapshot
+  carries nucleus and cytosol at that node and no longer carries GO:0005886.
+  This is a current-node comparison, not an inference from donor count. UniProt
+  and the SSA3-focused literature consistently identify Ssa3 as cytosolic; no
+  target-specific plasma-membrane evidence was found. A
   targeted OpenScientist hypothesis run independently preferred `REMOVE` because
   it found no SSA3-specific experimental support. Its live QuickGO claims that
   the P09435 IBA had been retired and that Ssa4 lacked the same IBA conflict with
@@ -46,3 +49,11 @@ The YAML `description` field was revised to keep it as a standalone biological s
   had access to more evidence than the cached abstract.
 - The UNFOLDED_PROTEIN_BINDING project row now uses GO:0140662 for SSA3, aligning
   the project decision with the review's ATP-dependent Hsp70 mechanism.
+
+## 2026-08-27 row-completeness follow-up
+
+- The review was promoted from `DRAFT` to `COMPLETE` after restoring one review
+  record for every one of the 55 pinned GOA rows. Repeated IPI and IGI rows are retained
+  separately by reference and `WITH/FROM` partner rather than collapsed.
+- Generic nucleotide binding is now `MODIFY` to the existing specific ATP-binding
+  term GO:0005524, matching the treatment of the same parent term in SSA4.

--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -2048,7 +2048,7 @@ established:</p>
 <td><a href="../../genes/yeast/SSA3/SSA3-ai-review.html">SSA3</a></td>
 <td><em>S. cerevisiae</em></td>
 <td>P09435</td>
-<td>26</td>
+<td>55</td>
 <td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140662">GO:0140662</a></td>
 <td>Stress-inducible cytosolic HSP70; ATP-driven folding/refolding</td>
 </tr>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -560,7 +560,7 @@ established:
 | SQT1 | *S. cerevisiae* | P35184 | 9 | MODIFY | Ribosome assembly |
 | SSA1 | *S. cerevisiae* | P10591 | 71 | MODIFY → GO:0044183 | HSP70 |
 | SSA2 | *S. cerevisiae* | P10592 | 58 | MODIFY → GO:0044183 | HSP70 |
-| SSA3 | *S. cerevisiae* | P09435 | 26 | MODIFY → GO:0140662 | Stress-inducible cytosolic HSP70; ATP-driven folding/refolding |
+| SSA3 | *S. cerevisiae* | P09435 | 55 | MODIFY → GO:0140662 | Stress-inducible cytosolic HSP70; ATP-driven folding/refolding |
 | SSA4 | *S. cerevisiae* | P22202 | 33 | MODIFY → GO:0140662 | Stress-inducible cytosolic HSP70; ATP-driven folding/refolding |
 | SSB1 | *S. cerevisiae* | P11484 | 36 | MODIFY → GO:0140662 | Ribosome-associated HSP70; ATP-driven nascent-chain folding at the tunnel exit |
 | SSB2 | *S. cerevisiae* | P40150 | 39 | MODIFY → GO:0140662 | Ribosome-associated HSP70 paralog of SSB1; ATP-driven nascent-chain folding |


### PR DESCRIPTION
Follow-up to #2664.

## What changed
- expanded the SSA3 review from 26 collapsed records to one record for each of the 55 pinned GOA rows
- preserved repeated interaction and genetic-interaction rows with exact WITH/FROM partner provenance and matching multiplicities
- aligned the plasma-membrane IBA diagnosis with the current PTHR19375 PAINT snapshot (`SOURCE_STALE_OR_MISSING`; no donor-count argument)
- replaced generic nucleotide binding with ATP binding and handled the two SSA4 interaction rows with the informative Hsp70-binding term
- strengthened primary-literature evidence and explicitly caveated indirect affinity-capture interaction datasets
- marked the review COMPLETE and updated the unfolded-protein-binding project count from 26 to 55
- regenerated the gene page, project page, and browser data through public `just` wrappers

No new OpenScientist job was launched: the existing hypothesis report already tests this question, and the deterministic current PAINT snapshot resolves the stale propagation claim.

## Verification
- `just validate yeast SSA3`
- independent reconciliation: 55 review rows / 55 GOA rows, matching grouped multiplicities
- `just render yeast SSA3`
- `just render-projects`
- `just deploy-browser`
- `just test` (1773 unit tests passed; 154 doctests passed, 37 skipped; mypy and Ruff clean)