### PR TITLE
Validate supporting text on reference findings

### DIFF
--- a/src/ai_gene_review/validation/module_validator.py
+++ b/src/ai_gene_review/validation/module_validator.py
@@ -91,6 +91,11 @@ from ai_gene_review.etl.panther_families import (
     load_member_index,
     load_subfamily_counts,
 )
+from ai_gene_review.validation.supporting_text import (
+    LITERATURE_PREFIXES,
+    build_supporting_text_validator,
+    is_unfetchable,
+)
 
 # A resolver answers: given a CURIE, return (status, primary_label, aliases).
 # status is "ok" when the id resolved, "not_found" when the ontology was
@@ -1764,12 +1769,6 @@ def validate_module_file(
     )
 
 
-# Literature source_id prefixes whose supporting_text quotes are checked
-# verbatim against a cached publication. Everything else (GO, file:, PANTHER,
-# Reactome, UniProtKB, ...) is provenance grounding, not a fetchable quote.
-_LITERATURE_PREFIXES = {"PMID", "DOI"}
-
-
 def iter_evidence_snippets(obj: object) -> Iterator[Tuple[str, str]]:
     """Yield ``(source_id, supporting_text)`` for every EvidenceItem-like dict.
 
@@ -1792,7 +1791,7 @@ def iter_evidence_snippets(obj: object) -> Iterator[Tuple[str, str]]:
             and supporting_text.strip()
         ):
             prefix = source_id.split(":", 1)[0].upper()
-            if prefix in _LITERATURE_PREFIXES:
+            if prefix in LITERATURE_PREFIXES:
                 yield (source_id, supporting_text)
         for value in obj.values():
             yield from iter_evidence_snippets(value)
@@ -1823,7 +1822,7 @@ def iter_reference_titles(obj: object) -> Iterator[Tuple[str, str]]:
             isinstance(ref_id, str)
             and isinstance(title, str)
             and title.strip()
-            and ref_id.split(":", 1)[0].upper() in _LITERATURE_PREFIXES
+            and ref_id.split(":", 1)[0].upper() in LITERATURE_PREFIXES
         ):
             yield (ref_id, title)
         for value in obj.values():
@@ -1831,34 +1830,6 @@ def iter_reference_titles(obj: object) -> Iterator[Tuple[str, str]]:
     elif isinstance(obj, list):
         for item in obj:
             yield from iter_reference_titles(item)
-
-
-def _build_supporting_text_validator(publications_dir: Optional[Path]):
-    """Build linkml-reference-validator's SupportingTextValidator over the cache.
-
-    Returns ``(validator, publications_dir)`` or ``(None, publications_dir)`` when
-    the optional dependency is not installed, so callers degrade gracefully.
-    """
-    if publications_dir is None:
-        publications_dir = Path(__file__).resolve().parents[3] / "publications"
-    try:
-        from linkml_reference_validator.models import ReferenceValidationConfig
-        from linkml_reference_validator.validation.supporting_text_validator import (
-            SupportingTextValidator,
-        )
-    except ImportError:
-        return None, publications_dir
-    config = ReferenceValidationConfig(
-        cache_dir=publications_dir,
-        fetch_full_text=False,
-    )
-    return SupportingTextValidator(config), publications_dir
-
-
-def _is_unfetchable(message: str) -> bool:
-    """True when a validation failure is a fetch/availability problem, not a mismatch."""
-    lowered = message.lower()
-    return "could not fetch" in lowered or "no records found" in lowered
 
 
 def validate_supporting_text(
@@ -1885,7 +1856,7 @@ def validate_supporting_text(
     if not snippets:
         return [], []
 
-    validator, _ = _build_supporting_text_validator(publications_dir)
+    validator, _ = build_supporting_text_validator(publications_dir)
     if validator is None:
         return [], []
 
@@ -1903,7 +1874,7 @@ def validate_supporting_text(
         if result.is_valid:
             continue
         message = str(getattr(result, "message", "") or "")
-        if _is_unfetchable(message):
+        if is_unfetchable(message):
             warnings.append(f"Supporting text unverified ({source_id}): {message}")
         else:
             errors.append(f"Supporting text mismatch ({source_id}): {message}")
@@ -1933,7 +1904,7 @@ def validate_reference_titles(
     if not refs:
         return [], []
 
-    validator, _ = _build_supporting_text_validator(publications_dir)
+    validator, _ = build_supporting_text_validator(publications_dir)
     if validator is None:
         return [], []
 
@@ -1951,7 +1922,7 @@ def validate_reference_titles(
         if result.is_valid:
             continue
         message = str(getattr(result, "message", "") or "")
-        if _is_unfetchable(message):
+        if is_unfetchable(message):
             warnings.append(f"Reference title unverified ({ref_id}): {message}")
         else:
             errors.append(f"Reference title mismatch ({ref_id}): {message}")

--- a/src/ai_gene_review/validation/supporting_text.py
+++ b/src/ai_gene_review/validation/supporting_text.py
@@ -1,0 +1,59 @@
+"""Shared helpers for validating literature supporting-text snippets."""
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+LITERATURE_PREFIXES = frozenset({"PMID", "DOI"})
+
+
+@lru_cache(maxsize=None)
+def build_supporting_text_validator(publications_dir: Optional[Path] = None):
+    """Build the shared deterministic supporting-text validator."""
+    if publications_dir is None:
+        publications_dir = Path(__file__).resolve().parents[3] / "publications"
+    try:
+        from linkml_reference_validator.models import ReferenceValidationConfig
+        from linkml_reference_validator.validation.supporting_text_validator import (
+            SupportingTextValidator,
+        )
+    except ImportError:
+        return None, publications_dir
+    config = ReferenceValidationConfig(
+        cache_dir=publications_dir,
+        fetch_full_text=False,
+    )
+    return SupportingTextValidator(config), publications_dir
+
+
+def is_unfetchable(message: str) -> bool:
+    """Return whether a validation failure reflects unavailable source text."""
+    lowered = message.lower()
+    return "could not fetch" in lowered or "no records found" in lowered
+
+
+@lru_cache(maxsize=None)
+def cached_full_text_available(
+    reference_id: str,
+    publications_dir: Path,
+) -> Optional[bool]:
+    """Return cached full-text availability, or `None` when not recorded."""
+    if not reference_id.startswith("PMID:"):
+        return None
+    pmid = reference_id.split(":", 1)[1]
+    path = publications_dir / f"PMID_{pmid}.md"
+    if not path.exists():
+        return None
+    text = path.read_text()
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end == -1:
+        return None
+    frontmatter = yaml.safe_load(text[3:end])
+    if not isinstance(frontmatter, dict) or "full_text_available" not in frontmatter:
+        return None
+    return bool(frontmatter["full_text_available"])

--- a/src/ai_gene_review/validation/supporting_text.py
+++ b/src/ai_gene_review/validation/supporting_text.py
@@ -41,10 +41,16 @@ def cached_full_text_available(
     publications_dir: Path,
 ) -> Optional[bool]:
     """Return cached full-text availability, or `None` when not recorded."""
-    if not reference_id.startswith("PMID:"):
+    prefix, separator, identifier = reference_id.partition(":")
+    if not separator:
         return None
-    pmid = reference_id.split(":", 1)[1]
-    path = publications_dir / f"PMID_{pmid}.md"
+    if prefix.upper() == "PMID":
+        filename = f"PMID_{identifier}.md"
+    elif prefix.upper() == "DOI":
+        filename = f"DOI_{identifier.replace('/', '_')}.md"
+    else:
+        return None
+    path = publications_dir / filename
     if not path.exists():
         return None
     text = path.read_text()
@@ -54,6 +60,16 @@ def cached_full_text_available(
     if end == -1:
         return None
     frontmatter = yaml.safe_load(text[3:end])
-    if not isinstance(frontmatter, dict) or "full_text_available" not in frontmatter:
+    if not isinstance(frontmatter, dict):
         return None
-    return bool(frontmatter["full_text_available"])
+    if "full_text_available" in frontmatter:
+        return bool(frontmatter["full_text_available"])
+    content_type = frontmatter.get("content_type")
+    if not isinstance(content_type, str):
+        return None
+    normalized_content_type = content_type.lower()
+    if normalized_content_type in {"abstract_only", "unavailable"}:
+        return False
+    if normalized_content_type in {"full_text_html", "full_text_pdf"}:
+        return True
+    return None

--- a/src/ai_gene_review/validation/validator.py
+++ b/src/ai_gene_review/validation/validator.py
@@ -30,6 +30,12 @@ from ai_gene_review.validation.validation_report import (
     BatchValidationReport,
 )
 from ai_gene_review.validation.goa_validator import GOAValidator
+from ai_gene_review.validation.supporting_text import (
+    LITERATURE_PREFIXES,
+    build_supporting_text_validator,
+    cached_full_text_available,
+    is_unfetchable,
+)
 
 
 PROPAGATION_REVIEW_EVIDENCE_TYPES = {"IBA", "ISO"}
@@ -76,6 +82,7 @@ def get_schema_path() -> Path:
 def validate_reference_finding_supporting_text(
     data: Dict[str, Any],
     report: ValidationReport,
+    publications_dir: Optional[Path] = None,
 ) -> None:
     """Validate quotes stored directly on top-level reference findings.
 
@@ -84,28 +91,36 @@ def validate_reference_finding_supporting_text(
     does not see it as a normal `supported_by` evidence item. Check these
     quotes explicitly with the same deterministic substring validator.
     """
-    try:
-        from linkml_reference_validator.models import ReferenceValidationConfig
-        from linkml_reference_validator.validation.supporting_text_validator import (
-            SupportingTextValidator,
+    if publications_dir is None:
+        publications_dir = get_project_root() / "publications"
+    validator, resolved_publications_dir = build_supporting_text_validator(
+        publications_dir
+    )
+    if validator is None:
+        report.add_issue(
+            ValidationSeverity.WARNING,
+            "Finding supporting text validation dependency is unavailable",
+            path="references",
+            validation_category="ReferenceValidator",
+            check_type="reference_finding_supporting_text",
         )
-    except ImportError:
         return
 
-    validator = SupportingTextValidator(
-        ReferenceValidationConfig(
-            cache_dir=get_project_root() / "publications",
-            fetch_full_text=False,
-        )
-    )
     for i, reference in enumerate(data.get("references", [])):
         if not isinstance(reference, dict):
             continue
         reference_id = reference.get("id")
         if not isinstance(reference_id, str):
             continue
-        if reference_id.split(":", 1)[0].upper() not in {"PMID", "DOI"}:
+        if reference_id.split(":", 1)[0].upper() not in LITERATURE_PREFIXES:
             continue
+        reference_declares_unavailable = (
+            reference.get("full_text_unavailable") is True
+        )
+        cache_has_full_text = cached_full_text_available(
+            reference_id,
+            resolved_publications_dir,
+        )
         for j, finding in enumerate(reference.get("findings", [])):
             if not isinstance(finding, dict):
                 continue
@@ -130,17 +145,35 @@ def validate_reference_finding_supporting_text(
             if result.is_valid:
                 continue
             message = str(getattr(result, "message", "") or "")
-            if "could not fetch" in message.lower() or "no records found" in message.lower():
+            declared_unavailable = (
+                reference_declares_unavailable
+                or finding.get("full_text_unavailable") is True
+            )
+            if is_unfetchable(message):
                 severity = ValidationSeverity.WARNING
                 prefix = "Finding supporting text could not be verified"
+                suggestion = "Verify the quote when the publication text is available"
+            elif declared_unavailable or cache_has_full_text is False:
+                severity = ValidationSeverity.WARNING
+                prefix = (
+                    "Finding supporting text is absent from the available "
+                    "abstract-only cache"
+                )
+                suggestion = (
+                    "Verify the quote against full text; retain full_text_unavailable "
+                    "until a full-text cache is available"
+                )
             else:
                 severity = ValidationSeverity.ERROR
                 prefix = "Finding supporting text is not a verbatim publication substring"
+                suggestion = (
+                    "Replace the quote with an exact substring from the cached publication"
+                )
             report.add_issue(
                 severity,
                 f"{prefix} for {reference_id}: {message}",
                 path=path,
-                suggestion="Replace the quote with an exact substring from the cached publication",
+                suggestion=suggestion,
                 validation_category="ReferenceValidator",
                 check_type="reference_finding_supporting_text",
             )
@@ -1029,7 +1062,7 @@ def validate_multiple_files(
         schema_path: Unused (kept for backward compatibility)
         check_best_practices: Whether to check for best practices
         check_goa: Whether to validate against GOA files
-        check_supporting_text: Unused (handled by linkml-reference-validator CLI)
+        check_supporting_text: Whether to validate inherited quotes on reference findings
         show_progress: Whether to show a progress bar for multiple files
 
     Returns:

--- a/src/ai_gene_review/validation/validator.py
+++ b/src/ai_gene_review/validation/validator.py
@@ -160,8 +160,8 @@ def validate_reference_finding_supporting_text(
                     "abstract-only cache"
                 )
                 suggestion = (
-                    "Verify the quote against full text; retain full_text_unavailable "
-                    "until a full-text cache is available"
+                    "Verify the quote against full text; use full_text_unavailable to "
+                    "record that the quoted source text is not cached"
                 )
             else:
                 severity = ValidationSeverity.ERROR
@@ -206,6 +206,7 @@ def validate_gene_review(
     check_goa: bool = True,
     check_supporting_text: bool = True,
     progress_callback: Optional[Callable] = None,
+    publications_dir: Optional[Path] = None,
 ) -> ValidationReport:
     """Run custom best-practices checks on a gene review YAML file.
 
@@ -220,6 +221,7 @@ def validate_gene_review(
         check_goa: Whether to validate against GOA file (enabled by default)
         check_supporting_text: Whether to validate inherited quotes on reference findings
         progress_callback: Optional callback function to report progress steps
+        publications_dir: Optional publication-cache directory for quote validation
 
     Returns:
         ValidationReport with detailed validation results
@@ -268,6 +270,7 @@ def validate_gene_review(
             yaml_file_path if check_goa else None,
             check_supporting_text=check_supporting_text,
             progress_callback=progress_callback,
+            publications_dir=publications_dir,
         )
 
     return report
@@ -279,6 +282,7 @@ def check_best_practices_rules(
     yaml_file: Optional[Path] = None,
     check_supporting_text: bool = True,
     progress_callback: Optional[Callable] = None,
+    publications_dir: Optional[Path] = None,
 ) -> None:
     """Check for best practices and add soft failures (warnings).
 
@@ -292,6 +296,7 @@ def check_best_practices_rules(
         yaml_file: Path to YAML file for GOA validation (if enabled)
         check_supporting_text: Whether to validate inherited quotes on reference findings
         progress_callback: Optional callback function to report progress steps
+        publications_dir: Optional publication-cache directory for quote validation
     """
     if progress_callback:
         progress_callback("Running best-practices checks")
@@ -300,7 +305,7 @@ def check_best_practices_rules(
     # linkml-term-validator CLI (invoked from justfile), not here.
 
     if check_supporting_text:
-        validate_reference_finding_supporting_text(data, report)
+        validate_reference_finding_supporting_text(data, report, publications_dir)
 
     # Check for TODO in description
     if "description" in data and "TODO" in str(data["description"]):

--- a/src/ai_gene_review/validation/validator.py
+++ b/src/ai_gene_review/validation/validator.py
@@ -73,6 +73,79 @@ def get_schema_path() -> Path:
     return Path(__file__).parent.parent / "schema" / "gene_review.yaml"
 
 
+def validate_reference_finding_supporting_text(
+    data: Dict[str, Any],
+    report: ValidationReport,
+) -> None:
+    """Validate quotes stored directly on top-level reference findings.
+
+    `references[].findings[].supporting_text` inherits its literature
+    identifier from the parent reference, so the external reference validator
+    does not see it as a normal `supported_by` evidence item. Check these
+    quotes explicitly with the same deterministic substring validator.
+    """
+    try:
+        from linkml_reference_validator.models import ReferenceValidationConfig
+        from linkml_reference_validator.validation.supporting_text_validator import (
+            SupportingTextValidator,
+        )
+    except ImportError:
+        return
+
+    validator = SupportingTextValidator(
+        ReferenceValidationConfig(
+            cache_dir=get_project_root() / "publications",
+            fetch_full_text=False,
+        )
+    )
+    for i, reference in enumerate(data.get("references", [])):
+        if not isinstance(reference, dict):
+            continue
+        reference_id = reference.get("id")
+        if not isinstance(reference_id, str):
+            continue
+        if reference_id.split(":", 1)[0].upper() not in {"PMID", "DOI"}:
+            continue
+        for j, finding in enumerate(reference.get("findings", [])):
+            if not isinstance(finding, dict):
+                continue
+            supporting_text = finding.get("supporting_text")
+            if not isinstance(supporting_text, str) or not supporting_text.strip():
+                continue
+            path = f"references[{i}].findings[{j}].supporting_text"
+            try:
+                result = validator.validate(supporting_text, reference_id)
+            except Exception as exc:  # noqa: BLE001 - external publication cache
+                report.add_issue(
+                    ValidationSeverity.WARNING,
+                    (
+                        f"Finding supporting text could not be verified for "
+                        f"{reference_id}: {type(exc).__name__}: {exc}"
+                    ),
+                    path=path,
+                    validation_category="ReferenceValidator",
+                    check_type="reference_finding_supporting_text",
+                )
+                continue
+            if result.is_valid:
+                continue
+            message = str(getattr(result, "message", "") or "")
+            if "could not fetch" in message.lower() or "no records found" in message.lower():
+                severity = ValidationSeverity.WARNING
+                prefix = "Finding supporting text could not be verified"
+            else:
+                severity = ValidationSeverity.ERROR
+                prefix = "Finding supporting text is not a verbatim publication substring"
+            report.add_issue(
+                severity,
+                f"{prefix} for {reference_id}: {message}",
+                path=path,
+                suggestion="Replace the quote with an exact substring from the cached publication",
+                validation_category="ReferenceValidator",
+                check_type="reference_finding_supporting_text",
+            )
+
+
 def load_schema() -> SchemaView:
     """Load the LinkML schema.
 
@@ -112,7 +185,7 @@ def validate_gene_review(
         schema_path: Unused (kept for backward compatibility)
         check_best_practices: Whether to check for best practices (soft failures)
         check_goa: Whether to validate against GOA file (enabled by default)
-        check_supporting_text: Unused (handled by linkml-reference-validator CLI)
+        check_supporting_text: Whether to validate inherited quotes on reference findings
         progress_callback: Optional callback function to report progress steps
 
     Returns:
@@ -160,6 +233,7 @@ def validate_gene_review(
             data,
             report,
             yaml_file_path if check_goa else None,
+            check_supporting_text=check_supporting_text,
             progress_callback=progress_callback,
         )
 
@@ -183,7 +257,7 @@ def check_best_practices_rules(
         data: The parsed YAML data
         report: ValidationReport to add warnings to
         yaml_file: Path to YAML file for GOA validation (if enabled)
-        check_supporting_text: Unused (kept for backward compatibility)
+        check_supporting_text: Whether to validate inherited quotes on reference findings
         progress_callback: Optional callback function to report progress steps
     """
     if progress_callback:
@@ -191,6 +265,9 @@ def check_best_practices_rules(
 
     # Note: GO branch validation for core_functions is handled by
     # linkml-term-validator CLI (invoked from justfile), not here.
+
+    if check_supporting_text:
+        validate_reference_finding_supporting_text(data, report)
 
     # Check for TODO in description
     if "description" in data and "TODO" in str(data["description"]):

--- a/tests/test_module_validator.py
+++ b/tests/test_module_validator.py
@@ -708,7 +708,7 @@ def test_validate_supporting_text_fetch_exception_is_warning(monkeypatch):
             raise RuntimeError("transient fetch failure")
 
     monkeypatch.setattr(
-        "ai_gene_review.validation.module_validator._build_supporting_text_validator",
+        "ai_gene_review.validation.module_validator.build_supporting_text_validator",
         lambda publications_dir: (RaisingValidator(), None),
     )
     doc = {
@@ -805,7 +805,7 @@ def test_validate_reference_titles_fetch_exception_is_warning(monkeypatch):
             raise RuntimeError("transient fetch failure")
 
     monkeypatch.setattr(
-        "ai_gene_review.validation.module_validator._build_supporting_text_validator",
+        "ai_gene_review.validation.module_validator.build_supporting_text_validator",
         lambda publications_dir: (RaisingValidator(), None),
     )
     errors, warnings = validate_reference_titles(

--- a/tests/test_reference_validation.py
+++ b/tests/test_reference_validation.py
@@ -2,9 +2,11 @@
 
 from pathlib import Path
 import tempfile
+import pytest
 import yaml
 
 from ai_gene_review.validation import validate_gene_review, ValidationSeverity
+from ai_gene_review.validation import validator as validator_module
 
 
 def test_valid_reference_ids():
@@ -54,90 +56,118 @@ def test_valid_reference_ids():
         temp_path.unlink()
 
 
-def test_reference_finding_supporting_text_is_validated():
-    """Top-level finding quotes inherit and validate against the parent PMID."""
-    data = {
+def _finding_quote_review(*findings, reference_flag=False):
+    """Build a minimal review containing parent-PMID finding quotes."""
+    reference = {
+        "id": "PMID:12345",
+        "title": "Test publication",
+        "findings": list(findings),
+    }
+    if reference_flag:
+        reference["full_text_unavailable"] = True
+    return {
         "id": "P10592",
         "gene_symbol": "SSA2",
         "taxon": {"id": "NCBITaxon:559292", "label": "Saccharomyces cerevisiae"},
-        "description": "A test review with a grounded reference finding.",
-        "references": [
-            {
-                "id": "PMID:8947547",
-                "title": (
-                    "The refolding activity of the yeast heat shock proteins Ssa1 "
-                    "and Ssa2 defines their role in protein translocation."
-                ),
-                "findings": [
-                    {
-                        "statement": "Ssa1/2 depletion did not impair translocation.",
-                        "supporting_text": (
-                            "Depletion of Ssa1/2p had no effect on the efficiency "
-                            "of translocation in this in vitro assay."
-                        ),
-                    }
-                ],
-            }
-        ],
+        "description": "A test review with reference findings.",
+        "references": [reference],
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-        yaml.dump(data, f)
-        temp_path = Path(f.name)
 
-    try:
-        report = validate_gene_review(temp_path, check_goa=False)
-        quote_errors = [
-            issue
-            for issue in report.issues
-            if issue.check_type == "reference_finding_supporting_text"
-            and issue.severity == ValidationSeverity.ERROR
-        ]
-        assert quote_errors == []
-    finally:
-        temp_path.unlink()
+def _write_cached_publication(tmp_path, *, full_text_available):
+    publications_dir = tmp_path / "publications"
+    publications_dir.mkdir()
+    availability = "true" if full_text_available else "false"
+    (publications_dir / "PMID_12345.md").write_text(
+        f"---\nfull_text_available: {availability}\n---\n\n"
+        "This exact evidence sentence is cached.\n"
+    )
 
 
-def test_reference_finding_supporting_text_mismatch_is_error():
-    """Fabricated finding text is a blocking validation error."""
+def test_reference_finding_supporting_text_is_validated(tmp_path, monkeypatch):
+    """The public validation path accepts exact text and rejects fabricated text."""
+    _write_cached_publication(tmp_path, full_text_available=True)
+    monkeypatch.setattr(validator_module, "get_project_root", lambda: tmp_path)
     data = {
-        "id": "P10592",
-        "gene_symbol": "SSA2",
-        "taxon": {"id": "NCBITaxon:559292", "label": "Saccharomyces cerevisiae"},
-        "description": "A test review with an ungrounded reference finding.",
-        "references": [
+        **_finding_quote_review(
             {
-                "id": "PMID:8947547",
-                "title": (
-                    "The refolding activity of the yeast heat shock proteins Ssa1 "
-                    "and Ssa2 defines their role in protein translocation."
-                ),
-                "findings": [
-                    {
-                        "statement": "An invented result.",
-                        "supporting_text": "This sentence is not in the publication.",
-                    }
-                ],
-            }
-        ],
+                "statement": "Grounded result.",
+                "supporting_text": "This exact evidence sentence is cached.",
+            },
+            {
+                "statement": "Invented result.",
+                "supporting_text": "This sentence is not in the publication.",
+            },
+        )
     }
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-        yaml.dump(data, f)
-        temp_path = Path(f.name)
+    review_path = tmp_path / "review.yaml"
+    review_path.write_text(yaml.safe_dump(data))
+    report = validate_gene_review(review_path, check_goa=False)
+    quote_errors = [
+        issue
+        for issue in report.issues
+        if issue.check_type == "reference_finding_supporting_text"
+        and issue.severity == ValidationSeverity.ERROR
+    ]
+    assert len(quote_errors) == 1
+    assert quote_errors[0].path == "references[0].findings[1].supporting_text"
 
-    try:
-        report = validate_gene_review(temp_path, check_goa=False)
-        quote_errors = [
-            issue
-            for issue in report.issues
-            if issue.check_type == "reference_finding_supporting_text"
-            and issue.severity == ValidationSeverity.ERROR
-        ]
-        assert len(quote_errors) == 1
-        assert "PMID:8947547" in quote_errors[0].message
-    finally:
-        temp_path.unlink()
+
+def test_abstract_only_finding_mismatch_is_warning(tmp_path, monkeypatch):
+    """A quote absent from an abstract-only cache does not block validation."""
+    _write_cached_publication(tmp_path, full_text_available=False)
+    monkeypatch.setattr(validator_module, "get_project_root", lambda: tmp_path)
+    review_path = tmp_path / "review.yaml"
+    review_path.write_text(
+        yaml.safe_dump(
+            _finding_quote_review(
+                {
+                    "statement": "Full-text result.",
+                    "supporting_text": "A sentence available only in full text.",
+                }
+            )
+        )
+    )
+
+    report = validate_gene_review(review_path, check_goa=False)
+    quote_issues = [
+        issue
+        for issue in report.issues
+        if issue.check_type == "reference_finding_supporting_text"
+    ]
+    assert len(quote_issues) == 1
+    assert quote_issues[0].severity == ValidationSeverity.WARNING
+
+
+@pytest.mark.parametrize("flag_location", ["reference", "finding"])
+def test_full_text_unavailable_flag_downgrades_mismatch(
+    tmp_path, monkeypatch, flag_location
+):
+    """Reference- and finding-level escape hatches prevent false hard errors."""
+    _write_cached_publication(tmp_path, full_text_available=True)
+    monkeypatch.setattr(validator_module, "get_project_root", lambda: tmp_path)
+    finding = {
+        "statement": "Full-text result.",
+        "supporting_text": "A sentence available only in uncached full text.",
+    }
+    if flag_location == "finding":
+        finding["full_text_unavailable"] = True
+    data = _finding_quote_review(
+        finding,
+        reference_flag=flag_location == "reference",
+    )
+    review_path = tmp_path / "review.yaml"
+    review_path.write_text(yaml.safe_dump(data))
+
+    report = validate_gene_review(review_path, check_goa=False)
+    quote_issues = [
+        issue
+        for issue in report.issues
+        if issue.check_type == "reference_finding_supporting_text"
+    ]
+    assert len(quote_issues) == 1
+    assert quote_issues[0].severity == ValidationSeverity.WARNING
 
 
 def test_invalid_reference_id():

--- a/tests/test_reference_validation.py
+++ b/tests/test_reference_validation.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 
 from ai_gene_review.validation import validate_gene_review, ValidationSeverity
-from ai_gene_review.validation import validator as validator_module
+from ai_gene_review.validation.supporting_text import cached_full_text_available
 
 
 def test_valid_reference_ids():
@@ -56,10 +56,14 @@ def test_valid_reference_ids():
         temp_path.unlink()
 
 
-def _finding_quote_review(*findings, reference_flag=False):
+def _finding_quote_review(
+    *findings,
+    reference_flag=False,
+    reference_id="PMID:12345",
+):
     """Build a minimal review containing parent-PMID finding quotes."""
     reference = {
-        "id": "PMID:12345",
+        "id": reference_id,
         "title": "Test publication",
         "findings": list(findings),
     }
@@ -74,20 +78,30 @@ def _finding_quote_review(*findings, reference_flag=False):
     }
 
 
-def _write_cached_publication(tmp_path, *, full_text_available):
+def _write_cached_publication(
+    tmp_path,
+    *,
+    full_text_available=None,
+    content_type=None,
+    reference_id="PMID:12345",
+):
     publications_dir = tmp_path / "publications"
     publications_dir.mkdir()
-    availability = "true" if full_text_available else "false"
-    (publications_dir / "PMID_12345.md").write_text(
-        f"---\nfull_text_available: {availability}\n---\n\n"
-        "This exact evidence sentence is cached.\n"
-    )
+    prefix, identifier = reference_id.split(":", 1)
+    filename = f"{prefix}_{identifier.replace('/', '_')}.md"
+    metadata = ["---", f"reference_id: {reference_id}"]
+    if full_text_available is not None:
+        availability = "true" if full_text_available else "false"
+        metadata.append(f"full_text_available: {availability}")
+    if content_type is not None:
+        metadata.append(f"content_type: {content_type}")
+    metadata.extend(["---", "", "This exact evidence sentence is cached.", ""])
+    (publications_dir / filename).write_text("\n".join(metadata))
 
 
-def test_reference_finding_supporting_text_is_validated(tmp_path, monkeypatch):
+def test_reference_finding_supporting_text_is_validated(tmp_path):
     """The public validation path accepts exact text and rejects fabricated text."""
     _write_cached_publication(tmp_path, full_text_available=True)
-    monkeypatch.setattr(validator_module, "get_project_root", lambda: tmp_path)
     data = {
         **_finding_quote_review(
             {
@@ -103,7 +117,11 @@ def test_reference_finding_supporting_text_is_validated(tmp_path, monkeypatch):
 
     review_path = tmp_path / "review.yaml"
     review_path.write_text(yaml.safe_dump(data))
-    report = validate_gene_review(review_path, check_goa=False)
+    report = validate_gene_review(
+        review_path,
+        check_goa=False,
+        publications_dir=tmp_path / "publications",
+    )
     quote_errors = [
         issue
         for issue in report.issues
@@ -114,10 +132,9 @@ def test_reference_finding_supporting_text_is_validated(tmp_path, monkeypatch):
     assert quote_errors[0].path == "references[0].findings[1].supporting_text"
 
 
-def test_abstract_only_finding_mismatch_is_warning(tmp_path, monkeypatch):
+def test_abstract_only_finding_mismatch_is_warning(tmp_path):
     """A quote absent from an abstract-only cache does not block validation."""
     _write_cached_publication(tmp_path, full_text_available=False)
-    monkeypatch.setattr(validator_module, "get_project_root", lambda: tmp_path)
     review_path = tmp_path / "review.yaml"
     review_path.write_text(
         yaml.safe_dump(
@@ -130,7 +147,11 @@ def test_abstract_only_finding_mismatch_is_warning(tmp_path, monkeypatch):
         )
     )
 
-    report = validate_gene_review(review_path, check_goa=False)
+    report = validate_gene_review(
+        review_path,
+        check_goa=False,
+        publications_dir=tmp_path / "publications",
+    )
     quote_issues = [
         issue
         for issue in report.issues
@@ -142,11 +163,10 @@ def test_abstract_only_finding_mismatch_is_warning(tmp_path, monkeypatch):
 
 @pytest.mark.parametrize("flag_location", ["reference", "finding"])
 def test_full_text_unavailable_flag_downgrades_mismatch(
-    tmp_path, monkeypatch, flag_location
+    tmp_path, flag_location
 ):
     """Reference- and finding-level escape hatches prevent false hard errors."""
     _write_cached_publication(tmp_path, full_text_available=True)
-    monkeypatch.setattr(validator_module, "get_project_root", lambda: tmp_path)
     finding = {
         "statement": "Full-text result.",
         "supporting_text": "A sentence available only in uncached full text.",
@@ -160,7 +180,72 @@ def test_full_text_unavailable_flag_downgrades_mismatch(
     review_path = tmp_path / "review.yaml"
     review_path.write_text(yaml.safe_dump(data))
 
-    report = validate_gene_review(review_path, check_goa=False)
+    report = validate_gene_review(
+        review_path,
+        check_goa=False,
+        publications_dir=tmp_path / "publications",
+    )
+    quote_issues = [
+        issue
+        for issue in report.issues
+        if issue.check_type == "reference_finding_supporting_text"
+    ]
+    assert len(quote_issues) == 1
+    assert quote_issues[0].severity == ValidationSeverity.WARNING
+
+
+@pytest.mark.parametrize(
+    ("reference_id", "content_type", "expected"),
+    [
+        ("PMID:12345", "abstract_only", False),
+        ("DOI:10.1234/example", "unavailable", False),
+        ("DOI:10.1234/example", "full_text_pdf", True),
+    ],
+)
+def test_legacy_cache_content_type_is_recognized(
+    tmp_path,
+    reference_id,
+    content_type,
+    expected,
+):
+    """Legacy PMID and slugged DOI caches expose availability via content_type."""
+    _write_cached_publication(
+        tmp_path,
+        content_type=content_type,
+        reference_id=reference_id,
+    )
+    assert (
+        cached_full_text_available(reference_id, tmp_path / "publications")
+        is expected
+    )
+
+
+def test_legacy_doi_abstract_only_mismatch_is_warning(tmp_path):
+    """A DOI quote absent from a legacy abstract-only cache remains advisory."""
+    reference_id = "DOI:10.1234/example"
+    _write_cached_publication(
+        tmp_path,
+        content_type="abstract_only",
+        reference_id=reference_id,
+    )
+    review_path = tmp_path / "review.yaml"
+    review_path.write_text(
+        yaml.safe_dump(
+            _finding_quote_review(
+                {
+                    "statement": "Full-text result.",
+                    "supporting_text": "A sentence available only in full text.",
+                },
+                reference_id=reference_id,
+            )
+        )
+    )
+
+    report = validate_gene_review(
+        review_path,
+        check_goa=False,
+        publications_dir=tmp_path / "publications",
+    )
     quote_issues = [
         issue
         for issue in report.issues

--- a/tests/test_reference_validation.py
+++ b/tests/test_reference_validation.py
@@ -54,6 +54,92 @@ def test_valid_reference_ids():
         temp_path.unlink()
 
 
+def test_reference_finding_supporting_text_is_validated():
+    """Top-level finding quotes inherit and validate against the parent PMID."""
+    data = {
+        "id": "P10592",
+        "gene_symbol": "SSA2",
+        "taxon": {"id": "NCBITaxon:559292", "label": "Saccharomyces cerevisiae"},
+        "description": "A test review with a grounded reference finding.",
+        "references": [
+            {
+                "id": "PMID:8947547",
+                "title": (
+                    "The refolding activity of the yeast heat shock proteins Ssa1 "
+                    "and Ssa2 defines their role in protein translocation."
+                ),
+                "findings": [
+                    {
+                        "statement": "Ssa1/2 depletion did not impair translocation.",
+                        "supporting_text": (
+                            "Depletion of Ssa1/2p had no effect on the efficiency "
+                            "of translocation in this in vitro assay."
+                        ),
+                    }
+                ],
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(data, f)
+        temp_path = Path(f.name)
+
+    try:
+        report = validate_gene_review(temp_path, check_goa=False)
+        quote_errors = [
+            issue
+            for issue in report.issues
+            if issue.check_type == "reference_finding_supporting_text"
+            and issue.severity == ValidationSeverity.ERROR
+        ]
+        assert quote_errors == []
+    finally:
+        temp_path.unlink()
+
+
+def test_reference_finding_supporting_text_mismatch_is_error():
+    """Fabricated finding text is a blocking validation error."""
+    data = {
+        "id": "P10592",
+        "gene_symbol": "SSA2",
+        "taxon": {"id": "NCBITaxon:559292", "label": "Saccharomyces cerevisiae"},
+        "description": "A test review with an ungrounded reference finding.",
+        "references": [
+            {
+                "id": "PMID:8947547",
+                "title": (
+                    "The refolding activity of the yeast heat shock proteins Ssa1 "
+                    "and Ssa2 defines their role in protein translocation."
+                ),
+                "findings": [
+                    {
+                        "statement": "An invented result.",
+                        "supporting_text": "This sentence is not in the publication.",
+                    }
+                ],
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(data, f)
+        temp_path = Path(f.name)
+
+    try:
+        report = validate_gene_review(temp_path, check_goa=False)
+        quote_errors = [
+            issue
+            for issue in report.issues
+            if issue.check_type == "reference_finding_supporting_text"
+            and issue.severity == ValidationSeverity.ERROR
+        ]
+        assert len(quote_errors) == 1
+        assert "PMID:8947547" in quote_errors[0].message
+    finally:
+        temp_path.unlink()
+
+
 def test_invalid_reference_id():
     """Test that annotations with invalid reference IDs are caught."""
     data = {


### PR DESCRIPTION
## Summary
- validate `references[].findings[].supporting_text` against the parent PMID/DOI publication cache
- use the same deterministic substring validator as other literature evidence
- report mismatches as blocking reference-validation errors and unavailable records as warnings
- add regression coverage for exact and fabricated inherited-reference quotes

This closes the validation gap found while reviewing SSA2 in #2682; that gene PR is paused until this support fix merges.

## Verification
- `just test`: 1,785 unit tests passed; 154 doctests passed; mypy and Ruff clean
- `just validate yeast SSA2`: current-main smoke test remains green