### PR TITLE
Re-review DANRE (zebrafish) gene annotations: clean descriptions, add IBA propagation metadata

### DIFF
--- a/cache/go/terms.csv
+++ b/cache/go/terms.csv
@@ -682,6 +682,7 @@ GO:0003963,RNA-3'-phosphate cyclase activity,2026-06-20T02:05:20.117661
 GO:0003964,RNA-directed DNA polymerase activity,2026-05-08T22:12:02.939352
 GO:0003968,RNA-directed RNA polymerase activity,2026-05-08T22:12:02.939356
 GO:0003973,(S)-2-hydroxy-acid oxidase activity,2026-05-08T22:12:02.939359
+GO:0003976,UDP-N-acetylglucosamine-lysosomal-enzyme N-acetylglucosaminephosphotransferase activity,2026-08-28T06:31:45.593940
 GO:0003978,UDP-glucose 4-epimerase activity,2026-07-24T14:04:53.252862
 GO:0003980,UDP-glucose:glycoprotein glucosyltransferase activity,2026-05-08T22:12:02.939363
 GO:0003983,UTP:glucose-1-phosphate uridylyltransferase activity,2026-07-24T14:04:53.762193
@@ -2975,6 +2976,7 @@ GO:0016247,channel regulator activity,2026-05-08T22:12:02.944303
 GO:0016248,channel inhibitor activity,2026-05-08T22:12:02.944306
 GO:0016251,RNA polymerase II general transcription initiation factor activity,2026-05-08T22:12:02.944309
 GO:0016255,attachment of GPI anchor to protein,2026-05-08T22:12:02.944322
+GO:0016256,N-glycan processing to lysosome,2026-08-28T06:31:45.680725
 GO:0016263,"N-acetylgalactosaminide beta-1,3-galactosyltransferase activity",2026-06-21T22:19:38.797275
 GO:0016266,protein O-linked glycosylation via N-acetylgalactosamine,2026-08-08T14:11:48.206203
 GO:0016272,prefoldin complex,2026-05-08T22:12:02.944326
@@ -4664,6 +4666,7 @@ GO:0035234,ectopic germ cell programmed cell death,2026-05-08T22:12:02.949018
 GO:0035235,ionotropic glutamate receptor signaling pathway,2026-05-08T22:12:02.949052
 GO:0035239,tube morphogenesis,2026-03-22T22:38:14.237952
 GO:0035240,dopamine binding,2026-05-08T22:12:02.949056
+GO:0035242,protein-arginine omega-N asymmetric methyltransferase activity,2026-08-28T06:35:12.079832
 GO:0035251,UDP-glucosyltransferase activity,2026-03-22T22:38:14.237952
 GO:0035253,ciliary rootlet,2026-05-08T22:12:02.949060
 GO:0035254,glutamate receptor binding,2026-05-08T22:12:02.949063
@@ -4835,6 +4838,7 @@ GO:0036120,cellular response to platelet-derived growth factor stimulus,2026-05-
 GO:0036122,BMP binding,2026-05-08T22:12:02.949531
 GO:0036126,sperm flagellum,2026-05-08T22:12:02.949534
 GO:0036128,CatSper complex,2026-05-08T22:12:02.949537
+GO:0036140,[protein]-asparagine 3-dioxygenase activity,2026-08-28T06:32:49.393687
 GO:0036148,phosphatidylglycerol acyl-chain remodeling,2026-05-08T22:12:02.949540
 GO:0036150,phosphatidylserine acyl-chain remodeling,2026-05-08T22:12:02.949544
 GO:0036151,phosphatidylcholine acyl-chain remodeling,2026-05-08T22:12:02.949547
@@ -6467,6 +6471,7 @@ GO:0050958,magnetoreception,2026-05-08T22:12:02.953644
 GO:0050962,detection of light stimulus involved in sensory perception,2026-03-22T22:38:14.237952
 GO:0050966,detection of mechanical stimulus involved in sensory perception of pain,2026-05-08T22:12:02.953648
 GO:0050973,detection of mechanical stimulus involved in equilibrioception,2026-03-22T22:38:14.237952
+GO:0050974,detection of mechanical stimulus involved in sensory perception,2026-08-28T06:36:43.440193
 GO:0050975,sensory perception of touch,2026-03-22T22:38:14.237952
 GO:0050976,detection of mechanical stimulus involved in sensory perception of touch,2026-05-08T22:12:02.953651
 GO:0050980,detection of light stimulus involved in magnetoreception,2026-05-08T22:12:02.953655
@@ -6848,6 +6853,7 @@ GO:0060081,membrane hyperpolarization,2026-05-08T22:12:02.954540
 GO:0060090,molecular adaptor activity,2026-05-08T22:12:02.954544
 GO:0060100,"positive regulation of phagocytosis, engulfment",2026-06-19T13:50:48.902615
 GO:0060102,cuticular extracellular matrix,2026-04-19T19:54:57.052347
+GO:0060122,inner ear receptor cell stereocilium organization,2026-08-28T06:36:43.380164
 GO:0060134,prepulse inhibition,2026-05-08T22:12:02.954547
 GO:0060137,maternal process involved in parturition,2026-05-08T22:12:02.954550
 GO:0060152,microtubule-based peroxisome localization,2026-05-08T22:12:02.954553
@@ -7193,6 +7199,7 @@ GO:0062153,C5-methylcytidine-containing RNA reader activity,2026-05-08T22:12:02.
 GO:0062158,chloride:proton antiporter activity,2026-06-21T22:16:22.510318
 GO:0062176,R-loop processing,2026-08-10T18:41:22.963600
 GO:0062177,radial spoke assembly,2026-04-19T20:00:31.190231
+GO:0062182,all-trans retinoic acid 4-hydrolase activity,2026-08-28T06:30:05.002865
 GO:0062183,all-trans retinoic acid 18-hydroxylase activity,2026-05-09T02:20:00
 GO:0062193,D-ribose pyranase activity,2026-05-08T22:12:02.955533
 GO:0062201,actin wave,2026-04-19T19:53:36.685111
@@ -7337,6 +7344,7 @@ GO:0070589,obsolete cellular component macromolecule biosynthetic process,2026-0
 GO:0070593,dendrite self-avoidance,2026-05-08T22:12:02.955903
 GO:0070600,fungal-type cell wall (1->3)-alpha-glucan biosynthetic process,2026-04-24T20:36:05.344869
 GO:0070602,regulation of centromeric sister chromatid cohesion,2026-05-08T22:12:02.955906
+GO:0070611,histone H3R2 methyltransferase activity,2026-08-28T06:35:12.172418
 GO:0070628,proteasome binding,2026-05-08T22:12:02.955910
 GO:0070665,positive regulation of leukocyte proliferation,2026-05-08T22:12:02.955913
 GO:0070670,response to interleukin-4,2026-05-08T22:12:02.955916
@@ -7379,6 +7387,8 @@ GO:0070880,fungal-type cell wall beta-glucan biosynthetic process,2026-05-08T22:
 GO:0070886,positive regulation of calcineurin-NFAT signaling cascade,2026-05-08T22:12:02.955997
 GO:0070887,cellular response to chemical stimulus,2026-03-22T22:38:14.237952
 GO:0070888,E-box binding,2026-05-08T22:12:02.956000
+GO:0070899,mitochondrial tRNA wobble uridine modification,2026-08-28T06:32:17.265480
+GO:0070900,mitochondrial tRNA modification,2026-08-28T06:32:17.324112
 GO:0070902,mitochondrial tRNA pseudouridine synthesis,2026-06-18T17:59:50.418226
 GO:0070911,global genome nucleotide-excision repair,2026-05-08T22:12:02.956003
 GO:0070914,UV-damage excision repair,2026-05-08T22:12:02.956007
@@ -7472,6 +7482,7 @@ GO:0071401,cellular response to triglyceride,2026-03-22T22:38:14.237952
 GO:0071404,cellular response to low-density lipoprotein particle stimulus,2026-05-08T22:12:02.956269
 GO:0071407,obsolete cellular response to organic cyclic compound,2026-03-22T22:38:14.237952
 GO:0071417,obsolete cellular response to organonitrogen compound,2026-03-22T22:38:14.237952
+GO:0071421,manganese ion transmembrane transport,2026-08-28T06:35:52.251423
 GO:0071425,hematopoietic stem cell proliferation,2026-05-08T22:12:02.956273
 GO:0071439,clathrin complex,2026-05-08T22:12:02.956276
 GO:0071447,cellular response to hydroperoxide,2026-05-08T22:12:02.956279
@@ -7516,6 +7527,7 @@ GO:0071561,nucleus-vacuole junction,2026-05-08T22:12:02.956387
 GO:0071564,npBAF complex,2026-05-08T22:12:02.956390
 GO:0071565,nBAF complex,2026-05-08T22:12:02.956393
 GO:0071567,deUFMylase activity,2026-04-19T19:53:21.908704
+GO:0071578,zinc ion import across plasma membrane,2026-08-28T06:35:52.180268
 GO:0071588,hydrogen peroxide mediated signaling pathway,2026-05-08T22:12:02.956396
 GO:0071598,neuronal ribonucleoprotein granule,2026-04-19T19:58:39.942845
 GO:0071599,otic vesicle development,2026-05-08T22:12:02.956399
@@ -8352,6 +8364,7 @@ GO:0140374,antiviral innate immune response,2026-05-08T22:12:02.958474
 GO:0140375,immune receptor activity,2026-05-08T22:12:02.958478
 GO:0140378,protein complex scaffold activity,2026-07-26T11:13:22.590689
 GO:0140403,effector-mediated suppression of host innate immune response,2026-03-22T22:38:14.237952
+GO:0140410,monoatomic cation:bicarbonate symporter activity,2026-08-28T06:35:52.096119
 GO:0140414,phosphopantetheine-dependent carrier activity,2026-03-22T22:38:14.237952
 GO:0140416,transcription regulator inhibitor activity,2026-05-08T22:12:02.958481
 GO:0140418,effector-mediated perturbation of host process by symbiont,2026-03-22T22:38:14.237952
@@ -8369,6 +8382,7 @@ GO:0140488,heme receptor activity,2026-05-08T22:12:02.958514
 GO:0140494,migrasome,2026-05-08T22:12:02.958523
 GO:0140506,endoplasmic reticulum-autophagosome adaptor activity,2026-06-14T08:10:58.630002
 GO:0140517,protein-RNA adaptor activity,2026-05-08T22:12:02.958526
+GO:0140523,GTPase-dependent fusogenic activity,2026-08-28T06:34:22.112547
 GO:0140534,endoplasmic reticulum protein-containing complex,2026-03-22T22:38:14.237952
 GO:0140537,transcription regulator activator activity,2026-05-08T22:12:02.958530
 GO:0140545,ATP-dependent protein disaggregase activity,2026-05-08T22:12:02.958533
@@ -9206,6 +9220,7 @@ GO:1990314,cellular response to insulin-like growth factor stimulus,2026-05-08T2
 GO:1990316,Atg1/ULK1 kinase complex,2026-05-08T22:12:02.960653
 GO:1990333,"mitotic checkpoint complex, CDC20-MAD2 subcomplex",2026-03-22T22:38:14.237952
 GO:1990342,heterochromatin island,2026-05-08T22:12:02.960656
+GO:1990379,lipid transport across blood-brain barrier,2026-08-28T06:33:51.000267
 GO:1990381,ubiquitin-specific protease binding,2026-05-08T22:12:02.960659
 GO:1990390,protein K33-linked ubiquitination,2026-05-08T22:12:02.960662
 GO:1990391,DNA repair complex,2026-05-08T22:12:02.960666

--- a/genes/DANRE/A0A8M9QG43/A0A8M9QG43-ai-review.yaml
+++ b/genes/DANRE/A0A8M9QG43/A0A8M9QG43-ai-review.yaml
@@ -168,6 +168,56 @@ existing_annotations:
         the perinuclear regions. These perinuclear zGAK- and zAux-positive
         structures showed overlaps with clathrin, most likely representing
         the TGN...
+- term:
+    id: GO:0030544
+    label: Hsp70 protein binding
+  evidence_type: IEA
+  original_reference_id: file:DANRE/A0A8M9QG43/A0A8M9QG43-deep-research-falcon.md
+  review:
+    summary: >-
+      NEW (proposed). As a J-domain co-chaperone (auxilin/dnajc6), the primary
+      molecular function is binding and recruiting the HSC70/HSPA8 chaperone to
+      clathrin-coated structures and stimulating its ATPase activity via the
+      conserved His-Pro-Asp (HPD) J-domain motif. Hsp70 protein binding is the
+      specific molecular function underlying the co-chaperone role and is not
+      otherwise represented in the GOA set.
+    action: NEW
+    reason: >-
+      The co-chaperone activity is defined by binding HSC70/HSPA8; this specific
+      Hsp70 protein binding term (not the uninformative generic protein binding)
+      captures the auxilin J-domain function and grounds the core molecular function.
+    supported_by:
+    - reference_id: file:DANRE/A0A8M9QG43/A0A8M9QG43-deep-research-falcon.md
+      supporting_text: >-
+        auxilin recruits HSC70 to clathrin-coated structures and stimulates HSC70's ATPase activity
+    - reference_id: PMID:20082716
+      supporting_text: >-
+        auxilin is known to cooperate with Hsc70 in mediating the disassembly
+- term:
+    id: GO:0072318
+    label: clathrin coat disassembly
+  evidence_type: IEA
+  original_reference_id: PMID:20082716
+  review:
+    summary: >-
+      NEW (proposed). Auxilin/dnajc6 catalyzes the terminal ATP-dependent
+      disassembly (uncoating) of clathrin coats from newly formed clathrin-coated
+      vesicles by recruiting HSC70, the essential final step of clathrin-mediated
+      endocytosis. Clathrin coat disassembly is the specific biological process
+      for this co-chaperone and is more informative than the broader
+      clathrin-dependent endocytosis term already annotated.
+    action: NEW
+    reason: >-
+      Clathrin coat disassembly is the specific, well-characterized process
+      auxilin mediates via HSC70 recruitment; it grounds the clathrin-uncoating
+      core function and is supported by direct in-vitro disassembly evidence.
+    supported_by:
+    - reference_id: PMID:20082716
+      supporting_text: >-
+        disassembly of clathrin triskelia and coat proteins from newly formed CCVs
+    - reference_id: file:DANRE/A0A8M9QG43/A0A8M9QG43-deep-research-falcon.md
+      supporting_text: >-
+        auxilin recruits HSC70 to clathrin-coated structures and stimulates HSC70's ATPase activity
 core_functions:
 - description: >-
     Co-chaperone that binds clathrin-coated vesicles and recruits HSC70/HSPA8

--- a/genes/DANRE/A0A8M9QG43/A0A8M9QG43-ai-review.yaml
+++ b/genes/DANRE/A0A8M9QG43/A0A8M9QG43-ai-review.yaml
@@ -218,6 +218,26 @@ existing_annotations:
     - reference_id: file:DANRE/A0A8M9QG43/A0A8M9QG43-deep-research-falcon.md
       supporting_text: >-
         auxilin recruits HSC70 to clathrin-coated structures and stimulates HSC70's ATPase activity
+- term:
+    id: GO:0001671
+    label: ATPase activator activity
+  evidence_type: IEA
+  original_reference_id: file:DANRE/A0A8M9QG43/A0A8M9QG43-deep-research-falcon.md
+  review:
+    summary: >-
+      NEW (proposed). Through its conserved J-domain His-Pro-Asp (HPD) motif, auxilin/dnajc6
+      stimulates the ATPase activity of the recruited HSC70/HSPA8 chaperone, the step that
+      powers ATP-dependent clathrin-coat disassembly. ATPase activator activity captures this
+      mechanistic aspect of the co-chaperone function alongside Hsp70 protein binding.
+    action: NEW
+    reason: >-
+      The HPD J-domain motif of auxilin activates HSC70 ATP hydrolysis; ATPase activator
+      activity is the specific molecular function for this stimulation and complements the
+      Hsp70 protein binding annotation, inferred from conserved auxilin co-chaperone mechanism.
+    supported_by:
+    - reference_id: file:DANRE/A0A8M9QG43/A0A8M9QG43-deep-research-falcon.md
+      supporting_text: >-
+        auxilin recruits HSC70 to clathrin-coated structures and stimulates HSC70's ATPase activity
 core_functions:
 - description: >-
     Co-chaperone that binds clathrin-coated vesicles and recruits HSC70/HSPA8

--- a/genes/DANRE/asah2/asah2-ai-review.yaml
+++ b/genes/DANRE/asah2/asah2-ai-review.yaml
@@ -23,6 +23,27 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: The evidence is better explained by the gene core function or downstream phenotype; this term should not be treated
       as a direct/core annotation.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - ROLE_CONFLATION
+      source_entities:
+      - source_id: PANTHER:PTN004377481
+        source_label: PANTHER family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Family-level node; asah2 is a neutral ceramidase whose released fatty acid is a catabolic hydrolysis
+          product, not evidence of a fatty acid biosynthetic role.
+      - source_id: UniProtKB:O06769
+        source_label: IBA donor family member
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Donor supports the family-level biosynthesis assertion but the reaction direction is reversed for the
+          ceramidase target.
+      - source_id: UniProtKB:Q9I596
+        source_label: IBA donor family member
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Long-chain fatty acid biosynthesis conflates ceramide-catabolism fatty acid release with de novo
+          biosynthesis for asah2.
     supported_by:
     - reference_id: file:DANRE/asah2/asah2-uniprot.txt
       supporting_text: hydrolyzes sphingolipid ceramides into sphingosine and free fatty acids at neutral pH

--- a/genes/DANRE/asah2/asah2-ai-review.yaml
+++ b/genes/DANRE/asah2/asah2-ai-review.yaml
@@ -21,8 +21,9 @@ existing_annotations:
       ceramide to sphingosine and a free fatty acid; the released fatty acid is a hydrolysis product
       of ceramide catabolism rather than evidence of a fatty acid biosynthetic pathway role.
     action: MARK_AS_OVER_ANNOTATED
-    reason: The evidence is better explained by the gene core function or downstream phenotype; this term should not be treated
-      as a direct/core annotation.
+    reason: asah2 is a neutral ceramidase that hydrolyzes ceramide to sphingosine and a free fatty acid; the released fatty
+      acid is a catabolic hydrolysis product, not evidence of a fatty acid biosynthetic pathway. The IBA transfers a
+      family-level biosynthesis term whose reaction direction is reversed for this ceramidase, so it over-annotates asah2.
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:

--- a/genes/DANRE/bdh2/bdh2-ai-review.yaml
+++ b/genes/DANRE/bdh2/bdh2-ai-review.yaml
@@ -443,3 +443,20 @@ core_functions:
   - reference_id: file:DANRE/bdh2/bdh2-deep-research-falcon.md
     supporting_text: |
       BDH2 catalyzes a **rate-limiting NAD-dependent step** in biosynthesis of **2,5-dihydroxybenzoic acid (2,5-DHBA)**, an endogenous catecholate that can coordinate iron
+proposed_new_terms:
+- proposed_name: 2,5-dihydroxybenzoate biosynthetic oxidoreductase activity
+  proposed_definition: Catalysis of the NAD-dependent oxidoreduction reaction, characteristic of the short-chain
+    dehydrogenase/reductase BDH2, that contributes to formation of 2,5-dihydroxybenzoate (2,5-DHBA), the iron-binding
+    catecholate moiety of the mammalian siderophore, during siderophore biosynthesis.
+  justification: BDH2 catalyzes a specific NAD-dependent step forming 2,5-DHBA for endogenous catecholate siderophore
+    biosynthesis, but no existing GO molecular-function term captures this exact reaction. It is currently grounded only by
+    the broader parent class GO:0016616 (oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP as
+    acceptor), which does not convey the siderophore-forming specificity; a dedicated child term would.
+  proposed_parent:
+    id: GO:0016616
+    label: oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP as acceptor
+  supported_by:
+  - reference_id: file:DANRE/bdh2/bdh2-uniprot.txt
+    supporting_text: formation of 2,5-dihydroxybenzoate (2,5-DHBA)
+  - reference_id: PMID:20550936
+    supporting_text: The iron-binding moiety of the mammalian siderophore is 2,5-DHBA

--- a/genes/DANRE/bdh2/bdh2-ai-review.yaml
+++ b/genes/DANRE/bdh2/bdh2-ai-review.yaml
@@ -5,10 +5,11 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: bdh2 encodes a cytosolic short-chain dehydrogenase/reductase implicated in mammalian/eukaryotic siderophore biogenesis,
-  mitochondrial iron delivery, heme synthesis, and erythroid maturation in zebrafish. The core review distinguishes the specific
-  4-oxoproline reductase detoxification activity from the separate 2,5-DHBA-associated siderophore/heme role, while 3-hydroxybutyrate
-  dehydrogenase activity is treated as a possible secondary/by-similarity activity rather than the main zebrafish functional theme.
+description: |-
+  bdh2 encodes a cytosolic short-chain dehydrogenase/reductase implicated in mammalian/eukaryotic siderophore biogenesis,
+  mitochondrial iron delivery, heme synthesis, and erythroid maturation in zebrafish. It has 4-oxoproline reductase
+  detoxification activity and a distinct 2,5-DHBA-associated siderophore/heme role; a 3-hydroxybutyrate dehydrogenase
+  activity is reported by similarity but appears secondary in zebrafish.
 existing_annotations:
 - term:
     id: GO:0003858
@@ -271,6 +272,51 @@ existing_annotations:
     - reference_id: file:DANRE/bdh2/bdh2-deep-research-falcon.md
       supporting_text: |
         globin genes (**hbae1/hbae3**) were reported as expressed normally, suggesting the phenotype reflects impaired heme/iron handling rather than globin transcription
+- term:
+    id: GO:1990748
+    label: cellular detoxification
+  evidence_type: IEA
+  original_reference_id: file:DANRE/bdh2/bdh2-uniprot.txt
+  review:
+    summary: >-
+      NEW (proposed). The 4-oxoproline reductase activity of Bdh2 reduces 4-oxo-L-proline
+      (a reactive ketoproline) to cis-4-hydroxy-L-proline; UniProt describes this as a
+      detoxification mechanism for ketoprolines. Cellular detoxification is the biological
+      process this core reductase activity serves and is not otherwise represented in the GOA set.
+    action: NEW
+    reason: >-
+      This process grounds the detoxification role assigned to the 4-oxoproline reductase
+      core function; it is inferred from the UniProt-described ketoproline detoxification
+      mechanism rather than from a direct zebrafish assay.
+    supported_by:
+    - reference_id: file:DANRE/bdh2/bdh2-uniprot.txt
+      supporting_text: detoxification mechanism for ketoprolines
+    - reference_id: file:DANRE/bdh2/bdh2-uniprot.txt
+      supporting_text: conversion of 4-oxo-L-proline to cis-4-hydroxy-L-proline
+- term:
+    id: GO:0016491
+    label: oxidoreductase activity
+  evidence_type: IEA
+  original_reference_id: file:DANRE/bdh2/bdh2-uniprot.txt
+  review:
+    summary: >-
+      NEW (proposed). Beyond 4-oxoproline reductase activity, Bdh2 catalyzes an
+      NAD-dependent oxidoreductase step forming 2,5-dihydroxybenzoate (2,5-DHBA), the
+      iron-binding moiety of the mammalian catecholate siderophore. No specific GO
+      molecular-function term currently captures this siderophore-forming reaction, so the
+      generic oxidoreductase activity is asserted with acknowledged uncertainty to ground
+      the siderophore/heme core function.
+    action: NEW
+    reason: >-
+      The 2,5-DHBA-forming activity is a genuine NAD-dependent oxidoreductase reaction
+      lacking a specific GO term; oxidoreductase activity is the most specific defensible
+      molecular function for the siderophore biosynthetic role and is inferred from UniProt
+      and 2,5-DHBA biosynthesis evidence rather than a direct zebrafish enzymatic assay.
+    supported_by:
+    - reference_id: file:DANRE/bdh2/bdh2-uniprot.txt
+      supporting_text: formation of 2,5-dihydroxybenzoate (2,5-DHBA)
+    - reference_id: PMID:20550936
+      supporting_text: The iron-binding moiety of the mammalian siderophore is 2,5-DHBA
 references:
 - id: GO_REF:0000024
   title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence

--- a/genes/DANRE/bdh2/bdh2-ai-review.yaml
+++ b/genes/DANRE/bdh2/bdh2-ai-review.yaml
@@ -294,23 +294,24 @@ existing_annotations:
     - reference_id: file:DANRE/bdh2/bdh2-uniprot.txt
       supporting_text: conversion of 4-oxo-L-proline to cis-4-hydroxy-L-proline
 - term:
-    id: GO:0016491
-    label: oxidoreductase activity
+    id: GO:0016616
+    label: oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP as acceptor
   evidence_type: IEA
   original_reference_id: file:DANRE/bdh2/bdh2-uniprot.txt
   review:
     summary: >-
-      NEW (proposed). Beyond 4-oxoproline reductase activity, Bdh2 catalyzes an
-      NAD-dependent oxidoreductase step forming 2,5-dihydroxybenzoate (2,5-DHBA), the
-      iron-binding moiety of the mammalian catecholate siderophore. No specific GO
-      molecular-function term currently captures this siderophore-forming reaction, so the
-      generic oxidoreductase activity is asserted with acknowledged uncertainty to ground
-      the siderophore/heme core function.
+      NEW (proposed). Beyond 4-oxoproline reductase activity, Bdh2 (a short-chain
+      dehydrogenase/reductase) catalyzes an NAD-dependent oxidoreductase step forming
+      2,5-dihydroxybenzoate (2,5-DHBA), the iron-binding moiety of the mammalian catecholate
+      siderophore. No GO term captures this exact siderophore-forming reaction, so the SDR
+      fold and NAD dependence are grounded with the CH-OH-donor / NAD-acceptor oxidoreductase
+      class (GO:0016616) rather than the uninformative root oxidoreductase term.
     action: NEW
     reason: >-
-      The 2,5-DHBA-forming activity is a genuine NAD-dependent oxidoreductase reaction
-      lacking a specific GO term; oxidoreductase activity is the most specific defensible
-      molecular function for the siderophore biosynthetic role and is inferred from UniProt
+      The 2,5-DHBA-forming activity is a genuine NAD-dependent CH-OH-donor oxidoreductase
+      reaction consistent with the Bdh2 SDR fold; GO:0016616 is the most specific defensible
+      molecular-function class (more informative than the root GO:0016491 and the parent of
+      the already-accepted GO:0016617 4-oxoproline reductase activity), inferred from UniProt
       and 2,5-DHBA biosynthesis evidence rather than a direct zebrafish enzymatic assay.
     supported_by:
     - reference_id: file:DANRE/bdh2/bdh2-uniprot.txt
@@ -419,11 +420,11 @@ core_functions:
   - reference_id: file:DANRE/bdh2/bdh2-uniprot.txt
     supporting_text: detoxification mechanism for ketoprolines
 - description: bdh2 also supports 2,5-DHBA-associated siderophore biosynthesis and iron delivery needed for heme metabolic
-    processes and erythroid maturation; no specific GO molecular-function term currently captures this siderophore-forming
-    activity.
+    processes and erythroid maturation; the exact siderophore-forming reaction has no dedicated GO term, so it is grounded
+    by the NAD-dependent CH-OH-donor oxidoreductase class consistent with the Bdh2 SDR fold.
   molecular_function:
-    id: GO:0016491
-    label: oxidoreductase activity
+    id: GO:0016616
+    label: oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP as acceptor
   directly_involved_in:
   - id: GO:0019290
     label: siderophore biosynthetic process

--- a/genes/DANRE/coq8a/coq8a-ai-review.yaml
+++ b/genes/DANRE/coq8a/coq8a-ai-review.yaml
@@ -8,8 +8,8 @@ taxon:
 description: |-
   coq8a encodes the atypical kinase COQ8A/ADCK3, an inner mitochondrial membrane UbiB/ADCK kinase-like protein required for
   de novo coenzyme Q (ubiquinone) biosynthesis. It has ATPase activity that supports assembly and function of the CoQ
-  biosynthetic machinery at the inner mitochondrial membrane; its physiological methyl/phospho-acceptor substrate specificity
-  is unclear, and it is not a classical protein-substrate kinase. Zebrafish coq8a function is inferred from conserved
+  biosynthetic machinery at the inner mitochondrial membrane; its physiological substrate specificity is unclear, and it
+  is not a classical protein-substrate kinase. Zebrafish coq8a function is inferred from conserved
   COQ8A/ADCK3 ortholog biology and CoQ-pathway context.
 alternative_products:
 - name: '1'

--- a/genes/DANRE/coq8a/coq8a-ai-review.yaml
+++ b/genes/DANRE/coq8a/coq8a-ai-review.yaml
@@ -5,14 +5,12 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: coq8a encodes mitochondrial atypical kinase COQ8A/ADCK3, a mitochondrial membrane protein involved in coenzyme
-  Q/ubiquinone biosynthesis. The core review emphasizes mitochondrial membrane ubiquinone biosynthesis with cautious kinase
-  activity because UniProt states that the physiological substrate specificity remains unclear; protein phosphorylation annotations
-  are treated as over-annotated relative to the available evidence. Falcon deep research of conserved COQ8A/ADCK3 ortholog
-  biology (2023-2024 sources) reinforces this picture, modeling COQ8A as a UbiB/ADCK kinase-like protein with ATPase activity
-  required for de novo coenzyme Q biosynthesis at the inner mitochondrial membrane, rather than a classical protein-substrate
-  kinase. No direct zebrafish coq8a perturbation/localization study was identified, so the annotation rests on orthology-based
-  inference together with zebrafish CoQ-pathway context.
+description: |-
+  coq8a encodes the atypical kinase COQ8A/ADCK3, an inner mitochondrial membrane UbiB/ADCK kinase-like protein required for
+  de novo coenzyme Q (ubiquinone) biosynthesis. It has ATPase activity that supports assembly and function of the CoQ
+  biosynthetic machinery at the inner mitochondrial membrane; its physiological methyl/phospho-acceptor substrate specificity
+  is unclear, and it is not a classical protein-substrate kinase. Zebrafish coq8a function is inferred from conserved
+  COQ8A/ADCK3 ortholog biology and CoQ-pathway context.
 alternative_products:
 - name: '1'
   id: Q5RGU1-1

--- a/genes/DANRE/cryaa/cryaa-ai-review.yaml
+++ b/genes/DANRE/cryaa/cryaa-ai-review.yaml
@@ -145,6 +145,23 @@ existing_annotations:
       conformation. A more appropriate term would capture the holdase/aggregation-prevention
       function. The IBA inference likely propagated from Drosophila sHSPs where the distinction
       between holdase and foldase activity may not have been well-captured.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000897708
+        source_label: sHSP / alpha-crystallin ancestral node (PTHR45620)
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Descent from this sHSP node correctly transfers chaperone involvement, but
+          GO:0042026 (protein refolding) overstates a foldase activity that alpha-crystallins
+          lack; they are ATP-independent holdases that prevent aggregation without refolding.
+      - source_id: FB:FBgn0001226
+        source_label: Drosophila small heat-shock protein donor
+        source_status: SUPPORTS_TRANSFER
+        comment: Representative Drosophila sHSP donor seeding the node; holdase-vs-foldase distinction not captured by the term.
     proposed_replacement_terms:
       - id: GO:0051082
         label: unfolded protein binding (retain until holdase NTR is created)
@@ -184,6 +201,22 @@ existing_annotations:
       project. While the carrier semantics imply escorting between compartments which does not
       perfectly describe in-situ holdase activity, GO:0140309 is the best available replacement
       that captures the holdase chaperone function.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000897708
+        source_label: sHSP / alpha-crystallin ancestral node (PTHR45620)
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          The node is well supported for unfolded-protein binding across sHSP orthologs, so the
+          transfer itself is sound. The issue is term scoping: GO:0051082 is slated for obsoletion,
+          so the term (not the propagation) needs updating.
+      - source_id: UniProtKB:P02489
+        source_label: Human alphaA-crystallin (CRYAA)
+        source_status: SUPPORTS_TRANSFER
+        comment: Experimentally characterized ortholog donor supporting holdase / unfolded-protein binding.
     proposed_replacement_terms:
       - id: GO:0051082
         label: unfolded protein binding (retain until holdase NTR is created)

--- a/genes/DANRE/cryaba/cryaba-ai-review.yaml
+++ b/genes/DANRE/cryaba/cryaba-ai-review.yaml
@@ -128,6 +128,23 @@ existing_annotations:
       activity, which is inaccurate for cryaba. GO:0140309 (unfolded protein carrier
       activity) is not appropriate because it is carrier-specific (per
       go-ontology#30552). Retain until a holdase chaperone activity NTR is created.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000897708
+        source_label: sHSP / alpha-crystallin ancestral node (PTHR45620)
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Descent from this sHSP node correctly transfers chaperone involvement, but
+          GO:0042026 (protein refolding) overstates a foldase activity that cryaba lacks;
+          it is an ATP-independent holdase preventing aggregation without refolding.
+      - source_id: FB:FBgn0001226
+        source_label: Drosophila small heat-shock protein donor
+        source_status: SUPPORTS_TRANSFER
+        comment: Representative Drosophila sHSP donor seeding the node; holdase-vs-foldase distinction not captured by the term.
     proposed_replacement_terms:
       - id: GO:0051082
         label: unfolded protein binding (retain until holdase NTR is created)
@@ -156,6 +173,22 @@ existing_annotations:
       chaperone assays (PMID:15692462, PMID:16420472). GO:0140309 (unfolded protein
       carrier activity) is not appropriate because it is carrier-specific (per
       go-ontology#30552). Retain until a holdase chaperone activity NTR is created.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000897708
+        source_label: sHSP / alpha-crystallin ancestral node (PTHR45620)
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          The node is well supported for unfolded-protein binding across sHSP orthologs, so the
+          transfer itself is sound. The issue is term scoping: GO:0051082 is proposed for
+          obsoletion, so the term (not the propagation) needs updating.
+      - source_id: UniProtKB:P02511
+        source_label: Human alphaB-crystallin (CRYAB)
+        source_status: SUPPORTS_TRANSFER
+        comment: Experimentally characterized alphaB-crystallin ortholog donor supporting holdase / unfolded-protein binding.
     proposed_replacement_terms:
       - id: GO:0051082
         label: unfolded protein binding (retain until holdase NTR is created)

--- a/genes/DANRE/cryabb/cryabb-ai-review.yaml
+++ b/genes/DANRE/cryabb/cryabb-ai-review.yaml
@@ -129,6 +129,23 @@ existing_annotations:
       activity, which is inaccurate for cryabb. GO:0140309 (unfolded protein carrier
       activity) is not appropriate because it is carrier-specific (per
       go-ontology#30552). Retain until a holdase chaperone activity NTR is created.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000897708
+        source_label: sHSP / alpha-crystallin ancestral node (PTHR45620)
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Descent from this sHSP node correctly transfers chaperone involvement, but
+          GO:0042026 (protein refolding) overstates a foldase activity that cryabb lacks;
+          it is an ATP-independent holdase preventing aggregation without refolding.
+      - source_id: FB:FBgn0001226
+        source_label: Drosophila small heat-shock protein donor
+        source_status: SUPPORTS_TRANSFER
+        comment: Representative Drosophila sHSP donor seeding the node; holdase-vs-foldase distinction not captured by the term.
     proposed_replacement_terms:
       - id: GO:0051082
         label: unfolded protein binding (retain until holdase NTR is created)
@@ -162,6 +179,22 @@ existing_annotations:
       aggregation (PMID:16420472). GO:0140309 (unfolded protein carrier activity) is
       not appropriate because it is carrier-specific (per go-ontology#30552). Retain
       until a holdase chaperone activity NTR is created.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000897708
+        source_label: sHSP / alpha-crystallin ancestral node (PTHR45620)
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          The node is well supported for unfolded-protein binding across sHSP orthologs, so the
+          transfer itself is sound. The issue is term scoping: GO:0051082 is proposed for
+          obsoletion, so the term (not the propagation) needs updating.
+      - source_id: UniProtKB:P02511
+        source_label: Human alphaB-crystallin (CRYAB)
+        source_status: SUPPORTS_TRANSFER
+        comment: Experimentally characterized alphaB-crystallin ortholog donor supporting holdase / unfolded-protein binding.
     proposed_replacement_terms:
       - id: GO:0051082
         label: unfolded protein binding (retain until holdase NTR is created)

--- a/genes/DANRE/cyp26a1/cyp26a1-ai-review.yaml
+++ b/genes/DANRE/cyp26a1/cyp26a1-ai-review.yaml
@@ -5,9 +5,9 @@ status: INITIALIZED
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: cyp26a1 encodes cytochrome P450 26A1, an endoplasmic-reticulum retinoic-acid hydroxylase that catabolizes all-trans
-  retinoic acid and thereby shapes retinoic-acid signaling during zebrafish development. Developmental patterning annotations
-  are treated as downstream consequences of this core retinoic-acid metabolic activity.
+description: |-
+  cyp26a1 encodes cytochrome P450 26A1, an endoplasmic-reticulum retinoic-acid hydroxylase that catabolizes all-trans
+  retinoic acid and thereby shapes retinoic-acid signaling and developmental patterning during zebrafish development.
 existing_annotations:
 - term:
     id: GO:0034653

--- a/genes/DANRE/cyp26b1/cyp26b1-ai-review.yaml
+++ b/genes/DANRE/cyp26b1/cyp26b1-ai-review.yaml
@@ -5,10 +5,10 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: cyp26b1 encodes cytochrome P450 26B1, an endoplasmic-reticulum retinoic-acid hydroxylase that catabolizes all-trans
-  retinoic acid and limits retinoic-acid receptor signaling during embryonic patterning. The core function is retinoic-acid
-  hydroxylation/catabolism; skeletal, tendon, craniofacial, and hindbrain phenotypes are retained as non-core developmental
-  consequences of altered retinoic-acid homeostasis.
+description: |-
+  cyp26b1 encodes cytochrome P450 26B1, an endoplasmic-reticulum retinoic-acid hydroxylase that catabolizes all-trans
+  retinoic acid and thereby limits retinoic-acid receptor signaling during embryonic patterning. Through this control of
+  retinoic-acid homeostasis it shapes skeletal, tendon, craniofacial, and hindbrain development.
 existing_annotations:
 - term:
     id: GO:0034653

--- a/genes/DANRE/cyp51/cyp51-ai-review.yaml
+++ b/genes/DANRE/cyp51/cyp51-ai-review.yaml
@@ -5,10 +5,10 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: cyp51 encodes sterol 14-alpha-demethylase, an endoplasmic-reticulum membrane cytochrome P450 monooxygenase in
-  cholesterol/zymosterol biosynthesis. Broad monooxygenase/oxidoreductase and heme/iron-binding annotations are less informative
-  than the core sterol 14-demethylase activity, while response-to-yeast evidence is treated as a non-core infection-response
-  observation.
+description: |-
+  cyp51 encodes sterol 14-alpha-demethylase, a heme-containing, endoplasmic-reticulum membrane cytochrome P450
+  monooxygenase that catalyzes 14-alpha-demethylation of sterol precursors (such as lanosterol and 24,25-dihydrolanosterol)
+  in the cholesterol/zymosterol biosynthetic pathway.
 existing_annotations:
 - term:
     id: GO:0033488

--- a/genes/DANRE/dph2/dph2-ai-review.yaml
+++ b/genes/DANRE/dph2/dph2-ai-review.yaml
@@ -256,7 +256,7 @@ references:
     - statement: Dph3 donates an iron atom to restore a functional [4Fe-4S] cluster
         in the Dph1-Dph2 complex under aerobic conditions
       supporting_text: >-
-        the small iron-containing protein Dph3 donates one Fe atom to convert the
+        the small iron-containing protein Dph3 donates one Fe atom
       reference_section_type: ABSTRACT
 - id: PMID:32576952
   title: Diphthamide-deficiency syndrome -- a novel human developmental disorder and

--- a/genes/DANRE/dph2/dph2-ai-review.yaml
+++ b/genes/DANRE/dph2/dph2-ai-review.yaml
@@ -256,9 +256,7 @@ references:
     - statement: Dph3 donates an iron atom to restore a functional [4Fe-4S] cluster
         in the Dph1-Dph2 complex under aerobic conditions
       supporting_text: >-
-        all radical S-adenosylmethionine (radical-SAM) enzymes, including the
-        noncanonical radical-SAM enzyme diphthamide biosynthetic enzyme
-        Dph1-Dph2, require at least one [4Fe-4S](Cys)3 cluster for activity
+        the small iron-containing protein Dph3 donates one Fe atom to convert the
       reference_section_type: ABSTRACT
 - id: PMID:32576952
   title: Diphthamide-deficiency syndrome -- a novel human developmental disorder and

--- a/genes/DANRE/fads2/fads2-ai-review.yaml
+++ b/genes/DANRE/fads2/fads2-ai-review.yaml
@@ -5,13 +5,12 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: fads2 encodes zebrafish fatty acid desaturase 2, an endoplasmic-reticulum membrane front-end desaturase with
-  bifunctional delta-6 and delta-5 (and in-vivo delta-8) activities in polyunsaturated fatty-acid biosynthesis. Experimental
-  yeast expression confirmed delta-6 desaturation of C18 PUFA (LA to GLA, ALA to SDA) and delta-5 desaturation of C20 PUFA
-  (to ARA and EPA), and the enzyme also acts on C24 substrates to support Sprecher-pathway DHA synthesis. The core function is
-  ER membrane acyl-CoA desaturation for unsaturated fatty-acid biosynthesis; liver-development evidence is retained as a
-  non-core phenotype from a GWAS candidate knockdown screen, and partial knockout additionally impairs female reproduction
-  (egg quality).
+description: |-
+  fads2 encodes zebrafish fatty acid desaturase 2, an endoplasmic-reticulum membrane front-end acyl-CoA desaturase with
+  bifunctional delta-6 and delta-5 (and in-vivo delta-8) activities in polyunsaturated fatty-acid biosynthesis. Yeast
+  expression assays confirmed delta-6 desaturation of C18 PUFA (LA to GLA, ALA to SDA) and delta-5 desaturation of C20 PUFA
+  (to ARA and EPA), and the enzyme also acts on C24 substrates to support Sprecher-pathway DHA synthesis. It contributes to
+  liver development, and partial loss of function impairs female reproduction (egg quality).
 existing_annotations:
 - term:
     id: GO:0016020
@@ -25,6 +24,22 @@ existing_annotations:
       and review evidence supports Fads2 as an ER membrane enzyme.
     action: MODIFY
     reason: The supported location is endoplasmic reticulum membrane.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN002321280
+        source_label: FADS fatty acid desaturase family node
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Membrane localization is real, but the generic membrane term is uninformative;
+          the supported compartment for Fads2 is the endoplasmic reticulum membrane.
+      - source_id: MGI:MGI:1923517
+        source_label: mouse Fads desaturase donor
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Donor supports membrane residence; specific ER membrane location is preferred.
     proposed_replacement_terms:
     - id: GO:0005789
       label: endoplasmic reticulum membrane

--- a/genes/DANRE/flvcr2a/flvcr2a-ai-review.yaml
+++ b/genes/DANRE/flvcr2a/flvcr2a-ai-review.yaml
@@ -5,9 +5,10 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: flvcr2a encodes zebrafish MFSD7c/FLVCR2A, a multi-pass membrane transporter now supported as a choline transporter
-  at the blood-brain barrier. The core function is choline transmembrane transport, with ethanolamine/heme transport and ER/mitochondrial
-  membrane annotations retained as supported but non-core or inferred contexts.
+description: |-
+  flvcr2a encodes zebrafish MFSD7c/FLVCR2A, a multi-pass membrane transporter that mediates choline transmembrane transport
+  at the blood-brain barrier, with additional reported ethanolamine and heme transport activities and localization to plasma,
+  endoplasmic-reticulum, and mitochondrial membranes.
 existing_annotations:
 - term:
     id: GO:0015232
@@ -48,6 +49,22 @@ existing_annotations:
     action: REMOVE
     reason: Specific membrane locations are reviewed separately; this generic CC annotation should be retired rather than
       replaced with MF/BP transport terms.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000858822
+        source_label: MFSD7/FLVCR2 MFS transporter family node
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Membrane residence is real, but the generic membrane term is uninformative and is
+          superseded by the specific cell-membrane/transporter localization reviewed separately.
+      - source_id: UniProtKB:Q9UPI3
+        source_label: human FLVCR2/MFSD7c donor
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Donor supports membrane residence; specific cell membrane location is preferred.
     supported_by:
     - reference_id: file:DANRE/flvcr2a/flvcr2a-uniprot.txt
       supporting_text: Choline uniporter that specifically mediates choline uptake

--- a/genes/DANRE/glceb/glceb-ai-review.yaml
+++ b/genes/DANRE/glceb/glceb-ai-review.yaml
@@ -8,13 +8,11 @@ taxon:
 description: |-
   glceb encodes zebrafish D-glucuronyl C5-epimerase B, a Golgi membrane (type II transmembrane) enzyme that converts
   D-glucuronic acid residues adjacent to N-sulfated sugars into L-iduronic acid during heparan sulfate and heparin chain
-  biosynthesis. The core function is heparosan-N-sulfate-glucuronate 5-epimerase activity (EC 5.1.3.17) in heparan
-  sulfate proteoglycan biosynthesis, performed as a homodimer with two catalytic sites per dimer and active-site
-  tyrosines (Tyr468/Tyr528/Tyr546) required for catalysis. glceb is one of two zebrafish paralogs (glce-A/glce-B) of
-  the single human GLCE gene. Functionally, glce activity tunes HS fine structure (IdoA content) that controls morphogen
-  signaling; in zebrafish embryos overexpression causes BMP-like ventralization and morpholino knockdown causes
-  dorsalization, placing glce in BMP-dependent dorsoventral axis formation. Homodimerization/protein-binding evidence is
-  retained as non-core structural information.
+  biosynthesis (heparosan-N-sulfate-glucuronate 5-epimerase, EC 5.1.3.17). It acts as a homodimer with two catalytic
+  sites per dimer and active-site tyrosines (Tyr468/Tyr528/Tyr546) required for catalysis. glceb is one of two zebrafish
+  paralogs (glce-A/glce-B) of the single human GLCE gene. Its epimerase activity tunes heparan sulfate fine structure
+  (IdoA content) that controls morphogen signaling; in zebrafish embryos overexpression causes BMP-like ventralization
+  and morpholino knockdown causes dorsalization, placing glce in BMP-dependent dorsoventral axis formation.
 existing_annotations:
 - term:
     id: GO:0015012

--- a/genes/DANRE/gmppb/gmppb-ai-review.yaml
+++ b/genes/DANRE/gmppb/gmppb-ai-review.yaml
@@ -5,10 +5,10 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: gmppb encodes the catalytic beta subunit of the GMPPA-GMPPB mannose-1-phosphate guanylyltransferase complex,
-  which produces GDP-mannose from mannose-1-phosphate and GTP. The core function is mannose-1-phosphate guanylyltransferase
-  activity in GDP-mannose biosynthesis and glycoprotein/glycan biosynthesis; muscle and neuron development annotations are
-  retained as non-core phenotypes of disrupted glycosylation.
+description: |-
+  gmppb encodes the catalytic beta subunit of the GMPPA-GMPPB mannose-1-phosphate guanylyltransferase complex, which
+  produces GDP-mannose from mannose-1-phosphate and GTP to supply activated mannose for protein glycosylation and glycan
+  biosynthesis. Its activity is required for normal muscle and neuron development, tissues that depend on proper glycosylation.
 existing_annotations:
 - term:
     id: GO:0009101

--- a/genes/DANRE/gtpbp3/gtpbp3-ai-review.yaml
+++ b/genes/DANRE/gtpbp3/gtpbp3-ai-review.yaml
@@ -17,26 +17,30 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: cytoplasm (GO:0005737) is not the appropriate direct annotation for gtpbp3.
+    summary: cytoplasm (GO:0005737) is too coarse for gtpbp3, whose specific mitochondrion location is annotated separately.
     action: REMOVE
-    reason: The synthesized evidence supports the specific core annotations reviewed separately; this broad or wrong-context
-      annotation should be retired rather than treated as a core function.
+    reason: gtpbp3 is a mitochondrial tRNA-modifying enzyme. Mitochondrion (GO:0005739) is part_of cytoplasm and is
+      annotated directly for this gene, so the transferred cytoplasm term is a true-but-uninformative parent and is
+      removed as redundant rather than retained.
     propagation_review:
-      root_cause: PROPAGATION_BAD
+      root_cause: TERM_SCOPING_PROBLEM
       failure_modes:
-      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      - GRANULARITY_MISMATCH
       source_entities:
       - source_id: PANTHER:PTN000182687
         source_label: GTPBP3/MnmE tRNA-modifying GTPase family node
-        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        source_status: SUPPORTS_TRANSFER
         comment: >-
-          gtpbp3 is a mitochondrial tRNA-modifying enzyme; the generic cytoplasm term does not
-          capture its mitochondrial compartment and is misleading for this target.
+          gtpbp3 is a mitochondrial tRNA-modifying enzyme. GO defines mitochondrion (GO:0005739)
+          as part_of cytoplasm, so the transferred cytoplasm term is technically true but too
+          coarse; it is removed as redundant with the specific mitochondrion annotation reviewed
+          separately.
       - source_id: SGD:S000004625
         source_label: yeast MSS1 mitochondrial GTPase donor
-        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        source_status: SUPPORTS_TRANSFER
         comment: >-
-          Donor cytoplasm annotation does not usefully transfer; the relevant compartment is mitochondrial.
+          Donor supports the localization; the specific mitochondrion term supersedes the
+          vague cytoplasm parent for this gene.
     supported_by:
     - reference_id: file:DANRE/gtpbp3/gtpbp3-uniprot.txt
       supporting_text: the 5-taurinomethyluridine (taum(5)U) modification at the 34th wobble position

--- a/genes/DANRE/gtpbp3/gtpbp3-ai-review.yaml
+++ b/genes/DANRE/gtpbp3/gtpbp3-ai-review.yaml
@@ -5,10 +5,11 @@ status: INITIALIZED
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: gtpbp3 encodes a mitochondrial GTPase subunit of the GTPBP3-MTO1 complex required for taurine-containing wobble
-  uridine modification of mitochondrial tRNAs. The core function is GTPase-supported mitochondrial tRNA wobble uridine modification;
-  reduced mitochondrial tRNA aminoacylation phenotypes are treated as downstream consequences rather than direct aminoacyl-tRNA
-  ligase activity.
+description: |-
+  gtpbp3 encodes a mitochondrial GTPase subunit of the GTPBP3-MTO1 complex required for taurine-containing wobble uridine
+  (tau-5-methyluridine) modification of mitochondrial tRNAs. Its GTPase activity drives this tRNA modification; loss impairs
+  mitochondrial translation, with reduced mitochondrial tRNA aminoacylation arising as a downstream consequence rather than
+  from a direct aminoacyl-tRNA ligase activity of the protein.
 existing_annotations:
 - term:
     id: GO:0005737
@@ -20,6 +21,22 @@ existing_annotations:
     action: REMOVE
     reason: The synthesized evidence supports the specific core annotations reviewed separately; this broad or wrong-context
       annotation should be retired rather than treated as a core function.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000182687
+        source_label: GTPBP3/MnmE tRNA-modifying GTPase family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: >-
+          gtpbp3 is a mitochondrial tRNA-modifying enzyme; the generic cytoplasm term does not
+          capture its mitochondrial compartment and is misleading for this target.
+      - source_id: SGD:S000004625
+        source_label: yeast MSS1 mitochondrial GTPase donor
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: >-
+          Donor cytoplasm annotation does not usefully transfer; the relevant compartment is mitochondrial.
     supported_by:
     - reference_id: file:DANRE/gtpbp3/gtpbp3-uniprot.txt
       supporting_text: the 5-taurinomethyluridine (taum(5)U) modification at the 34th wobble position

--- a/genes/DANRE/henmt1/henmt1-ai-review.yaml
+++ b/genes/DANRE/henmt1/henmt1-ai-review.yaml
@@ -5,7 +5,10 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: henmt1 encodes HEN1 small RNA 2-O-methyltransferase, which methylates the 3-prime ends of piRNAs to stabilize them. The core function is small RNA 2-O-ribose methyltransferase activity in primary piRNA processing/RNA methylation, with oocyte development retained as a biologically important non-core consequence.
+description: |-
+  henmt1 encodes HEN1 small RNA 2-O-methyltransferase, which adds a 2-O-methyl group to the 3-prime ends of piRNAs to
+  stabilize them during primary piRNA processing. This RNA methylation activity is important for germline piRNA function
+  and oocyte development.
 existing_annotations:
 - term:
     id: GO:0034587

--- a/genes/DANRE/hs6st2/hs6st2-ai-review.yaml
+++ b/genes/DANRE/hs6st2/hs6st2-ai-review.yaml
@@ -5,10 +5,11 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: hs6st2 encodes heparan-sulfate 6-O-sulfotransferase 2, a membrane-associated sulfotransferase that transfers
-  sulfate from PAPS to N-sulfoglucosamine residues in heparan sulfate. Its core function is heparan sulfate 6-sulfotransferase
-  activity in heparan sulfate proteoglycan biosynthesis; vascular branching, eye morphogenesis, and muscle phenotypes are
-  retained as non-core developmental consequences of altered heparan sulfate sulfation.
+description: |-
+  hs6st2 encodes heparan-sulfate 6-O-sulfotransferase 2, a Golgi membrane-associated sulfotransferase that transfers
+  sulfate from PAPS to the 6-O position of N-sulfoglucosamine residues in heparan sulfate during heparan sulfate
+  proteoglycan biosynthesis. Its sulfation of heparan sulfate shapes vascular branching, eye morphogenesis, and muscle
+  development.
 existing_annotations:
 - term:
     id: GO:0015012

--- a/genes/DANRE/ldhd/ldhd-ai-review.yaml
+++ b/genes/DANRE/ldhd/ldhd-ai-review.yaml
@@ -5,10 +5,9 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: ldhd encodes mitochondrial D-lactate dehydrogenase, an FAD-dependent oxidoreductase that acts on D-lactate and
-  related (2R)-2-hydroxycarboxylates to prevent toxic D-lactate accumulation. The core function is mitochondrial D-lactate
-  dehydrogenase/(2R)-2-hydroxycarboxylate dehydrogenase activity in lactate catabolism; generic catalytic activity and cofactor-binding
-  terms are treated as less informative.
+description: |-
+  ldhd encodes mitochondrial D-lactate dehydrogenase, an FAD-dependent oxidoreductase that oxidizes D-lactate and related
+  (2R)-2-hydroxycarboxylates in lactate catabolism, preventing toxic D-lactate accumulation.
 existing_annotations:
 - term:
     id: GO:1903457

--- a/genes/DANRE/mfsd2aa/mfsd2aa-ai-review.yaml
+++ b/genes/DANRE/mfsd2aa/mfsd2aa-ai-review.yaml
@@ -21,8 +21,9 @@ existing_annotations:
       (lysophospholipid carrying a long-chain unsaturated fatty acid such as DHA), not a free fatty acid, so the
       lysophospholipid:sodium symporter terms better capture the molecular function.
     action: MARK_AS_OVER_ANNOTATED
-    reason: The evidence is better explained by the gene core function or downstream phenotype; this term should not be treated
-      as a direct/core annotation.
+    reason: The MFSD2A family transports LPC-esterified fatty acids (a lysophospholipid carrying a long-chain unsaturated
+      fatty acid such as DHA), not free fatty acids, acting as a sodium-dependent lysophospholipid symporter/flippase. The
+      free fatty-acid transporter term misdescribes the molecular function, so it over-annotates mfsd2aa.
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
@@ -78,8 +79,9 @@ existing_annotations:
       Falcon deep research clarifies that mfsd2aa does not transport free fatty acids but rather LPC-esterified
       fatty acids (lysophospholipid transport), so the lysophospholipid transport terms are preferred.
     action: MARK_AS_OVER_ANNOTATED
-    reason: The evidence is better explained by the gene core function or downstream phenotype; this term should not be treated
-      as a direct/core annotation.
+    reason: mfsd2aa does not transport free fatty acids; it moves LPC-esterified fatty acids by lysophospholipid
+      translocation (acting as a lysolipid flippase). The free fatty acid transport process term therefore misdirects the
+      gene's role, so it over-annotates mfsd2aa; lysophospholipid transport terms are the accurate process annotation.
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:

--- a/genes/DANRE/mfsd2aa/mfsd2aa-ai-review.yaml
+++ b/genes/DANRE/mfsd2aa/mfsd2aa-ai-review.yaml
@@ -23,6 +23,26 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: The evidence is better explained by the gene core function or downstream phenotype; this term should not be treated
       as a direct/core annotation.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN002602210
+        source_label: PANTHER family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: MFSD2A family transports LPC-esterified fatty acids (e.g. DHA-LPC), not free fatty acids; the free
+          fatty-acid transporter framing misdescribes the target's molecular function.
+      - source_id: MGI:MGI:1923824
+        source_label: mouse Mfsd2a
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Donor characterized as a sodium-dependent lysophospholipid symporter/flippase, not a free fatty acid
+          transporter.
+      - source_id: UniProtKB:Q8NA29
+        source_label: human MFSD2A
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Physiological substrates are LPC species carrying long-chain fatty acids, better captured by
+          lysophospholipid transport terms.
     supported_by:
     - reference_id: file:DANRE/mfsd2aa/mfsd2aa-uniprot.txt
       supporting_text: Sodium-dependent lysophospholipid symporter
@@ -60,6 +80,25 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: The evidence is better explained by the gene core function or downstream phenotype; this term should not be treated
       as a direct/core annotation.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN002602210
+        source_label: PANTHER family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The family moves LPC-esterified fatty acids by lysophospholipid translocation, not free fatty acid
+          transport, so this process term misdirects the target's role.
+      - source_id: MGI:MGI:1923824
+        source_label: mouse Mfsd2a
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Donor is a lysophospholipid flippase; free fatty acid transport is not its assayed function.
+      - source_id: UniProtKB:Q8NA29
+        source_label: human MFSD2A
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Substrate is LPC-carried fatty acid; lysophospholipid transport terms are the accurate process
+          annotation for the target.
     supported_by:
     - reference_id: file:DANRE/mfsd2aa/mfsd2aa-uniprot.txt
       supporting_text: Sodium-dependent lysophospholipid symporter

--- a/genes/DANRE/naa50/naa50-ai-review.yaml
+++ b/genes/DANRE/naa50/naa50-ai-review.yaml
@@ -5,7 +5,10 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: naa50 encodes N-alpha-acetyltransferase 50/NAT13, an N-terminal methionine/protein amino-acid acetyltransferase associated with embryonic growth and cell proliferation. The core function is protein N-terminal acetylation; sister-chromatid cohesion annotations are retained as non-core transferred roles and the zebrafish somitogenesis annotation is left undecided because the accessible abstract supports embryonic growth/vascular defects rather than a specific somitogenesis mechanism.
+description: |-
+  naa50 encodes N-alpha-acetyltransferase 50/NAT13, an N-terminal acetyltransferase that acetylates protein N-termini
+  (with reported N-terminal methionine and internal lysine acetyltransferase activities) and supports embryonic growth
+  and cell proliferation. In other species NAA50 also contributes to sister-chromatid cohesion.
 existing_annotations:
 - term:
     id: GO:0031415

--- a/genes/DANRE/opa1/opa1-ai-review.yaml
+++ b/genes/DANRE/opa1/opa1-ai-review.yaml
@@ -38,6 +38,21 @@ existing_annotations:
     reason: GO:0031966 (mitochondrial membrane) is an is_a ancestor of GO:0005743 (mitochondrial inner membrane), confirmed
       via OLS getAncestors. GO:0005743 is independently ACCEPTED on this review and is the correct specific localization for
       OPA1 (inner mitochondrial membrane), so the broader parent term is an over-annotation.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN007514526
+        source_label: dynamin-family ancestral node
+        source_status: SUPPORTS_TRANSFER
+        comment: Node correctly places OPA1 at the mitochondrial membrane; the transfer
+          is sound but the term is a broad parent of the accepted inner-membrane location.
+      - source_id: UniProtKB:O60313
+        source_label: human OPA1
+        source_status: SUPPORTS_TRANSFER
+        comment: Ortholog localizes to the mitochondrial inner membrane; supports a
+          more specific CC than the generic parent.
     supported_by:
     - reference_id: file:DANRE/opa1/opa1-deep-research-falcon.md
       supporting_text: |-
@@ -54,6 +69,22 @@ existing_annotations:
       has no known role in peroxisome biology. This IBA term is most plausibly a mis-transfer from other dynamin-superfamily
       members (e.g., DRP1/DNM1L) that do mediate peroxisome fission. It conflicts with the gene's established mitochondrial
       fusion function on both organelle and process-direction grounds.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN008520527
+        source_label: dynamin-superfamily ancestral node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Peroxisome-fission activity belongs to fission-type dynamin paralogs
+          (DRP1/DNM1L), not to the OPA1 fusion clade; the transfer to opa1 is misplaced.
+      - source_id: UniProtKB:O00429
+        source_label: human DNM1L (DRP1)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: DNM1L legitimately mediates peroxisome fission, but it is a distinct
+          paralog; opa1 is a mitochondrial inner-membrane fusion GTPase.
     supported_by:
     - reference_id: file:DANRE/opa1/opa1-uniprot.txt
       supporting_text: mediating fusion of the mitochondrial inner membranes
@@ -88,6 +119,19 @@ existing_annotations:
       evidence for zebrafish opa1 exists in the UniProt entry, the cited PMID:23516612, or the falcon deep research report,
       and none refutes it either. The previously cited supporting_text described mitochondrial inner-membrane fusion, which
       is unrelated to microtubule binding, so it has been removed. Marked UNDECIDED pending experimental evidence.
+    propagation_review:
+      root_cause: UNRESOLVED
+      source_entities:
+      - source_id: PANTHER:PTN000170013
+        source_label: dynamin-superfamily ancestral node
+        source_status: UNRESOLVED
+        comment: Microtubule-binding function is characterized in classical dynamins
+          but not established for the OPA1 subfamily; cannot confirm or refute for zebrafish opa1.
+      - source_id: FB:FBgn0003392
+        source_label: Drosophila shibire (dynamin)
+        source_status: UNRESOLVED
+        comment: Donor is a classical endocytic dynamin whose microtubule association
+          may not transfer to the OPA1 fusion clade; no zebrafish-specific evidence.
 - term:
     id: GO:0003924
     label: GTPase activity

--- a/genes/DANRE/pcif1/pcif1-ai-review.yaml
+++ b/genes/DANRE/pcif1/pcif1-ai-review.yaml
@@ -5,10 +5,11 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: pcif1 encodes the cap-specific adenosine methyltransferase CAPAM, a nuclear enzyme that methylates the first
-  transcribed adenosine of capped mRNAs to form m6Am. The core function is mRNA cap-adjacent adenosine N6 methylation during
-  mRNA processing; RNA polymerase II CTD binding, SAM binding, and translational effects are treated as supporting or downstream
-  features.
+description: |-
+  pcif1 encodes the cap-specific adenosine methyltransferase CAPAM, a nuclear enzyme that uses SAM to methylate the N6
+  position of the first transcribed adenosine of capped mRNAs, forming m6Am during mRNA processing. It binds the RNA
+  polymerase II C-terminal domain, coupling the modification to transcription, and the resulting m6Am cap can influence
+  mRNA translation and stability.
 existing_annotations:
 - term:
     id: GO:0005634

--- a/genes/DANRE/rpe65a/rpe65a-ai-review.yaml
+++ b/genes/DANRE/rpe65a/rpe65a-ai-review.yaml
@@ -48,6 +48,26 @@ existing_annotations:
       The supported Rpe65a activity is retinyl-ester hydrolase/retinol isomerase activity for 11-cis-retinoid production,
       not beta-carotene cleavage. Falcon explicitly contrasts RPE65 with oxygenase carotenoid cleavage dioxygenases:
       RPE65's iron acts as a Lewis acid for O-alkyl cleavage and isomerization, not for dioxygen activation.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000830314
+        source_label: PANTHER family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The carotenoid-oxygenase family node includes true beta-carotene dioxygenases; rpe65a is the
+          isomerohydrolase paralog and does not perform dioxygen-activating cleavage.
+      - source_id: UniProtKB:Q9HAY6
+        source_label: carotenoid dioxygenase donor
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Donor has genuine beta-carotene 15,15'-dioxygenase activity, but this activity belongs to the
+          BCO1-type paralog, not the RPE65 isomerohydrolase.
+      - source_id: UniProtKB:Q9I993
+        source_label: family member donor
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Supports the family-level oxygenase assertion but not the isomerohydrolase target rpe65a.
     supported_by:
     - reference_id: file:DANRE/rpe65a/rpe65a-uniprot.txt
       supporting_text: Reaction=an all-trans-retinyl ester + H2O = 11-cis-retinol

--- a/genes/DANRE/slc15a2/slc15a2-ai-review.yaml
+++ b/genes/DANRE/slc15a2/slc15a2-ai-review.yaml
@@ -5,9 +5,9 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: slc15a2 encodes PEPT2, a proton-coupled high-affinity peptide transporter that imports dipeptides and tripeptides
-  at plasma/apical membranes. The core function is peptide:proton symport/dipeptide import; pathogen-response and NLR signaling
-  annotations are treated as non-core or over-annotated relative to transporter evidence.
+description: |-
+  slc15a2 encodes PEPT2, a proton-coupled high-affinity peptide transporter that imports dipeptides and tripeptides across
+  plasma/apical membranes by peptide:proton symport.
 alternative_products:
 - name: '1'
   id: B0S6T2-1

--- a/genes/DANRE/slc25a37/slc25a37-ai-review.yaml
+++ b/genes/DANRE/slc25a37/slc25a37-ai-review.yaml
@@ -5,10 +5,10 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: slc25a37 encodes mitoferrin-1, a mitochondrial inner-membrane ferrous iron transporter required for mitochondrial
-  iron uptake during erythroid heme biosynthesis. The core function is mitochondrial inner-membrane ferrous iron transport/iron
-  import into mitochondria; erythrocyte development, erythrocyte maturation, and embryonic hemopoiesis are retained as non-core
-  developmental consequences of impaired erythroid mitochondrial iron delivery.
+description: |-
+  slc25a37 encodes mitoferrin-1, a mitochondrial inner-membrane ferrous iron transporter that imports iron into
+  mitochondria to supply erythroid heme biosynthesis. Its iron-delivery activity is required for erythrocyte development,
+  erythrocyte maturation, and embryonic hematopoiesis.
 existing_annotations:
 - term:
     id: GO:0015093

--- a/genes/DANRE/slc39a14/slc39a14-ai-review.yaml
+++ b/genes/DANRE/slc39a14/slc39a14-ai-review.yaml
@@ -5,7 +5,10 @@ status: INITIALIZED
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: slc39a14 encodes ZIP14, a broad-scope divalent metal cation transporter that imports zinc, manganese, and non-transferrin-bound iron, likely as a metal:bicarbonate symporter, at plasma and endomembrane locations. Cadmium and signaling-response annotations are retained as non-core context relative to the core metal-cation uptake function.
+description: |-
+  slc39a14 encodes ZIP14, a broad-scope divalent metal cation transporter that imports zinc, manganese, and
+  non-transferrin-bound iron, likely as a metal:bicarbonate symporter, at plasma and endomembrane locations. It can also
+  transport cadmium.
 existing_annotations:
 - term:
     id: GO:0005385

--- a/genes/DANRE/slc5a12/slc5a12-ai-review.yaml
+++ b/genes/DANRE/slc5a12/slc5a12-ai-review.yaml
@@ -23,6 +23,25 @@ existing_annotations:
     proposed_replacement_terms:
     - id: GO:0140161
       label: monocarboxylate:sodium symporter activity
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN008448647
+        source_label: PANTHER family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The symporter class is correctly transferred; the annotation is simply too general and is better
+          stated as monocarboxylate:sodium symporter activity.
+      - source_id: UniProtKB:Q8N695
+        source_label: human SLC5A8 (SMCT1) donor
+        source_status: SUPPORTS_TRANSFER
+        comment: Donor establishes sodium-coupled monocarboxylate symport, supporting the more specific replacement
+          term.
+      - source_id: MGI:MGI:2384916
+        source_label: mouse Slc5a8/Slc5a12 donor
+        source_status: SUPPORTS_TRANSFER
+        comment: Consistent with sodium-coupled monocarboxylate transport for the target.
     supported_by:
     - reference_id: file:DANRE/slc5a12/slc5a12-uniprot.txt
       supporting_text: Acts as an electroneutral and low-affinity sodium (Na(+))-dependent sodium-coupled solute transporter
@@ -58,6 +77,21 @@ existing_annotations:
     proposed_replacement_terms:
     - id: GO:0035725
       label: sodium ion transmembrane transport
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000213468
+        source_label: PANTHER family node
+        source_status: SUPPORTS_TRANSFER
+        comment: Sodium movement is correctly transferred but the generic sodium ion transport term should be narrowed
+          to sodium ion transmembrane transport coupled to monocarboxylate symport.
+      - source_id: RGD:69267
+        source_label: rat sodium-coupled monocarboxylate transporter donor
+        source_status: SUPPORTS_TRANSFER
+        comment: Donor supports Na+-coupled transmembrane transport, consistent with the more specific replacement
+          term.
     supported_by:
     - reference_id: file:DANRE/slc5a12/slc5a12-uniprot.txt
       supporting_text: Reaction=(S)-lactate(out) + Na(+)(out) = (S)-lactate(in) + Na(+)(in)

--- a/genes/DANRE/slc5a12/slc5a12-ai-review.yaml
+++ b/genes/DANRE/slc5a12/slc5a12-ai-review.yaml
@@ -321,7 +321,7 @@ references:
   - statement: The zebrafish Slc5a12 paper characterizes SMCTn as an electroneutral sodium monocarboxylate transporter.
     supporting_text: Zebrafish Slc5a12 encodes an electroneutral sodium monocarboxylate transporter
   - statement: Monocarboxylates stimulate sodium uptake in the transporter assay.
-    supporting_text: increased [Na(+)](i) with addition of monocarboxylates
+    supporting_text: with addition of monocarboxylates (MC) such as lactate, pyruvate, nicotinate, and butyrate
 - id: file:DANRE/slc5a12/slc5a12-uniprot.txt
   title: UniProtKB entry Q7T384 for Danio rerio slc5a12
   findings:

--- a/genes/DANRE/slc5a12/slc5a12-ai-review.yaml
+++ b/genes/DANRE/slc5a12/slc5a12-ai-review.yaml
@@ -320,8 +320,8 @@ references:
   findings:
   - statement: The zebrafish Slc5a12 paper characterizes SMCTn as an electroneutral sodium monocarboxylate transporter.
     supporting_text: Zebrafish Slc5a12 encodes an electroneutral sodium monocarboxylate transporter
-  - statement: Monocarboxylates stimulate sodium uptake in the transporter assay.
-    supporting_text: with addition of monocarboxylates (MC) such as lactate, pyruvate, nicotinate, and butyrate
+  - statement: Zebrafish SMCTs, including the electroneutral zSMCTn (Slc5a12), are sodium-coupled monocarboxylate cotransporters.
+    supporting_text: We have identified and characterized two different sodium-coupled monocarboxylate cotransporters (SMCT) from zebrafish (Danio rerio), electrogenic (zSMCTe) and electroneutral (zSMCTn)
 - id: file:DANRE/slc5a12/slc5a12-uniprot.txt
   title: UniProtKB entry Q7T384 for Danio rerio slc5a12
   findings:

--- a/genes/DANRE/spns1/spns1-ai-review.yaml
+++ b/genes/DANRE/spns1/spns1-ai-review.yaml
@@ -55,6 +55,22 @@ existing_annotations:
       late-endosomal membrane protein (colocalizing with LAMP1 and Rab7), supporting the narrower term.
     action: MODIFY
     reason: The broad membrane location should be narrowed to lysosomal membrane.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000605425
+        source_label: Spinster/SPNS MFS transporter family node
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Membrane localization is real, but the generic membrane term is uninformative;
+          the supported compartment for Spns1 is the lysosomal membrane.
+      - source_id: UniProtKB:O96156
+        source_label: Drosophila Spinster donor
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Donor supports membrane residence; specific lysosomal membrane location is preferred.
     proposed_replacement_terms:
     - id: GO:0005765
       label: lysosomal membrane

--- a/genes/DANRE/sult1st2/sult1st2-ai-review.yaml
+++ b/genes/DANRE/sult1st2/sult1st2-ai-review.yaml
@@ -5,10 +5,10 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: sult1st2 encodes zebrafish cytosolic sulfotransferase 2, a SULT1-family enzyme that uses PAPS to sulfate endogenous
-  and xenobiotic substrates including hydroxychlorobiphenyls, thyroid hormones, estrone, and DOPA. The core review keeps aryl/estrone
-  sulfotransferase activity, sulfation, xenobiotic metabolism, estrogen metabolism, and cytoplasmic localization, while generic
-  sulfotransferase activity is modified to the more informative substrate-class terms.
+description: |-
+  sult1st2 encodes zebrafish cytosolic sulfotransferase 2, a SULT1-family enzyme that uses PAPS to sulfate endogenous and
+  xenobiotic substrates including hydroxychlorobiphenyls, thyroid hormones, estrone, and DOPA. It acts as an aryl/estrone
+  sulfotransferase in the cytoplasm, contributing to xenobiotic metabolism and estrogen metabolism.
 existing_annotations:
 - term:
     id: GO:0051923

--- a/genes/DANRE/tdp2/tdp2-ai-review.yaml
+++ b/genes/DANRE/tdp2/tdp2-ai-review.yaml
@@ -5,17 +5,17 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: tdp2 encodes tyrosyl-DNA phosphodiesterase 2, a metal-dependent DNA repair enzyme that hydrolyzes 5-prime phosphotyrosyl-DNA
-  adducts, including topoisomerase II-linked DNA breaks. The core function is nuclear/PML-body tyrosyl-DNA phosphodiesterase
-  activity in double-strand break repair; the Smad/Nodal, gastrulation, and left-right phenotypes (originally from
-  Esguerra et al. 2007 morpholino IMP evidence, PMID:18039968) are currently UNDECIDED pending re-evaluation, as Anticevic
-  et al. 2024 (PMID:39228401) identified design flaws in those morpholinos and concluded the phenotypes are likely
-  non-specific. This UniProt entry (Q5XJA0) corresponds to the zebrafish tdp2b paralog (ZFIN ZDB-GENE-050816-1); zebrafish
-  has two orthologs (tdp2a/tdp2b), and in-vivo morpholino studies establish tdp2b as the dominant embryonic ortholog whose
+description: |-
+  tdp2 encodes tyrosyl-DNA phosphodiesterase 2, a metal-dependent nuclear/PML-body DNA repair enzyme that hydrolyzes
+  5-prime phosphotyrosyl-DNA adducts, including topoisomerase II-linked DNA breaks, acting in double-strand break repair.
+  This UniProt entry (Q5XJA0) corresponds to the zebrafish tdp2b paralog (ZFIN ZDB-GENE-050816-1); zebrafish has two
+  orthologs (tdp2a/tdp2b), and in-vivo morpholino studies establish tdp2b as the dominant embryonic ortholog whose
   silencing causes loss of Tdp2 activity and accumulation of DNA-protein crosslinks (DPCs) and double-strand breaks, with
-  rescue dependent on catalytic activity (a D285A active-site mutant fails to rescue), directly supporting that the
-  phosphodiesterase activity is the protective function in vivo and that TOP2-DPC processing is channeled toward error-free
-  non-homologous end joining (NHEJ).
+  rescue dependent on catalytic activity (a D285A active-site mutant fails to rescue), indicating the phosphodiesterase
+  activity is the protective function in vivo and that TOP2-DPC processing is channeled toward error-free non-homologous
+  end joining (NHEJ). An earlier morpholino study (Esguerra et al. 2007) additionally proposed roles in Smad3/Nodal
+  signaling, gastrulation, and left-right axis determination; a later study (Anticevic et al. 2024) found those morpholinos
+  to be flawed and their phenotypes likely non-specific, leaving those developmental roles unresolved.
 existing_annotations:
 - term:
     id: GO:0005737
@@ -26,6 +26,22 @@ existing_annotations:
     summary: cytoplasm (GO:0005737) is less specific than the supported nuclear/PML-body localization.
     action: MODIFY
     reason: UniProt emphasizes nucleus/PML body for Tdp2 localization.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN001039821
+        source_label: TDP2 tyrosyl-DNA phosphodiesterase family node
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          The cytoplasm localization is real for TDP2, but the generic term is uninformative;
+          UniProt emphasizes the nuclear/PML-body localization for this gene.
+      - source_id: UniProtKB:O95551
+        source_label: human TDP2 donor
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Donor supports the localization; the more specific nucleus/PML-body terms are preferred.
     proposed_replacement_terms:
     - id: GO:0005634
       label: nucleus

--- a/genes/DANRE/tdp2/tdp2-ai-review.yaml
+++ b/genes/DANRE/tdp2/tdp2-ai-review.yaml
@@ -23,28 +23,28 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: cytoplasm (GO:0005737) is less specific than the supported nuclear/PML-body localization.
+    summary: cytoplasm (GO:0005737) is a different compartment from the nuclear/PML-body localization where Tdp2 functions.
     action: MODIFY
-    reason: UniProt emphasizes nucleus/PML body for Tdp2 localization.
+    reason: Tdp2 acts in the nucleus/PML body. Nucleus (GO:0005634) is not part_of cytoplasm, so the transferred cytoplasm
+      term is corrected to the functionally relevant nuclear/PML-body compartment rather than narrowed within cytoplasm.
     propagation_review:
-      root_cause: TERM_SCOPING_PROBLEM
+      root_cause: PROPAGATION_BAD
       failure_modes:
       - COMPARTMENT_OR_COMPLEX_MISMATCH
       source_entities:
       - source_id: PANTHER:PTN001039821
         source_label: TDP2 tyrosyl-DNA phosphodiesterase family node
-        source_status: SUPPORTS_TRANSFER
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
         comment: >-
-          TDP2's functionally relevant localization is the nucleus/PML body. GO defines nucleus
-          (GO:0005634) as distinct from cytoplasm (not a sub-compartment), so replacing the
-          transferred cytoplasm term is a compartment refinement to the correct location, not a
-          granularity narrowing of cytoplasm.
+          GO defines nucleus (GO:0005634) as distinct from cytoplasm (not a sub-compartment), so the
+          transferred cytoplasm compartment does not apply to this nuclear/PML-body enzyme; it is
+          replaced by the correct compartment rather than narrowed within cytoplasm.
       - source_id: UniProtKB:O95551
         source_label: human TDP2 donor
-        source_status: SUPPORTS_TRANSFER
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
         comment: >-
-          Donor supports localization of the family; the nucleus/PML-body compartment is the
-          functionally relevant one for this gene.
+          The donor annotation is sound at source, but the cytoplasm compartment does not transfer to
+          this gene, whose functionally relevant localization is the nucleus/PML body.
     proposed_replacement_terms:
     - id: GO:0005634
       label: nucleus

--- a/genes/DANRE/tdp2/tdp2-ai-review.yaml
+++ b/genes/DANRE/tdp2/tdp2-ai-review.yaml
@@ -29,19 +29,22 @@ existing_annotations:
     propagation_review:
       root_cause: TERM_SCOPING_PROBLEM
       failure_modes:
-      - GRANULARITY_MISMATCH
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
       source_entities:
       - source_id: PANTHER:PTN001039821
         source_label: TDP2 tyrosyl-DNA phosphodiesterase family node
         source_status: SUPPORTS_TRANSFER
         comment: >-
-          The cytoplasm localization is real for TDP2, but the generic term is uninformative;
-          UniProt emphasizes the nuclear/PML-body localization for this gene.
+          TDP2's functionally relevant localization is the nucleus/PML body. GO defines nucleus
+          (GO:0005634) as distinct from cytoplasm (not a sub-compartment), so replacing the
+          transferred cytoplasm term is a compartment refinement to the correct location, not a
+          granularity narrowing of cytoplasm.
       - source_id: UniProtKB:O95551
         source_label: human TDP2 donor
         source_status: SUPPORTS_TRANSFER
         comment: >-
-          Donor supports the localization; the more specific nucleus/PML-body terms are preferred.
+          Donor supports localization of the family; the nucleus/PML-body compartment is the
+          functionally relevant one for this gene.
     proposed_replacement_terms:
     - id: GO:0005634
       label: nucleus

--- a/genes/DANRE/tomt/tomt-ai-review.yaml
+++ b/genes/DANRE/tomt/tomt-ai-review.yaml
@@ -5,13 +5,12 @@ status: INITIALIZED
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: tomt encodes transmembrane O-methyltransferase (TOMT/mercury), an ER/Golgi/basolateral membrane protein required
-  in zebrafish hair cells for TMC1/2 trafficking into stereocilia and mechanotransduction-complex assembly. Its catechol O-methyltransferase-like
-  activity is retained as by-similarity biochemical context, but the core zebrafish role is hair-cell mechanotransduction
-  machinery organization independent of methyltransferase catalysis. Falcon deep research and UniProt converge on a Golgi/ER
-  secretory-pathway chaperone/escort that physically interacts with TMC1 and is selectively required for Tmc1/Tmc2 delivery
-  to the hair bundle; the physiological methyl-acceptor substrate is unknown and a simple catecholamine-metabolism role is
-  argued against.
+description: |-
+  tomt encodes transmembrane O-methyltransferase (TOMT/mercury), an ER/Golgi/basolateral membrane protein required in
+  zebrafish hair cells for TMC1/2 trafficking into stereocilia and assembly of the mechanotransduction complex. It acts as
+  a Golgi/ER secretory-pathway chaperone/escort that physically interacts with TMC1 and is selectively required for Tmc1/Tmc2
+  delivery to the hair bundle. It carries a catechol O-methyltransferase-like domain, but its physiological methyl-acceptor
+  substrate is unknown and its hair-cell role appears independent of methyltransferase catalysis.
 existing_annotations:
 - term:
     id: GO:0032502
@@ -25,6 +24,22 @@ existing_annotations:
       The evidence is better explained by the gene core function (selective Tmc trafficking for mechanotransduction) than
       by a general developmental role. Falcon shows the tomt loss-of-function phenotype is a specific MET defect, with other
       hair-cell properties retained, rather than a broad developmental failure.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000053580
+        source_label: COMT/TOMT-family ancestral node
+        source_status: SUPPORTS_TRANSFER
+        comment: Transfer is not wrong per se, but 'developmental process' is an
+          uninformative high-level BP; the specific role is Tmc trafficking for
+          mechanotransduction.
+      - source_id: ZFIN:ZDB-GENE-160629-1
+        source_label: zebrafish tomt/family donor
+        source_status: SUPPORTS_TRANSFER
+        comment: Donor supports a developmental context but at too coarse a granularity
+          to be informative for this gene.
     supported_by:
     - reference_id: file:DANRE/tomt/tomt-uniprot.txt
       supporting_text: Required for transportation of TMC1 and TMC2 proteins into the mechanically sensitive stereocilia
@@ -69,6 +84,22 @@ existing_annotations:
       This is a phylogenetic/by-similarity transfer from COMT-like enzymes. Falcon shows several results argue against a simple
       catecholamine-metabolism function for Tomt (COMT cannot rescue tomt mutants, only modest in vitro activity, active-site
       H183A still rescues), and no dopamine-metabolism role is demonstrated in zebrafish hair cells.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000053580
+        source_label: COMT/TOMT-family ancestral node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Dopamine-metabolism activity derives from COMT-like members; tomt has
+          functionally diverged toward Tmc trafficking and COMT cannot rescue tomt mutants.
+      - source_id: MGI:MGI:88470
+        source_label: mouse Comt
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Comt genuinely performs dopamine metabolism, but it is a distinct paralog;
+          tomt's physiological role is hair-cell mechanotransduction, not catecholamine metabolism.
     supported_by:
     - reference_id: file:DANRE/tomt/tomt-uniprot.txt
       supporting_text: Required for transportation of TMC1 and TMC2 proteins into the mechanically sensitive stereocilia
@@ -90,6 +121,22 @@ existing_annotations:
       This is a by-similarity transfer from COMT-like enzymes. Falcon shows the data argue against a simple catecholamine-metabolism
       function, including that COMT cannot rescue tomt mutants and an active-site histidine mutation still supports rescue; no
       catecholamine catabolism role is demonstrated for zebrafish Tomt.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000053580
+        source_label: COMT/TOMT-family ancestral node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Catecholamine catabolism derives from COMT-like members; tomt has
+          functionally diverged toward Tmc trafficking and COMT cannot rescue tomt mutants.
+      - source_id: UniProtKB:P21964
+        source_label: human COMT
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: COMT genuinely catabolizes catecholamines, but it is a distinct paralog;
+          tomt's role is hair-cell mechanotransduction, not catecholamine catabolism.
     supported_by:
     - reference_id: file:DANRE/tomt/tomt-uniprot.txt
       supporting_text: Required for transportation of TMC1 and TMC2 proteins into the mechanically sensitive stereocilia

--- a/genes/DANRE/tpp1/tpp1-ai-review.yaml
+++ b/genes/DANRE/tpp1/tpp1-ai-review.yaml
@@ -5,9 +5,10 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: tpp1 encodes lysosomal tripeptidyl-peptidase 1, a serine peptidase that releases N-terminal tripeptides during
-  lysosomal proteolysis. The core function is lysosomal tripeptidyl-peptidase/proteolysis activity; neurodevelopmental, neurodegeneration,
-  and locomotor phenotypes are retained as non-core consequences of Tpp1 deficiency.
+description: |-
+  tpp1 encodes lysosomal tripeptidyl-peptidase 1, a serine peptidase that sequentially removes N-terminal tripeptides
+  from polypeptides during lysosomal proteolysis. Its activity supports normal neurodevelopment and locomotor function,
+  and its deficiency causes neurodegeneration.
 existing_annotations:
 - term:
     id: GO:0006508

--- a/genes/DANRE/trpm7/trpm7-ai-review.yaml
+++ b/genes/DANRE/trpm7/trpm7-ai-review.yaml
@@ -26,6 +26,21 @@ existing_annotations:
     reason: While TRPM7 does have protein kinase activity, the more specific term
       GO:0004674 (protein serine/threonine kinase activity) better represents the
       actual molecular function of the alpha-kinase domain.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN002674401
+        source_label: TRPM channel-kinase ancestral node
+        source_status: SUPPORTS_TRANSFER
+        comment: Transfer is sound but 'protein kinase activity' is too generic; TRPM7's
+          C-terminal alpha-kinase is a serine/threonine kinase (GO:0004674).
+      - source_id: UniProtKB:Q96QT4
+        source_label: human TRPM7
+        source_status: SUPPORTS_TRANSFER
+        comment: Ortholog's alpha-kinase domain has serine/threonine kinase activity,
+          supporting the more specific replacement term.
     proposed_replacement_terms:
     - id: GO:0004674
       label: protein serine/threonine kinase activity

--- a/genes/DANRE/ucp2/ucp2-ai-review.yaml
+++ b/genes/DANRE/ucp2/ucp2-ai-review.yaml
@@ -5,7 +5,10 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: ucp2 encodes a mitochondrial inner-membrane carrier related to uncoupling proteins. The zebrafish protein is best reviewed as a mitochondrial transmembrane transporter/proton leak protein, with cold response, thermogenesis, and fatty-acid transport annotations treated as supported but peripheral or overly broad relative to the core mitochondrial carrier role.
+description: |-
+  ucp2 encodes a mitochondrial inner-membrane carrier of the uncoupling-protein family that mediates regulated proton leak
+  and metabolite transport across the inner mitochondrial membrane. It has been linked to cold response, thermogenesis, and
+  fatty-acid transport.
 existing_annotations:
 - term:
     id: GO:0015078
@@ -19,6 +22,24 @@ existing_annotations:
     proposed_replacement_terms:
     - id: GO:0017077
       label: oxidative phosphorylation uncoupler activity
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000642156
+        source_label: PANTHER family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The proton-transport function is correctly transferred; the generic proton transporter term is
+          under-informative and is better stated as oxidative phosphorylation uncoupler activity.
+      - source_id: UniProtKB:P55851
+        source_label: human UCP2
+        source_status: SUPPORTS_TRANSFER
+        comment: UCP2 proton leak uncouples oxidative phosphorylation, supporting the more specific uncoupler term.
+      - source_id: UniProtKB:P25874
+        source_label: human UCP1
+        source_status: SUPPORTS_TRANSFER
+        comment: Family uncoupler activity supports the proton-leak molecular function transferred to the target.
     supported_by:
     - reference_id: file:DANRE/ucp2/ucp2-uniprot.txt
       supporting_text: UCP are mitochondrial transporter proteins that create proton
@@ -77,6 +98,21 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: |-
       Falcon synthesis states 'UCP2 differs from UCP1 (non-thermogenic role)' and notes that in zebrafish it is UCP1 (not UCP2) whose cold/thermogenic involvement is distinguished; UCP2 is better described as a mitochondrial bioenergetic/redox regulator and metabolite carrier than as a thermogenic uncoupler. The term is not flatly wrong for the family but over-annotates this specific protein.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN001183920
+        source_label: PANTHER family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Adaptive thermogenesis reflects the thermogenic UCP1 branch; UCP2 has functionally diverged to a
+          non-thermogenic bioenergetic/redox role.
+      - source_id: MGI:MGI:98894
+        source_label: mouse Ucp1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Thermogenic donor UCP1 supports the term at the source, but zebrafish ucp2 is non-thermogenic, so the
+          transfer over-annotates the target.
     supported_by:
     - reference_id: file:DANRE/ucp2/ucp2-uniprot.txt
       supporting_text: UCP are mitochondrial transporter proteins that create proton

--- a/genes/DANRE/ufsp2/ufsp2-ai-review.yaml
+++ b/genes/DANRE/ufsp2/ufsp2-ai-review.yaml
@@ -273,6 +273,22 @@ existing_annotations:
       explicitly covers removal of ubiquitin-like proteins (a sibling of protein
       deneddylation and protein desumoylation). A dedicated protein deUFMylation term
       is requested in proposed_new_terms.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN008489070
+        source_label: UFSP UFM1-specific protease ancestral node
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          The node correctly transfers proteolytic activity to UFSP2, so the propagation is sound.
+          The problem is granularity: GO:0006508 (proteolysis) is far broader than the specific
+          UFM1 deconjugation (deUFMylation) that UFSP2 catalyzes.
+      - source_id: UniProtKB:Q9NUQ7
+        source_label: Human UFSP2
+        source_status: SUPPORTS_TRANSFER
+        comment: Experimentally characterized ortholog donor establishing UFM1-specific isopeptidase activity.
     proposed_replacement_terms:
     - id: GO:0070646
       label: protein modification by small protein removal

--- a/genes/DANRE/uox/uox-ai-review.yaml
+++ b/genes/DANRE/uox/uox-ai-review.yaml
@@ -5,10 +5,9 @@ status: DRAFT
 taxon:
   id: NCBITaxon:7955
   label: Danio rerio
-description: uox encodes zebrafish urate oxidase/uricase, a peroxisomal enzyme that catalyzes the first oxidative step of
-  urate degradation, converting urate to 5-hydroxyisourate. The core function is urate oxidase activity in urate catabolism;
-  broader purine-catabolism terms are treated as less specific, and homotetramerization is retained only as non-core structural
-  information.
+description: |-
+  uox encodes zebrafish urate oxidase/uricase, a peroxisomal enzyme that catalyzes the first oxidative step of purine/urate
+  degradation, converting urate to 5-hydroxyisourate. It functions as a homotetramer.
 existing_annotations:
 - term:
     id: GO:0019628
@@ -41,6 +40,22 @@ existing_annotations:
     action: MODIFY
     reason: The annotation should be narrowed from broad purine nucleobase catabolism to the specific urate degradation reaction
       catalyzed by Uox.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000044668
+        source_label: urate oxidase (Uox) ancestral node
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          The node correctly transfers urate-degradation involvement, so the propagation is sound.
+          The problem is granularity: GO:0006145 (purine nucleobase catabolic process) is broader
+          than the specific urate catabolic process (GO:0019628) that Uox catalyzes.
+      - source_id: UniProtKB:P33282
+        source_label: Urate oxidase ortholog donor
+        source_status: SUPPORTS_TRANSFER
+        comment: Characterized urate oxidase ortholog donor supporting the urate-degradation step.
     proposed_replacement_terms:
     - id: GO:0019628
       label: urate catabolic process


### PR DESCRIPTION
## Summary

- Re-reviewed all 58 existing *Danio rerio* (DANRE) gene reviews. All files validate with **zero errors**; best-practice warnings dropped from **33 to 1** (the remaining `dph2` case is an intentional, correct qualifier-based ACCEPT/OVER_ANNOTATED split on GO:0090560, not a defect).
- Rewrote 23 top-level `description` fields to remove curation/workflow commentary ("core function is", "retained as non-core", "treated as over-annotated", "UNDECIDED pending", "the core review") so they read as project-independent biological summaries.
- Added structured `propagation_review` metadata (root_cause, failure_modes, source_entities) to 28 IBA annotations across 18 genes that carried a non-ACCEPT action; every source-entity ID was copied verbatim from each gene's GOA WITH/FROM column and verified against the GOA files (no fabricated IDs). Added 4 grounding `action: NEW` annotations (bdh2 ×2 — cellular detoxification, oxidoreductase activity for the 2,5-DHBA siderophore step; dnajc6/A0A8M9QG43 ×2 — Hsp70 protein binding, clathrin coat disassembly) with verbatim supporting quotes, and confirmed the UNDECIDED calls (asah2, naa50, opa1, tdp2, trpm7) remain correct (no full text available).

Closes #

## Validation

`ai-gene-review validate genes/DANRE/*/*-ai-review.yaml --terms` — 58 files, 0 errors, 1 best-practice warning:

```
Total errors: 0
Total warnings: 1
dph2: Inconsistent review actions for term GO:0090560 (2-(3-amino-3-carboxypropyl)histidine synthase activity): ACCEPT (ISS); MARK_AS_OVER_ANNOTATED (IEA)
```

The single remaining warning is intentional: the IEA copy implies the `enables` qualifier (over-annotation, since Dph2 only contributes to the Dph1–Dph2 complex activity) while the ISS copy correctly uses `contributes_to`; the two actions are deliberately different and biologically correct.

## Test plan

- [x] `ai-gene-review validate genes/DANRE/*/*-ai-review.yaml --terms` passes (0 errors)
- [x] All `propagation_review` source IDs verified present in the corresponding GOA WITH/FROM columns
- [x] All new `supporting_text` quotes are verbatim substrings of their cited references
- [x] No derived files committed (only `*-ai-review.yaml` and the append-only `cache/go/terms.csv`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)