### PR TITLE
Quote IMPReSS project recipe paths

### DIFF
--- a/projects/BEHAVIOR/impress/justfile
+++ b/projects/BEHAVIOR/impress/justfile
@@ -13,25 +13,25 @@ pipelines := "IMPC_001,JAX_001,ESLIM_002,GMC_001,ICS_001"
 
 # List available recipes
 _default:
-    @just --list --justfile {{justfile()}}
+    @"{{just_executable()}}" --list --justfile "{{justfile()}}"
 
 # Fetch the IMPReSS pipelines and regenerate procedures.tsv / behavioural_assays.yaml / REPORT.md
 ingest:
-    cd {{root}} && uv run python projects/BEHAVIOR/impress/ingest_impress.py \
+    cd "{{root}}" && uv run python projects/BEHAVIOR/impress/ingest_impress.py \
         --pipelines {{pipelines}} --out-dir projects/BEHAVIOR/impress
 
 # Check behaviour annotations against the assay that produced them (-> ASSAY_CHECK.md)
 check:
-    cd {{root}} && uv run python projects/BEHAVIOR/impress/check_behaviour_assays.py \
+    cd "{{root}}" && uv run python projects/BEHAVIOR/impress/check_behaviour_assays.py \
         --out-dir projects/BEHAVIOR/impress
 
 # Validate the curated assay->GO map (structure + exact join to the ingest)
 validate:
-    cd {{root}} && uv run python projects/BEHAVIOR/impress/validate_map.py
+    cd "{{root}}" && uv run python projects/BEHAVIOR/impress/validate_map.py
 
 # Validate the map AND verify every GO id/label against QuickGO (needs network)
 validate-online:
-    cd {{root}} && uv run python projects/BEHAVIOR/impress/validate_map.py --online
+    cd "{{root}}" && uv run python projects/BEHAVIOR/impress/validate_map.py --online
 
 # Full refresh: ingest, validate (online), then check
 all: ingest validate-online check

--- a/projects/BEHAVIOR/impress/justfile
+++ b/projects/BEHAVIOR/impress/justfile
@@ -8,7 +8,7 @@
 # repo root is three levels up from projects/BEHAVIOR/impress
 root := justfile_directory() / ".." / ".." / ".."
 
-# Pipelines to ingest (override: `just ingest pipelines=IMPC_001`)
+# Pipelines to ingest (override: `just pipelines=IMPC_001 ingest`)
 pipelines := "IMPC_001,JAX_001,ESLIM_002,GMC_001,ICS_001"
 
 # List available recipes
@@ -18,7 +18,7 @@ _default:
 # Fetch the IMPReSS pipelines and regenerate procedures.tsv / behavioural_assays.yaml / REPORT.md
 ingest:
     cd "{{root}}" && uv run python projects/BEHAVIOR/impress/ingest_impress.py \
-        --pipelines {{pipelines}} --out-dir projects/BEHAVIOR/impress
+        --pipelines "{{pipelines}}" --out-dir projects/BEHAVIOR/impress
 
 # Check behaviour annotations against the assay that produced them (-> ASSAY_CHECK.md)
 check:

--- a/tests/justfile_quoting.py
+++ b/tests/justfile_quoting.py
@@ -1,0 +1,27 @@
+"""Shared assertions for shell-path interpolation in project justfiles."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Collection
+
+
+INTERPOLATION = re.compile(r"\{\{(?P<body>[^{}]+)\}\}")
+
+
+def find_unquoted_recipe_path_interpolations(
+    text: str, path_names: Collection[str]
+) -> list[str]:
+    """Return recipe-line path interpolations that do not start inside a quote."""
+    normalized_path_names = {re.sub(r"\s+", "", name) for name in path_names}
+    unquoted: list[str] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line[:1].isspace():
+            continue
+        for match in INTERPOLATION.finditer(line):
+            normalized_name = re.sub(r"\s+", "", match.group("body"))
+            if normalized_name not in normalized_path_names:
+                continue
+            if match.start() == 0 or line[match.start() - 1] not in {'"', "'"}:
+                unquoted.append(f"line {line_number}: {match.group(0)}")
+    return unquoted

--- a/tests/test_behavior_impress_justfile.py
+++ b/tests/test_behavior_impress_justfile.py
@@ -8,6 +8,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from tests.justfile_quoting import find_unquoted_recipe_path_interpolations
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_JUSTFILE = REPO_ROOT / "projects/BEHAVIOR/impress/justfile"
@@ -22,20 +24,7 @@ def _copy_project_justfile(tmp_path: Path) -> tuple[Path, Path]:
     return copied_root, copied_justfile
 
 
-def test_all_impress_recipe_paths_are_quoted() -> None:
-    """Every root or justfile interpolation used as a shell path should be quoted."""
-    unquoted_occurrences = [
-        token
-        for line in PROJECT_JUSTFILE.read_text().splitlines()
-        for token in ("{{root}}", "{{justfile()}}", "{{just_executable()}}")
-        if token in line and f'"{token}' not in line and f"'{token}" not in line
-    ]
-    assert unquoted_occurrences == []
-
-
-def test_check_supports_repository_paths_with_spaces(tmp_path: Path) -> None:
-    """Root-changing recipes should preserve a space-containing repository path."""
-    copied_root, copied_justfile = _copy_project_justfile(tmp_path)
+def _write_fake_uv(tmp_path: Path) -> tuple[Path, Path]:
     fake_bin = tmp_path / "fake bin"
     fake_bin.mkdir()
     log_path = tmp_path / "uv-call.json"
@@ -51,19 +40,40 @@ with open(os.environ["IMPRESS_JUSTFILE_LOG"], "w") as handle:
 """
     )
     fake_uv.chmod(0o755)
+    return fake_bin, log_path
 
+
+def _run_with_fake_uv(
+    tmp_path: Path, copied_justfile: Path, *recipe_args: str
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    fake_bin, log_path = _write_fake_uv(tmp_path)
     env = os.environ.copy()
     env.pop("VIRTUAL_ENV", None)
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
     env["IMPRESS_JUSTFILE_LOG"] = str(log_path)
     result = subprocess.run(
-        ["just", "--justfile", str(copied_justfile), "check"],
+        ["just", "--justfile", str(copied_justfile), *recipe_args],
         capture_output=True,
         text=True,
         check=False,
         env=env,
         timeout=30,
     )
+    return result, log_path
+
+
+def test_all_impress_recipe_paths_are_quoted() -> None:
+    """Every root or justfile interpolation used as a shell path should be quoted."""
+    assert find_unquoted_recipe_path_interpolations(
+        PROJECT_JUSTFILE.read_text(),
+        {"root", "justfile()", "just_executable()", "justfile_directory()"},
+    ) == []
+
+
+def test_check_supports_repository_paths_with_spaces(tmp_path: Path) -> None:
+    """Root-changing recipes should preserve a space-containing repository path."""
+    copied_root, copied_justfile = _copy_project_justfile(tmp_path)
+    result, log_path = _run_with_fake_uv(tmp_path, copied_justfile, "check")
 
     assert result.returncode == 0, result.stderr
     assert json.loads(log_path.read_text()) == {
@@ -78,11 +88,39 @@ with open(os.environ["IMPRESS_JUSTFILE_LOG"], "w") as handle:
     }
 
 
+def test_ingest_preserves_pipeline_override_with_spaces(tmp_path: Path) -> None:
+    """A user-supplied pipeline value should remain one command argument."""
+    copied_root, copied_justfile = _copy_project_justfile(tmp_path)
+    result, log_path = _run_with_fake_uv(
+        tmp_path, copied_justfile, "pipelines=IMPC_001 custom", "ingest"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == {
+        "argv": [
+            "run",
+            "python",
+            "projects/BEHAVIOR/impress/ingest_impress.py",
+            "--pipelines",
+            "IMPC_001 custom",
+            "--out-dir",
+            "projects/BEHAVIOR/impress",
+        ],
+        "cwd": str(copied_root),
+    }
+
+
 def test_default_listing_supports_justfile_paths_with_spaces(tmp_path: Path) -> None:
-    """The nested recipe listing should preserve the copied justfile path."""
+    """The nested listing should preserve spaced executable and justfile paths."""
     _, copied_justfile = _copy_project_justfile(tmp_path)
+    real_just = shutil.which("just")
+    assert real_just is not None
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    copied_just = fake_bin / "just"
+    shutil.copy2(real_just, copied_just)
     result = subprocess.run(
-        ["just", "--justfile", str(copied_justfile)],
+        [str(copied_just), "--justfile", str(copied_justfile)],
         capture_output=True,
         text=True,
         check=False,
@@ -90,4 +128,5 @@ def test_default_listing_supports_justfile_paths_with_spaces(tmp_path: Path) -> 
     )
 
     assert result.returncode == 0, result.stderr
-    assert "check" in result.stdout
+    assert "ingest" in result.stdout
+    assert "validate-online" in result.stdout

--- a/tests/test_behavior_impress_justfile.py
+++ b/tests/test_behavior_impress_justfile.py
@@ -1,0 +1,93 @@
+"""Regression tests for the IMPReSS project-local justfile."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_JUSTFILE = REPO_ROOT / "projects/BEHAVIOR/impress/justfile"
+
+
+def _copy_project_justfile(tmp_path: Path) -> tuple[Path, Path]:
+    copied_root = tmp_path / "repository with spaces"
+    copied_project = copied_root / "projects/BEHAVIOR/impress"
+    copied_project.mkdir(parents=True)
+    copied_justfile = copied_project / "justfile"
+    shutil.copyfile(PROJECT_JUSTFILE, copied_justfile)
+    return copied_root, copied_justfile
+
+
+def test_all_impress_recipe_paths_are_quoted() -> None:
+    """Every root or justfile interpolation used as a shell path should be quoted."""
+    unquoted_occurrences = [
+        token
+        for line in PROJECT_JUSTFILE.read_text().splitlines()
+        for token in ("{{root}}", "{{justfile()}}", "{{just_executable()}}")
+        if token in line and f'"{token}' not in line and f"'{token}" not in line
+    ]
+    assert unquoted_occurrences == []
+
+
+def test_check_supports_repository_paths_with_spaces(tmp_path: Path) -> None:
+    """Root-changing recipes should preserve a space-containing repository path."""
+    copied_root, copied_justfile = _copy_project_justfile(tmp_path)
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    log_path = tmp_path / "uv-call.json"
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["IMPRESS_JUSTFILE_LOG"], "w") as handle:
+    json.dump({"argv": sys.argv[1:], "cwd": os.getcwd()}, handle)
+"""
+    )
+    fake_uv.chmod(0o755)
+
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["IMPRESS_JUSTFILE_LOG"] = str(log_path)
+    result = subprocess.run(
+        ["just", "--justfile", str(copied_justfile), "check"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == {
+        "argv": [
+            "run",
+            "python",
+            "projects/BEHAVIOR/impress/check_behaviour_assays.py",
+            "--out-dir",
+            "projects/BEHAVIOR/impress",
+        ],
+        "cwd": str(copied_root),
+    }
+
+
+def test_default_listing_supports_justfile_paths_with_spaces(tmp_path: Path) -> None:
+    """The nested recipe listing should preserve the copied justfile path."""
+    _, copied_justfile = _copy_project_justfile(tmp_path)
+    result = subprocess.run(
+        ["just", "--justfile", str(copied_justfile)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "check" in result.stdout

--- a/tests/test_bioreason_project_justfile.py
+++ b/tests/test_bioreason_project_justfile.py
@@ -4,28 +4,23 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import shutil
 import subprocess
 from pathlib import Path
 
+from tests.justfile_quoting import find_unquoted_recipe_path_interpolations
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_JUSTFILE = REPO_ROOT / "projects/BIOREASON_COMPARISON/justfile"
-PATH_FUNCTION_INTERPOLATION = re.compile(
-    r"\{\{\s*(?:justfile_directory|just_executable|invocation_directory)\(\)\s*\}\}"
-)
 
 
 def test_all_path_function_interpolations_are_quoted() -> None:
     """Every path-producing interpolation should begin inside a shell quote."""
-    text = PROJECT_JUSTFILE.read_text()
-    unquoted_occurrences = [
-        match.group(0)
-        for match in PATH_FUNCTION_INTERPOLATION.finditer(text)
-        if match.start() == 0 or text[match.start() - 1] not in {'"', "'"}
-    ]
-    assert unquoted_occurrences == []
+    assert find_unquoted_recipe_path_interpolations(
+        PROJECT_JUSTFILE.read_text(),
+        {"justfile_directory()", "just_executable()", "invocation_directory()"},
+    ) == []
 
 
 def test_gogpt_overlap_supports_repository_paths_with_spaces(tmp_path: Path) -> None:

--- a/tests/test_justfile_quoting.py
+++ b/tests/test_justfile_quoting.py
@@ -1,0 +1,22 @@
+"""Unit tests for shared justfile quoting assertions."""
+
+from tests.justfile_quoting import find_unquoted_recipe_path_interpolations
+
+
+def test_finds_each_unquoted_occurrence_on_a_mixed_line() -> None:
+    text = 'recipe:\n    cd "{{root}}" && cp {{root}}/x.tsv out\n'
+    assert find_unquoted_recipe_path_interpolations(text, {"root"}) == [
+        "line 2: {{root}}"
+    ]
+
+
+def test_finds_whitespace_variant_and_new_path_function() -> None:
+    text = "recipe:\n    cd {{ justfile_directory() }} && true\n"
+    assert find_unquoted_recipe_path_interpolations(
+        text, {"justfile_directory()"}
+    ) == ["line 2: {{ justfile_directory() }}"]
+
+
+def test_accepts_single_and_double_quotes() -> None:
+    text = "recipe:\n    cd '{{ root }}' && cp \"{{root}}/x.tsv\" out\n"
+    assert find_unquoted_recipe_path_interpolations(text, {"root"}) == []


### PR DESCRIPTION
Summary:
- quote repository-root and justfile path interpolations in the IMPReSS project recipes
- reuse the active just executable for the nested recipe listing
- add behavior and breadth regressions using paths with spaces

Testing:
- uv run pytest -q tests/test_behavior_impress_justfile.py tests/test_bioreason_project_justfile.py tests/test_bioreason_sidecar_wrapper.py
- just test
- git diff --check