### PR TITLE
Fix Nmnat supporting-text validation

### DIFF
--- a/genes/DROME/Nmnat/Nmnat-ai-review.html
+++ b/genes/DROME/Nmnat/Nmnat-ai-review.html
@@ -3573,7 +3573,7 @@
                     <li class="finding-item">
                         <div class="finding-statement">Alternative splicing produces functionally distinct isoforms. Isoform C (nuclear) has holdase but not refoldase activity and is not neuroprotective. Isoform D (cytoplasmic) has both holdase and refoldase activity and is strongly neuroprotective. Neurons preferentially produce the neuroprotective isoform under stress.</div>
 
-                        <div class="finding-text">"RA produces nuclear protein PC with strong holdase activity, but with minimal refolding activity; RB produces cytoplasmic protein PD with strong refolding activity. Importantly, these specific cellular features of PC, that is, strong holdase but minimal refolding activity and nuclear localization, are consistent with its ability to enhance hAtx-1[82Q] aggregation when co-expressed."</div>
+                        <div class="finding-text">"The protein isoforms share some aspects of biochemical properties but have distinct cellular characteristics. Specifically, RA produces nuclear protein PC with strong holdase activity, but with minimal refolding activity; RB produces cytoplasmic protein PD with strong refolding activity."</div>
 
                     </li>
 
@@ -4918,7 +4918,7 @@ references:
         holdase but not refoldase activity and is not neuroprotective. Isoform D (cytoplasmic)
         has both holdase and refoldase activity and is strongly neuroprotective. Neurons
         preferentially produce the neuroprotective isoform under stress.
-      supporting_text: &#34;RA produces nuclear protein PC with strong holdase activity, but with minimal refolding activity; RB produces cytoplasmic protein PD with strong refolding activity. Importantly, these specific cellular features of PC, that is, strong holdase but minimal refolding activity and nuclear localization, are consistent with its ability to enhance hAtx-1[82Q] aggregation when co-expressed.&#34;
+      supporting_text: &#34;The protein isoforms share some aspects of biochemical properties but have distinct cellular characteristics. Specifically, RA produces nuclear protein PC with strong holdase activity, but with minimal refolding activity; RB produces cytoplasmic protein PD with strong refolding activity.&#34;
 - id: PMID:30692130
   title: The E3 ligase Highwire promotes synaptic transmission by targeting the NAD-synthesizing
     enzyme dNmnat.

--- a/genes/DROME/Nmnat/Nmnat-ai-review.yaml
+++ b/genes/DROME/Nmnat/Nmnat-ai-review.yaml
@@ -698,7 +698,7 @@ references:
         holdase but not refoldase activity and is not neuroprotective. Isoform D (cytoplasmic)
         has both holdase and refoldase activity and is strongly neuroprotective. Neurons
         preferentially produce the neuroprotective isoform under stress.
-      supporting_text: "RA produces nuclear protein PC with strong holdase activity, but with minimal refolding activity; RB produces cytoplasmic protein PD with strong refolding activity. Importantly, these specific cellular features of PC, that is, strong holdase but minimal refolding activity and nuclear localization, are consistent with its ability to enhance hAtx-1[82Q] aggregation when co-expressed."
+      supporting_text: "The protein isoforms share some aspects of biochemical properties but have distinct cellular characteristics. Specifically, RA produces nuclear protein PC with strong holdase activity, but with minimal refolding activity; RB produces cytoplasmic protein PD with strong refolding activity."
 - id: PMID:30692130
   title: The E3 ligase Highwire promotes synaptic transmission by targeting the NAD-synthesizing
     enzyme dNmnat.


### PR DESCRIPTION
## Summary
- replace the non-matching PMID:26616331 supporting-text excerpt with an exact publication substring
- preserve the same evidence claim about PC/PD isoform chaperone properties
- regenerate the Nmnat review page and browser payload

This was exposed by strict changed-file validation on #2690 and is split into a separate bug PR.

## Validation
- `just validate DROME Nmnat`
- `just render DROME Nmnat`
- `just deploy-browser`
- `git diff --check`