### PR TITLE
Fix stale PANTHER family labels in modules

### DIFF
--- a/modules/bacterial_imuabc_damage_induced_mutagenesis.yaml
+++ b/modules/bacterial_imuabc_damage_induced_mutagenesis.yaml
@@ -86,7 +86,7 @@ module:
                 preferred_term: bacterial RecA family
                 term:
                   id: PANTHER:PTHR45900
-                  label: RecA family
+                  label: RECA
                 representative_members:
                   - preferred_term: PSEPK RecA
                     term:
@@ -128,7 +128,7 @@ module:
                 preferred_term: LexA repressor family
                 term:
                   id: PANTHER:PTHR33516
-                  label: LexA repressor family
+                  label: LEXA REPRESSOR
                 representative_members:
                   - preferred_term: PSEPK LexA2
                     term:

--- a/modules/bacterial_twin_arginine_translocation.yaml
+++ b/modules/bacterial_twin_arginine_translocation.yaml
@@ -98,7 +98,7 @@ module:
                 preferred_term: TatC family
                 term:
                   id: PANTHER:PTHR30371
-                  label: TWIN-ARGININE TRANSLOCATION PROTEIN TATC
+                  label: SEC-INDEPENDENT PROTEIN TRANSLOCASE PROTEIN TATC
                 representative_members:
                   - preferred_term: PSEPK TatC-I exemplar
                     term:
@@ -139,7 +139,7 @@ module:
                 preferred_term: TatB family
                 term:
                   id: PANTHER:PTHR33162
-                  label: Twin-arginine translocation protein B
+                  label: SEC-INDEPENDENT PROTEIN TRANSLOCASE PROTEIN TATA, CHLOROPLASTIC
                 representative_members:
                   - preferred_term: PSEPK TatB-I exemplar
                     term:
@@ -180,7 +180,7 @@ module:
                 preferred_term: TatA/E family, represented here by TatA proteins
                 term:
                   id: PANTHER:PTHR42982
-                  label: Twin-arginine translocation system
+                  label: SEC-INDEPENDENT PROTEIN TRANSLOCASE PROTEIN TATA
                 representative_members:
                   - preferred_term: PSEPK TatA-I exemplar
                     term:

--- a/modules/bacterial_type_ii_secretion.yaml
+++ b/modules/bacterial_type_ii_secretion.yaml
@@ -237,7 +237,7 @@ module:
             preferred_term: prepilin leader peptidase/N-methyltransferase family
             term:
               id: PANTHER:PTHR30487
-              label: Prepilin leader peptidase/N-methyltransferase
+              label: TYPE 4 PREPILIN-LIKE PROTEINS LEADER PEPTIDE-PROCESSING ENZYME
             representative_members:
             - preferred_term: PilD exemplar
               term:
@@ -270,7 +270,7 @@ module:
             preferred_term: prepilin leader peptidase/N-methyltransferase family
             term:
               id: PANTHER:PTHR30487
-              label: Prepilin leader peptidase/N-methyltransferase
+              label: TYPE 4 PREPILIN-LIKE PROTEINS LEADER PEPTIDE-PROCESSING ENZYME
             representative_members:
             - preferred_term: PilD exemplar
               term:

--- a/modules/glutathione_dependent_formaldehyde_detoxification.yaml
+++ b/modules/glutathione_dependent_formaldehyde_detoxification.yaml
@@ -119,7 +119,7 @@ module:
                 preferred_term: zinc-containing alcohol dehydrogenase family, class-3 lineage
                 term:
                   id: PANTHER:PTHR43880
-                  label: Zinc-containing alcohol dehydrogenase
+                  label: ALCOHOL DEHYDROGENASE
                 representative_members:
                   - preferred_term: PSEPK FrmA exemplar
                     term:


### PR DESCRIPTION
## Summary
- synchronize eight module family labels with the bundled PANTHER ontology
- retain the verified family IDs, biological preferred terms, and representative proteins
- unblock `just validate-modules` and full CI for unrelated PRs

## Verification
- `just validate-modules`
- `just test`
- `git diff --check`