### PR TITLE
Complete yeast SSQ1 annotation review

### DIFF
--- a/genes/yeast/SSQ1/SSQ1-ai-review.html
+++ b/genes/yeast/SSQ1/SSQ1-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -989,6 +989,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452554</span>
+
+                                    &middot; PANTHER:PTN000452554
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The eukaryotic mitochondrial Hsp70 node correctly places Ssq1 in mitochondria; the matrix child term is more informative.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1061,6 +1090,35 @@ this ATPase activity to drive productive Fe-S transfer complex formation.
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; PANTHER:PTN000452648
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The conserved Hsp70 ATPase inference agrees with direct Ssq1 biochemical evidence; SSQ1 itself is among the experimentally grounded descendants supporting this ancestral node.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1073,6 +1131,19 @@ this ATPase activity to drive productive Fe-S transfer complex formation.
                                 </span>
 
                                 <div class="support-text">The **J-domain cochaperone Jac1** recruits the Fe–S-loaded scaffold and stimulates Ssq1 ATP hydrolysis; Jac1 and Isu1 act **synergistically** to stimulate Ssq1 ATPase activity</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12756240" target="_blank" class="term-link">
+                                        PMID:12756240
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Jac1 and Isu1 cooperatively stimulate the ATPase activity of Ssq1.</div>
 
                             </div>
 
@@ -1130,6 +1201,53 @@ this ATPase activity to drive productive Fe-S transfer complex formation.
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452648</span>
+
+                                    &middot; PANTHER:PTN000452648
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The ancestral Hsp70 interaction term is compatible with Ssq1&#39;s Jac1/Mge1 chaperone system but is ancillary to its core activity.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11601843" target="_blank" class="term-link">
+                                        PMID:11601843
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ssq1 was able to form a specific complex with the nucleotide exchange factor Mge1.</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -1303,6 +1421,35 @@ off from the Isu1/Isu2 scaffold to the carrier Grx5.
                             <strong>Reason:</strong> Phylogenetic transfer is safe because Ssq1-specific biochemical and genetic evidence independently establishes its ISC release/handoff role.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000452554</span>
+
+                                    &middot; PANTHER:PTN000452554
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The PAINT node is seeded by experimentally grounded Ssq-type mitochondrial Hsp70s, including SSQ1 itself, and target-specific mutant evidence independently establishes this conserved role.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -2617,16 +2764,15 @@ Mge1 acting as the nucleotide exchange factor that resets the cycle.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding captures Ssq1&#39;s Hsp70
-substrate-binding behavior, but for this specialized chaperone the
-physiological client is the folded Isu1 scaffold recognized via its
-conserved LPPVK peptide motif rather than generic unfolded proteins.
-The ATP-dependent protein folding chaperone term better represents Ssq1&#39;s biology.
+                            <strong>Summary:</strong> PMID:11601843 directly supports ATP-regulated binding of unfolded substrate
+proteins, so the experiment is sound. GO:0051082 is now obsolete; the
+ATP-dependent protein folding chaperone term captures the Hsp70 activity
+without preserving the obsolete binding-only annotation.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Unfolded protein binding is a valid but nonspecific activity proxy. Ssq1 is directly characterized as an ATP-dependent Hsp70 chaperone with a specialized Isu substrate, so GO:0140662 captures both mechanism and function.
+                            <strong>Reason:</strong> Modify because GO:0051082 is obsolete, not because the IDA is deficient. Ssq1 directly binds unfolded substrates in an ATP-regulated manner and also uses its ATPase cycle on the physiological Isu scaffold, supporting GO:0140662.
                         </div>
 
 
@@ -2649,11 +2795,13 @@ The ATP-dependent protein folding chaperone term better represents Ssq1&#39;s bi
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:yeast/SSQ1/SSQ1-deep-research-falcon.md
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11601843" target="_blank" class="term-link">
+                                        PMID:11601843
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">Ssq1 recognizes the scaffold **Isu1** through the conserved **LPPVK** motif (a peptide loop) that engages the Hsp70 substrate-binding site</div>
+                                <div class="support-text">Ssq1 showed typical chaperone properties by binding to unfolded substrate proteins in an ATP-regulated manner.</div>
 
                             </div>
 
@@ -3784,6 +3932,48 @@ this with annotations you find in gene/protein databases, but these can be outda
   functional compartment. Intracellular iron homeostasis is retained as a<br />
   genuine downstream phenotype, not a core direct function.</li>
 </ul>
+<h2 id="2026-08-28-completion-audit">2026-08-28 completion audit</h2>
+<ul>
+<li>Reconciled all 29 GOA rows by the exact machine signature (GO term, evidence<br />
+  code, reference, and qualifier); <code>just validate-goa yeast SSQ1</code> passes and no<br />
+  review remains <code>PENDING</code>.</li>
+<li>Audited all seven IBA rows against the current GOA <code>WITH/FROM</code> field and<br />
+<code>interpro/panther/PTHR19375/PTHR19375-paint.tsv</code>. The actual PAINT nodes are<br />
+  PTN002321897 for cytoplasm, PTN000452554 for mitochondrion and iron-sulfur<br />
+  cluster assembly, and PTN000452648 for ATP hydrolysis, heat-shock-protein<br />
+  binding, protein-folding chaperone, and protein refolding. SSQ1 appearing<br />
+  among the experimental descendants for conserved ATPase/ISC assertions is<br />
+  expected phylogenetic grounding, not circularity.</li>
+<li>The core ATPase and ISC-transfer calls have direct target evidence. Jac1 and<br />
+  Isu1 stimulate Ssq1 ATPase [PMID:12756240, "Jac1 and Isu1 cooperatively<br />
+  stimulate the ATPase activity of Ssq1."], and a ferredoxin maturation assay<br />
+  established a mitochondrial Fe-S assembly requirement [PMID:11273703,<br />
+  "Ssq1 was demonstrated to be required for the FeS cluster assembly in<br />
+  mitochondria."].</li>
+<li>GO:0051082 is retained only as the imported legacy row and changed to<br />
+<code>MODIFY</code> because the term is obsolete, not because the experiment is weak:<br />
+  Ssq1 directly showed ATP-regulated binding to unfolded substrates<br />
+  [PMID:11601843, "Ssq1 showed typical chaperone properties by binding to<br />
+  unfolded substrate proteins in an ATP-regulated manner."]. GO:0140662 is the<br />
+  proposed replacement already used in the core-function synthesis.</li>
+<li>Live-ontology recheck on 2026-08-28 confirmed this obsoletion in the official<br />
+  EBI OLS GO record (<code>is_obsolete: true</code>, label <code>obsolete unfolded protein
+  binding</code>, with <code>consider</code> GO:0044183 and GO:0140309). The repository cache row<br />
+  that still says <code>False</code> is timestamped 2026-03-21, and the SSQ1 GOA/UniProt<br />
+  snapshots are dated 2026-01; all predate closure of the official GO obsoletion<br />
+  request on 2026-05-29 (geneontology/go-ontology#30962). They are stale evidence<br />
+  for current term status, not a contradiction of the live ontology.</li>
+<li>GO:0042026 remains marked as an over-propagated general-Hsp70 process rather<br />
+  than removed. The available literature establishes specialized ISC client<br />
+  handling but does not provide a target-specific refolding assay; this avoids<br />
+  claiming loss of all refolding capacity from incomplete evidence.</li>
+<li>The five protein-binding IPI rows were retained as over-annotated rather than<br />
+  removed. Isu1 is the physiological client, while the Nop1 rows are<br />
+  compartmentally discordant high-throughput observations; bare protein binding<br />
+  is uninformative in either case.</li>
+<li>Final curation state: 9 <code>ACCEPT</code>, 8 <code>KEEP_AS_NON_CORE</code>, 10<br />
+<code>MARK_AS_OVER_ANNOTATED</code>, 2 <code>MODIFY</code>, 0 <code>PENDING</code>; status set to <code>COMPLETE</code>.</li>
+</ul>
             </div>
         </details>
 
@@ -3800,7 +3990,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: Q05931
 gene_symbol: SSQ1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -3823,6 +4013,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: Cytoplasm is a true but uninformatively broad ancestor of Ssq1&#39;s
       experimentally supported mitochondrial matrix location.
@@ -3845,6 +4036,7 @@ existing_annotations:
     label: mitochondrion
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: Mitochondrion is correct but less precise than the experimentally supported
       mitochondrial matrix localization.
@@ -3855,11 +4047,20 @@ existing_annotations:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: Ssq1 and Jac1 are localized to the **mitochondrial matrix**
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452554
+        source_label: PANTHER:PTN000452554
+        source_status: SUPPORTS_TRANSFER
+        comment: The eukaryotic mitochondrial Hsp70 node correctly places Ssq1
+          in mitochondria; the matrix child term is more informative.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: |-
       Manual review: ATP hydrolysis activity is consistent with known biology of
@@ -3875,22 +4076,48 @@ existing_annotations:
       supporting_text: The **J-domain cochaperone Jac1** recruits the Fe–S-loaded
         scaffold and stimulates Ssq1 ATP hydrolysis; Jac1 and Isu1 act **synergistically**
         to stimulate Ssq1 ATPase activity
+    - reference_id: PMID:12756240
+      reference_section_type: ABSTRACT
+      supporting_text: Jac1 and Isu1 cooperatively stimulate the ATPase activity of Ssq1.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PANTHER:PTN000452648
+        source_status: SUPPORTS_TRANSFER
+        comment: The conserved Hsp70 ATPase inference agrees with direct Ssq1
+          biochemical evidence; SSQ1 itself is among the experimentally grounded
+          descendants supporting this ancestral node.
 - term:
     id: GO:0031072
     label: heat shock protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: Ssq1 participates in an Hsp70 cochaperone system with Jac1 and Mge1,
       but this binding term is ancillary to its ATP-dependent chaperone activity.
     action: KEEP_AS_NON_CORE
     reason: The cochaperone interactions are real, but heat shock protein binding does
       not describe Ssq1&#39;s direct core activity in Fe-S cluster transfer.
+    supported_by:
+    - reference_id: PMID:11601843
+      reference_section_type: ABSTRACT
+      supporting_text: Ssq1 was able to form a specific complex with the nucleotide exchange factor Mge1.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PANTHER:PTN000452648
+        source_status: SUPPORTS_TRANSFER
+        comment: The ancestral Hsp70 interaction term is compatible with Ssq1&#39;s
+          Jac1/Mge1 chaperone system but is ancillary to its core activity.
 - term:
     id: GO:0044183
     label: protein folding chaperone
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: |-
       Protein folding chaperone reflects the Hsp70 fold and chaperone mechanism
@@ -3925,6 +4152,7 @@ existing_annotations:
     label: iron-sulfur cluster assembly
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: iron-sulfur cluster assembly is the core biological process
@@ -3941,11 +4169,21 @@ existing_annotations:
         the Isu scaffold** and facilitates **handoff** to downstream factors (notably
         Grx5), enabling maturation of mitochondrial Fe–S proteins and supporting
         downstream cytosolic/nuclear Fe–S biogenesis
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452554
+        source_label: PANTHER:PTN000452554
+        source_status: SUPPORTS_TRANSFER
+        comment: The PAINT node is seeded by experimentally grounded Ssq-type
+          mitochondrial Hsp70s, including SSQ1 itself, and target-specific mutant
+          evidence independently establishes this conserved role.
 - term:
     id: GO:0042026
     label: protein refolding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: protein refolding (restoring activity of unfolded/misfolded
@@ -3983,6 +4221,7 @@ existing_annotations:
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: Generic nucleotide binding is true but uninformative relative to ATP
       binding and directly measured ATP hydrolysis.
@@ -3994,6 +4233,7 @@ existing_annotations:
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: ATP binding is required for Ssq1&#39;s Hsp70 chaperone cycle.
     action: KEEP_AS_NON_CORE
@@ -4004,6 +4244,7 @@ existing_annotations:
     label: mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: located_in
   review:
     summary: Mitochondrion is correct but less precise than mitochondrial matrix.
     action: KEEP_AS_NON_CORE
@@ -4014,6 +4255,7 @@ existing_annotations:
     label: mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: Mitochondrial matrix is the precise site of Ssq1-mediated Fe-S
       cluster transfer.
@@ -4029,6 +4271,7 @@ existing_annotations:
     label: hydrolase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: Generic hydrolase activity is an over-broad parent of Ssq1&#39;s ATP
       hydrolysis activity.
@@ -4040,6 +4283,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: Ssq1 is an Hsp70 ATPase whose catalytic cycle drives Isu engagement
       and Fe-S cluster release.
@@ -4051,6 +4295,7 @@ existing_annotations:
     label: intracellular organelle lumen
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: located_in
   review:
     summary: Intracellular organelle lumen is a very broad parent of the mitochondrial
       matrix localization.
@@ -4062,6 +4307,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12756240
+  qualifier: enables
   review:
     summary: |-
       Manual review: protein binding is too generic for SSQ1. The biologically
@@ -4085,6 +4331,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12947415
+  qualifier: enables
   review:
     summary: This IPI records interaction with the Isu1 scaffold (Q03020), Ssq1&#39;s
       physiological LPPVK-motif client, but generic protein binding is uninformative.
@@ -4097,6 +4344,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
+  qualifier: enables
   review:
     summary: This high-throughput IPI records Nop1 (P15646), a nucleolar protein,
       as the partner of matrix-localized Ssq1; this is likely a non-physiological
@@ -4110,6 +4358,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
+  qualifier: enables
   review:
     summary: This chaperone-network IPI records Nop1 (P15646), a nucleolar protein,
       as the partner of mitochondrial-matrix Ssq1; the compartment mismatch makes
@@ -4123,6 +4372,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
+  qualifier: enables
   review:
     summary: This interactome IPI records Isu1 (Q03020), the physiological scaffold
       client of Ssq1, but generic protein binding is uninformative.
@@ -4134,6 +4384,7 @@ existing_annotations:
     label: iron-sulfur cluster assembly
   evidence_type: IMP
   original_reference_id: PMID:11171977
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: iron-sulfur cluster assembly is the core process for SSQ1.
@@ -4155,6 +4406,7 @@ existing_annotations:
     label: &#39;[2Fe-2S] cluster assembly&#39;
   evidence_type: IMP
   original_reference_id: PMID:11273703
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: [2Fe-2S] cluster assembly is consistent with the core
@@ -4176,6 +4428,7 @@ existing_annotations:
     label: mitochondrion
   evidence_type: IMP
   original_reference_id: PMID:11273703
+  qualifier: is_active_in
   review:
     summary: The mitochondrial phenotype is consistent with Ssq1&#39;s matrix-localized
       role, but mitochondrion is less precise than the matrix term.
@@ -4187,6 +4440,7 @@ existing_annotations:
     label: intracellular iron ion homeostasis
   evidence_type: IMP
   original_reference_id: PMID:9660806
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: intracellular iron ion homeostasis is a downstream
@@ -4206,6 +4460,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IDA
   original_reference_id: PMID:12756240
+  qualifier: enables
   review:
     summary: |-
       Manual review: ATP hydrolysis activity is directly demonstrated for Ssq1
@@ -4226,31 +4481,30 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:11601843
+  qualifier: enables
   review:
     summary: |-
-      Manual review: unfolded protein binding captures Ssq1&#39;s Hsp70
-      substrate-binding behavior, but for this specialized chaperone the
-      physiological client is the folded Isu1 scaffold recognized via its
-      conserved LPPVK peptide motif rather than generic unfolded proteins.
-      The ATP-dependent protein folding chaperone term better represents Ssq1&#39;s biology.
+      PMID:11601843 directly supports ATP-regulated binding of unfolded substrate
+      proteins, so the experiment is sound. GO:0051082 is now obsolete; the
+      ATP-dependent protein folding chaperone term captures the Hsp70 activity
+      without preserving the obsolete binding-only annotation.
     action: MODIFY
-    reason: Unfolded protein binding is a valid but nonspecific activity proxy. Ssq1 is
-      directly characterized as an ATP-dependent Hsp70 chaperone with a specialized
-      Isu substrate, so GO:0140662 captures both mechanism and function.
+    reason: Modify because GO:0051082 is obsolete, not because the IDA is deficient.
+      Ssq1 directly binds unfolded substrates in an ATP-regulated manner and also
+      uses its ATPase cycle on the physiological Isu scaffold, supporting GO:0140662.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone
     supported_by:
-    - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
-      reference_section_type: OTHER
-      supporting_text: Ssq1 recognizes the scaffold **Isu1** through the conserved
-        **LPPVK** motif (a peptide loop) that engages the Hsp70 substrate-binding
-        site
+    - reference_id: PMID:11601843
+      reference_section_type: ABSTRACT
+      supporting_text: Ssq1 showed typical chaperone properties by binding to unfolded substrate proteins in an ATP-regulated manner.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HDA
   original_reference_id: PMID:24769239
+  qualifier: located_in
   review:
     summary: Mitochondrial proteomics supports the organelle assignment but not a
       more specific function than the matrix-localized ISC role.
@@ -4261,6 +4515,7 @@ existing_annotations:
     label: mitochondrion
   evidence_type: HDA
   original_reference_id: PMID:16823961
+  qualifier: located_in
   review:
     summary: Mitochondrial proteomics supports the organelle assignment but not a
       more specific function than the matrix-localized ISC role.
@@ -4271,6 +4526,7 @@ existing_annotations:
     label: mitochondrial matrix
   evidence_type: IDA
   original_reference_id: PMID:8707841
+  qualifier: located_in
   review:
     summary: Direct localization places Ssq1 in the mitochondrial matrix, the site
       of its Fe-S cluster transfer activity.
@@ -4281,6 +4537,7 @@ existing_annotations:
     label: iron-sulfur cluster assembly
   evidence_type: IMP
   original_reference_id: PMID:9813017
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: iron-sulfur cluster assembly is the core process for SSQ1.

--- a/genes/yeast/SSQ1/SSQ1-ai-review.yaml
+++ b/genes/yeast/SSQ1/SSQ1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q05931
 gene_symbol: SSQ1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -24,6 +24,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: Cytoplasm is a true but uninformatively broad ancestor of Ssq1's
       experimentally supported mitochondrial matrix location.
@@ -46,6 +47,7 @@ existing_annotations:
     label: mitochondrion
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: Mitochondrion is correct but less precise than the experimentally supported
       mitochondrial matrix localization.
@@ -56,11 +58,20 @@ existing_annotations:
     - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: Ssq1 and Jac1 are localized to the **mitochondrial matrix**
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452554
+        source_label: PANTHER:PTN000452554
+        source_status: SUPPORTS_TRANSFER
+        comment: The eukaryotic mitochondrial Hsp70 node correctly places Ssq1
+          in mitochondria; the matrix child term is more informative.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: |-
       Manual review: ATP hydrolysis activity is consistent with known biology of
@@ -76,22 +87,48 @@ existing_annotations:
       supporting_text: The **J-domain cochaperone Jac1** recruits the Fe–S-loaded
         scaffold and stimulates Ssq1 ATP hydrolysis; Jac1 and Isu1 act **synergistically**
         to stimulate Ssq1 ATPase activity
+    - reference_id: PMID:12756240
+      reference_section_type: ABSTRACT
+      supporting_text: Jac1 and Isu1 cooperatively stimulate the ATPase activity of Ssq1.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PANTHER:PTN000452648
+        source_status: SUPPORTS_TRANSFER
+        comment: The conserved Hsp70 ATPase inference agrees with direct Ssq1
+          biochemical evidence; SSQ1 itself is among the experimentally grounded
+          descendants supporting this ancestral node.
 - term:
     id: GO:0031072
     label: heat shock protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: Ssq1 participates in an Hsp70 cochaperone system with Jac1 and Mge1,
       but this binding term is ancillary to its ATP-dependent chaperone activity.
     action: KEEP_AS_NON_CORE
     reason: The cochaperone interactions are real, but heat shock protein binding does
       not describe Ssq1's direct core activity in Fe-S cluster transfer.
+    supported_by:
+    - reference_id: PMID:11601843
+      reference_section_type: ABSTRACT
+      supporting_text: Ssq1 was able to form a specific complex with the nucleotide exchange factor Mge1.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452648
+        source_label: PANTHER:PTN000452648
+        source_status: SUPPORTS_TRANSFER
+        comment: The ancestral Hsp70 interaction term is compatible with Ssq1's
+          Jac1/Mge1 chaperone system but is ancillary to its core activity.
 - term:
     id: GO:0044183
     label: protein folding chaperone
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: |-
       Protein folding chaperone reflects the Hsp70 fold and chaperone mechanism
@@ -126,6 +163,7 @@ existing_annotations:
     label: iron-sulfur cluster assembly
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: iron-sulfur cluster assembly is the core biological process
@@ -142,11 +180,21 @@ existing_annotations:
         the Isu scaffold** and facilitates **handoff** to downstream factors (notably
         Grx5), enabling maturation of mitochondrial Fe–S proteins and supporting
         downstream cytosolic/nuclear Fe–S biogenesis
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000452554
+        source_label: PANTHER:PTN000452554
+        source_status: SUPPORTS_TRANSFER
+        comment: The PAINT node is seeded by experimentally grounded Ssq-type
+          mitochondrial Hsp70s, including SSQ1 itself, and target-specific mutant
+          evidence independently establishes this conserved role.
 - term:
     id: GO:0042026
     label: protein refolding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: protein refolding (restoring activity of unfolded/misfolded
@@ -184,6 +232,7 @@ existing_annotations:
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: Generic nucleotide binding is true but uninformative relative to ATP
       binding and directly measured ATP hydrolysis.
@@ -195,6 +244,7 @@ existing_annotations:
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: ATP binding is required for Ssq1's Hsp70 chaperone cycle.
     action: KEEP_AS_NON_CORE
@@ -205,6 +255,7 @@ existing_annotations:
     label: mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: located_in
   review:
     summary: Mitochondrion is correct but less precise than mitochondrial matrix.
     action: KEEP_AS_NON_CORE
@@ -215,6 +266,7 @@ existing_annotations:
     label: mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: Mitochondrial matrix is the precise site of Ssq1-mediated Fe-S
       cluster transfer.
@@ -230,6 +282,7 @@ existing_annotations:
     label: hydrolase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: Generic hydrolase activity is an over-broad parent of Ssq1's ATP
       hydrolysis activity.
@@ -241,6 +294,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: Ssq1 is an Hsp70 ATPase whose catalytic cycle drives Isu engagement
       and Fe-S cluster release.
@@ -252,6 +306,7 @@ existing_annotations:
     label: intracellular organelle lumen
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: located_in
   review:
     summary: Intracellular organelle lumen is a very broad parent of the mitochondrial
       matrix localization.
@@ -263,6 +318,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12756240
+  qualifier: enables
   review:
     summary: |-
       Manual review: protein binding is too generic for SSQ1. The biologically
@@ -286,6 +342,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12947415
+  qualifier: enables
   review:
     summary: This IPI records interaction with the Isu1 scaffold (Q03020), Ssq1's
       physiological LPPVK-motif client, but generic protein binding is uninformative.
@@ -298,6 +355,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
+  qualifier: enables
   review:
     summary: This high-throughput IPI records Nop1 (P15646), a nucleolar protein,
       as the partner of matrix-localized Ssq1; this is likely a non-physiological
@@ -311,6 +369,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
+  qualifier: enables
   review:
     summary: This chaperone-network IPI records Nop1 (P15646), a nucleolar protein,
       as the partner of mitochondrial-matrix Ssq1; the compartment mismatch makes
@@ -324,6 +383,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
+  qualifier: enables
   review:
     summary: This interactome IPI records Isu1 (Q03020), the physiological scaffold
       client of Ssq1, but generic protein binding is uninformative.
@@ -335,6 +395,7 @@ existing_annotations:
     label: iron-sulfur cluster assembly
   evidence_type: IMP
   original_reference_id: PMID:11171977
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: iron-sulfur cluster assembly is the core process for SSQ1.
@@ -356,6 +417,7 @@ existing_annotations:
     label: '[2Fe-2S] cluster assembly'
   evidence_type: IMP
   original_reference_id: PMID:11273703
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: [2Fe-2S] cluster assembly is consistent with the core
@@ -377,6 +439,7 @@ existing_annotations:
     label: mitochondrion
   evidence_type: IMP
   original_reference_id: PMID:11273703
+  qualifier: is_active_in
   review:
     summary: The mitochondrial phenotype is consistent with Ssq1's matrix-localized
       role, but mitochondrion is less precise than the matrix term.
@@ -388,6 +451,7 @@ existing_annotations:
     label: intracellular iron ion homeostasis
   evidence_type: IMP
   original_reference_id: PMID:9660806
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: intracellular iron ion homeostasis is a downstream
@@ -407,6 +471,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IDA
   original_reference_id: PMID:12756240
+  qualifier: enables
   review:
     summary: |-
       Manual review: ATP hydrolysis activity is directly demonstrated for Ssq1
@@ -427,31 +492,30 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:11601843
+  qualifier: enables
   review:
     summary: |-
-      Manual review: unfolded protein binding captures Ssq1's Hsp70
-      substrate-binding behavior, but for this specialized chaperone the
-      physiological client is the folded Isu1 scaffold recognized via its
-      conserved LPPVK peptide motif rather than generic unfolded proteins.
-      The ATP-dependent protein folding chaperone term better represents Ssq1's biology.
+      PMID:11601843 directly supports ATP-regulated binding of unfolded substrate
+      proteins, so the experiment is sound. GO:0051082 is now obsolete; the
+      ATP-dependent protein folding chaperone term captures the Hsp70 activity
+      without preserving the obsolete binding-only annotation.
     action: MODIFY
-    reason: Unfolded protein binding is a valid but nonspecific activity proxy. Ssq1 is
-      directly characterized as an ATP-dependent Hsp70 chaperone with a specialized
-      Isu substrate, so GO:0140662 captures both mechanism and function.
+    reason: Modify because GO:0051082 is obsolete, not because the IDA is deficient.
+      Ssq1 directly binds unfolded substrates in an ATP-regulated manner and also
+      uses its ATPase cycle on the physiological Isu scaffold, supporting GO:0140662.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone
     supported_by:
-    - reference_id: file:yeast/SSQ1/SSQ1-deep-research-falcon.md
-      reference_section_type: OTHER
-      supporting_text: Ssq1 recognizes the scaffold **Isu1** through the conserved
-        **LPPVK** motif (a peptide loop) that engages the Hsp70 substrate-binding
-        site
+    - reference_id: PMID:11601843
+      reference_section_type: ABSTRACT
+      supporting_text: Ssq1 showed typical chaperone properties by binding to unfolded substrate proteins in an ATP-regulated manner.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HDA
   original_reference_id: PMID:24769239
+  qualifier: located_in
   review:
     summary: Mitochondrial proteomics supports the organelle assignment but not a
       more specific function than the matrix-localized ISC role.
@@ -462,6 +526,7 @@ existing_annotations:
     label: mitochondrion
   evidence_type: HDA
   original_reference_id: PMID:16823961
+  qualifier: located_in
   review:
     summary: Mitochondrial proteomics supports the organelle assignment but not a
       more specific function than the matrix-localized ISC role.
@@ -472,6 +537,7 @@ existing_annotations:
     label: mitochondrial matrix
   evidence_type: IDA
   original_reference_id: PMID:8707841
+  qualifier: located_in
   review:
     summary: Direct localization places Ssq1 in the mitochondrial matrix, the site
       of its Fe-S cluster transfer activity.
@@ -482,6 +548,7 @@ existing_annotations:
     label: iron-sulfur cluster assembly
   evidence_type: IMP
   original_reference_id: PMID:9813017
+  qualifier: involved_in
   review:
     summary: |-
       Manual review: iron-sulfur cluster assembly is the core process for SSQ1.

--- a/genes/yeast/SSQ1/SSQ1-notes.md
+++ b/genes/yeast/SSQ1/SSQ1-notes.md
@@ -26,3 +26,45 @@
   GO cytoplasm, but it is marked over-annotated because matrix is the precise
   functional compartment. Intracellular iron homeostasis is retained as a
   genuine downstream phenotype, not a core direct function.
+
+## 2026-08-28 completion audit
+
+- Reconciled all 29 GOA rows by the exact machine signature (GO term, evidence
+  code, reference, and qualifier); `just validate-goa yeast SSQ1` passes and no
+  review remains `PENDING`.
+- Audited all seven IBA rows against the current GOA `WITH/FROM` field and
+  `interpro/panther/PTHR19375/PTHR19375-paint.tsv`. The actual PAINT nodes are
+  PTN002321897 for cytoplasm, PTN000452554 for mitochondrion and iron-sulfur
+  cluster assembly, and PTN000452648 for ATP hydrolysis, heat-shock-protein
+  binding, protein-folding chaperone, and protein refolding. SSQ1 appearing
+  among the experimental descendants for conserved ATPase/ISC assertions is
+  expected phylogenetic grounding, not circularity.
+- The core ATPase and ISC-transfer calls have direct target evidence. Jac1 and
+  Isu1 stimulate Ssq1 ATPase [PMID:12756240, "Jac1 and Isu1 cooperatively
+  stimulate the ATPase activity of Ssq1."], and a ferredoxin maturation assay
+  established a mitochondrial Fe-S assembly requirement [PMID:11273703,
+  "Ssq1 was demonstrated to be required for the FeS cluster assembly in
+  mitochondria."].
+- GO:0051082 is retained only as the imported legacy row and changed to
+  `MODIFY` because the term is obsolete, not because the experiment is weak:
+  Ssq1 directly showed ATP-regulated binding to unfolded substrates
+  [PMID:11601843, "Ssq1 showed typical chaperone properties by binding to
+  unfolded substrate proteins in an ATP-regulated manner."]. GO:0140662 is the
+  proposed replacement already used in the core-function synthesis.
+- Live-ontology recheck on 2026-08-28 confirmed this obsoletion in the official
+  EBI OLS GO record (`is_obsolete: true`, label `obsolete unfolded protein
+  binding`, with `consider` GO:0044183 and GO:0140309). The repository cache row
+  that still says `False` is timestamped 2026-03-21, and the SSQ1 GOA/UniProt
+  snapshots are dated 2026-01; all predate closure of the official GO obsoletion
+  request on 2026-05-29 (geneontology/go-ontology#30962). They are stale evidence
+  for current term status, not a contradiction of the live ontology.
+- GO:0042026 remains marked as an over-propagated general-Hsp70 process rather
+  than removed. The available literature establishes specialized ISC client
+  handling but does not provide a target-specific refolding assay; this avoids
+  claiming loss of all refolding capacity from incomplete evidence.
+- The five protein-binding IPI rows were retained as over-annotated rather than
+  removed. Isu1 is the physiological client, while the Nop1 rows are
+  compartmentally discordant high-throughput observations; bare protein binding
+  is uninformative in either case.
+- Final curation state: 9 `ACCEPT`, 8 `KEEP_AS_NON_CORE`, 10
+  `MARK_AS_OVER_ANNOTATED`, 2 `MODIFY`, 0 `PENDING`; status set to `COMPLETE`.


### PR DESCRIPTION
## Summary
- mark the specialized mitochondrial Hsp70 SSQ1 review COMPLETE after exact reconciliation of all 29 GOA assertion signatures
- audit all seven IBA rows against their actual PAINT nodes and add missing structured propagation decisions
- preserve direct experimental support while replacing obsolete GO:0051082 with GO:0140662
- add exact qualifiers and provenance-rich completion notes

## Validation
- just validate yeast SSQ1
- just validate-goa yeast SSQ1
- just render yeast SSQ1
- just deploy-browser
- git diff --check

No support-code changes or wrapper bypasses.