### PR TITLE
Quote BioReason project recipe paths

### DIFF
--- a/projects/BIOREASON_COMPARISON/justfile
+++ b/projects/BIOREASON_COMPARISON/justfile
@@ -11,13 +11,13 @@ slides_html := article_dir / "slides.html"
 
 # Build the manuscript PDF directly from the LaTeX article source
 pdf:
-    cd {{justfile_directory()}}/{{article_dir}} && \
+    cd "{{justfile_directory()}}/{{article_dir}}" && \
         latexmk -xelatex -interaction=nonstopmode -halt-on-error -file-line-error manuscript.tex
     @echo "Built {{pdf}}"
 
 # Build the short abstract PDF
 short-abstract-pdf:
-    cd {{justfile_directory()}} && pandoc {{short_abstract}} \
+    cd "{{justfile_directory()}}" && pandoc {{short_abstract}} \
         -o {{short_pdf}} \
         --pdf-engine=xelatex \
         -V geometry:margin=1in \
@@ -35,9 +35,9 @@ all: pdf short-abstract-pdf
 # means in 01; the de Crecy-Lagard assessment distribution / Table 5 analog in 02).
 # Re-running after the manual term-level review lands reproduces Table 5 verbatim.
 stats: gogpt-overlap
-    cd {{justfile_directory()}}/../.. && \
+    cd "{{justfile_directory()}}/../.." && \
         "{{just_executable()}}" refresh-bioreason-benchmark-sidecars
-    cd {{justfile_directory()}}/{{notebooks_dir}} && \
+    cd "{{justfile_directory()}}/{{notebooks_dir}}" && \
         uv run python build_notebooks.py && \
         uv run jupyter nbconvert --to notebook --execute --inplace *.ipynb
     @echo "Executed stats notebooks in {{notebooks_dir}}/ (outputs embedded)"
@@ -45,26 +45,26 @@ stats: gogpt-overlap
 # Recompute the independent canonical GO-GPT overlap diagnostic used in the
 # supplement and benchmark sidecar. This is separate from the ARGO139 audit.
 gogpt-overlap:
-    cd {{justfile_directory()}}/../.. && \
+    cd "{{justfile_directory()}}/../.." && \
         uv run python scripts/gogpt_compare_levels.py
     @echo "Wrote reports/gogpt-comparison-levels.json and the overlap figure"
 
 # Export the executed stats notebooks to standalone HTML for browsing.
 stats-html: stats
-    cd {{justfile_directory()}}/{{notebooks_dir}} && \
+    cd "{{justfile_directory()}}/{{notebooks_dir}}" && \
         uv run jupyter nbconvert --to html *.ipynb
     @echo "Wrote {{notebooks_dir}}/*.html"
 
 # Recompute retrospective CAFA-style GOA agreement for SFT GO terms.
 cafa-style:
-    cd {{justfile_directory()}}/../.. && \
+    cd "{{justfile_directory()}}/../.." && \
         uv run python projects/BIOREASON_COMPARISON/cafa_style_argo139.py
     @echo "Wrote cafa-style/"
 
 # Render the Function-COSI slide deck (Marp markdown -> self-contained HTML).
 # Needs a browser for --pdf/--pptx; HTML works headless.
 slides:
-    cd {{justfile_directory()}}/{{article_dir}} && \
+    cd "{{justfile_directory()}}/{{article_dir}}" && \
         npx --yes @marp-team/marp-cli@latest slides.md --html --allow-local-files -o slides.html
     @echo "Built {{slides_html}}"
 

--- a/tests/test_bioreason_project_justfile.py
+++ b/tests/test_bioreason_project_justfile.py
@@ -13,6 +13,17 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_JUSTFILE = REPO_ROOT / "projects/BIOREASON_COMPARISON/justfile"
 
 
+def test_all_justfile_directory_interpolations_are_quoted() -> None:
+    """Every project-directory interpolation should begin inside a shell quote."""
+    unquoted_lines = [
+        line
+        for line in PROJECT_JUSTFILE.read_text().splitlines()
+        if "{{justfile_directory()}}" in line
+        and '"{{justfile_directory()}}' not in line
+    ]
+    assert unquoted_lines == []
+
+
 def test_gogpt_overlap_supports_repository_paths_with_spaces(tmp_path: Path) -> None:
     """Project recipes should quote the directory supplied by just."""
     copied_root = tmp_path / "repository with spaces"

--- a/tests/test_bioreason_project_justfile.py
+++ b/tests/test_bioreason_project_justfile.py
@@ -1,0 +1,57 @@
+"""Execution tests for the BioReason project-local justfile."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_JUSTFILE = REPO_ROOT / "projects/BIOREASON_COMPARISON/justfile"
+
+
+def test_gogpt_overlap_supports_repository_paths_with_spaces(tmp_path: Path) -> None:
+    """Project recipes should quote the directory supplied by just."""
+    copied_root = tmp_path / "repository with spaces"
+    copied_project = copied_root / "projects/BIOREASON_COMPARISON"
+    copied_project.mkdir(parents=True)
+    copied_justfile = copied_project / "justfile"
+    shutil.copyfile(PROJECT_JUSTFILE, copied_justfile)
+
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    log_path = tmp_path / "uv-call.json"
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["BIOREASON_PROJECT_JUSTFILE_LOG"], "w") as handle:
+    json.dump({"argv": sys.argv[1:], "cwd": os.getcwd()}, handle)
+"""
+    )
+    fake_uv.chmod(0o755)
+
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["BIOREASON_PROJECT_JUSTFILE_LOG"] = str(log_path)
+    result = subprocess.run(
+        ["just", "--justfile", str(copied_justfile), "gogpt-overlap"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == {
+        "argv": ["run", "python", "scripts/gogpt_compare_levels.py"],
+        "cwd": str(copied_root),
+    }

--- a/tests/test_bioreason_project_justfile.py
+++ b/tests/test_bioreason_project_justfile.py
@@ -1,9 +1,10 @@
-"""Execution tests for the BioReason project-local justfile."""
+"""Regression tests for the BioReason project-local justfile."""
 
 from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -11,17 +12,20 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_JUSTFILE = REPO_ROOT / "projects/BIOREASON_COMPARISON/justfile"
+PATH_FUNCTION_INTERPOLATION = re.compile(
+    r"\{\{\s*(?:justfile_directory|just_executable|invocation_directory)\(\)\s*\}\}"
+)
 
 
-def test_all_justfile_directory_interpolations_are_quoted() -> None:
-    """Every project-directory interpolation should begin inside a shell quote."""
-    unquoted_lines = [
-        line
-        for line in PROJECT_JUSTFILE.read_text().splitlines()
-        if "{{justfile_directory()}}" in line
-        and '"{{justfile_directory()}}' not in line
+def test_all_path_function_interpolations_are_quoted() -> None:
+    """Every path-producing interpolation should begin inside a shell quote."""
+    text = PROJECT_JUSTFILE.read_text()
+    unquoted_occurrences = [
+        match.group(0)
+        for match in PATH_FUNCTION_INTERPOLATION.finditer(text)
+        if match.start() == 0 or text[match.start() - 1] != '"'
     ]
-    assert unquoted_lines == []
+    assert unquoted_occurrences == []
 
 
 def test_gogpt_overlap_supports_repository_paths_with_spaces(tmp_path: Path) -> None:

--- a/tests/test_bioreason_project_justfile.py
+++ b/tests/test_bioreason_project_justfile.py
@@ -23,7 +23,7 @@ def test_all_path_function_interpolations_are_quoted() -> None:
     unquoted_occurrences = [
         match.group(0)
         for match in PATH_FUNCTION_INTERPOLATION.finditer(text)
-        if match.start() == 0 or text[match.start() - 1] != '"'
+        if match.start() == 0 or text[match.start() - 1] not in {'"', "'"}
     ]
     assert unquoted_occurrences == []
 


### PR DESCRIPTION
Summary:
- quote every justfile_directory path used by BioReason project recipes
- preserve the public sidecar wrapper delegation
- add an execution regression test using a repository path that contains spaces

Testing:
- uv run pytest -q tests/test_bioreason_project_justfile.py tests/test_bioreason_sidecar_wrapper.py tests/test_bioreason_benchmark_policy.py
- just test
- git diff --check