### PR TITLE
Add BioReason sidecar refresh wrapper

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -1477,6 +1477,10 @@ render-bioreason-eval:
     uv run python -m ai_gene_review.render_prediction_eval 'genes/*/*/*-gogpt-leaf-predictions.yaml' -o 'pages/projects/BIOREASON_COMPARISON/gogpt-eval.html' --title 'BioReason-Pro GO-GPT Prediction Evaluation'
     uv run python -m ai_gene_review.render_prediction_eval 'projects/BIOREASON_COMPARISON/recapitulation-experiment/claude-expt-1/genes/ECOLI/*/*-det-predictions-review.yaml' -o 'pages/projects/BIOREASON_COMPARISON/deepectf-eval.html' --title 'BioReason-Pro DeepECTF Evaluation (ESR-ECOLI-DET-Mini)'
 
+# Refresh the deterministic BioReason benchmark cohort, gene, quality, and metrics sidecars
+refresh-bioreason-benchmark-sidecars:
+    uv run python projects/BIOREASON_COMPARISON/write_benchmark_sidecars.py
+
 # Render project markdown files to HTML with auto-linked gene symbols
 render-projects:
     uv run ai-gene-review render-projects --all

--- a/projects/BIOREASON_COMPARISON/justfile
+++ b/projects/BIOREASON_COMPARISON/justfile
@@ -36,7 +36,7 @@ all: pdf short-abstract-pdf
 # Re-running after the manual term-level review lands reproduces Table 5 verbatim.
 stats: gogpt-overlap
     cd {{justfile_directory()}}/../.. && \
-        uv run python projects/BIOREASON_COMPARISON/write_benchmark_sidecars.py
+        just refresh-bioreason-benchmark-sidecars
     cd {{justfile_directory()}}/{{notebooks_dir}} && \
         uv run python build_notebooks.py && \
         uv run jupyter nbconvert --to notebook --execute --inplace *.ipynb

--- a/projects/BIOREASON_COMPARISON/justfile
+++ b/projects/BIOREASON_COMPARISON/justfile
@@ -36,7 +36,7 @@ all: pdf short-abstract-pdf
 # Re-running after the manual term-level review lands reproduces Table 5 verbatim.
 stats: gogpt-overlap
     cd {{justfile_directory()}}/../.. && \
-        just refresh-bioreason-benchmark-sidecars
+        "{{just_executable()}}" refresh-bioreason-benchmark-sidecars
     cd {{justfile_directory()}}/{{notebooks_dir}} && \
         uv run python build_notebooks.py && \
         uv run jupyter nbconvert --to notebook --execute --inplace *.ipynb

--- a/tests/test_bioreason_benchmark_policy.py
+++ b/tests/test_bioreason_benchmark_policy.py
@@ -182,7 +182,7 @@ def test_generated_sidecars_match_current_sources(tmp_path: Path) -> None:
     ):
         assert (tmp_path / filename).read_bytes() == (PROJECT_DIR / filename).read_bytes(), (
             f"{filename} is stale; run "
-            "just refresh-bioreason-benchmark-sidecars"
+            "`just refresh-bioreason-benchmark-sidecars` from the repository root"
         )
 
 

--- a/tests/test_bioreason_benchmark_policy.py
+++ b/tests/test_bioreason_benchmark_policy.py
@@ -182,7 +182,7 @@ def test_generated_sidecars_match_current_sources(tmp_path: Path) -> None:
     ):
         assert (tmp_path / filename).read_bytes() == (PROJECT_DIR / filename).read_bytes(), (
             f"{filename} is stale; run "
-            "python projects/BIOREASON_COMPARISON/write_benchmark_sidecars.py"
+            "just refresh-bioreason-benchmark-sidecars"
         )
 
 

--- a/tests/test_bioreason_sidecar_wrapper.py
+++ b/tests/test_bioreason_sidecar_wrapper.py
@@ -13,6 +13,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 def test_refresh_bioreason_sidecars_uses_project_generator(tmp_path: Path) -> None:
     """The public recipe should invoke the deterministic generator through uv."""
+    generator = REPO_ROOT / "projects/BIOREASON_COMPARISON/write_benchmark_sidecars.py"
+    assert generator.exists()
+
     fake_bin = tmp_path / "fake bin"
     fake_bin.mkdir()
     log_path = tmp_path / "argv.json"
@@ -34,8 +37,14 @@ with open(os.environ["BIOREASON_SIDECAR_ARGV_LOG"], "w") as handle:
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
     env["BIOREASON_SIDECAR_ARGV_LOG"] = str(log_path)
     result = subprocess.run(
-        ["just", "refresh-bioreason-benchmark-sidecars"],
-        cwd=REPO_ROOT,
+        [
+            "just",
+            "--justfile",
+            str(REPO_ROOT / "justfile"),
+            "--working-directory",
+            str(tmp_path),
+            "refresh-bioreason-benchmark-sidecars",
+        ],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/test_bioreason_sidecar_wrapper.py
+++ b/tests/test_bioreason_sidecar_wrapper.py
@@ -1,0 +1,51 @@
+"""Argument-boundary test for the public BioReason sidecar wrapper."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_refresh_bioreason_sidecars_uses_project_generator(tmp_path: Path) -> None:
+    """The public recipe should invoke the deterministic generator through uv."""
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    log_path = tmp_path / "argv.json"
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["BIOREASON_SIDECAR_ARGV_LOG"], "w") as handle:
+    json.dump(sys.argv[1:], handle)
+"""
+    )
+    fake_uv.chmod(0o755)
+
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["BIOREASON_SIDECAR_ARGV_LOG"] = str(log_path)
+    result = subprocess.run(
+        ["just", "refresh-bioreason-benchmark-sidecars"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == [
+        "run",
+        "python",
+        "projects/BIOREASON_COMPARISON/write_benchmark_sidecars.py",
+    ]


### PR DESCRIPTION
## What changed
- add public `just refresh-bioreason-benchmark-sidecars` recipe for the deterministic BioReason sidecar generator
- add an end-to-end wrapper argument-boundary test
- update stale-sidecar test guidance to name the public wrapper instead of the internal Python script

This fixes the wrapper gap discovered while completing the SSA1 review; the gene PR remains separate.

## Verification
- red/green: wrapper test failed before recipe and passes after
- `uv run pytest tests/test_bioreason_sidecar_wrapper.py tests/test_bioreason_benchmark_policy.py -q` (11 passed)
- `just test` (1774 unit tests passed; 154 doctests passed, 37 skipped; mypy and Ruff clean)