### PR TITLE
Complete yeast SSB1 annotation review

### DIFF
--- a/genes/yeast/SSB1/SSB1-ai-review.html
+++ b/genes/yeast/SSB1/SSB1-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -900,6 +900,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002321897</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The PAINT node contains SSB1 among its experimentally grounded descendants and correctly transfers a broad cytoplasmic localization; cytosol is more informative for this target.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
 
                     </td>
@@ -951,6 +980,35 @@
                             <strong>Reason:</strong> ATP hydrolysis powers the Hsp70 substrate-binding cycle and is directly supported by PMID:9860955.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">SSB1 is among the experimentally grounded descendants used for this conserved Hsp70-family ATPase inference.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1025,9 +1083,9 @@
                                 <strong>Sources checked:</strong>
 
                                 <div class="propagation-row">
-                                    <span class="propagation-source-id">GO_REF:0000033</span>
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
 
-                                    &middot; PANTHER phylogenetic annotation
+                                    &middot; PAINT Hsp70 family node
 
 
                                     <span class="badge">SUPPORTS TRANSFER</span>
@@ -1124,6 +1182,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002500132</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The family inference is compatible with Ssb1 nuclear shuttling and RAC-Ssb participation in nuclear ribosome biogenesis, but this is not its predominant site of action.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
 
                     </td>
@@ -1175,6 +1262,35 @@
                             <strong>Reason:</strong> Interactions with RAC and the Hsp110 nucleotide-exchange factor Sse1 are real, but this binding term is ancillary to Ssb1&#39;s direct folding-chaperone activity.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Conserved Hsp70-network interactions support the transfer, while the binding term remains ancillary to Ssb1&#39;s ATP-dependent chaperone activity.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1230,6 +1346,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002500132</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The ancestral localization inference agrees with direct localization and Ssb1&#39;s experimentally established function on cytosolic translating ribosomes.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1278,10 +1423,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P11484" data-a="GO:0042026" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0042026" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1289,16 +1434,81 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> General protein refolding is plausible for an Hsp70, but Ssb1&#39;s defining role is folding newly synthesized chains.
+                            <strong>Summary:</strong> Ssb1 promotes folding of newly synthesized nascent chains, not a demonstrated general refolding program for pre-existing denatured proteins.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The strongest Ssb-specific evidence supports de novo cotranslational folding rather than refolding of pre-existing denatured proteins.
+                            <strong>Reason:</strong> The family-level refolding claim is unsupported for the specialized Ssb subfamily. GO:0051083 is already directly annotated by IDA from PMID:9670014, so this MODIFY effectively removes the propagated general-refolding claim in favor of the independently established de novo cotranslational process.
                         </div>
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">General refolding is defensible elsewhere in the Hsp70 family, but the ribosome-specialized Ssb subfamily is directly established as a de novo cotranslational chaperone and lacks target-specific evidence for refolding pre-existing denatured clients.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051083" target="_blank" class="term-link">
+                                    &#39;de novo&#39; cotranslational protein folding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" target="_blank" class="term-link">
+                                        PMID:9670014
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These interactions allow Ssb to function as a chaperone on the ribosome, preventing the misfolding of newly synthesized proteins.</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -1543,10 +1753,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P11484" data-a="GO:0006450" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0006450" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1559,7 +1769,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:15456889 and PMID:31114879 experimentally support a genuine role in translational fidelity.
+                            <strong>Reason:</strong> PMID:15456889 and PMID:31114879 experimentally support a genuine role in translational fidelity, but this phenotype is downstream of the core cotranslational chaperone cycle.
                         </div>
 
 
@@ -1596,10 +1806,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P11484" data-a="GO:0006452" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0006452" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1612,7 +1822,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:16607023 directly measured inhibition of -1, but not +1, programmed frameshifting in ssb1 ssb2 mutants.
+                            <strong>Reason:</strong> PMID:16607023 directly measured inhibition of -1, but not +1, programmed frameshifting in ssb1 ssb2 mutants; this is a genuine secondary translation phenotype rather than Ssb1&#39;s core molecular role.
                         </div>
 
 
@@ -2360,10 +2570,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P11484" data-a="GO:0005886" data-r="PMID:16622836" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0005886" data-r="PMID:16622836" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2371,16 +2581,34 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Plasma-membrane fraction detection is inconsistent with direct evidence that Ssb1 is a soluble cytosolic Hsp70.
+                            <strong>Summary:</strong> A bulk plasma-membrane-fraction hit is weak localization evidence for the abundant soluble cytosolic Hsp70 Ssb1.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:16622836 is a high-throughput membrane-fraction proteome survey and provides no specific membrane residence or membrane function for abundant cytosolic Ssb1.
+                            <strong>Reason:</strong> PMID:16622836 is a high-throughput survey of a stripped plasma-membrane fraction, whereas direct studies place Ssb1 in the cytosol and on cytosolic translating ribosomes. The fraction-detection annotation is retained as an experimental observation but should not be interpreted as evidence that the plasma membrane is a functional Ssb1 compartment.
                         </div>
 
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16622836" target="_blank" class="term-link">
+                                        PMID:16622836
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Proteins from a stripped plasma membrane fraction were solubilized with the neutral and non-denaturing detergent, the n-dodecyl beta-D-maltoside.</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -2424,10 +2652,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P11484" data-a="GO:0006452" data-r="PMID:16607023" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0006452" data-r="PMID:16607023" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2440,7 +2668,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:16607023 directly measured a selective effect on -1 PRF, with no effect on +1 PRF.
+                            <strong>Reason:</strong> PMID:16607023 directly measured a selective effect on -1 PRF, with no effect on +1 PRF; this is a secondary translational consequence of losing the ribosome-associated chaperone system.
                         </div>
 
 
@@ -2552,10 +2780,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P11484" data-a="GO:0002181" data-r="PMID:1394434" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0002181" data-r="PMID:1394434" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2568,7 +2796,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:1394434 shows slow growth, fewer translating ribosomes, and sensitivity to translation inhibitors in ssb1 ssb2 mutants.
+                            <strong>Reason:</strong> PMID:1394434 shows slow growth, fewer translating ribosomes, and sensitivity to translation inhibitors in ssb1 ssb2 mutants. Cytoplasmic translation is the functional context for Ssb1&#39;s core nascent-chain chaperone activity, not a separate primary activity.
                         </div>
 
 
@@ -2616,10 +2844,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P11484" data-a="GO:0002181" data-r="PMID:1394434" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0002181" data-r="PMID:1394434" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2632,7 +2860,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:1394434 directly links Ssb1/2 to translating ribosomes and nascent-polypeptide handling.
+                            <strong>Reason:</strong> PMID:1394434 directly links Ssb1/2 to translating ribosomes and nascent-polypeptide handling, supporting translation as the context for the core folding mechanism rather than a distinct core process.
                         </div>
 
 
@@ -2872,10 +3100,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P11484" data-a="GO:0006415" data-r="PMID:17483428" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0006415" data-r="PMID:17483428" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2888,7 +3116,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:17483428 identified SSB1 as one of the strongest antisuppressors in a chromosomal stop-codon readthrough screen.
+                            <strong>Reason:</strong> PMID:17483428 identified SSB1 as one of the strongest antisuppressors in a chromosomal stop-codon readthrough screen, a genuine but downstream role relative to cotranslational folding.
                         </div>
 
 
@@ -2954,10 +3182,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P11484" data-a="GO:0006450" data-r="PMID:15456889" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0006450" data-r="PMID:15456889" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2970,7 +3198,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:15456889 directly measured impaired fidelity in vivo and in vitro; PMID:31114879 later established complementary nascent-chain and ribosome-biogenesis mechanisms.
+                            <strong>Reason:</strong> PMID:15456889 directly measured impaired fidelity in vivo and in vitro; PMID:31114879 later established complementary nascent-chain and ribosome-biogenesis mechanisms. This is a supported secondary consequence of RAC-Ssb function.
                         </div>
 
 
@@ -3108,6 +3336,183 @@
                     </td>
                 </tr>
 
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043022" target="_blank" class="term-link">
+                                    GO:0043022
+                                </a>
+                            </span>
+                            <span class="term-label">ribosome binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9670014
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The molecular chaperone Ssb from Saccharomyces cerevisiae is...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0043022" data-r="PMID:9670014" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation for Ssb1&#39;s directly characterized physical association with translating ribosomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PMID:9670014 used puromycin release, salt resistance, and nascent-chain cross-linking to characterize Ssb-ribosome interaction; the current GOA set lacks a ribosome-binding molecular-function annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" target="_blank" class="term-link">
+                                        PMID:9670014
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We propose that Ssb is a core component of the translating ribosome which interacts with both the nascent polypeptide chain and the ribosome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022626" target="_blank" class="term-link">
+                                    GO:0022626
+                                </a>
+                            </span>
+                            <span class="term-label">cytosolic ribosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9670014
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The molecular chaperone Ssb from Saccharomyces cerevisiae is...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P11484" data-a="GO:0022626" data-r="PMID:9670014" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation for the cytosolic translating ribosome where Ssb1 performs its cotranslational chaperone cycle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PMID:9670014 directly demonstrates stable Ssb association with translating ribosomes, and PMID:1394434 identifies the SSB proteins as cytosolic Hsp70s associated with translating ribosomes.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" target="_blank" class="term-link">
+                                        PMID:9670014
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The Ssbs of Saccharomyces cerevisiae are an abundant type of Hsp70 found associated with translating ribosomes.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1394434" target="_blank" class="term-link">
+                                        PMID:1394434
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We suggest that cytosolic hsp70 aids in the passage of the nascent polypeptide chain through the ribosome in a manner analogous to the role played by organelle-localized hsp70 in the transport of proteins across membranes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </div>
@@ -3163,6 +3568,12 @@
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022626" target="_blank" class="term-link">
+                                cytosolic ribosome
                             </a>
                         </span>
 
@@ -4758,6 +5169,47 @@
   fetched/collapsed review has 36, and it recommends obsolete GO:0051082. Those<br />
   claims were not adopted. The curated replacement remains GO:0140662.</li>
 </ul>
+<h2 id="completion-audit-2026-08-28">Completion audit (2026-08-28)</h2>
+<ul>
+<li>Row-by-row reconciliation found 39 fetched GOA rows representing 36 distinct<br />
+  review assertions. The three extra rows are duplicate assertion keys that<br />
+  differ only in <code>WITH/FROM</code>: three PMID:16429126 protein-binding rows collapse<br />
+  to one review entry, and two PMID:1394434 cytoplasmic-translation IPI rows<br />
+  collapse to one. No GO term/evidence/reference/qualifier assertion is absent.</li>
+<li>All seven IBA rows were re-read against their GOA <code>WITH/FROM</code> fields and PAINT<br />
+  nodes. The cytoplasm, ATPase, generic chaperone, nucleus, heat-shock-protein<br />
+  binding, and cytosol transfers are biologically defensible; broad or secondary<br />
+  assertions are distinguished from the core ATP-dependent cotranslational<br />
+  chaperone function. The broad protein-refolding IBA was narrowed to directly<br />
+  demonstrated de novo cotranslational folding rather than being accepted as a<br />
+  generic refolding program.</li>
+<li>The plasma-membrane HDA was initially changed from <code>REMOVE</code> to <code>UNDECIDED</code><br />
+  because PMID:16622836 is abstract-only in the cache and describes a stripped<br />
+  plasma-membrane fraction, while direct evidence places Ssb1 in the cytosol.</li>
+<li>Translation, frameshifting, termination, and fidelity phenotypes were retained<br />
+  as genuine but non-core. This brings row actions into agreement with the core<br />
+  function synthesis, which identifies ATP-dependent nascent-chain folding as<br />
+  primary and the translation phenotypes as downstream/contextual.</li>
+</ul>
+<h2 id="pr-review-follow-up-2026-08-28">PR review follow-up (2026-08-28)</h2>
+<ul>
+<li>The missing ribosome-associated annotations are now explicit <code>action: NEW</code><br />
+  rows: GO:0043022 <code>ribosome binding</code> and GO:0022626 <code>cytosolic ribosome</code>.<br />
+  PMID:9670014 directly characterizes Ssb-ribosome interaction, and PMID:1394434<br />
+  identifies Ssb1/2 as cytosolic Hsp70s associated with translating ribosomes.<br />
+  Because both are existing GO terms rather than ontology gaps, they belong in<br />
+<code>existing_annotations</code>, not <code>proposed_new_terms</code>. GO:0022626 was also added<br />
+  to the core-function locations.</li>
+<li>The GO:0042026 IBA is now classified as <code>PROPAGATION_BAD</code> with<br />
+<code>FUNCTIONAL_DIVERGENCE</code>, rather than a parent/child granularity problem.<br />
+  Protein refolding and de novo cotranslational folding are sibling processes;<br />
+  GO:0051083 is already present with direct IDA evidence from PMID:9670014, so<br />
+  MODIFY here effectively rejects the unsupported propagated refolding claim.</li>
+<li>The plasma-membrane HDA is now <code>MARK_AS_OVER_ANNOTATED</code>, harmonizing the call<br />
+  with the nearly identical Ssb2 paralog. This retains the bulk high-throughput<br />
+  fraction observation without treating plasma membrane as a demonstrated<br />
+  functional compartment for the soluble cytosolic chaperone.</li>
+</ul>
             </div>
         </details>
 
@@ -4774,7 +5226,7 @@
                 <pre><code>id: P11484
 gene_symbol: SSB1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -4797,6 +5249,13 @@ existing_annotations:
     summary: Ssb1 is cytoplasmic, but cytosol and ribosome association are more informative localizations.
     action: KEEP_AS_NON_CORE
     reason: Correct broad localization for a cytosolic ribosome-associated Hsp70; retained as non-core because GO:0005829 is more precise.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002321897
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The PAINT node contains SSB1 among its experimentally grounded descendants and correctly transfers a broad cytoplasmic localization; cytosol is more informative for this target.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -4807,6 +5266,13 @@ existing_annotations:
     summary: Ssb1 is a directly characterized Hsp70 ATPase.
     action: ACCEPT
     reason: ATP hydrolysis powers the Hsp70 substrate-binding cycle and is directly supported by PMID:9860955.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: SSB1 is among the experimentally grounded descendants used for this conserved Hsp70-family ATPase inference.
 - term:
     id: GO:0044183
     label: protein folding chaperone
@@ -4829,8 +5295,8 @@ existing_annotations:
       failure_modes:
       - GRANULARITY_MISMATCH
       source_entities:
-      - source_id: GO_REF:0000033
-        source_label: PANTHER phylogenetic annotation
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
         source_status: SUPPORTS_TRANSFER
         comment: The family-level inference correctly identifies folding-chaperone activity, but the ATP-dependent child term is more informative for this directly characterized Hsp70.
 - term:
@@ -4843,6 +5309,13 @@ existing_annotations:
     summary: RAC-Ssb contributes to nuclear steps of ribosome biogenesis, although Ssb1 is cytosolic at steady state and actively exported.
     action: KEEP_AS_NON_CORE
     reason: PMID:20368619 supports a nuclear RAC-Ssb role in ribosome biogenesis, while PMID:10347213 shows that Ssb1 is cytosolic at steady state; nucleus is therefore a specialized/non-core site rather than the principal localization.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002500132
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The family inference is compatible with Ssb1 nuclear shuttling and RAC-Ssb participation in nuclear ribosome biogenesis, but this is not its predominant site of action.
 - term:
     id: GO:0031072
     label: heat shock protein binding
@@ -4853,6 +5326,13 @@ existing_annotations:
     summary: Ssb1 engages other heat-shock proteins and cochaperones in the cytosolic chaperone network.
     action: KEEP_AS_NON_CORE
     reason: Interactions with RAC and the Hsp110 nucleotide-exchange factor Sse1 are real, but this binding term is ancillary to Ssb1&#39;s direct folding-chaperone activity.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: Conserved Hsp70-network interactions support the transfer, while the binding term remains ancillary to Ssb1&#39;s ATP-dependent chaperone activity.
 - term:
     id: GO:0005829
     label: cytosol
@@ -4867,6 +5347,13 @@ existing_annotations:
     - reference_id: file:yeast/SSB1/SSB1-deep-research-openscientist.md
       supporting_text: encodes **Ssb1**, a cytosolic, ATP-dependent molecular chaperone of the **heat shock protein 70 (Hsp70) family**
       reference_section_type: OTHER
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002500132
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The ancestral localization inference agrees with direct localization and Ssb1&#39;s experimentally established function on cytosolic translating ribosomes.
 - term:
     id: GO:0042026
     label: protein refolding
@@ -4874,9 +5361,25 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   qualifier: involved_in
   review:
-    summary: General protein refolding is plausible for an Hsp70, but Ssb1&#39;s defining role is folding newly synthesized chains.
-    action: KEEP_AS_NON_CORE
-    reason: The strongest Ssb-specific evidence supports de novo cotranslational folding rather than refolding of pre-existing denatured proteins.
+    summary: Ssb1 promotes folding of newly synthesized nascent chains, not a demonstrated general refolding program for pre-existing denatured proteins.
+    action: MODIFY
+    reason: The family-level refolding claim is unsupported for the specialized Ssb subfamily. GO:0051083 is already directly annotated by IDA from PMID:9670014, so this MODIFY effectively removes the propagated general-refolding claim in favor of the independently established de novo cotranslational process.
+    proposed_replacement_terms:
+    - id: GO:0051083
+      label: &#39;&#39;&#39;de novo&#39;&#39; cotranslational protein folding&#39;
+    supported_by:
+    - reference_id: PMID:9670014
+      supporting_text: These interactions allow Ssb to function as a chaperone on the ribosome, preventing the misfolding of newly synthesized proteins.
+      reference_section_type: ABSTRACT
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: General refolding is defensible elsewhere in the Hsp70 family, but the ribosome-specialized Ssb subfamily is directly established as a de novo cotranslational chaperone and lacks target-specific evidence for refolding pre-existing denatured clients.
 - term:
     id: GO:0000054
     label: ribosomal subunit export from nucleus
@@ -4925,8 +5428,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Ssb1 and RAC are required for accurate translation, especially termination.
-    action: ACCEPT
-    reason: PMID:15456889 and PMID:31114879 experimentally support a genuine role in translational fidelity.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:15456889 and PMID:31114879 experimentally support a genuine role in translational fidelity, but this phenotype is downstream of the core cotranslational chaperone cycle.
 - term:
     id: GO:0006452
     label: translational frameshifting
@@ -4935,8 +5438,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Loss of Ssb1/2 specifically alters programmed -1 ribosomal frameshifting.
-    action: ACCEPT
-    reason: PMID:16607023 directly measured inhibition of -1, but not +1, programmed frameshifting in ssb1 ssb2 mutants.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:16607023 directly measured inhibition of -1, but not +1, programmed frameshifting in ssb1 ssb2 mutants; this is a genuine secondary translation phenotype rather than Ssb1&#39;s core molecular role.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -5058,9 +5561,13 @@ existing_annotations:
   original_reference_id: PMID:16622836
   qualifier: located_in
   review:
-    summary: Plasma-membrane fraction detection is inconsistent with direct evidence that Ssb1 is a soluble cytosolic Hsp70.
-    action: REMOVE
-    reason: PMID:16622836 is a high-throughput membrane-fraction proteome survey and provides no specific membrane residence or membrane function for abundant cytosolic Ssb1.
+    summary: A bulk plasma-membrane-fraction hit is weak localization evidence for the abundant soluble cytosolic Hsp70 Ssb1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PMID:16622836 is a high-throughput survey of a stripped plasma-membrane fraction, whereas direct studies place Ssb1 in the cytosol and on cytosolic translating ribosomes. The fraction-detection annotation is retained as an experimental observation but should not be interpreted as evidence that the plasma membrane is a functional Ssb1 compartment.
+    supported_by:
+    - reference_id: PMID:16622836
+      supporting_text: Proteins from a stripped plasma membrane fraction were solubilized with the neutral and non-denaturing detergent, the n-dodecyl beta-D-maltoside.
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0006452
     label: translational frameshifting
@@ -5069,8 +5576,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Deletion of SSB1 and SSB2 specifically inhibits programmed -1 ribosomal frameshifting.
-    action: ACCEPT
-    reason: PMID:16607023 directly measured a selective effect on -1 PRF, with no effect on +1 PRF.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:16607023 directly measured a selective effect on -1 PRF, with no effect on +1 PRF; this is a secondary translational consequence of losing the ribosome-associated chaperone system.
 - term:
     id: GO:0000054
     label: ribosomal subunit export from nucleus
@@ -5089,8 +5596,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Ssb1/2 associate with translating ribosomes and are required for normal protein synthesis.
-    action: ACCEPT
-    reason: PMID:1394434 shows slow growth, fewer translating ribosomes, and sensitivity to translation inhibitors in ssb1 ssb2 mutants.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:1394434 shows slow growth, fewer translating ribosomes, and sensitivity to translation inhibitors in ssb1 ssb2 mutants. Cytoplasmic translation is the functional context for Ssb1&#39;s core nascent-chain chaperone activity, not a separate primary activity.
 - term:
     id: GO:0002181
     label: cytoplasmic translation
@@ -5099,8 +5606,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Puromycin-sensitive Ssb-ribosome association supports direct engagement of nascent chains during cytoplasmic translation.
-    action: ACCEPT
-    reason: PMID:1394434 directly links Ssb1/2 to translating ribosomes and nascent-polypeptide handling.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:1394434 directly links Ssb1/2 to translating ribosomes and nascent-polypeptide handling, supporting translation as the context for the core folding mechanism rather than a distinct core process.
 - term:
     id: GO:0005516
     label: calmodulin binding
@@ -5139,8 +5646,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: SSB1 overexpression increases translation termination efficiency.
-    action: ACCEPT
-    reason: PMID:17483428 identified SSB1 as one of the strongest antisuppressors in a chromosomal stop-codon readthrough screen.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:17483428 identified SSB1 as one of the strongest antisuppressors in a chromosomal stop-codon readthrough screen, a genuine but downstream role relative to cotranslational folding.
     supported_by:
     - reference_id: PMID:17483428
       supporting_text: Among them, SSB1 and snR18, two factors close to the exit tunnel of the ribosome, directed the strongest antisuppression effects when overexpressed, showing that they may be involved in fine-tuning of the translation termination level.
@@ -5153,8 +5660,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: RAC and Ssb1/2 are required for accurate translation, with the strongest defect at termination.
-    action: ACCEPT
-    reason: PMID:15456889 directly measured impaired fidelity in vivo and in vitro; PMID:31114879 later established complementary nascent-chain and ribosome-biogenesis mechanisms.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:15456889 directly measured impaired fidelity in vivo and in vitro; PMID:31114879 later established complementary nascent-chain and ribosome-biogenesis mechanisms. This is a supported secondary consequence of RAC-Ssb function.
     additional_reference_ids:
     - PMID:31114879
 - term:
@@ -5177,6 +5684,39 @@ existing_annotations:
     summary: Ssb directly contacts nascent chains on translating ribosomes and prevents misfolding of newly synthesized proteins.
     action: ACCEPT
     reason: PMID:9670014 provides direct puromycin-release and cross-linking evidence for Ssb as a ribosome-nascent-chain chaperone.
+- term:
+    id: GO:0043022
+    label: ribosome binding
+  evidence_type: IDA
+  original_reference_id: PMID:9670014
+  qualifier: enables
+  review:
+    summary: Proposed new annotation for Ssb1&#39;s directly characterized physical association with translating ribosomes.
+    action: NEW
+    reason: PMID:9670014 used puromycin release, salt resistance, and nascent-chain cross-linking to characterize Ssb-ribosome interaction; the current GOA set lacks a ribosome-binding molecular-function annotation.
+    supported_by:
+    - reference_id: PMID:9670014
+      supporting_text: We propose that Ssb is a core component of the translating ribosome which interacts with both the nascent polypeptide chain and the ribosome.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0022626
+    label: cytosolic ribosome
+  evidence_type: IDA
+  original_reference_id: PMID:9670014
+  qualifier: is_active_in
+  review:
+    summary: Proposed new annotation for the cytosolic translating ribosome where Ssb1 performs its cotranslational chaperone cycle.
+    action: NEW
+    reason: PMID:9670014 directly demonstrates stable Ssb association with translating ribosomes, and PMID:1394434 identifies the SSB proteins as cytosolic Hsp70s associated with translating ribosomes.
+    additional_reference_ids:
+    - PMID:1394434
+    supported_by:
+    - reference_id: PMID:9670014
+      supporting_text: The Ssbs of Saccharomyces cerevisiae are an abundant type of Hsp70 found associated with translating ribosomes.
+      reference_section_type: ABSTRACT
+    - reference_id: PMID:1394434
+      supporting_text: We suggest that cytosolic hsp70 aids in the passage of the nascent polypeptide chain through the ribosome in a manner analogous to the role played by organelle-localized hsp70 in the transport of proteins across membranes.
+      reference_section_type: ABSTRACT
 core_functions:
 - description: &gt;-
     Ssb1 is an ATP-dependent Hsp70 folding chaperone on cytosolic translating
@@ -5193,6 +5733,8 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  - id: GO:0022626
+    label: cytosolic ribosome
   supported_by:
   - reference_id: PMID:9670014
     supporting_text: These interactions allow Ssb to function as a chaperone on the ribosome, preventing the misfolding of newly synthesized proteins.

--- a/genes/yeast/SSB1/SSB1-ai-review.yaml
+++ b/genes/yeast/SSB1/SSB1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P11484
 gene_symbol: SSB1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -24,6 +24,13 @@ existing_annotations:
     summary: Ssb1 is cytoplasmic, but cytosol and ribosome association are more informative localizations.
     action: KEEP_AS_NON_CORE
     reason: Correct broad localization for a cytosolic ribosome-associated Hsp70; retained as non-core because GO:0005829 is more precise.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002321897
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The PAINT node contains SSB1 among its experimentally grounded descendants and correctly transfers a broad cytoplasmic localization; cytosol is more informative for this target.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -34,6 +41,13 @@ existing_annotations:
     summary: Ssb1 is a directly characterized Hsp70 ATPase.
     action: ACCEPT
     reason: ATP hydrolysis powers the Hsp70 substrate-binding cycle and is directly supported by PMID:9860955.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: SSB1 is among the experimentally grounded descendants used for this conserved Hsp70-family ATPase inference.
 - term:
     id: GO:0044183
     label: protein folding chaperone
@@ -56,8 +70,8 @@ existing_annotations:
       failure_modes:
       - GRANULARITY_MISMATCH
       source_entities:
-      - source_id: GO_REF:0000033
-        source_label: PANTHER phylogenetic annotation
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
         source_status: SUPPORTS_TRANSFER
         comment: The family-level inference correctly identifies folding-chaperone activity, but the ATP-dependent child term is more informative for this directly characterized Hsp70.
 - term:
@@ -70,6 +84,13 @@ existing_annotations:
     summary: RAC-Ssb contributes to nuclear steps of ribosome biogenesis, although Ssb1 is cytosolic at steady state and actively exported.
     action: KEEP_AS_NON_CORE
     reason: PMID:20368619 supports a nuclear RAC-Ssb role in ribosome biogenesis, while PMID:10347213 shows that Ssb1 is cytosolic at steady state; nucleus is therefore a specialized/non-core site rather than the principal localization.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002500132
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The family inference is compatible with Ssb1 nuclear shuttling and RAC-Ssb participation in nuclear ribosome biogenesis, but this is not its predominant site of action.
 - term:
     id: GO:0031072
     label: heat shock protein binding
@@ -80,6 +101,13 @@ existing_annotations:
     summary: Ssb1 engages other heat-shock proteins and cochaperones in the cytosolic chaperone network.
     action: KEEP_AS_NON_CORE
     reason: Interactions with RAC and the Hsp110 nucleotide-exchange factor Sse1 are real, but this binding term is ancillary to Ssb1's direct folding-chaperone activity.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: Conserved Hsp70-network interactions support the transfer, while the binding term remains ancillary to Ssb1's ATP-dependent chaperone activity.
 - term:
     id: GO:0005829
     label: cytosol
@@ -94,6 +122,13 @@ existing_annotations:
     - reference_id: file:yeast/SSB1/SSB1-deep-research-openscientist.md
       supporting_text: encodes **Ssb1**, a cytosolic, ATP-dependent molecular chaperone of the **heat shock protein 70 (Hsp70) family**
       reference_section_type: OTHER
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002500132
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The ancestral localization inference agrees with direct localization and Ssb1's experimentally established function on cytosolic translating ribosomes.
 - term:
     id: GO:0042026
     label: protein refolding
@@ -101,9 +136,25 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   qualifier: involved_in
   review:
-    summary: General protein refolding is plausible for an Hsp70, but Ssb1's defining role is folding newly synthesized chains.
-    action: KEEP_AS_NON_CORE
-    reason: The strongest Ssb-specific evidence supports de novo cotranslational folding rather than refolding of pre-existing denatured proteins.
+    summary: Ssb1 promotes folding of newly synthesized nascent chains, not a demonstrated general refolding program for pre-existing denatured proteins.
+    action: MODIFY
+    reason: The family-level refolding claim is unsupported for the specialized Ssb subfamily. GO:0051083 is already directly annotated by IDA from PMID:9670014, so this MODIFY effectively removes the propagated general-refolding claim in favor of the independently established de novo cotranslational process.
+    proposed_replacement_terms:
+    - id: GO:0051083
+      label: '''de novo'' cotranslational protein folding'
+    supported_by:
+    - reference_id: PMID:9670014
+      supporting_text: These interactions allow Ssb to function as a chaperone on the ribosome, preventing the misfolding of newly synthesized proteins.
+      reference_section_type: ABSTRACT
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: General refolding is defensible elsewhere in the Hsp70 family, but the ribosome-specialized Ssb subfamily is directly established as a de novo cotranslational chaperone and lacks target-specific evidence for refolding pre-existing denatured clients.
 - term:
     id: GO:0000054
     label: ribosomal subunit export from nucleus
@@ -152,8 +203,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Ssb1 and RAC are required for accurate translation, especially termination.
-    action: ACCEPT
-    reason: PMID:15456889 and PMID:31114879 experimentally support a genuine role in translational fidelity.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:15456889 and PMID:31114879 experimentally support a genuine role in translational fidelity, but this phenotype is downstream of the core cotranslational chaperone cycle.
 - term:
     id: GO:0006452
     label: translational frameshifting
@@ -162,8 +213,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Loss of Ssb1/2 specifically alters programmed -1 ribosomal frameshifting.
-    action: ACCEPT
-    reason: PMID:16607023 directly measured inhibition of -1, but not +1, programmed frameshifting in ssb1 ssb2 mutants.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:16607023 directly measured inhibition of -1, but not +1, programmed frameshifting in ssb1 ssb2 mutants; this is a genuine secondary translation phenotype rather than Ssb1's core molecular role.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -285,9 +336,13 @@ existing_annotations:
   original_reference_id: PMID:16622836
   qualifier: located_in
   review:
-    summary: Plasma-membrane fraction detection is inconsistent with direct evidence that Ssb1 is a soluble cytosolic Hsp70.
-    action: REMOVE
-    reason: PMID:16622836 is a high-throughput membrane-fraction proteome survey and provides no specific membrane residence or membrane function for abundant cytosolic Ssb1.
+    summary: A bulk plasma-membrane-fraction hit is weak localization evidence for the abundant soluble cytosolic Hsp70 Ssb1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PMID:16622836 is a high-throughput survey of a stripped plasma-membrane fraction, whereas direct studies place Ssb1 in the cytosol and on cytosolic translating ribosomes. The fraction-detection annotation is retained as an experimental observation but should not be interpreted as evidence that the plasma membrane is a functional Ssb1 compartment.
+    supported_by:
+    - reference_id: PMID:16622836
+      supporting_text: Proteins from a stripped plasma membrane fraction were solubilized with the neutral and non-denaturing detergent, the n-dodecyl beta-D-maltoside.
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0006452
     label: translational frameshifting
@@ -296,8 +351,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Deletion of SSB1 and SSB2 specifically inhibits programmed -1 ribosomal frameshifting.
-    action: ACCEPT
-    reason: PMID:16607023 directly measured a selective effect on -1 PRF, with no effect on +1 PRF.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:16607023 directly measured a selective effect on -1 PRF, with no effect on +1 PRF; this is a secondary translational consequence of losing the ribosome-associated chaperone system.
 - term:
     id: GO:0000054
     label: ribosomal subunit export from nucleus
@@ -316,8 +371,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Ssb1/2 associate with translating ribosomes and are required for normal protein synthesis.
-    action: ACCEPT
-    reason: PMID:1394434 shows slow growth, fewer translating ribosomes, and sensitivity to translation inhibitors in ssb1 ssb2 mutants.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:1394434 shows slow growth, fewer translating ribosomes, and sensitivity to translation inhibitors in ssb1 ssb2 mutants. Cytoplasmic translation is the functional context for Ssb1's core nascent-chain chaperone activity, not a separate primary activity.
 - term:
     id: GO:0002181
     label: cytoplasmic translation
@@ -326,8 +381,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Puromycin-sensitive Ssb-ribosome association supports direct engagement of nascent chains during cytoplasmic translation.
-    action: ACCEPT
-    reason: PMID:1394434 directly links Ssb1/2 to translating ribosomes and nascent-polypeptide handling.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:1394434 directly links Ssb1/2 to translating ribosomes and nascent-polypeptide handling, supporting translation as the context for the core folding mechanism rather than a distinct core process.
 - term:
     id: GO:0005516
     label: calmodulin binding
@@ -366,8 +421,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: SSB1 overexpression increases translation termination efficiency.
-    action: ACCEPT
-    reason: PMID:17483428 identified SSB1 as one of the strongest antisuppressors in a chromosomal stop-codon readthrough screen.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:17483428 identified SSB1 as one of the strongest antisuppressors in a chromosomal stop-codon readthrough screen, a genuine but downstream role relative to cotranslational folding.
     supported_by:
     - reference_id: PMID:17483428
       supporting_text: Among them, SSB1 and snR18, two factors close to the exit tunnel of the ribosome, directed the strongest antisuppression effects when overexpressed, showing that they may be involved in fine-tuning of the translation termination level.
@@ -380,8 +435,8 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: RAC and Ssb1/2 are required for accurate translation, with the strongest defect at termination.
-    action: ACCEPT
-    reason: PMID:15456889 directly measured impaired fidelity in vivo and in vitro; PMID:31114879 later established complementary nascent-chain and ribosome-biogenesis mechanisms.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:15456889 directly measured impaired fidelity in vivo and in vitro; PMID:31114879 later established complementary nascent-chain and ribosome-biogenesis mechanisms. This is a supported secondary consequence of RAC-Ssb function.
     additional_reference_ids:
     - PMID:31114879
 - term:
@@ -404,6 +459,39 @@ existing_annotations:
     summary: Ssb directly contacts nascent chains on translating ribosomes and prevents misfolding of newly synthesized proteins.
     action: ACCEPT
     reason: PMID:9670014 provides direct puromycin-release and cross-linking evidence for Ssb as a ribosome-nascent-chain chaperone.
+- term:
+    id: GO:0043022
+    label: ribosome binding
+  evidence_type: IDA
+  original_reference_id: PMID:9670014
+  qualifier: enables
+  review:
+    summary: Proposed new annotation for Ssb1's directly characterized physical association with translating ribosomes.
+    action: NEW
+    reason: PMID:9670014 used puromycin release, salt resistance, and nascent-chain cross-linking to characterize Ssb-ribosome interaction; the current GOA set lacks a ribosome-binding molecular-function annotation.
+    supported_by:
+    - reference_id: PMID:9670014
+      supporting_text: We propose that Ssb is a core component of the translating ribosome which interacts with both the nascent polypeptide chain and the ribosome.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0022626
+    label: cytosolic ribosome
+  evidence_type: IDA
+  original_reference_id: PMID:9670014
+  qualifier: is_active_in
+  review:
+    summary: Proposed new annotation for the cytosolic translating ribosome where Ssb1 performs its cotranslational chaperone cycle.
+    action: NEW
+    reason: PMID:9670014 directly demonstrates stable Ssb association with translating ribosomes, and PMID:1394434 identifies the SSB proteins as cytosolic Hsp70s associated with translating ribosomes.
+    additional_reference_ids:
+    - PMID:1394434
+    supported_by:
+    - reference_id: PMID:9670014
+      supporting_text: The Ssbs of Saccharomyces cerevisiae are an abundant type of Hsp70 found associated with translating ribosomes.
+      reference_section_type: ABSTRACT
+    - reference_id: PMID:1394434
+      supporting_text: We suggest that cytosolic hsp70 aids in the passage of the nascent polypeptide chain through the ribosome in a manner analogous to the role played by organelle-localized hsp70 in the transport of proteins across membranes.
+      reference_section_type: ABSTRACT
 core_functions:
 - description: >-
     Ssb1 is an ATP-dependent Hsp70 folding chaperone on cytosolic translating
@@ -420,6 +508,8 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  - id: GO:0022626
+    label: cytosolic ribosome
   supported_by:
   - reference_id: PMID:9670014
     supporting_text: These interactions allow Ssb to function as a chaperone on the ribosome, preventing the misfolding of newly synthesized proteins.

--- a/genes/yeast/SSB1/SSB1-notes.md
+++ b/genes/yeast/SSB1/SSB1-notes.md
@@ -128,3 +128,44 @@
 - Provider-output caveats: its GO table says 39 current annotations although the
   fetched/collapsed review has 36, and it recommends obsolete GO:0051082. Those
   claims were not adopted. The curated replacement remains GO:0140662.
+
+## Completion audit (2026-08-28)
+
+- Row-by-row reconciliation found 39 fetched GOA rows representing 36 distinct
+  review assertions. The three extra rows are duplicate assertion keys that
+  differ only in `WITH/FROM`: three PMID:16429126 protein-binding rows collapse
+  to one review entry, and two PMID:1394434 cytoplasmic-translation IPI rows
+  collapse to one. No GO term/evidence/reference/qualifier assertion is absent.
+- All seven IBA rows were re-read against their GOA `WITH/FROM` fields and PAINT
+  nodes. The cytoplasm, ATPase, generic chaperone, nucleus, heat-shock-protein
+  binding, and cytosol transfers are biologically defensible; broad or secondary
+  assertions are distinguished from the core ATP-dependent cotranslational
+  chaperone function. The broad protein-refolding IBA was narrowed to directly
+  demonstrated de novo cotranslational folding rather than being accepted as a
+  generic refolding program.
+- The plasma-membrane HDA was initially changed from `REMOVE` to `UNDECIDED`
+  because PMID:16622836 is abstract-only in the cache and describes a stripped
+  plasma-membrane fraction, while direct evidence places Ssb1 in the cytosol.
+- Translation, frameshifting, termination, and fidelity phenotypes were retained
+  as genuine but non-core. This brings row actions into agreement with the core
+  function synthesis, which identifies ATP-dependent nascent-chain folding as
+  primary and the translation phenotypes as downstream/contextual.
+
+## PR review follow-up (2026-08-28)
+
+- The missing ribosome-associated annotations are now explicit `action: NEW`
+  rows: GO:0043022 `ribosome binding` and GO:0022626 `cytosolic ribosome`.
+  PMID:9670014 directly characterizes Ssb-ribosome interaction, and PMID:1394434
+  identifies Ssb1/2 as cytosolic Hsp70s associated with translating ribosomes.
+  Because both are existing GO terms rather than ontology gaps, they belong in
+  `existing_annotations`, not `proposed_new_terms`. GO:0022626 was also added
+  to the core-function locations.
+- The GO:0042026 IBA is now classified as `PROPAGATION_BAD` with
+  `FUNCTIONAL_DIVERGENCE`, rather than a parent/child granularity problem.
+  Protein refolding and de novo cotranslational folding are sibling processes;
+  GO:0051083 is already present with direct IDA evidence from PMID:9670014, so
+  MODIFY here effectively rejects the unsupported propagated refolding claim.
+- The plasma-membrane HDA is now `MARK_AS_OVER_ANNOTATED`, harmonizing the call
+  with the nearly identical Ssb2 paralog. This retains the bulk high-throughput
+  fraction observation without treating plasma membrane as a demonstrated
+  functional compartment for the soluble cytosolic chaperone.


### PR DESCRIPTION
## Summary
- complete the yeast SSB1 review after reconciling 39 GOA rows to 36 fetched assertions, plus two evidence-backed NEW annotation proposals
- audit all seven IBA annotations against their PAINT nodes and add structured propagation metadata
- narrow propagated protein refolding to de novo cotranslational folding as PROPAGATION_BAD/FUNCTIONAL_DIVERGENCE
- add NEW IDA proposals for GO:0043022 ribosome binding and GO:0022626 cytosolic ribosome with exact cached evidence
- retain the bulk plasma-membrane HDA as MARK_AS_OVER_ANNOTATED rather than treating the fraction hit as a functional compartment
- retain translation/fidelity/frameshifting/termination phenotypes as non-core
- append completion/follow-up notes and regenerate the SSB1 page/browser payload

No source-code or publication-cache changes are included.

## Validation
- `just validate yeast SSB1` (clean, no warnings)
- `just validate-goa yeast SSB1`
- `just render yeast SSB1`
- `just deploy-browser` (131,482 annotations)
- `git diff --check`