### PR TITLE
Complete yeast SSB2 annotation review

### DIFF
--- a/genes/yeast/SSB2/SSB2-ai-review.html
+++ b/genes/yeast/SSB2/SSB2-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -913,12 +913,41 @@ ribosome biogenesis). Not a core localization.
 
 
                         <div>
-                            <strong>Reason:</strong> Ssb is overwhelmingly cytosolic and ribosome-associated. The falcon report
-localizes Ssb to the cytosol and 60S tunnel exit with no evidence for an
-autonomous nuclear function; any nuclear signal is best treated as
-peripheral/context-dependent.
+                            <strong>Reason:</strong> PMID:20368619 directly supports a specialized nuclear RAC-Ssb role in
+ribosome biogenesis, while direct localization and biochemical studies
+place the principal Ssb pool in the cytosol and on translating ribosomes.
+Nucleus is therefore retained as a non-core site of action.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002500132</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The family inference is compatible with Ssb2 participation in nuclear ribosome biogenesis, but nucleus is not its predominant site.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -992,6 +1021,35 @@ cytosolic translating ribosome (see cytosol annotation).
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002321897</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The broad cytoplasmic inference is correct for Ssb2, although cytosol and cytosolic ribosome are more informative.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1051,16 +1109,17 @@ cytosolic translating ribosome (see cytosol annotation).
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Plasma membrane is not a site of Ssb2 function. This likely reflects
-high-throughput proteome surveys detecting the abundant cytosolic Ssb pool.
+                            <strong>Summary:</strong> Plasma membrane is not a site of Ssb2 function; this PAINT inference
+transfers a compartment occupied by other Hsp70-family proteins to the
+ribosome-specialized soluble Ssb2 subfamily.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> No experimental or literature support for plasma membrane function. The
-falcon report and UniProt localize Ssb to the cytosol and ribosome; a
-plasma membrane assignment for this abundant cytosolic Hsp70 is an
-over-annotation from high-throughput localization datasets.
+                            <strong>Reason:</strong> Direct localization and biochemical evidence place Ssb2 in the cytosol and
+on cytosolic translating ribosomes. The GOA WITH/FROM identifies
+PTN002500132, whose plasma-membrane seeds do not establish this mutually
+exclusive compartment for Ssb2.
                         </div>
 
 
@@ -1172,6 +1231,35 @@ and the ATP-driven conformational cycle is central to its function.
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The conserved Hsp70-family ATPase inference agrees with direct Ssb biochemistry from PMID:9860955.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1220,10 +1308,10 @@ and the ATP-driven conformational cycle is central to its function.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0031072" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0031072" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1237,10 +1325,39 @@ RAC J-protein Zuo1/Ssz1 and the Hsp110 nucleotide exchange factor Sse1.
 
 
                         <div>
-                            <strong>Reason:</strong> Consistent with the documented Ssb-RAC and Ssb-Sse1 (Hsp110) functional
-interactions that constitute the ribosome-associated Hsp70 chaperone system.
+                            <strong>Reason:</strong> Consistent with documented Ssb-RAC and Ssb-Sse1 interactions, but this
+binding term is ancillary to Ssb2&#39;s direct ATP-dependent folding activity.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Conserved Hsp70-network interactions support the transfer, while heat-shock-protein binding remains non-core for Ssb2.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1433,6 +1550,35 @@ ribosomes) is where Ssb2 carries out its function.
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002500132</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The ancestral cytosol inference agrees with Ssb2&#39;s direct localization and ribosome-associated folding function.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1481,10 +1627,10 @@ ribosomes) is where Ssb2 carries out its function.
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0042026" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0042026" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1492,20 +1638,67 @@ ribosomes) is where Ssb2 carries out its function.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Ssb&#39;s primary, best-supported role is de novo cotranslational folding of
-nascent chains rather than refolding of pre-existing denatured proteins,
-though as an Hsp70 it can contribute to general proteostasis/aggregation
-prevention.
+                            <strong>Summary:</strong> Ssb2 promotes de novo cotranslational folding of newly synthesized chains;
+this is ontologically distinct from restoring activity to a pre-existing
+unfolded or misfolded protein (GO:0042026).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Plausible Hsp70 activity but not the core, distinguishing function of Ssb.
-The falcon report and primary literature emphasize cotranslational folding
-of nascent chains; refolding is a generic Hsp70 capability kept as non-core.
+                            <strong>Reason:</strong> The family-level refolding claim is unsupported for the ribosome-specialized
+Ssb subfamily. PMID:9670014 directly establishes de novo cotranslational
+folding, which is a sibling protein-folding process rather than evidence
+for refolding pre-existing denatured clients.
                         </div>
 
 
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; PAINT Hsp70 family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">General refolding is defensible elsewhere in the Hsp70 family, but direct Ssb2 evidence establishes its specialized de novo cotranslational folding role and not refolding of mature clients.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051083" target="_blank" class="term-link">
+                                    &#39;de novo&#39; cotranslational protein folding
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -1518,7 +1711,7 @@ of nascent chains; refolding is a generic Hsp70 capability kept as non-core.
 
                                 </span>
 
-                                <div class="support-text">Ssb suppresses formation and/or inheritance of multiple **amyloid/prion-like elements**</div>
+                                <div class="support-text">Ssb1/2 (including Ssb2) act as the **direct nascent-chain binders** during co-translational folding in yeast</div>
 
                             </div>
 
@@ -1904,10 +2097,10 @@ cotranslational protein folding) are preferred.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0006450" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0006450" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1921,8 +2114,9 @@ translation termination. A genuine, experimentally supported downstream role.
 
 
                         <div>
-                            <strong>Reason:</strong> Supported experimentally (PMID:15456889): RAC and Ssb1/2p are crucial for
-translational fidelity, with the principal defect in translation termination.
+                            <strong>Reason:</strong> Supported experimentally (PMID:15456889), but translational fidelity is a
+downstream consequence of the RAC-Ssb system rather than the chaperone&#39;s
+direct core molecular activity.
                         </div>
 
 
@@ -2135,16 +2329,16 @@ stimulated by the RAC J-protein Zuo1.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Ssb2 binds exposed hydrophobic segments of unfolded/nascent polypeptides.
-The chaperone activity is better captured by ATP-dependent protein folding
-chaperone (GO:0140662).
+                            <strong>Summary:</strong> GO:0051082 is obsolete. OLS records protein folding chaperone
+(GO:0044183) as a term to consider; for the ATP-dependent Ssb2 Hsp70,
+the more specific GO:0140662 captures the supported activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The binding term is accurate but a holdase/binding-only term understates
-the ATP-driven Hsp70 mechanism. Modify to the ATP-dependent protein folding
-chaperone MF.
+                            <strong>Reason:</strong> Modify because GO:0051082 is obsolete, not because substrate binding lacks
+support. OLS directs curators to consider GO:0044183; Ssb2&#39;s ATP-dependent
+Hsp70 mechanism supports its child GO:0140662.
                         </div>
 
 
@@ -2816,10 +3010,10 @@ but generic relative to cytosol/ribosome-associated.
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0005886" data-r="PMID:16622836" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0005886" data-r="PMID:16622836" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2827,14 +3021,16 @@ but generic relative to cytosol/ribosome-associated.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Plasma membrane proteome detection of the abundant cytosolic Ssb; not a
-genuine functional localization.
+                            <strong>Summary:</strong> Ssb2 was detected in a stripped plasma-membrane fraction in a bulk
+proteomic survey; this is weak evidence for a functional localization of
+an abundant soluble cytosolic chaperone.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Over-annotation from a plasma-membrane proteome survey. Ssb is a cytosolic
-ribosome-associated Hsp70 with no functional role at the plasma membrane.
+                            <strong>Reason:</strong> PMID:16622836 reports fraction detection, whereas direct studies place Ssb
+in the cytosol and on cytosolic translating ribosomes. Retain the HDA
+observation but do not interpret it as a functional plasma-membrane site.
                         </div>
 
 
@@ -2846,11 +3042,13 @@ ribosome-associated Hsp70 with no functional role at the plasma membrane.
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:yeast/SSB2/SSB2-deep-research-falcon.md
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16622836" target="_blank" class="term-link">
+                                        PMID:16622836
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">Ssb proteins (Ssb1/Ssb2) are **cytosolic** and **ribosome-associated**, positioned at the **60S tunnel exit**</div>
+                                <div class="support-text">Proteins from a stripped plasma membrane fraction were solubilized with the neutral and non-denaturing detergent, the n-dodecyl beta-D-maltoside.</div>
 
                             </div>
 
@@ -3050,10 +3248,10 @@ non-core.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0002181" data-r="PMID:1394434" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0002181" data-r="PMID:1394434" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3068,8 +3266,9 @@ synthesis inhibitors, linking Ssb to cytoplasmic translation.
 
 
                         <div>
-                            <strong>Reason:</strong> Supported by IMP (PMID:1394434). Ssb participates in cytoplasmic translation
-as a ribosome-associated cotranslational chaperone.
+                            <strong>Reason:</strong> Supported by IMP (PMID:1394434), but cytoplasmic translation is the context
+for Ssb2&#39;s nascent-chain folding activity rather than a separate core
+activity of the chaperone.
                         </div>
 
 
@@ -3146,10 +3345,10 @@ as a ribosome-associated cotranslational chaperone.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0002181" data-r="PMID:1394434" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0002181" data-r="PMID:1394434" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3164,8 +3363,9 @@ polypeptide during cytoplasmic translation.
 
 
                         <div>
-                            <strong>Reason:</strong> Supported (PMID:1394434). Consistent IPI/IMP support for Ssb&#39;s role at the
-translating cytoplasmic ribosome (same action as the paired IMP annotation).
+                            <strong>Reason:</strong> Supported (PMID:1394434). The interaction places Ssb2 in cytoplasmic
+translation, but this is the context for its core cotranslational folding
+role rather than a distinct core process.
                         </div>
 
 
@@ -3298,10 +3498,10 @@ cotranslational folding role.
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P40150" data-a="GO:0006450" data-r="PMID:15456889" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0006450" data-r="PMID:15456889" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3316,8 +3516,8 @@ paromomycin.
 
 
                         <div>
-                            <strong>Reason:</strong> Strong direct IMP evidence (PMID:15456889) that Ssb1/2p are crucial for
-translational fidelity beyond their chaperone role for nascent chains.
+                            <strong>Reason:</strong> Strong direct IMP evidence (PMID:15456889), retained as a genuine secondary
+consequence beyond Ssb2&#39;s core nascent-chain chaperone role.
                         </div>
 
 
@@ -3578,15 +3778,15 @@ signaling.
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Ssb can be cross-linked to nascent chains and is released with nascent
 chains upon puromycin treatment, demonstrating direct binding to
-unfolded/nascent polypeptides. The ATP-driven chaperone mechanism is better
-captured by ATP-dependent protein folding chaperone (GO:0140662).
+unfolded/nascent polypeptides. GO:0051082 is obsolete; for this
+ATP-dependent Hsp70, GO:0140662 captures the supported activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The binding term is directly supported (PMID:9670014) but a binding-only
-term understates the ATP-dependent Hsp70 mechanism. Modify to the
-ATP-dependent protein folding chaperone MF.
+                            <strong>Reason:</strong> Modify because GO:0051082 is obsolete, not because the IDA evidence is
+deficient. OLS directs curators to consider GO:0044183; Ssb2&#39;s
+ATP-dependent Hsp70 mechanism supports its child GO:0140662.
                         </div>
 
 
@@ -3732,6 +3932,183 @@ biological role of Ssb2.
                     </td>
                 </tr>
 
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043022" target="_blank" class="term-link">
+                                    GO:0043022
+                                </a>
+                            </span>
+                            <span class="term-label">ribosome binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9670014
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The molecular chaperone Ssb from Saccharomyces cerevisiae is...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0043022" data-r="PMID:9670014" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation for Ssb2&#39;s directly characterized physical association with translating ribosomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PMID:9670014 used puromycin release, salt resistance, and nascent-chain cross-linking to characterize the Ssb-ribosome interaction; the current SSB2 GOA set lacks ribosome-binding molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" target="_blank" class="term-link">
+                                        PMID:9670014
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We propose that Ssb is a core component of the translating ribosome which interacts with both the nascent polypeptide chain and the ribosome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022626" target="_blank" class="term-link">
+                                    GO:0022626
+                                </a>
+                            </span>
+                            <span class="term-label">cytosolic ribosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9670014
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The molecular chaperone Ssb from Saccharomyces cerevisiae is...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P40150" data-a="GO:0022626" data-r="PMID:9670014" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation for the cytosolic translating ribosome where Ssb2 performs its cotranslational chaperone cycle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PMID:9670014 directly demonstrates stable Ssb association with translating ribosomes, while PMID:1394434 identifies the SSB proteins as cytosolic Hsp70s associated with translating ribosomes.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" target="_blank" class="term-link">
+                                        PMID:9670014
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The Ssbs of Saccharomyces cerevisiae are an abundant type of Hsp70 found associated with translating ribosomes.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1394434" target="_blank" class="term-link">
+                                        PMID:1394434
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We suggest that cytosolic hsp70 aids in the passage of the nascent polypeptide chain through the ribosome in a manner analogous to the role played by organelle-localized hsp70 in the transport of proteins across membranes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </div>
@@ -3790,6 +4167,12 @@ J-protein Zuo1) to promote de novo cotranslational protein folding.</h3>
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022626" target="_blank" class="term-link">
+                                cytosolic ribosome
                             </a>
                         </span>
 
@@ -4771,6 +5154,26 @@ These values imply Ssb2 participates in folding/biogenesis decisions for a large
   than stable complex membership, so the core function uses cytosol as location<br />
   and describes the 60S tunnel-exit position in prose instead of <code>in_complex</code>.</li>
 </ul>
+<h2 id="2026-08-28-completion-audit">2026-08-28 completion audit</h2>
+<ul>
+<li>Reconciled every distinct GOA assertion and added the original qualifiers.</li>
+<li>Audited all eight IBA rows against their actual GOA PAINT nodes:<br />
+  PTN002500132 for nucleus, plasma membrane, and cytosol; PTN002321897 for<br />
+  cytoplasm; and PTN000452648 for ATP hydrolysis, heat-shock-protein binding,<br />
+  protein-folding chaperone activity, and protein refolding.</li>
+<li>The plasma-membrane IBA is a compartment-mismatch propagation failure. The<br />
+  independent HDA row from PMID:16622836 is instead retained as an<br />
+  over-annotated bulk-fraction observation, using the paper's exact abstract<br />
+  description of a stripped plasma-membrane fraction.</li>
+<li>GO:0042026 protein refolding restores activity to an already unfolded or<br />
+  misfolded protein; GO:0051083 describes folding a ribosome-bound nascent chain.<br />
+  Because the direct Ssb evidence establishes the latter rather than the former,<br />
+  the IBA refolding row is modified to GO:0051083 rather than retained as a<br />
+  generic Hsp70 capability. <a href="https://pubmed.ncbi.nlm.nih.gov/9670014" title="preventing the misfolding of newly   synthesized proteins">PMID:9670014</a></li>
+<li>Added machine-readable NEW proposals for GO:0043022 ribosome binding and<br />
+  GO:0022626 cytosolic ribosome, both directly supported by PMID:9670014 and<br />
+  consistent with PMID:1394434. These are missing from the current SSB2 GOA set.</li>
+</ul>
             </div>
         </details>
 
@@ -4787,7 +5190,7 @@ These values imply Ssb2 participates in folding/biogenesis decisions for a large
                 <pre><code>id: P40150
 gene_symbol: SSB2
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -4815,6 +5218,7 @@ existing_annotations:
     label: nucleus
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: |-
       Ssb2 functions on cytosolic translating ribosomes; a nuclear pool is at
@@ -4822,10 +5226,18 @@ existing_annotations:
       ribosome biogenesis). Not a core localization.
     action: KEEP_AS_NON_CORE
     reason: |-
-      Ssb is overwhelmingly cytosolic and ribosome-associated. The falcon report
-      localizes Ssb to the cytosol and 60S tunnel exit with no evidence for an
-      autonomous nuclear function; any nuclear signal is best treated as
-      peripheral/context-dependent.
+      PMID:20368619 directly supports a specialized nuclear RAC-Ssb role in
+      ribosome biogenesis, while direct localization and biochemical studies
+      place the principal Ssb pool in the cytosol and on translating ribosomes.
+      Nucleus is therefore retained as a non-core site of action.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002500132
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The family inference is compatible with Ssb2 participation in
+          nuclear ribosome biogenesis, but nucleus is not its predominant site.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -4837,6 +5249,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: |-
       Ssb2 is a cytoplasmic/cytosolic chaperone. Cytoplasm is correct but
@@ -4845,6 +5258,14 @@ existing_annotations:
     reason: |-
       Correct but non-specific. The functionally meaningful localization is the
       cytosolic translating ribosome (see cytosol annotation).
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002321897
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The broad cytoplasmic inference is correct for Ssb2, although
+          cytosol and cytosolic ribosome are more informative.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -4856,16 +5277,18 @@ existing_annotations:
     label: plasma membrane
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: |-
-      Plasma membrane is not a site of Ssb2 function. This likely reflects
-      high-throughput proteome surveys detecting the abundant cytosolic Ssb pool.
+      Plasma membrane is not a site of Ssb2 function; this PAINT inference
+      transfers a compartment occupied by other Hsp70-family proteins to the
+      ribosome-specialized soluble Ssb2 subfamily.
     action: REMOVE
     reason: |-
-      No experimental or literature support for plasma membrane function. The
-      falcon report and UniProt localize Ssb to the cytosol and ribosome; a
-      plasma membrane assignment for this abundant cytosolic Hsp70 is an
-      over-annotation from high-throughput localization datasets.
+      Direct localization and biochemical evidence place Ssb2 in the cytosol and
+      on cytosolic translating ribosomes. The GOA WITH/FROM identifies
+      PTN002500132, whose plasma-membrane seeds do not establish this mutually
+      exclusive compartment for Ssb2.
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
@@ -4887,6 +5310,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: |-
       Ssb2 is an Hsp70 ATPase (EC 3.6.4.10); ATP hydrolysis powers its chaperone
@@ -4895,6 +5319,14 @@ existing_annotations:
     reason: |-
       Directly supported. The Ssb ATPase activity is experimentally characterized
       and the ATP-driven conformational cycle is central to its function.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The conserved Hsp70-family ATPase inference agrees with direct
+          Ssb biochemistry from PMID:9860955.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -4906,14 +5338,23 @@ existing_annotations:
     label: heat shock protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: |-
       Ssb2 interacts with co-chaperone partners of the Hsp70 system, notably the
       RAC J-protein Zuo1/Ssz1 and the Hsp110 nucleotide exchange factor Sse1.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
-      Consistent with the documented Ssb-RAC and Ssb-Sse1 (Hsp110) functional
-      interactions that constitute the ribosome-associated Hsp70 chaperone system.
+      Consistent with documented Ssb-RAC and Ssb-Sse1 interactions, but this
+      binding term is ancillary to Ssb2&#39;s direct ATP-dependent folding activity.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: Conserved Hsp70-network interactions support the transfer, while
+          heat-shock-protein binding remains non-core for Ssb2.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -4925,6 +5366,7 @@ existing_annotations:
     label: protein folding chaperone
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: |-
       Ssb2 is a protein folding chaperone that assists cotranslational folding of
@@ -4958,6 +5400,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: |-
       Ssb2 is a cytosolic chaperone; ~50% is ribosome-associated and the
@@ -4966,6 +5409,14 @@ existing_annotations:
     reason: |-
       Strongly supported. The cytosol (and specifically cytosolic translating
       ribosomes) is where Ssb2 carries out its function.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002500132
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The ancestral cytosol inference agrees with Ssb2&#39;s direct
+          localization and ribosome-associated folding function.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -4977,28 +5428,44 @@ existing_annotations:
     label: protein refolding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: |-
-      Ssb&#39;s primary, best-supported role is de novo cotranslational folding of
-      nascent chains rather than refolding of pre-existing denatured proteins,
-      though as an Hsp70 it can contribute to general proteostasis/aggregation
-      prevention.
-    action: KEEP_AS_NON_CORE
+      Ssb2 promotes de novo cotranslational folding of newly synthesized chains;
+      this is ontologically distinct from restoring activity to a pre-existing
+      unfolded or misfolded protein (GO:0042026).
+    action: MODIFY
     reason: |-
-      Plausible Hsp70 activity but not the core, distinguishing function of Ssb.
-      The falcon report and primary literature emphasize cotranslational folding
-      of nascent chains; refolding is a generic Hsp70 capability kept as non-core.
+      The family-level refolding claim is unsupported for the ribosome-specialized
+      Ssb subfamily. PMID:9670014 directly establishes de novo cotranslational
+      folding, which is a sibling protein-folding process rather than evidence
+      for refolding pre-existing denatured clients.
+    proposed_replacement_terms:
+    - id: GO:0051083
+      label: &#39;&#39;&#39;de novo&#39;&#39; cotranslational protein folding&#39;
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: General refolding is defensible elsewhere in the Hsp70 family,
+          but direct Ssb2 evidence establishes its specialized de novo
+          cotranslational folding role and not refolding of mature clients.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
     - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
-      supporting_text: Ssb suppresses formation and/or inheritance of multiple **amyloid/prion-like elements**
+      supporting_text: Ssb1/2 (including Ssb2) act as the **direct nascent-chain binders** during co-translational folding in yeast
       reference_section_type: OTHER
 - term:
     id: GO:0000054
     label: ribosomal subunit export from nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: |-
       Ssb/RAC participates in a ribosome-anchored chaperone network linked to
@@ -5013,6 +5480,7 @@ existing_annotations:
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: |-
       Generic parent of ATP binding. Ssb2 binds ATP via its NBD; the more
@@ -5026,6 +5494,7 @@ existing_annotations:
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: |-
       Ssb2&#39;s N-terminal nucleotide-binding domain binds ATP, the basis of its
@@ -5045,6 +5514,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: |-
       Cytoplasm is correct but generic; cytosol/ribosome-associated is the
@@ -5057,6 +5527,7 @@ existing_annotations:
     label: rRNA processing
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: |-
       Ssb/RAC is part of a ribosome-anchored chaperone network implicated in
@@ -5071,6 +5542,7 @@ existing_annotations:
     label: translation
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: involved_in
   review:
     summary: |-
       Generic parent. Ssb acts on translating ribosomes; the more specific
@@ -5086,14 +5558,16 @@ existing_annotations:
     label: regulation of translational fidelity
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: |-
       Loss of Ssb1/2 (or RAC) impairs translational fidelity, primarily at
       translation termination. A genuine, experimentally supported downstream role.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
-      Supported experimentally (PMID:15456889): RAC and Ssb1/2p are crucial for
-      translational fidelity, with the principal defect in translation termination.
+      Supported experimentally (PMID:15456889), but translational fidelity is a
+      downstream consequence of the RAC-Ssb system rather than the chaperone&#39;s
+      direct core molecular activity.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
 - term:
@@ -5101,6 +5575,7 @@ existing_annotations:
     label: translational frameshifting
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: |-
       Deletion of Ssb1/2 (or RAC) specifically inhibits -1 programmed ribosomal
@@ -5115,6 +5590,7 @@ existing_annotations:
     label: hydrolase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: |-
       Uninformative parent term. Ssb2&#39;s relevant activity is ATP hydrolysis
@@ -5128,6 +5604,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: |-
       Ssb2 hydrolyzes ATP as part of its Hsp70 chaperone cycle (EC 3.6.4.10),
@@ -5142,16 +5619,17 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: enables
   review:
     summary: |-
-      Ssb2 binds exposed hydrophobic segments of unfolded/nascent polypeptides.
-      The chaperone activity is better captured by ATP-dependent protein folding
-      chaperone (GO:0140662).
+      GO:0051082 is obsolete. OLS records protein folding chaperone
+      (GO:0044183) as a term to consider; for the ATP-dependent Ssb2 Hsp70,
+      the more specific GO:0140662 captures the supported activity.
     action: MODIFY
     reason: |-
-      The binding term is accurate but a holdase/binding-only term understates
-      the ATP-driven Hsp70 mechanism. Modify to the ATP-dependent protein folding
-      chaperone MF.
+      Modify because GO:0051082 is obsolete, not because substrate binding lacks
+      support. OLS directs curators to consider GO:0044183; Ssb2&#39;s ATP-dependent
+      Hsp70 mechanism supports its child GO:0140662.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone
@@ -5166,6 +5644,7 @@ existing_annotations:
     label: &#39;&#39;&#39;de novo&#39;&#39; cotranslational protein folding&#39;
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: |-
       This is the core biological process of Ssb2: direct binding to nascent
@@ -5186,6 +5665,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16429126
+  qualifier: enables
   review:
     summary: |-
       Generic protein-binding from a high-throughput proteome survey; provides no
@@ -5199,6 +5679,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
+  qualifier: enables
   review:
     summary: |-
       Generic protein-binding from a high-throughput complex landscape study; no
@@ -5211,6 +5692,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
+  qualifier: enables
   review:
     summary: |-
       Generic protein-binding from a chaperone-interaction atlas; no specific
@@ -5223,6 +5705,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23332755
+  qualifier: enables
   review:
     summary: |-
       This reference actually documents Ssb&#39;s cotranslational nascent-chain
@@ -5238,6 +5721,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37070168
+  qualifier: enables
   review:
     summary: |-
       Generic protein-binding from an RNA-dependent interactome study; no specific
@@ -5250,6 +5734,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
+  qualifier: enables
   review:
     summary: |-
       Generic protein-binding from a global interactome architecture study; no
@@ -5262,6 +5747,7 @@ existing_annotations:
     label: cytoplasmic stress granule
   evidence_type: HDA
   original_reference_id: PMID:26777405
+  qualifier: located_in
   review:
     summary: |-
       As an abundant cytosolic Hsp70, Ssb2 is detected in stress granules; this
@@ -5275,6 +5761,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:11914276
+  qualifier: located_in
   review:
     summary: |-
       Cytoplasm localization confirmed by genome-wide GFP localization; correct
@@ -5287,25 +5774,27 @@ existing_annotations:
     label: plasma membrane
   evidence_type: HDA
   original_reference_id: PMID:16622836
+  qualifier: located_in
   review:
     summary: |-
-      Plasma membrane proteome detection of the abundant cytosolic Ssb; not a
-      genuine functional localization.
-    action: REMOVE
+      Ssb2 was detected in a stripped plasma-membrane fraction in a bulk
+      proteomic survey; this is weak evidence for a functional localization of
+      an abundant soluble cytosolic chaperone.
+    action: MARK_AS_OVER_ANNOTATED
     reason: |-
-      Over-annotation from a plasma-membrane proteome survey. Ssb is a cytosolic
-      ribosome-associated Hsp70 with no functional role at the plasma membrane.
-    additional_reference_ids:
-    - file:yeast/SSB2/SSB2-deep-research-falcon.md
+      PMID:16622836 reports fraction detection, whereas direct studies place Ssb
+      in the cytosol and on cytosolic translating ribosomes. Retain the HDA
+      observation but do not interpret it as a functional plasma-membrane site.
     supported_by:
-    - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
-      supporting_text: Ssb proteins (Ssb1/Ssb2) are **cytosolic** and **ribosome-associated**, positioned at the **60S tunnel exit**
-      reference_section_type: OTHER
+    - reference_id: PMID:16622836
+      supporting_text: Proteins from a stripped plasma membrane fraction were solubilized with the neutral and non-denaturing detergent, the n-dodecyl beta-D-maltoside.
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0006452
     label: translational frameshifting
   evidence_type: IMP
   original_reference_id: PMID:16607023
+  qualifier: involved_in
   review:
     summary: |-
       Deletion of Ssb1p/Ssb2p (or RAC) specifically inhibits -1 programmed
@@ -5324,6 +5813,7 @@ existing_annotations:
     label: ribosomal subunit export from nucleus
   evidence_type: IGI
   original_reference_id: PMID:20368619
+  qualifier: involved_in
   review:
     summary: |-
       Genetic interaction evidence places Ssb/RAC in a ribosome-anchored
@@ -5338,15 +5828,17 @@ existing_annotations:
     label: cytoplasmic translation
   evidence_type: IMP
   original_reference_id: PMID:1394434
+  qualifier: involved_in
   review:
     summary: |-
       Ssb1/2 are associated with translating ribosomes; ssb1 ssb2 mutants grow
       slowly, have fewer translating ribosomes, and are hypersensitive to protein
       synthesis inhibitors, linking Ssb to cytoplasmic translation.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
-      Supported by IMP (PMID:1394434). Ssb participates in cytoplasmic translation
-      as a ribosome-associated cotranslational chaperone.
+      Supported by IMP (PMID:1394434), but cytoplasmic translation is the context
+      for Ssb2&#39;s nascent-chain folding activity rather than a separate core
+      activity of the chaperone.
     supported_by:
     - reference_id: PMID:1394434
       supporting_text: Mutant ssb1 ssb2
@@ -5359,15 +5851,17 @@ existing_annotations:
     label: cytoplasmic translation
   evidence_type: IPI
   original_reference_id: PMID:1394434
+  qualifier: involved_in
   review:
     summary: |-
       Ssb1/2p associate with translating ribosomes and the association is
       disrupted by puromycin, suggesting direct binding to the nascent
       polypeptide during cytoplasmic translation.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
-      Supported (PMID:1394434). Consistent IPI/IMP support for Ssb&#39;s role at the
-      translating cytoplasmic ribosome (same action as the paired IMP annotation).
+      Supported (PMID:1394434). The interaction places Ssb2 in cytoplasmic
+      translation, but this is the context for its core cotranslational folding
+      role rather than a distinct core process.
     supported_by:
     - reference_id: PMID:1394434
       supporting_text: The SSB hsp70s (Ssb1/2p) are associated with
@@ -5377,6 +5871,7 @@ existing_annotations:
     label: rRNA processing
   evidence_type: IGI
   original_reference_id: PMID:20368619
+  qualifier: involved_in
   review:
     summary: |-
       Genetic interaction places Ssb/RAC in a ribosome-anchored chaperone network
@@ -5391,15 +5886,16 @@ existing_annotations:
     label: regulation of translational fidelity
   evidence_type: IMP
   original_reference_id: PMID:15456889
+  qualifier: involved_in
   review:
     summary: |-
       Absence of RAC or Ssb1/2p impairs translational fidelity in vivo and in
       vitro, primarily through a defect in translation termination, enhanced by
       paromomycin.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
-      Strong direct IMP evidence (PMID:15456889) that Ssb1/2p are crucial for
-      translational fidelity beyond their chaperone role for nascent chains.
+      Strong direct IMP evidence (PMID:15456889), retained as a genuine secondary
+      consequence beyond Ssb2&#39;s core nascent-chain chaperone role.
     supported_by:
     - reference_id: PMID:15456889
       supporting_text: Translational fidelity was impaired in the absence of functional RAC or Ssb1/2p
@@ -5409,6 +5905,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IDA
   original_reference_id: PMID:9860955
+  qualifier: enables
   review:
     summary: |-
       Ssb has direct, biochemically characterized ATPase activity with unusual
@@ -5430,6 +5927,7 @@ existing_annotations:
     label: cellular response to glucose starvation
   evidence_type: IGI
   original_reference_id: PMID:19723765
+  qualifier: involved_in
   review:
     summary: |-
       Ssb is required for glucose sensing via the SNF1 kinase network: the
@@ -5449,17 +5947,18 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:9670014
+  qualifier: enables
   review:
     summary: |-
       Ssb can be cross-linked to nascent chains and is released with nascent
       chains upon puromycin treatment, demonstrating direct binding to
-      unfolded/nascent polypeptides. The ATP-driven chaperone mechanism is better
-      captured by ATP-dependent protein folding chaperone (GO:0140662).
+      unfolded/nascent polypeptides. GO:0051082 is obsolete; for this
+      ATP-dependent Hsp70, GO:0140662 captures the supported activity.
     action: MODIFY
     reason: |-
-      The binding term is directly supported (PMID:9670014) but a binding-only
-      term understates the ATP-dependent Hsp70 mechanism. Modify to the
-      ATP-dependent protein folding chaperone MF.
+      Modify because GO:0051082 is obsolete, not because the IDA evidence is
+      deficient. OLS directs curators to consider GO:0044183; Ssb2&#39;s
+      ATP-dependent Hsp70 mechanism supports its child GO:0140662.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone
@@ -5475,6 +5974,7 @@ existing_annotations:
     label: &#39;&#39;&#39;de novo&#39;&#39; cotranslational protein folding&#39;
   evidence_type: IDA
   original_reference_id: PMID:9670014
+  qualifier: involved_in
   review:
     summary: |-
       Ssb is a core component of the translating ribosome that interacts with both
@@ -5491,6 +5991,39 @@ existing_annotations:
     - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
       supporting_text: Ssb2 belongs to an **Hsp70 triad at the exit tunnel**
       reference_section_type: OTHER
+- term:
+    id: GO:0043022
+    label: ribosome binding
+  evidence_type: IDA
+  original_reference_id: PMID:9670014
+  qualifier: enables
+  review:
+    summary: Proposed new annotation for Ssb2&#39;s directly characterized physical association with translating ribosomes.
+    action: NEW
+    reason: PMID:9670014 used puromycin release, salt resistance, and nascent-chain cross-linking to characterize the Ssb-ribosome interaction; the current SSB2 GOA set lacks ribosome-binding molecular function.
+    supported_by:
+    - reference_id: PMID:9670014
+      supporting_text: We propose that Ssb is a core component of the translating ribosome which interacts with both the nascent polypeptide chain and the ribosome.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0022626
+    label: cytosolic ribosome
+  evidence_type: IDA
+  original_reference_id: PMID:9670014
+  qualifier: is_active_in
+  review:
+    summary: Proposed new annotation for the cytosolic translating ribosome where Ssb2 performs its cotranslational chaperone cycle.
+    action: NEW
+    reason: PMID:9670014 directly demonstrates stable Ssb association with translating ribosomes, while PMID:1394434 identifies the SSB proteins as cytosolic Hsp70s associated with translating ribosomes.
+    additional_reference_ids:
+    - PMID:1394434
+    supported_by:
+    - reference_id: PMID:9670014
+      supporting_text: The Ssbs of Saccharomyces cerevisiae are an abundant type of Hsp70 found associated with translating ribosomes.
+      reference_section_type: ABSTRACT
+    - reference_id: PMID:1394434
+      supporting_text: We suggest that cytosolic hsp70 aids in the passage of the nascent polypeptide chain through the ribosome in a manner analogous to the role played by organelle-localized hsp70 in the transport of proteins across membranes.
+      reference_section_type: ABSTRACT
 core_functions:
 - description: |-
     ATP-dependent Hsp70 molecular chaperone that binds short, largely hydrophobic
@@ -5506,6 +6039,8 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  - id: GO:0022626
+    label: cytosolic ribosome
   supported_by:
   - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
     supporting_text: Ssb1/2 (including Ssb2) act as the **direct nascent-chain binders** during co-translational folding in yeast

--- a/genes/yeast/SSB2/SSB2-ai-review.yaml
+++ b/genes/yeast/SSB2/SSB2-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P40150
 gene_symbol: SSB2
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -29,6 +29,7 @@ existing_annotations:
     label: nucleus
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: |-
       Ssb2 functions on cytosolic translating ribosomes; a nuclear pool is at
@@ -36,10 +37,18 @@ existing_annotations:
       ribosome biogenesis). Not a core localization.
     action: KEEP_AS_NON_CORE
     reason: |-
-      Ssb is overwhelmingly cytosolic and ribosome-associated. The falcon report
-      localizes Ssb to the cytosol and 60S tunnel exit with no evidence for an
-      autonomous nuclear function; any nuclear signal is best treated as
-      peripheral/context-dependent.
+      PMID:20368619 directly supports a specialized nuclear RAC-Ssb role in
+      ribosome biogenesis, while direct localization and biochemical studies
+      place the principal Ssb pool in the cytosol and on translating ribosomes.
+      Nucleus is therefore retained as a non-core site of action.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002500132
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The family inference is compatible with Ssb2 participation in
+          nuclear ribosome biogenesis, but nucleus is not its predominant site.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -51,6 +60,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: |-
       Ssb2 is a cytoplasmic/cytosolic chaperone. Cytoplasm is correct but
@@ -59,6 +69,14 @@ existing_annotations:
     reason: |-
       Correct but non-specific. The functionally meaningful localization is the
       cytosolic translating ribosome (see cytosol annotation).
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002321897
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The broad cytoplasmic inference is correct for Ssb2, although
+          cytosol and cytosolic ribosome are more informative.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -70,16 +88,18 @@ existing_annotations:
     label: plasma membrane
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: |-
-      Plasma membrane is not a site of Ssb2 function. This likely reflects
-      high-throughput proteome surveys detecting the abundant cytosolic Ssb pool.
+      Plasma membrane is not a site of Ssb2 function; this PAINT inference
+      transfers a compartment occupied by other Hsp70-family proteins to the
+      ribosome-specialized soluble Ssb2 subfamily.
     action: REMOVE
     reason: |-
-      No experimental or literature support for plasma membrane function. The
-      falcon report and UniProt localize Ssb to the cytosol and ribosome; a
-      plasma membrane assignment for this abundant cytosolic Hsp70 is an
-      over-annotation from high-throughput localization datasets.
+      Direct localization and biochemical evidence place Ssb2 in the cytosol and
+      on cytosolic translating ribosomes. The GOA WITH/FROM identifies
+      PTN002500132, whose plasma-membrane seeds do not establish this mutually
+      exclusive compartment for Ssb2.
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
@@ -101,6 +121,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: |-
       Ssb2 is an Hsp70 ATPase (EC 3.6.4.10); ATP hydrolysis powers its chaperone
@@ -109,6 +130,14 @@ existing_annotations:
     reason: |-
       Directly supported. The Ssb ATPase activity is experimentally characterized
       and the ATP-driven conformational cycle is central to its function.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The conserved Hsp70-family ATPase inference agrees with direct
+          Ssb biochemistry from PMID:9860955.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -120,14 +149,23 @@ existing_annotations:
     label: heat shock protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: |-
       Ssb2 interacts with co-chaperone partners of the Hsp70 system, notably the
       RAC J-protein Zuo1/Ssz1 and the Hsp110 nucleotide exchange factor Sse1.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
-      Consistent with the documented Ssb-RAC and Ssb-Sse1 (Hsp110) functional
-      interactions that constitute the ribosome-associated Hsp70 chaperone system.
+      Consistent with documented Ssb-RAC and Ssb-Sse1 interactions, but this
+      binding term is ancillary to Ssb2's direct ATP-dependent folding activity.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: Conserved Hsp70-network interactions support the transfer, while
+          heat-shock-protein binding remains non-core for Ssb2.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -139,6 +177,7 @@ existing_annotations:
     label: protein folding chaperone
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: |-
       Ssb2 is a protein folding chaperone that assists cotranslational folding of
@@ -172,6 +211,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: |-
       Ssb2 is a cytosolic chaperone; ~50% is ribosome-associated and the
@@ -180,6 +220,14 @@ existing_annotations:
     reason: |-
       Strongly supported. The cytosol (and specifically cytosolic translating
       ribosomes) is where Ssb2 carries out its function.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN002500132
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_TRANSFER
+        comment: The ancestral cytosol inference agrees with Ssb2's direct
+          localization and ribosome-associated folding function.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
@@ -191,28 +239,44 @@ existing_annotations:
     label: protein refolding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: |-
-      Ssb's primary, best-supported role is de novo cotranslational folding of
-      nascent chains rather than refolding of pre-existing denatured proteins,
-      though as an Hsp70 it can contribute to general proteostasis/aggregation
-      prevention.
-    action: KEEP_AS_NON_CORE
+      Ssb2 promotes de novo cotranslational folding of newly synthesized chains;
+      this is ontologically distinct from restoring activity to a pre-existing
+      unfolded or misfolded protein (GO:0042026).
+    action: MODIFY
     reason: |-
-      Plausible Hsp70 activity but not the core, distinguishing function of Ssb.
-      The falcon report and primary literature emphasize cotranslational folding
-      of nascent chains; refolding is a generic Hsp70 capability kept as non-core.
+      The family-level refolding claim is unsupported for the ribosome-specialized
+      Ssb subfamily. PMID:9670014 directly establishes de novo cotranslational
+      folding, which is a sibling protein-folding process rather than evidence
+      for refolding pre-existing denatured clients.
+    proposed_replacement_terms:
+    - id: GO:0051083
+      label: '''de novo'' cotranslational protein folding'
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PAINT Hsp70 family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: General refolding is defensible elsewhere in the Hsp70 family,
+          but direct Ssb2 evidence establishes its specialized de novo
+          cotranslational folding role and not refolding of mature clients.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
     supported_by:
     - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
-      supporting_text: Ssb suppresses formation and/or inheritance of multiple **amyloid/prion-like elements**
+      supporting_text: Ssb1/2 (including Ssb2) act as the **direct nascent-chain binders** during co-translational folding in yeast
       reference_section_type: OTHER
 - term:
     id: GO:0000054
     label: ribosomal subunit export from nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: |-
       Ssb/RAC participates in a ribosome-anchored chaperone network linked to
@@ -227,6 +291,7 @@ existing_annotations:
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: |-
       Generic parent of ATP binding. Ssb2 binds ATP via its NBD; the more
@@ -240,6 +305,7 @@ existing_annotations:
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: |-
       Ssb2's N-terminal nucleotide-binding domain binds ATP, the basis of its
@@ -259,6 +325,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: |-
       Cytoplasm is correct but generic; cytosol/ribosome-associated is the
@@ -271,6 +338,7 @@ existing_annotations:
     label: rRNA processing
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: |-
       Ssb/RAC is part of a ribosome-anchored chaperone network implicated in
@@ -285,6 +353,7 @@ existing_annotations:
     label: translation
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: involved_in
   review:
     summary: |-
       Generic parent. Ssb acts on translating ribosomes; the more specific
@@ -300,14 +369,16 @@ existing_annotations:
     label: regulation of translational fidelity
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: |-
       Loss of Ssb1/2 (or RAC) impairs translational fidelity, primarily at
       translation termination. A genuine, experimentally supported downstream role.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
-      Supported experimentally (PMID:15456889): RAC and Ssb1/2p are crucial for
-      translational fidelity, with the principal defect in translation termination.
+      Supported experimentally (PMID:15456889), but translational fidelity is a
+      downstream consequence of the RAC-Ssb system rather than the chaperone's
+      direct core molecular activity.
     additional_reference_ids:
     - file:yeast/SSB2/SSB2-deep-research-falcon.md
 - term:
@@ -315,6 +386,7 @@ existing_annotations:
     label: translational frameshifting
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: |-
       Deletion of Ssb1/2 (or RAC) specifically inhibits -1 programmed ribosomal
@@ -329,6 +401,7 @@ existing_annotations:
     label: hydrolase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: |-
       Uninformative parent term. Ssb2's relevant activity is ATP hydrolysis
@@ -342,6 +415,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: |-
       Ssb2 hydrolyzes ATP as part of its Hsp70 chaperone cycle (EC 3.6.4.10),
@@ -356,16 +430,17 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: enables
   review:
     summary: |-
-      Ssb2 binds exposed hydrophobic segments of unfolded/nascent polypeptides.
-      The chaperone activity is better captured by ATP-dependent protein folding
-      chaperone (GO:0140662).
+      GO:0051082 is obsolete. OLS records protein folding chaperone
+      (GO:0044183) as a term to consider; for the ATP-dependent Ssb2 Hsp70,
+      the more specific GO:0140662 captures the supported activity.
     action: MODIFY
     reason: |-
-      The binding term is accurate but a holdase/binding-only term understates
-      the ATP-driven Hsp70 mechanism. Modify to the ATP-dependent protein folding
-      chaperone MF.
+      Modify because GO:0051082 is obsolete, not because substrate binding lacks
+      support. OLS directs curators to consider GO:0044183; Ssb2's ATP-dependent
+      Hsp70 mechanism supports its child GO:0140662.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone
@@ -380,6 +455,7 @@ existing_annotations:
     label: '''de novo'' cotranslational protein folding'
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: |-
       This is the core biological process of Ssb2: direct binding to nascent
@@ -400,6 +476,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16429126
+  qualifier: enables
   review:
     summary: |-
       Generic protein-binding from a high-throughput proteome survey; provides no
@@ -413,6 +490,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
+  qualifier: enables
   review:
     summary: |-
       Generic protein-binding from a high-throughput complex landscape study; no
@@ -425,6 +503,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
+  qualifier: enables
   review:
     summary: |-
       Generic protein-binding from a chaperone-interaction atlas; no specific
@@ -437,6 +516,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23332755
+  qualifier: enables
   review:
     summary: |-
       This reference actually documents Ssb's cotranslational nascent-chain
@@ -452,6 +532,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37070168
+  qualifier: enables
   review:
     summary: |-
       Generic protein-binding from an RNA-dependent interactome study; no specific
@@ -464,6 +545,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
+  qualifier: enables
   review:
     summary: |-
       Generic protein-binding from a global interactome architecture study; no
@@ -476,6 +558,7 @@ existing_annotations:
     label: cytoplasmic stress granule
   evidence_type: HDA
   original_reference_id: PMID:26777405
+  qualifier: located_in
   review:
     summary: |-
       As an abundant cytosolic Hsp70, Ssb2 is detected in stress granules; this
@@ -489,6 +572,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:11914276
+  qualifier: located_in
   review:
     summary: |-
       Cytoplasm localization confirmed by genome-wide GFP localization; correct
@@ -501,25 +585,27 @@ existing_annotations:
     label: plasma membrane
   evidence_type: HDA
   original_reference_id: PMID:16622836
+  qualifier: located_in
   review:
     summary: |-
-      Plasma membrane proteome detection of the abundant cytosolic Ssb; not a
-      genuine functional localization.
-    action: REMOVE
+      Ssb2 was detected in a stripped plasma-membrane fraction in a bulk
+      proteomic survey; this is weak evidence for a functional localization of
+      an abundant soluble cytosolic chaperone.
+    action: MARK_AS_OVER_ANNOTATED
     reason: |-
-      Over-annotation from a plasma-membrane proteome survey. Ssb is a cytosolic
-      ribosome-associated Hsp70 with no functional role at the plasma membrane.
-    additional_reference_ids:
-    - file:yeast/SSB2/SSB2-deep-research-falcon.md
+      PMID:16622836 reports fraction detection, whereas direct studies place Ssb
+      in the cytosol and on cytosolic translating ribosomes. Retain the HDA
+      observation but do not interpret it as a functional plasma-membrane site.
     supported_by:
-    - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
-      supporting_text: Ssb proteins (Ssb1/Ssb2) are **cytosolic** and **ribosome-associated**, positioned at the **60S tunnel exit**
-      reference_section_type: OTHER
+    - reference_id: PMID:16622836
+      supporting_text: Proteins from a stripped plasma membrane fraction were solubilized with the neutral and non-denaturing detergent, the n-dodecyl beta-D-maltoside.
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0006452
     label: translational frameshifting
   evidence_type: IMP
   original_reference_id: PMID:16607023
+  qualifier: involved_in
   review:
     summary: |-
       Deletion of Ssb1p/Ssb2p (or RAC) specifically inhibits -1 programmed
@@ -538,6 +624,7 @@ existing_annotations:
     label: ribosomal subunit export from nucleus
   evidence_type: IGI
   original_reference_id: PMID:20368619
+  qualifier: involved_in
   review:
     summary: |-
       Genetic interaction evidence places Ssb/RAC in a ribosome-anchored
@@ -552,15 +639,17 @@ existing_annotations:
     label: cytoplasmic translation
   evidence_type: IMP
   original_reference_id: PMID:1394434
+  qualifier: involved_in
   review:
     summary: |-
       Ssb1/2 are associated with translating ribosomes; ssb1 ssb2 mutants grow
       slowly, have fewer translating ribosomes, and are hypersensitive to protein
       synthesis inhibitors, linking Ssb to cytoplasmic translation.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
-      Supported by IMP (PMID:1394434). Ssb participates in cytoplasmic translation
-      as a ribosome-associated cotranslational chaperone.
+      Supported by IMP (PMID:1394434), but cytoplasmic translation is the context
+      for Ssb2's nascent-chain folding activity rather than a separate core
+      activity of the chaperone.
     supported_by:
     - reference_id: PMID:1394434
       supporting_text: Mutant ssb1 ssb2
@@ -573,15 +662,17 @@ existing_annotations:
     label: cytoplasmic translation
   evidence_type: IPI
   original_reference_id: PMID:1394434
+  qualifier: involved_in
   review:
     summary: |-
       Ssb1/2p associate with translating ribosomes and the association is
       disrupted by puromycin, suggesting direct binding to the nascent
       polypeptide during cytoplasmic translation.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
-      Supported (PMID:1394434). Consistent IPI/IMP support for Ssb's role at the
-      translating cytoplasmic ribosome (same action as the paired IMP annotation).
+      Supported (PMID:1394434). The interaction places Ssb2 in cytoplasmic
+      translation, but this is the context for its core cotranslational folding
+      role rather than a distinct core process.
     supported_by:
     - reference_id: PMID:1394434
       supporting_text: The SSB hsp70s (Ssb1/2p) are associated with
@@ -591,6 +682,7 @@ existing_annotations:
     label: rRNA processing
   evidence_type: IGI
   original_reference_id: PMID:20368619
+  qualifier: involved_in
   review:
     summary: |-
       Genetic interaction places Ssb/RAC in a ribosome-anchored chaperone network
@@ -605,15 +697,16 @@ existing_annotations:
     label: regulation of translational fidelity
   evidence_type: IMP
   original_reference_id: PMID:15456889
+  qualifier: involved_in
   review:
     summary: |-
       Absence of RAC or Ssb1/2p impairs translational fidelity in vivo and in
       vitro, primarily through a defect in translation termination, enhanced by
       paromomycin.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: |-
-      Strong direct IMP evidence (PMID:15456889) that Ssb1/2p are crucial for
-      translational fidelity beyond their chaperone role for nascent chains.
+      Strong direct IMP evidence (PMID:15456889), retained as a genuine secondary
+      consequence beyond Ssb2's core nascent-chain chaperone role.
     supported_by:
     - reference_id: PMID:15456889
       supporting_text: Translational fidelity was impaired in the absence of functional RAC or Ssb1/2p
@@ -623,6 +716,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IDA
   original_reference_id: PMID:9860955
+  qualifier: enables
   review:
     summary: |-
       Ssb has direct, biochemically characterized ATPase activity with unusual
@@ -644,6 +738,7 @@ existing_annotations:
     label: cellular response to glucose starvation
   evidence_type: IGI
   original_reference_id: PMID:19723765
+  qualifier: involved_in
   review:
     summary: |-
       Ssb is required for glucose sensing via the SNF1 kinase network: the
@@ -663,17 +758,18 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:9670014
+  qualifier: enables
   review:
     summary: |-
       Ssb can be cross-linked to nascent chains and is released with nascent
       chains upon puromycin treatment, demonstrating direct binding to
-      unfolded/nascent polypeptides. The ATP-driven chaperone mechanism is better
-      captured by ATP-dependent protein folding chaperone (GO:0140662).
+      unfolded/nascent polypeptides. GO:0051082 is obsolete; for this
+      ATP-dependent Hsp70, GO:0140662 captures the supported activity.
     action: MODIFY
     reason: |-
-      The binding term is directly supported (PMID:9670014) but a binding-only
-      term understates the ATP-dependent Hsp70 mechanism. Modify to the
-      ATP-dependent protein folding chaperone MF.
+      Modify because GO:0051082 is obsolete, not because the IDA evidence is
+      deficient. OLS directs curators to consider GO:0044183; Ssb2's
+      ATP-dependent Hsp70 mechanism supports its child GO:0140662.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone
@@ -689,6 +785,7 @@ existing_annotations:
     label: '''de novo'' cotranslational protein folding'
   evidence_type: IDA
   original_reference_id: PMID:9670014
+  qualifier: involved_in
   review:
     summary: |-
       Ssb is a core component of the translating ribosome that interacts with both
@@ -705,6 +802,39 @@ existing_annotations:
     - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
       supporting_text: Ssb2 belongs to an **Hsp70 triad at the exit tunnel**
       reference_section_type: OTHER
+- term:
+    id: GO:0043022
+    label: ribosome binding
+  evidence_type: IDA
+  original_reference_id: PMID:9670014
+  qualifier: enables
+  review:
+    summary: Proposed new annotation for Ssb2's directly characterized physical association with translating ribosomes.
+    action: NEW
+    reason: PMID:9670014 used puromycin release, salt resistance, and nascent-chain cross-linking to characterize the Ssb-ribosome interaction; the current SSB2 GOA set lacks ribosome-binding molecular function.
+    supported_by:
+    - reference_id: PMID:9670014
+      supporting_text: We propose that Ssb is a core component of the translating ribosome which interacts with both the nascent polypeptide chain and the ribosome.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0022626
+    label: cytosolic ribosome
+  evidence_type: IDA
+  original_reference_id: PMID:9670014
+  qualifier: is_active_in
+  review:
+    summary: Proposed new annotation for the cytosolic translating ribosome where Ssb2 performs its cotranslational chaperone cycle.
+    action: NEW
+    reason: PMID:9670014 directly demonstrates stable Ssb association with translating ribosomes, while PMID:1394434 identifies the SSB proteins as cytosolic Hsp70s associated with translating ribosomes.
+    additional_reference_ids:
+    - PMID:1394434
+    supported_by:
+    - reference_id: PMID:9670014
+      supporting_text: The Ssbs of Saccharomyces cerevisiae are an abundant type of Hsp70 found associated with translating ribosomes.
+      reference_section_type: ABSTRACT
+    - reference_id: PMID:1394434
+      supporting_text: We suggest that cytosolic hsp70 aids in the passage of the nascent polypeptide chain through the ribosome in a manner analogous to the role played by organelle-localized hsp70 in the transport of proteins across membranes.
+      reference_section_type: ABSTRACT
 core_functions:
 - description: |-
     ATP-dependent Hsp70 molecular chaperone that binds short, largely hydrophobic
@@ -720,6 +850,8 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  - id: GO:0022626
+    label: cytosolic ribosome
   supported_by:
   - reference_id: file:yeast/SSB2/SSB2-deep-research-falcon.md
     supporting_text: Ssb1/2 (including Ssb2) act as the **direct nascent-chain binders** during co-translational folding in yeast

--- a/genes/yeast/SSB2/SSB2-notes.md
+++ b/genes/yeast/SSB2/SSB2-notes.md
@@ -27,3 +27,24 @@
 - Roughly half of cellular Ssb is ribosome-associated, but this is dynamic rather
   than stable complex membership, so the core function uses cytosol as location
   and describes the 60S tunnel-exit position in prose instead of `in_complex`.
+
+## 2026-08-28 completion audit
+
+- Reconciled every distinct GOA assertion and added the original qualifiers.
+- Audited all eight IBA rows against their actual GOA PAINT nodes:
+  PTN002500132 for nucleus, plasma membrane, and cytosol; PTN002321897 for
+  cytoplasm; and PTN000452648 for ATP hydrolysis, heat-shock-protein binding,
+  protein-folding chaperone activity, and protein refolding.
+- The plasma-membrane IBA is a compartment-mismatch propagation failure. The
+  independent HDA row from PMID:16622836 is instead retained as an
+  over-annotated bulk-fraction observation, using the paper's exact abstract
+  description of a stripped plasma-membrane fraction.
+- GO:0042026 protein refolding restores activity to an already unfolded or
+  misfolded protein; GO:0051083 describes folding a ribosome-bound nascent chain.
+  Because the direct Ssb evidence establishes the latter rather than the former,
+  the IBA refolding row is modified to GO:0051083 rather than retained as a
+  generic Hsp70 capability. [PMID:9670014 "preventing the misfolding of newly
+  synthesized proteins"]
+- Added machine-readable NEW proposals for GO:0043022 ribosome binding and
+  GO:0022626 cytosolic ribosome, both directly supported by PMID:9670014 and
+  consistent with PMID:1394434. These are missing from the current SSB2 GOA set.


### PR DESCRIPTION
## Summary
- complete yeast SSB2 after exact reconciliation of 39 GOA assertion signatures, plus two evidence-backed NEW proposals
- audit all eight IBA rows against their actual PAINT nodes and add structured propagation reviews
- retain the plasma-membrane IBA as a compartment-mismatch removal while treating PMID:16622836 bulk HDA fraction detection as over-annotated
- narrow propagated protein refolding to directly supported de novo cotranslational folding as functional divergence
- add NEW IDA proposals for GO:0043022 ribosome binding and GO:0022626 cytosolic ribosome with exact cached evidence
- retain downstream translation/fidelity/frameshifting and heat-shock-protein binding as non-core
- mark the review COMPLETE, append audit notes, and regenerate HTML/browser data

No source-code or cache changes are included.

## Validation
- `just validate yeast SSB2` (clean, no warnings)
- `just validate-goa yeast SSB2`
- `just render yeast SSB2`
- `just deploy-browser` (131,484 annotations)
- `git diff --check`