### PR TITLE
Fix HSP82 review wording inconsistencies

### DIFF
--- a/genes/yeast/HSP82/HSP82-ai-review.html
+++ b/genes/yeast/HSP82/HSP82-ai-review.html
@@ -895,7 +895,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Protein folding is a core biological process for Hsp90. UniProt describes HSP82 as a &#34;Molecular chaperone that promotes the maturation, structural maintenance and proper regulation of specific target proteins.&#34; Multiple IMP and IDA evidence codes confirm involvement in de novo protein folding (PMID:10564510, PMID:9371781).
+                            <strong>Reason:</strong> Protein folding is a core biological process for Hsp90. UniProt describes HSP82 as a &#34;Molecular chaperone that promotes the maturation, structural maintenance and proper regulation of specific target proteins.&#34; Multiple IMP and IDA evidence codes confirm involvement in selective client-protein folding (PMID:10564510, PMID:9371781).
                         </div>
 
 
@@ -1583,7 +1583,7 @@
                                     <span class="badge">SUPPORTS TRANSFER</span>
 
 
-                                    <div class="propagation-comment">The ancestral assertion captures genuine non-native-client binding, but the obsolete binding term should be replaced by the ATP-dependent chaperone activity term.</div>
+                                    <div class="propagation-comment">The ancestral assertion captures genuine non-native-client binding, but the binding term proposed for obsoletion (go-ontology#30962) should be replaced by the ATP-dependent chaperone activity term.</div>
 
                                 </div>
 
@@ -8155,7 +8155,8 @@ existing_annotations:
     reason: &gt;-
       Protein folding is a core biological process for Hsp90. UniProt describes HSP82 as a &#34;Molecular chaperone
       that promotes the maturation, structural maintenance and proper regulation of specific target proteins.&#34;
-      Multiple IMP and IDA evidence codes confirm involvement in de novo protein folding (PMID:10564510, PMID:9371781).
+      Multiple IMP and IDA evidence codes confirm involvement in selective client-protein folding
+      (PMID:10564510, PMID:9371781).
     additional_reference_ids:
     - file:yeast/HSP82/HSP82-deep-research-falcon.md
     supported_by:
@@ -8374,8 +8375,8 @@ existing_annotations:
         source_label: PAINT Hsp90 family node
         source_status: SUPPORTS_TRANSFER
         comment: &gt;-
-          The ancestral assertion captures genuine non-native-client binding, but the obsolete binding
-          term should be replaced by the ATP-dependent chaperone activity term.
+          The ancestral assertion captures genuine non-native-client binding, but the binding term proposed
+          for obsoletion (go-ontology#30962) should be replaced by the ATP-dependent chaperone activity term.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm

--- a/genes/yeast/HSP82/HSP82-ai-review.html
+++ b/genes/yeast/HSP82/HSP82-ai-review.html
@@ -1546,12 +1546,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0051082 is proposed for obsoletion (go-ontology#30962). HSP82 does interact with unfolded/misfolded client proteins but its mechanism is better captured by GO:0140662 (ATP-dependent protein folding chaperone).
+                            <strong>Summary:</strong> GO:0051082 is now formally obsolete (go-ontology#30962). HSP82 does interact with unfolded/misfolded client proteins but its mechanism is better captured by GO:0140662 (ATP-dependent protein folding chaperone).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is proposed for obsoletion (go-ontology#30962). HSP82 is an ATP-dependent foldase; while it does bind unfolded/non-native proteins as part of its chaperone cycle, the binding is coupled to ATP-driven conformational changes. The more appropriate term is GO:0140662 &#34;ATP-dependent protein folding chaperone&#34; which captures both the binding and the active folding mechanism. IDA evidence from PMID:10564510 demonstrated binding to denatured substrates, but this is part of the broader chaperone activity.
+                            <strong>Reason:</strong> GO:0051082 is now formally obsolete (go-ontology#30962). HSP82 is an ATP-dependent foldase; while it does bind unfolded/non-native proteins as part of its chaperone cycle, the binding is coupled to ATP-driven conformational changes. The more appropriate term is GO:0140662 &#34;ATP-dependent protein folding chaperone&#34; which captures both the binding and the active folding mechanism. IDA evidence from PMID:10564510 demonstrated binding to denatured substrates, but this is part of the broader chaperone activity.
                         </div>
 
 
@@ -1583,7 +1583,7 @@
                                     <span class="badge">SUPPORTS TRANSFER</span>
 
 
-                                    <div class="propagation-comment">The ancestral assertion captures genuine non-native-client binding, but the binding term proposed for obsoletion (go-ontology#30962) should be replaced by the ATP-dependent chaperone activity term.</div>
+                                    <div class="propagation-comment">The ancestral assertion captures genuine non-native-client binding, but the now formally obsolete binding term (go-ontology#30962) should be replaced by the ATP-dependent chaperone activity term.</div>
 
                                 </div>
 
@@ -2151,7 +2151,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is proposed for obsoletion (go-ontology#30962). It should be replaced with GO:0140662 &#34;ATP-dependent protein folding chaperone&#34; which better captures the active chaperone mechanism.
+                            <strong>Reason:</strong> GO:0051082 is now formally obsolete (go-ontology#30962). It should be replaced with GO:0140662 &#34;ATP-dependent protein folding chaperone&#34; which better captures the active chaperone mechanism.
                         </div>
 
 
@@ -5916,7 +5916,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> While the experimental evidence is solid (HSP82 does bind unfolded proteins as shown by PMID:10564510), GO:0051082 is proposed for obsoletion (go-ontology#30962). The binding of unfolded proteins is part of the ATP-dependent chaperone mechanism, better captured by GO:0140662 &#34;ATP-dependent protein folding chaperone.&#34;
+                            <strong>Reason:</strong> While the experimental evidence is solid (HSP82 does bind unfolded proteins as shown by PMID:10564510), GO:0051082 is now formally obsolete (go-ontology#30962). The binding of unfolded proteins is part of the ATP-dependent chaperone mechanism, better captured by GO:0140662 &#34;ATP-dependent protein folding chaperone.&#34;
                         </div>
 
 
@@ -8353,11 +8353,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: &gt;-
-      GO:0051082 is proposed for obsoletion (go-ontology#30962). HSP82 does interact with unfolded/misfolded client proteins
+      GO:0051082 is now formally obsolete (go-ontology#30962). HSP82 does interact with unfolded/misfolded client proteins
       but its mechanism is better captured by GO:0140662 (ATP-dependent protein folding chaperone).
     action: MODIFY
     reason: &gt;-
-      GO:0051082 is proposed for obsoletion (go-ontology#30962). HSP82 is an ATP-dependent foldase; while it does bind
+      GO:0051082 is now formally obsolete (go-ontology#30962). HSP82 is an ATP-dependent foldase; while it does bind
       unfolded/non-native proteins as part of its chaperone cycle, the binding is coupled to ATP-driven
       conformational changes. The more appropriate term is GO:0140662 &#34;ATP-dependent protein folding
       chaperone&#34; which captures both the binding and the active folding mechanism. IDA evidence
@@ -8375,8 +8375,8 @@ existing_annotations:
         source_label: PAINT Hsp90 family node
         source_status: SUPPORTS_TRANSFER
         comment: &gt;-
-          The ancestral assertion captures genuine non-native-client binding, but the binding term proposed
-          for obsoletion (go-ontology#30962) should be replaced by the ATP-dependent chaperone activity term.
+          The ancestral assertion captures genuine non-native-client binding, but the now formally obsolete
+          binding term (go-ontology#30962) should be replaced by the ATP-dependent chaperone activity term.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm
@@ -8509,7 +8509,7 @@ existing_annotations:
       for obsoletion (go-ontology#30962).
     action: MODIFY
     reason: &gt;-
-      GO:0051082 is proposed for obsoletion (go-ontology#30962). It should be replaced with GO:0140662 &#34;ATP-dependent
+      GO:0051082 is now formally obsolete (go-ontology#30962). It should be replaced with GO:0140662 &#34;ATP-dependent
       protein folding chaperone&#34; which better captures the active chaperone mechanism.
     proposed_replacement_terms:
     - id: GO:0140662
@@ -9260,7 +9260,7 @@ existing_annotations:
     action: MODIFY
     reason: &gt;-
       While the experimental evidence is solid (HSP82 does bind unfolded proteins as shown by
-      PMID:10564510), GO:0051082 is proposed for obsoletion (go-ontology#30962). The binding of unfolded proteins
+      PMID:10564510), GO:0051082 is now formally obsolete (go-ontology#30962). The binding of unfolded proteins
       is part of the ATP-dependent chaperone mechanism, better captured by GO:0140662
       &#34;ATP-dependent protein folding chaperone.&#34;
     proposed_replacement_terms:

--- a/genes/yeast/HSP82/HSP82-ai-review.html
+++ b/genes/yeast/HSP82/HSP82-ai-review.html
@@ -2146,7 +2146,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA annotation for unfolded protein binding. Same issue as the IBA annotation: the term is proposed for obsoletion (go-ontology#30962).
+                            <strong>Summary:</strong> IEA annotation for unfolded protein binding. Same issue as the IBA annotation: the term is now formally obsolete (go-ontology#30962).
                         </div>
 
 
@@ -5911,7 +5911,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA evidence showing HSP82 binds unfolded/denatured proteins. The imported term is proposed for obsoletion (go-ontology#30962).
+                            <strong>Summary:</strong> IDA evidence showing HSP82 binds unfolded/denatured proteins. The imported term is now formally obsolete (go-ontology#30962).
                         </div>
 
 
@@ -8505,8 +8505,8 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   review:
     summary: &gt;-
-      IEA annotation for unfolded protein binding. Same issue as the IBA annotation: the term is proposed
-      for obsoletion (go-ontology#30962).
+      IEA annotation for unfolded protein binding. Same issue as the IBA annotation: the term is now
+      formally obsolete (go-ontology#30962).
     action: MODIFY
     reason: &gt;-
       GO:0051082 is now formally obsolete (go-ontology#30962). It should be replaced with GO:0140662 &#34;ATP-dependent
@@ -9255,8 +9255,8 @@ existing_annotations:
   original_reference_id: PMID:10564510
   review:
     summary: &gt;-
-      IDA evidence showing HSP82 binds unfolded/denatured proteins. The imported term is proposed for
-      obsoletion (go-ontology#30962).
+      IDA evidence showing HSP82 binds unfolded/denatured proteins. The imported term is now formally
+      obsolete (go-ontology#30962).
     action: MODIFY
     reason: &gt;-
       While the experimental evidence is solid (HSP82 does bind unfolded proteins as shown by

--- a/genes/yeast/HSP82/HSP82-ai-review.yaml
+++ b/genes/yeast/HSP82/HSP82-ai-review.yaml
@@ -228,11 +228,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: >-
-      GO:0051082 is proposed for obsoletion (go-ontology#30962). HSP82 does interact with unfolded/misfolded client proteins
+      GO:0051082 is now formally obsolete (go-ontology#30962). HSP82 does interact with unfolded/misfolded client proteins
       but its mechanism is better captured by GO:0140662 (ATP-dependent protein folding chaperone).
     action: MODIFY
     reason: >-
-      GO:0051082 is proposed for obsoletion (go-ontology#30962). HSP82 is an ATP-dependent foldase; while it does bind
+      GO:0051082 is now formally obsolete (go-ontology#30962). HSP82 is an ATP-dependent foldase; while it does bind
       unfolded/non-native proteins as part of its chaperone cycle, the binding is coupled to ATP-driven
       conformational changes. The more appropriate term is GO:0140662 "ATP-dependent protein folding
       chaperone" which captures both the binding and the active folding mechanism. IDA evidence
@@ -250,8 +250,8 @@ existing_annotations:
         source_label: PAINT Hsp90 family node
         source_status: SUPPORTS_TRANSFER
         comment: >-
-          The ancestral assertion captures genuine non-native-client binding, but the binding term proposed
-          for obsoletion (go-ontology#30962) should be replaced by the ATP-dependent chaperone activity term.
+          The ancestral assertion captures genuine non-native-client binding, but the now formally obsolete
+          binding term (go-ontology#30962) should be replaced by the ATP-dependent chaperone activity term.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm
@@ -384,7 +384,7 @@ existing_annotations:
       for obsoletion (go-ontology#30962).
     action: MODIFY
     reason: >-
-      GO:0051082 is proposed for obsoletion (go-ontology#30962). It should be replaced with GO:0140662 "ATP-dependent
+      GO:0051082 is now formally obsolete (go-ontology#30962). It should be replaced with GO:0140662 "ATP-dependent
       protein folding chaperone" which better captures the active chaperone mechanism.
     proposed_replacement_terms:
     - id: GO:0140662
@@ -1135,7 +1135,7 @@ existing_annotations:
     action: MODIFY
     reason: >-
       While the experimental evidence is solid (HSP82 does bind unfolded proteins as shown by
-      PMID:10564510), GO:0051082 is proposed for obsoletion (go-ontology#30962). The binding of unfolded proteins
+      PMID:10564510), GO:0051082 is now formally obsolete (go-ontology#30962). The binding of unfolded proteins
       is part of the ATP-dependent chaperone mechanism, better captured by GO:0140662
       "ATP-dependent protein folding chaperone."
     proposed_replacement_terms:

--- a/genes/yeast/HSP82/HSP82-ai-review.yaml
+++ b/genes/yeast/HSP82/HSP82-ai-review.yaml
@@ -380,8 +380,8 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   review:
     summary: >-
-      IEA annotation for unfolded protein binding. Same issue as the IBA annotation: the term is proposed
-      for obsoletion (go-ontology#30962).
+      IEA annotation for unfolded protein binding. Same issue as the IBA annotation: the term is now
+      formally obsolete (go-ontology#30962).
     action: MODIFY
     reason: >-
       GO:0051082 is now formally obsolete (go-ontology#30962). It should be replaced with GO:0140662 "ATP-dependent
@@ -1130,8 +1130,8 @@ existing_annotations:
   original_reference_id: PMID:10564510
   review:
     summary: >-
-      IDA evidence showing HSP82 binds unfolded/denatured proteins. The imported term is proposed for
-      obsoletion (go-ontology#30962).
+      IDA evidence showing HSP82 binds unfolded/denatured proteins. The imported term is now formally
+      obsolete (go-ontology#30962).
     action: MODIFY
     reason: >-
       While the experimental evidence is solid (HSP82 does bind unfolded proteins as shown by

--- a/genes/yeast/HSP82/HSP82-ai-review.yaml
+++ b/genes/yeast/HSP82/HSP82-ai-review.yaml
@@ -30,7 +30,8 @@ existing_annotations:
     reason: >-
       Protein folding is a core biological process for Hsp90. UniProt describes HSP82 as a "Molecular chaperone
       that promotes the maturation, structural maintenance and proper regulation of specific target proteins."
-      Multiple IMP and IDA evidence codes confirm involvement in de novo protein folding (PMID:10564510, PMID:9371781).
+      Multiple IMP and IDA evidence codes confirm involvement in selective client-protein folding
+      (PMID:10564510, PMID:9371781).
     additional_reference_ids:
     - file:yeast/HSP82/HSP82-deep-research-falcon.md
     supported_by:
@@ -249,8 +250,8 @@ existing_annotations:
         source_label: PAINT Hsp90 family node
         source_status: SUPPORTS_TRANSFER
         comment: >-
-          The ancestral assertion captures genuine non-native-client binding, but the obsolete binding
-          term should be replaced by the ATP-dependent chaperone activity term.
+          The ancestral assertion captures genuine non-native-client binding, but the binding term proposed
+          for obsoletion (go-ontology#30962) should be replaced by the ATP-dependent chaperone activity term.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm


### PR DESCRIPTION
## Summary
- describe GO:0051082 consistently as proposed for obsoletion
- align the protein-folding IBA rationale with the reviewed selective-client evidence
- regenerate the HSP82 HTML and browser payload

## Validation
- `just validate yeast HSP82`
- `just validate-goa yeast HSP82`
- `just render yeast HSP82`
- `just deploy-browser`