### PR TITLE
Complete yeast HSP104 annotation review

### DIFF
--- a/genes/yeast/HSP104/HSP104-ai-review.html
+++ b/genes/yeast/HSP104/HSP104-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -836,6 +836,51 @@
 
 
 
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>prion fibril fragmentation activity</h3>
+                <span class="vote-buttons" data-g="P31539" data-a="prion fibril fragmentation activity" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> A molecular function that fragments a prion amyloid fibril into smaller oligomeric seeds that can be transmitted to daughter cells and thereby maintain cellular prion propagation.</p>
+
+
+
+            <p><strong>Justification:</strong> HSP104-dependent fragmentation of prion fibrils is a directly established, mechanistically distinct yeast function required to create infectious seeds. Current GO lacks a term that represents prion fibril fragmentation; the existing ATP-dependent protein disaggregase term does not capture the propagation-producing outcome of partial fibril fragmentation.</p>
+
+
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/18312264" target="_blank" class="term-link">
+                        PMID:18312264
+                    </a>
+
+
+                    : Prion propagation requires the Hsp104-dependent fragmentation of prion fibrils to create infectious seeds.
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
 
 
 
@@ -898,6 +943,35 @@
                             <strong>Reason:</strong> HSP104 cytoplasmic localization is its primary site of action for protein disaggregation. Confirmed by IDA (PMID:10467108): &#34;a small amount of Hsp104 was located in the cytoplasm and nucleus&#34; and by HDA (PMID:22842922).
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000181243</span>
+
+                                    &middot; PANTHER:PTN000181243
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The PTHR11638 PAINT record places cytoplasm at this broad family node using experimentally localized fungal, bacterial, plant, and protist descendants, including S. cerevisiae HSP104 itself.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -982,6 +1056,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000181243</span>
+
+                                    &middot; PANTHER:PTN000181243
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">ATP hydrolysis is conserved across the PTHR11638 AAA+ family and HSP104 is itself among the experimentally grounded descendants.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1062,6 +1165,35 @@
                             <strong>Reason:</strong> While HSP104 itself does not refold proteins (that is done by Hsp70/40), it is an essential component of the refolding pathway by extracting substrates from aggregates. PMID:9674429 demonstrates that &#34;in concert with Hsp40 and Hsp70, Hsp104 can reactivate proteins that have been denatured and allowed to aggregate.&#34; The annotation to the BP &#34;protein refolding&#34; is appropriate.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN007521008</span>
+
+                                    &middot; PANTHER:PTN007521008
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The fungal node is seeded by the experimentally characterized S. pombe ortholog; HSP104&#39;s direct reactivation studies independently support participation in protein refolding.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1146,6 +1278,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN007521008</span>
+
+                                    &middot; PANTHER:PTN007521008
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The fungal node is grounded by S. pombe and S. cerevisiae descendants, and substrate threading directly establishes this conserved process for HSP104.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1228,6 +1389,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN007521008</span>
+
+                                    &middot; PANTHER:PTN007521008
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">This fungal-node inference is seeded by S. cerevisiae HSP104 and agrees with its directly established cytosolic activity.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
 
                     </td>
@@ -1260,10 +1450,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P31539" data-a="GO:0051082" data-r="GO_REF:0000033" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P31539" data-a="GO:0051082" data-r="GO_REF:0000033" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1271,43 +1461,55 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> While HSP104 does bind unfolded/aggregated polypeptides in an ATP-dependent manner (PMID:16135516), this annotation understates its core molecular function. HSP104 is the canonical protein disaggregase; its binding of unfolded substrates is in service of the disaggregation mechanism, not passive chaperone holdase activity. GO:0140545 &#34;ATP-dependent protein disaggregase activity&#34; is the more appropriate and specific term.
+                            <strong>Summary:</strong> The fungal PAINT node correctly propagates ATP-regulated binding of unfolded polypeptides to HSP104, and PMID:16135516 directly confirms that binding. However, GO:0051082 is now obsolete and neither official consider target matches the asserted binding step without adding an untested activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0051082 &#34;unfolded protein binding&#34; is too general for HSP104. The protein does not merely bind unfolded proteins; it actively threads them through its central pore in an ATP-dependent disaggregation reaction. GO:0140545 &#34;ATP-dependent protein disaggregase activity&#34; precisely describes HSP104&#39;s core molecular function. PMID:16135516 shows ATP-regulated substrate binding, and PMID:7984243 established the disaggregation function. PMID:18312264 demonstrated the threading mechanism.
+                            <strong>Reason:</strong> GO:0051082 is obsolete; its official consider targets are GO:0044183 &#34;protein folding chaperone&#34; and GO:0140309 &#34;unfolded protein holdase activity.&#34; GO:0044183 adds assistance of folding and GO:0140309 adds prevention of aggregation during client escort, neither of which is the molecular-function claim asserted by this PAINT row. GO:0140545 is the correct defining activity of HSP104 but is not an evidence-matched replacement for this binding assertion. It is represented separately by a NEW annotation grounded in direct disaggregation studies.
                         </div>
 
 
 
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
 
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140545" target="_blank" class="term-link">
-                                    ATP-dependent protein disaggregase activity
-                                </a>
-                            </span>
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN007521008</span>
+
+                                    &middot; PANTHER:PTN007521008
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The node and its HSP104 seed support ATP-dependent polypeptide binding. The unresolved issue is ontology replacement after obsoletion, not a failure of the PAINT propagation.</div>
+
+                                </div>
+
+                            </div>
 
                         </div>
+
 
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7984243" target="_blank" class="term-link">
-                                        PMID:7984243
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">Hsp104 functions in a manner not previously described for other heat-shock proteins: it mediates the resolubilization of heat-inactivated luciferase from insoluble aggregates.</div>
-
-                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -1319,17 +1521,6 @@
                                 </span>
 
                                 <div class="support-text">the affinity of Hsp104 toward polypeptides is regulated by nucleotides. In the presence of ATP or adenosine-5&#39; -O-(3-thiotriphosphate), the chaperone formed complexes with RCMLa, whereas no binding was observed in the presence of ADP.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:yeast/HSP104/HSP104-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">Hsp104 is a member of the Hsp100/Clp family of oligomeric AAA+ ATPases that does not itself perform proteolysis but instead remodels aggregated proteins to enable their reactivation.</div>
 
                             </div>
 
@@ -1385,6 +1576,35 @@
                             <strong>Reason:</strong> Chaperone binding is essential for HSP104 function. It requires cooperation with Hsp70/Hsp40 to disaggregate and refold substrates. PMID:9674429 directly demonstrates the physical and functional interaction.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN007521008</span>
+
+                                    &middot; PANTHER:PTN007521008
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The fungal-node assertion is seeded by S. cerevisiae HSP104 and agrees with direct functional interaction with Hsp70/Hsp40.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1480,6 +1700,35 @@
                             <strong>Reason:</strong> Cellular heat acclimation (induced thermotolerance) is the core biological process for which HSP104 was originally identified. PMID:2188365: &#34;when given a mild pre-heat treatment, the mutant cells did not acquire tolerance to heat, as did wild-type cells.&#34;
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN007521008</span>
+
+                                    &middot; PANTHER:PTN007521008
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The fungal node is grounded by Candida, S. pombe, and S. cerevisiae descendants; HSP104&#39;s own mutant phenotype directly establishes acquired thermotolerance.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1649,10 +1898,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P31539" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P31539" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1665,7 +1914,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Confirmed by IDA at PMID:10467108. UniProt subcellular location mapping is accurate here.
+                            <strong>Reason:</strong> Confirmed by IDA at PMID:10467108. UniProt subcellular location mapping is accurate here, but the nuclear pool is stress-enhanced and secondary to HSP104&#39;s predominant cytosolic disaggregase function.
                         </div>
 
 
@@ -3189,10 +3438,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P31539" data-a="GO:0034399" data-r="PMID:25817432" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P31539" data-a="GO:0034399" data-r="PMID:25817432" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3282,10 +3531,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P31539" data-a="GO:0035617" data-r="PMID:24291094" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P31539" data-a="GO:0035617" data-r="PMID:24291094" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3457,10 +3706,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P31539" data-a="GO:0005634" data-r="PMID:10467108" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P31539" data-a="GO:0005634" data-r="PMID:10467108" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3949,10 +4198,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P31539" data-a="GO:0051082" data-r="PMID:16135516" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P31539" data-a="GO:0051082" data-r="PMID:16135516" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3960,26 +4209,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:16135516 directly demonstrates ATP-dependent binding of HSP104 to the permanently unfolded substrate RCMLa. While the substrate binding data is correct, the GO term &#34;unfolded protein binding&#34; understates the mechanistic specificity of HSP104. The core function is ATP-dependent protein disaggregation (GO:0140545), not passive unfolded protein binding.
+                            <strong>Summary:</strong> PMID:16135516 directly demonstrates ATP-dependent binding of HSP104 to RCMLa, a permanently unfolded model substrate. This directly supports the biological claim represented by the original annotation, but GO:0051082 is now obsolete.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Same reasoning as for the IBA annotation of this term. HSP104 does not merely bind unfolded proteins; it uses ATP hydrolysis to actively thread and solubilize aggregated substrates. GO:0140545 &#34;ATP-dependent protein disaggregase activity&#34; is the correct and specific term. PMID:16135516: &#34;the affinity of Hsp104 toward polypeptides is regulated by nucleotides... the occupation of the N-terminally located nucleotide-binding domain with ATP seems to be crucial for substrate interaction.&#34;
+                            <strong>Reason:</strong> The cited experiment measures nucleotide-regulated binding to an unfolded substrate; it does not assay disaggregation, refolding, or prevention of aggregation during client escort. Consequently it cannot support GO:0140545, and neither of GO:0051082&#39;s official consider targets is an evidence-matched replacement: GO:0044183 adds folding assistance, while GO:0140309 adds carrier/holdase semantics. The obsolete annotation should not be accepted as a current term, but no replacement can be asserted from PMID:16135516 alone. HSP104&#39;s disaggregase activity remains captured separately by the NEW GO:0140545 annotation using direct disaggregation sources.
                         </div>
 
 
-
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140545" target="_blank" class="term-link">
-                                    ATP-dependent protein disaggregase activity
-                                </a>
-                            </span>
-
-                        </div>
 
 
                         <div class="supported-by">
@@ -3995,19 +4233,6 @@
                                 </span>
 
                                 <div class="support-text">the affinity of Hsp104 toward polypeptides is regulated by nucleotides. In the presence of ATP or adenosine-5&#39; -O-(3-thiotriphosphate), the chaperone formed complexes with RCMLa, whereas no binding was observed in the presence of ADP.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7984243" target="_blank" class="term-link">
-                                        PMID:7984243
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">Hsp104 functions in a manner not previously described for other heat-shock proteins: it mediates the resolubilization of heat-inactivated luciferase from insoluble aggregates.</div>
 
                             </div>
 
@@ -4454,41 +4679,6 @@
 
                     </div>
                 </div>
-
-
-
-
-
-            </div>
-
-
-        </div>
-
-        <div class="core-function-card">
-
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>ATP hydrolysis by two AAA ATPase domains (NBD1 and NBD2) per monomer powers the disaggregation mechanism. NBD1 has low affinity/high turnover; NBD2 has high affinity/slow hydrolysis.</h3>
-                <span class="vote-buttons" data-g="P31539" data-a="FUNCTION: ATP hydrolysis by two AAA ATPase domains (NBD1 and..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-
-
-            <div class="core-function-terms">
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
-                            ATP hydrolysis activity
-                        </a>
-                    </span>
-                </div>
-
-
-
-
 
 
 
@@ -5661,6 +5851,105 @@ In parallel, cellular ATP decreases &gt;2-fold in 30 min and ~5-fold by 90 min i
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(HSP104-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P31539" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="hsp104-review-notes">HSP104 review notes</h1>
+<h2 id="2026-08-28-annotation-audit">2026-08-28 annotation audit</h2>
+<ul>
+<li>
+<p>HSP104 is the canonical cytosolic Hsp100/ClpB-family AAA+ disaggregase. Its<br />
+  defining activity is ATP-dependent extraction of proteins from aggregates,<br />
+  followed by Hsp70/Hsp40-dependent reactivation. The original resolubilization<br />
+  study states that Hsp104 “mediates the resolubilization of heat-inactivated<br />
+  luciferase from insoluble aggregates” [PMID:7984243, “Protein disaggregation<br />
+  mediated by heat-shock protein Hsp104.”]. The reconstitution study further<br />
+  reports that, with Hsp40 and Hsp70, Hsp104 reactivates proteins that were<br />
+  denatured and allowed to aggregate [PMID:9674429, “Hsp104, Hsp70, and Hsp40:<br />
+  a novel chaperone system that rescues previously aggregated proteins.”].<br />
+  These data justify a NEW annotation to GO:0140545, ATP-dependent protein<br />
+  disaggregase activity.</p>
+</li>
+<li>
+<p>All 45 unique non-NEW GOA signatures were reconciled exactly by GO term,<br />
+  evidence code, reference, and relation qualifier. The 67 GOA rows collapse to<br />
+  45 signatures because the two high-throughput protein-binding publications<br />
+  contain multiple WITH/FROM interaction partners. Those repeated partner rows<br />
+  do not represent distinct GO assertions in this review.</p>
+</li>
+<li>
+<p>The eight IBA rows were checked against the current PTHR11638 PAINT cache.<br />
+  Cytoplasm and ATP hydrolysis are asserted at PTN000181243. Protein refolding,<br />
+  protein unfolding, cytosol, unfolded protein binding, protein-folding<br />
+  chaperone binding, and cellular heat acclimation are asserted at the fungal<br />
+  node PTN007521008. S. cerevisiae HSP104 is itself an experimental descendant<br />
+  seed for several of these assertions; this is valid PAINT grounding, not<br />
+  circular evidence. The inherited biology is supported for HSP104. The<br />
+  GO:0051082 IBA correctly propagates substrate-binding biology but the term is<br />
+  obsolete. Neither official consider target preserves that assertion without<br />
+  adding foldase or carrier/holdase semantics, so it is UNDECIDED rather than<br />
+  branch-swapped to the separately established disaggregase activity.</p>
+</li>
+<li>
+<p>The PMID:16135516 IDA row is treated separately. The paper directly assays<br />
+  nucleotide-regulated binding to permanently unfolded RCMLa, but it does not<br />
+  assay folding, aggregation prevention/escort, or disaggregation. Live QuickGO<br />
+  records GO:0051082 as obsolete and offers GO:0044183 protein folding chaperone<br />
+  and GO:0140309 unfolded protein holdase activity as <code>consider</code> targets. Neither<br />
+  is evidence-matched to this assay, so the row is UNDECIDED rather than ACCEPT<br />
+  on an obsolete term or MODIFY to an activity that this paper did not test. The<br />
+  separate NEW GO:0140545 annotation retains direct disaggregation evidence.</p>
+</li>
+<li>
+<p>Generic protein-binding annotations from the global TAP and chaperone-network<br />
+  studies remain marked over-annotated. The full-text chaperone atlas explicitly<br />
+  cautions that its TAP-tag interactions are indirect rather than binary<br />
+  [PMID:19536198, “An atlas of chaperone-protein interactions in Saccharomyces<br />
+  cerevisiae: implications to protein folding pathways in the cell.”]. Specific<br />
+  homo-oligomerization and protein-folding-chaperone binding annotations are<br />
+  retained separately.</p>
+</li>
+<li>
+<p>Nuclear, nuclear-periphery, stress-granule, ER-folding, and TRC/ER-targeting<br />
+  annotations are retained as non-core context. Direct microscopy supports a<br />
+  nuclear pool [PMID:10467108, “At normal temperature (25 degrees C), a small<br />
+  amount of Hsp104 was located in the cytoplasm and nucleus.”], and stress-granule<br />
+  recovery requires Hsp104/Hsp70 activity [PMID:24291094, “Coordination of<br />
+  translational control and protein homeostasis during severe heat stress.”].<br />
+  These roles are credible consequences or specialized deployments of the core<br />
+  disaggregation machinery rather than separate defining activities.</p>
+</li>
+<li>
+<p>The trehalose-metabolism phenotype remains marked over-annotated: reduced<br />
+  trehalose enzyme activities in an hsp104 mutant establish an indirect<br />
+  proteostasis consequence, not a direct metabolic activity [PMID:9797333,<br />
+  “The activities of trehalose-synthesizing and -hydrolyzing enzymes are low in<br />
+  the HSP104 disruption mutant during heat shock.”]. The ARBA intracellular<br />
+  organelle lumen annotation is likewise over-annotated because HSP104 is a<br />
+  cytosolic/nuclear protein; an effect on repair within the ER does not establish<br />
+  luminal localization.</p>
+</li>
+<li>
+<p>Prion fibril fragmentation is a major yeast-specific function described by<br />
+  UniProt and the literature, but a current QuickGO ontology search did not find<br />
+  a GO term specifically representing prion propagation or fibril fragmentation.<br />
+  A term request for “prion fibril fragmentation activity” is therefore captured<br />
+  under <code>proposed_new_terms</code> without guessing an identifier; PMID:18312264 states<br />
+  that Hsp104-dependent fibril fragmentation creates infectious seeds.</p>
+</li>
+</ul>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
                     <h3 style="display: inline;">Bioreason Rl Predictions</h3>
                     <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(HSP104-bioreason-rl-predictions.md)</span>
                 </div>
@@ -5768,7 +6057,7 @@ In parallel, cellular ATP decreases &gt;2-fold in 30 min and ~5-fold by 90 min i
                 <pre><code>id: P31539
 gene_symbol: HSP104
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -5795,6 +6084,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: &gt;-
       HSP104 is well-established to localize to the cytoplasm, confirmed by
@@ -5807,6 +6097,16 @@ existing_annotations:
       disaggregation. Confirmed by IDA (PMID:10467108): &#34;a small amount of
       Hsp104 was located in the cytoplasm and nucleus&#34; and by HDA
       (PMID:22842922).
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN000181243
+          source_label: PANTHER:PTN000181243
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The PTHR11638 PAINT record places cytoplasm at this broad family
+            node using experimentally localized fungal, bacterial, plant, and
+            protist descendants, including S. cerevisiae HSP104 itself.
     supported_by:
       - reference_id: PMID:10467108
         supporting_text: &gt;-
@@ -5821,6 +6121,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: &gt;-
       HSP104 is a well-characterized ATPase with two AAA-type nucleotide-binding
@@ -5833,6 +6134,15 @@ existing_annotations:
       protein disaggregation mechanism. Supported by multiple IDA and IMP
       annotations. PMID:16135516 directly demonstrates ATPase activity and its
       regulation by substrate binding.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN000181243
+          source_label: PANTHER:PTN000181243
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            ATP hydrolysis is conserved across the PTHR11638 AAA+ family and
+            HSP104 is itself among the experimentally grounded descendants.
     supported_by:
       - reference_id: PMID:16135516
         supporting_text: &gt;-
@@ -5848,6 +6158,7 @@ existing_annotations:
     label: protein refolding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: &gt;-
       HSP104 participates in protein refolding, though it does so indirectly
@@ -5862,6 +6173,16 @@ existing_annotations:
       with Hsp40 and Hsp70, Hsp104 can reactivate proteins that have been
       denatured and allowed to aggregate.&#34; The annotation to the BP &#34;protein
       refolding&#34; is appropriate.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The fungal node is seeded by the experimentally characterized
+            S. pombe ortholog; HSP104&#39;s direct reactivation studies independently
+            support participation in protein refolding.
     supported_by:
       - reference_id: PMID:9674429
         supporting_text: &gt;-
@@ -5877,6 +6198,7 @@ existing_annotations:
     label: protein unfolding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: &gt;-
       HSP104 unfolds/threads aggregated proteins through its central pore as
@@ -5889,6 +6211,16 @@ existing_annotations:
       through the narrow central pore of the hexamer. Supported by
       PMID:18312264 &#34;Substrate threading through the central pore of the
       Hsp104 chaperone as a common mechanism for protein disaggregation.&#34;
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The fungal node is grounded by S. pombe and S. cerevisiae
+            descendants, and substrate threading directly establishes this
+            conserved process for HSP104.
     supported_by:
       - reference_id: PMID:7984243
         supporting_text: &gt;-
@@ -5904,6 +6236,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: &gt;-
       HSP104 is active in the cytosol, consistent with its role in
@@ -5914,55 +6247,65 @@ existing_annotations:
       The cytosol is the primary compartment where HSP104 performs its
       disaggregation function. Consistent with IDA evidence at PMID:10467108
       and NAS at PMID:20850366.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            This fungal-node inference is seeded by S. cerevisiae HSP104 and
+            agrees with its directly established cytosolic activity.
 
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: &gt;-
-      While HSP104 does bind unfolded/aggregated polypeptides in an
-      ATP-dependent manner (PMID:16135516), this annotation understates its
-      core molecular function. HSP104 is the canonical protein disaggregase;
-      its binding of unfolded substrates is in service of the disaggregation
-      mechanism, not passive chaperone holdase activity. GO:0140545
-      &#34;ATP-dependent protein disaggregase activity&#34; is the more appropriate
-      and specific term.
-    action: MODIFY
+      The fungal PAINT node correctly propagates ATP-regulated binding of
+      unfolded polypeptides to HSP104, and PMID:16135516 directly confirms that
+      binding. However, GO:0051082 is now obsolete and neither official
+      consider target matches the asserted binding step without adding an
+      untested activity.
+    action: UNDECIDED
     reason: &gt;-
-      GO:0051082 &#34;unfolded protein binding&#34; is too general for HSP104. The
-      protein does not merely bind unfolded proteins; it actively threads
-      them through its central pore in an ATP-dependent disaggregation
-      reaction. GO:0140545 &#34;ATP-dependent protein disaggregase activity&#34;
-      precisely describes HSP104&#39;s core molecular function. PMID:16135516
-      shows ATP-regulated substrate binding, and PMID:7984243 established
-      the disaggregation function. PMID:18312264 demonstrated the threading
-      mechanism.
-    proposed_replacement_terms:
-      - id: GO:0140545
-        label: ATP-dependent protein disaggregase activity
+      GO:0051082 is obsolete; its official consider targets are GO:0044183
+      &#34;protein folding chaperone&#34; and GO:0140309 &#34;unfolded protein holdase
+      activity.&#34; GO:0044183 adds assistance of folding and GO:0140309 adds
+      prevention of aggregation during client escort, neither of which is the
+      molecular-function claim asserted by this PAINT row. GO:0140545 is the
+      correct defining activity of HSP104 but is not an evidence-matched
+      replacement for this binding assertion. It is represented separately by
+      a NEW annotation grounded in direct disaggregation studies.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+        - GRANULARITY_MISMATCH
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The node and its HSP104 seed support ATP-dependent polypeptide
+            binding. The unresolved issue is ontology replacement after
+            obsoletion, not a failure of the PAINT propagation.
     supported_by:
-      - reference_id: PMID:7984243
-        supporting_text: &gt;-
-          Hsp104 functions in a manner not previously described for other
-          heat-shock proteins: it mediates the resolubilization of
-          heat-inactivated luciferase from insoluble aggregates.
       - reference_id: PMID:16135516
         supporting_text: &gt;-
           the affinity of Hsp104 toward polypeptides is regulated by
           nucleotides. In the presence of ATP or
           adenosine-5&#39; -O-(3-thiotriphosphate), the chaperone formed complexes
           with RCMLa, whereas no binding was observed in the presence of ADP.
-      - reference_id: file:yeast/HSP104/HSP104-deep-research-falcon.md
-        supporting_text: |-
-          Hsp104 is a member of the Hsp100/Clp family of oligomeric AAA+ ATPases that does not itself perform proteolysis but instead remodels aggregated proteins to enable their reactivation.
 
 - term:
     id: GO:0051087
     label: protein-folding chaperone binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: &gt;-
       HSP104 interacts directly with Hsp70 (Ssa1) and Hsp40 (Ydj1)
@@ -5976,6 +6319,15 @@ existing_annotations:
       cooperation with Hsp70/Hsp40 to disaggregate and refold substrates.
       PMID:9674429 directly demonstrates the physical and functional
       interaction.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The fungal-node assertion is seeded by S. cerevisiae HSP104 and
+            agrees with direct functional interaction with Hsp70/Hsp40.
     supported_by:
       - reference_id: PMID:9674429
         supporting_text: &gt;-
@@ -5998,6 +6350,7 @@ existing_annotations:
     label: cellular heat acclimation
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: &gt;-
       HSP104 is the defining gene for induced thermotolerance in yeast.
@@ -6010,6 +6363,16 @@ existing_annotations:
       biological process for which HSP104 was originally identified.
       PMID:2188365: &#34;when given a mild pre-heat treatment, the mutant cells
       did not acquire tolerance to heat, as did wild-type cells.&#34;
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The fungal node is grounded by Candida, S. pombe, and
+            S. cerevisiae descendants; HSP104&#39;s own mutant phenotype directly
+            establishes acquired thermotolerance.
     supported_by:
       - reference_id: PMID:2188365
         supporting_text: &gt;-
@@ -6027,6 +6390,7 @@ existing_annotations:
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: &gt;-
       HSP104 has two AAA ATPase domains (NBD1 and NBD2) that bind ATP and
@@ -6044,6 +6408,7 @@ existing_annotations:
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: &gt;-
       HSP104 binds ATP at both NBD1 and NBD2. This is supported by extensive
@@ -6059,21 +6424,24 @@ existing_annotations:
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: &gt;-
       HSP104 shuttles between cytoplasm and nucleus. Nuclear localization
       is confirmed by immunoelectron microscopy (PMID:10467108) and is
       enhanced under heat stress. IEA is consistent with IDA evidence.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       Confirmed by IDA at PMID:10467108. UniProt subcellular location
-      mapping is accurate here.
+      mapping is accurate here, but the nuclear pool is stress-enhanced and
+      secondary to HSP104&#39;s predominant cytosolic disaggregase function.
 
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: &gt;-
       Duplicate of IBA and IDA annotations for cytoplasm. The IEA from
@@ -6088,6 +6456,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: located_in
   review:
     summary: &gt;-
       Cytosol annotation by ARBA machine learning. Consistent with IBA and
@@ -6101,6 +6470,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: &gt;-
       ARBA annotation for protein folding. HSP104 participates in the
@@ -6122,6 +6492,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation for ATP hydrolysis activity from InterPro domain
@@ -6136,6 +6507,7 @@ existing_annotations:
     label: cellular response to heat
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: &gt;-
       ARBA annotation for cellular response to heat. HSP104 is massively
@@ -6151,6 +6523,7 @@ existing_annotations:
     label: identical protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: enables
   review:
     summary: &gt;-
       HSP104 forms a homohexamer, so identical protein binding is expected.
@@ -6166,6 +6539,7 @@ existing_annotations:
     label: protein unfolding
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: &gt;-
       IEA annotation for protein unfolding by ARBA. Consistent with IBA
@@ -6180,6 +6554,7 @@ existing_annotations:
     label: intracellular organelle lumen
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: located_in
   review:
     summary: &gt;-
       ARBA annotation placing HSP104 in intracellular organelle lumen.
@@ -6203,6 +6578,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
+  qualifier: enables
   review:
     summary: &gt;-
       High-throughput TAP-tag study identifying global protein complexes in
@@ -6227,6 +6603,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
+  qualifier: enables
   review:
     summary: &gt;-
       Another high-throughput chaperone interaction study (TAP-tag based)
@@ -6252,6 +6629,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20850366
+  qualifier: enables
   review:
     summary: &gt;-
       This study identified HSP104 as part of a chaperone cascade for
@@ -6274,6 +6652,7 @@ existing_annotations:
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:20404203
+  qualifier: enables
   review:
     summary: &gt;-
       CryoEM structure of the HSP104 hexamer confirms self-association.
@@ -6297,6 +6676,7 @@ existing_annotations:
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:21474779
+  qualifier: enables
   review:
     summary: &gt;-
       Species-specificity study using Hsp104/ClpB chimeras confirms
@@ -6315,6 +6695,7 @@ existing_annotations:
     label: cytosol
   evidence_type: NAS
   original_reference_id: PMID:20850366
+  qualifier: located_in
   review:
     summary: &gt;-
       ComplexPortal annotation placing HSP104 in cytosol based on the TRC
@@ -6329,6 +6710,7 @@ existing_annotations:
     label: post-translational protein targeting to endoplasmic reticulum membrane
   evidence_type: NAS
   original_reference_id: PMID:20850366
+  qualifier: involved_in
   review:
     summary: &gt;-
       ComplexPortal annotation based on HSP104&#39;s role in the TRC complex
@@ -6355,6 +6737,7 @@ existing_annotations:
     label: cellular response to heat
   evidence_type: IDA
   original_reference_id: PMID:24291094
+  qualifier: involved_in
   review:
     summary: &gt;-
       Study demonstrating HSP104/Hsp70-dependent protein disaggregation
@@ -6380,6 +6763,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IDA
   original_reference_id: PMID:16135516
+  qualifier: enables
   review:
     summary: &gt;-
       Direct biochemical demonstration of HSP104 ATPase activity and its
@@ -6402,6 +6786,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IMP
   original_reference_id: PMID:16135516
+  qualifier: enables
   review:
     summary: &gt;-
       Mutant phenotype evidence for ATP hydrolysis. Walker A (K218T) and
@@ -6424,6 +6809,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IMP
   original_reference_id: PMID:9674429
+  qualifier: enables
   review:
     summary: &gt;-
       Mutant phenotype evidence from the landmark Glover &amp; Lindquist (1998)
@@ -6446,6 +6832,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:22842922
+  qualifier: located_in
   review:
     summary: &gt;-
       High-throughput microscopy study of GFP-tagged proteins under DNA
@@ -6466,6 +6853,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IDA
   original_reference_id: PMID:9674429
+  qualifier: involved_in
   review:
     summary: &gt;-
       PMID:9674429 demonstrates that HSP104 in concert with Hsp70/Hsp40
@@ -6495,12 +6883,13 @@ existing_annotations:
     label: nuclear periphery
   evidence_type: IDA
   original_reference_id: PMID:25817432
+  qualifier: located_in
   review:
     summary: &gt;-
       PMID:25817432 identifies the intranuclear quality control compartment
       (INQ) where HSP104 colocalizes with Cmr1 and misfolded proteins at
       the nuclear periphery in response to genotoxic stress.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       PMID:25817432 provides direct evidence for HSP104 localization at
       the nuclear periphery as part of the INQ compartment, which
@@ -6523,13 +6912,14 @@ existing_annotations:
     label: stress granule disassembly
   evidence_type: IDA
   original_reference_id: PMID:24291094
+  qualifier: involved_in
   review:
     summary: &gt;-
       PMID:24291094 demonstrates that HSP104 is required for stress granule
       disassembly during recovery from severe heat stress. Heat-SGs
       coassemble with protein aggregates, and their disassembly is coupled
       to Hsp104-dependent protein disaggregation.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       This is a well-supported secondary function of HSP104. Stress granule
       disassembly is mechanistically linked to its core disaggregase
@@ -6551,6 +6941,7 @@ existing_annotations:
     label: ATP binding
   evidence_type: IMP
   original_reference_id: PMID:11867765
+  qualifier: enables
   review:
     summary: &gt;-
       Mutagenesis study of the AAA sensor-2 motif in NBD2. R826M mutation
@@ -6574,11 +6965,12 @@ existing_annotations:
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:10467108
+  qualifier: located_in
   review:
     summary: &gt;-
       Immunoelectron microscopy demonstrating HSP104 presence in the
       nucleus. Nuclear accumulation is enhanced by heat shock.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       Direct immunoEM evidence for nuclear localization. PMID:10467108:
       &#34;a small amount of Hsp104 was located in the cytoplasm and nucleus.&#34;
@@ -6595,6 +6987,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:10467108
+  qualifier: located_in
   review:
     summary: &gt;-
       Same immunoelectron microscopy study confirming cytoplasmic
@@ -6617,6 +7010,7 @@ existing_annotations:
     label: trehalose metabolic process
   evidence_type: IMP
   original_reference_id: PMID:9797333
+  qualifier: involved_in
   review:
     summary: &gt;-
       PMID:9797333 shows that HSP104 disruption affects trehalose
@@ -6646,6 +7040,7 @@ existing_annotations:
     label: protein folding in endoplasmic reticulum
   evidence_type: IMP
   original_reference_id: PMID:10931304
+  qualifier: involved_in
   review:
     summary: &gt;-
       PMID:10931304 shows that HSP104 is required for conformational repair
@@ -6673,6 +7068,7 @@ existing_annotations:
     label: protein unfolding
   evidence_type: IMP
   original_reference_id: PMID:7984243
+  qualifier: involved_in
   review:
     summary: &gt;-
       The landmark Parsell et al. (1994) paper demonstrating that HSP104
@@ -6696,6 +7092,7 @@ existing_annotations:
     label: ADP binding
   evidence_type: IMP
   original_reference_id: PMID:11867765
+  qualifier: enables
   review:
     summary: &gt;-
       PMID:11867765 uses a site-specific fluorescent probe (Y819W) to
@@ -6718,27 +7115,25 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:16135516
+  qualifier: enables
   review:
     summary: &gt;-
       PMID:16135516 directly demonstrates ATP-dependent binding of HSP104
-      to the permanently unfolded substrate RCMLa. While the substrate
-      binding data is correct, the GO term &#34;unfolded protein binding&#34;
-      understates the mechanistic specificity of HSP104. The core function
-      is ATP-dependent protein disaggregation (GO:0140545), not passive
-      unfolded protein binding.
-    action: MODIFY
+      to RCMLa, a permanently unfolded model substrate. This directly supports
+      the biological claim represented by the original annotation, but
+      GO:0051082 is now obsolete.
+    action: UNDECIDED
     reason: &gt;-
-      Same reasoning as for the IBA annotation of this term. HSP104 does
-      not merely bind unfolded proteins; it uses ATP hydrolysis to actively
-      thread and solubilize aggregated substrates. GO:0140545 &#34;ATP-dependent
-      protein disaggregase activity&#34; is the correct and specific term.
-      PMID:16135516: &#34;the affinity of Hsp104 toward polypeptides is
-      regulated by nucleotides... the occupation of the N-terminally
-      located nucleotide-binding domain with ATP seems to be crucial for
-      substrate interaction.&#34;
-    proposed_replacement_terms:
-      - id: GO:0140545
-        label: ATP-dependent protein disaggregase activity
+      The cited experiment measures nucleotide-regulated binding to an
+      unfolded substrate; it does not assay disaggregation, refolding, or
+      prevention of aggregation during client escort. Consequently it cannot
+      support GO:0140545, and neither of GO:0051082&#39;s official consider targets
+      is an evidence-matched replacement: GO:0044183 adds folding assistance,
+      while GO:0140309 adds carrier/holdase semantics. The obsolete annotation
+      should not be accepted as a current term, but no replacement can be
+      asserted from PMID:16135516 alone. HSP104&#39;s disaggregase activity remains
+      captured separately by the NEW GO:0140545 annotation using direct
+      disaggregation sources.
     supported_by:
       - reference_id: PMID:16135516
         supporting_text: &gt;-
@@ -6747,17 +7142,13 @@ existing_annotations:
           adenosine-5&#39; -O-(3-thiotriphosphate), the chaperone formed
           complexes with RCMLa, whereas no binding was observed in the
           presence of ADP.
-      - reference_id: PMID:7984243
-        supporting_text: &gt;-
-          Hsp104 functions in a manner not previously described for other
-          heat-shock proteins: it mediates the resolubilization of
-          heat-inactivated luciferase from insoluble aggregates.
 
 - term:
     id: GO:0051087
     label: protein-folding chaperone binding
   evidence_type: IDA
   original_reference_id: PMID:9674429
+  qualifier: enables
   review:
     summary: &gt;-
       PMID:9674429 demonstrates direct functional cooperation between
@@ -6782,6 +7173,7 @@ existing_annotations:
     label: cellular heat acclimation
   evidence_type: IMP
   original_reference_id: PMID:2188365
+  qualifier: involved_in
   review:
     summary: &gt;-
       The foundational paper showing HSP104 is required for induced
@@ -6804,6 +7196,7 @@ existing_annotations:
     label: TRC complex
   evidence_type: IDA
   original_reference_id: PMID:20850366
+  qualifier: part_of
   review:
     summary: &gt;-
       PMID:20850366 identifies HSP104 as a component of the TMD recognition
@@ -6831,6 +7224,7 @@ existing_annotations:
     label: ATP-dependent protein disaggregase activity
   evidence_type: IDA
   original_reference_id: PMID:7984243
+  qualifier: enables
   review:
     summary: &gt;-
       HSP104 is the founding member of the ATP-dependent protein disaggregase
@@ -7178,13 +7572,6 @@ core_functions:
       Hsp70/Hsp40. HSP104 is essential for induced thermotolerance and
       mechanically unfolds aggregated polypeptides as part of disaggregation.
   - molecular_function:
-      id: GO:0016887
-      label: ATP hydrolysis activity
-    description: &gt;-
-      ATP hydrolysis by two AAA ATPase domains (NBD1 and NBD2) per monomer
-      powers the disaggregation mechanism. NBD1 has low affinity/high turnover;
-      NBD2 has high affinity/slow hydrolysis.
-  - molecular_function:
       id: GO:0051087
       label: protein-folding chaperone binding
     description: &gt;-
@@ -7192,7 +7579,23 @@ core_functions:
       chaperones, which are required for substrate delivery and downstream
       refolding.
 
-proposed_new_terms: []
+proposed_new_terms:
+  - proposed_name: prion fibril fragmentation activity
+    proposed_definition: &gt;-
+      A molecular function that fragments a prion amyloid fibril into smaller
+      oligomeric seeds that can be transmitted to daughter cells and thereby
+      maintain cellular prion propagation.
+    justification: &gt;-
+      HSP104-dependent fragmentation of prion fibrils is a directly established,
+      mechanistically distinct yeast function required to create infectious
+      seeds. Current GO lacks a term that represents prion fibril fragmentation;
+      the existing ATP-dependent protein disaggregase term does not capture the
+      propagation-producing outcome of partial fibril fragmentation.
+    supported_by:
+      - reference_id: PMID:18312264
+        supporting_text: &gt;-
+          Prion propagation requires the Hsp104-dependent fragmentation of prion
+          fibrils to create infectious seeds.
 
 suggested_questions:
   - question: &gt;-

--- a/genes/yeast/HSP104/HSP104-ai-review.yaml
+++ b/genes/yeast/HSP104/HSP104-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P31539
 gene_symbol: HSP104
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -28,6 +28,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: >-
       HSP104 is well-established to localize to the cytoplasm, confirmed by
@@ -40,6 +41,16 @@ existing_annotations:
       disaggregation. Confirmed by IDA (PMID:10467108): "a small amount of
       Hsp104 was located in the cytoplasm and nucleus" and by HDA
       (PMID:22842922).
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN000181243
+          source_label: PANTHER:PTN000181243
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The PTHR11638 PAINT record places cytoplasm at this broad family
+            node using experimentally localized fungal, bacterial, plant, and
+            protist descendants, including S. cerevisiae HSP104 itself.
     supported_by:
       - reference_id: PMID:10467108
         supporting_text: >-
@@ -54,6 +65,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: >-
       HSP104 is a well-characterized ATPase with two AAA-type nucleotide-binding
@@ -66,6 +78,15 @@ existing_annotations:
       protein disaggregation mechanism. Supported by multiple IDA and IMP
       annotations. PMID:16135516 directly demonstrates ATPase activity and its
       regulation by substrate binding.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN000181243
+          source_label: PANTHER:PTN000181243
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            ATP hydrolysis is conserved across the PTHR11638 AAA+ family and
+            HSP104 is itself among the experimentally grounded descendants.
     supported_by:
       - reference_id: PMID:16135516
         supporting_text: >-
@@ -81,6 +102,7 @@ existing_annotations:
     label: protein refolding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: >-
       HSP104 participates in protein refolding, though it does so indirectly
@@ -95,6 +117,16 @@ existing_annotations:
       with Hsp40 and Hsp70, Hsp104 can reactivate proteins that have been
       denatured and allowed to aggregate." The annotation to the BP "protein
       refolding" is appropriate.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The fungal node is seeded by the experimentally characterized
+            S. pombe ortholog; HSP104's direct reactivation studies independently
+            support participation in protein refolding.
     supported_by:
       - reference_id: PMID:9674429
         supporting_text: >-
@@ -110,6 +142,7 @@ existing_annotations:
     label: protein unfolding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: >-
       HSP104 unfolds/threads aggregated proteins through its central pore as
@@ -122,6 +155,16 @@ existing_annotations:
       through the narrow central pore of the hexamer. Supported by
       PMID:18312264 "Substrate threading through the central pore of the
       Hsp104 chaperone as a common mechanism for protein disaggregation."
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The fungal node is grounded by S. pombe and S. cerevisiae
+            descendants, and substrate threading directly establishes this
+            conserved process for HSP104.
     supported_by:
       - reference_id: PMID:7984243
         supporting_text: >-
@@ -137,6 +180,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: >-
       HSP104 is active in the cytosol, consistent with its role in
@@ -147,55 +191,65 @@ existing_annotations:
       The cytosol is the primary compartment where HSP104 performs its
       disaggregation function. Consistent with IDA evidence at PMID:10467108
       and NAS at PMID:20850366.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            This fungal-node inference is seeded by S. cerevisiae HSP104 and
+            agrees with its directly established cytosolic activity.
 
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: >-
-      While HSP104 does bind unfolded/aggregated polypeptides in an
-      ATP-dependent manner (PMID:16135516), this annotation understates its
-      core molecular function. HSP104 is the canonical protein disaggregase;
-      its binding of unfolded substrates is in service of the disaggregation
-      mechanism, not passive chaperone holdase activity. GO:0140545
-      "ATP-dependent protein disaggregase activity" is the more appropriate
-      and specific term.
-    action: MODIFY
+      The fungal PAINT node correctly propagates ATP-regulated binding of
+      unfolded polypeptides to HSP104, and PMID:16135516 directly confirms that
+      binding. However, GO:0051082 is now obsolete and neither official
+      consider target matches the asserted binding step without adding an
+      untested activity.
+    action: UNDECIDED
     reason: >-
-      GO:0051082 "unfolded protein binding" is too general for HSP104. The
-      protein does not merely bind unfolded proteins; it actively threads
-      them through its central pore in an ATP-dependent disaggregation
-      reaction. GO:0140545 "ATP-dependent protein disaggregase activity"
-      precisely describes HSP104's core molecular function. PMID:16135516
-      shows ATP-regulated substrate binding, and PMID:7984243 established
-      the disaggregation function. PMID:18312264 demonstrated the threading
-      mechanism.
-    proposed_replacement_terms:
-      - id: GO:0140545
-        label: ATP-dependent protein disaggregase activity
+      GO:0051082 is obsolete; its official consider targets are GO:0044183
+      "protein folding chaperone" and GO:0140309 "unfolded protein holdase
+      activity." GO:0044183 adds assistance of folding and GO:0140309 adds
+      prevention of aggregation during client escort, neither of which is the
+      molecular-function claim asserted by this PAINT row. GO:0140545 is the
+      correct defining activity of HSP104 but is not an evidence-matched
+      replacement for this binding assertion. It is represented separately by
+      a NEW annotation grounded in direct disaggregation studies.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+        - GRANULARITY_MISMATCH
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The node and its HSP104 seed support ATP-dependent polypeptide
+            binding. The unresolved issue is ontology replacement after
+            obsoletion, not a failure of the PAINT propagation.
     supported_by:
-      - reference_id: PMID:7984243
-        supporting_text: >-
-          Hsp104 functions in a manner not previously described for other
-          heat-shock proteins: it mediates the resolubilization of
-          heat-inactivated luciferase from insoluble aggregates.
       - reference_id: PMID:16135516
         supporting_text: >-
           the affinity of Hsp104 toward polypeptides is regulated by
           nucleotides. In the presence of ATP or
           adenosine-5' -O-(3-thiotriphosphate), the chaperone formed complexes
           with RCMLa, whereas no binding was observed in the presence of ADP.
-      - reference_id: file:yeast/HSP104/HSP104-deep-research-falcon.md
-        supporting_text: |-
-          Hsp104 is a member of the Hsp100/Clp family of oligomeric AAA+ ATPases that does not itself perform proteolysis but instead remodels aggregated proteins to enable their reactivation.
 
 - term:
     id: GO:0051087
     label: protein-folding chaperone binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: >-
       HSP104 interacts directly with Hsp70 (Ssa1) and Hsp40 (Ydj1)
@@ -209,6 +263,15 @@ existing_annotations:
       cooperation with Hsp70/Hsp40 to disaggregate and refold substrates.
       PMID:9674429 directly demonstrates the physical and functional
       interaction.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The fungal-node assertion is seeded by S. cerevisiae HSP104 and
+            agrees with direct functional interaction with Hsp70/Hsp40.
     supported_by:
       - reference_id: PMID:9674429
         supporting_text: >-
@@ -231,6 +294,7 @@ existing_annotations:
     label: cellular heat acclimation
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: >-
       HSP104 is the defining gene for induced thermotolerance in yeast.
@@ -243,6 +307,16 @@ existing_annotations:
       biological process for which HSP104 was originally identified.
       PMID:2188365: "when given a mild pre-heat treatment, the mutant cells
       did not acquire tolerance to heat, as did wild-type cells."
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN007521008
+          source_label: PANTHER:PTN007521008
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The fungal node is grounded by Candida, S. pombe, and
+            S. cerevisiae descendants; HSP104's own mutant phenotype directly
+            establishes acquired thermotolerance.
     supported_by:
       - reference_id: PMID:2188365
         supporting_text: >-
@@ -260,6 +334,7 @@ existing_annotations:
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: >-
       HSP104 has two AAA ATPase domains (NBD1 and NBD2) that bind ATP and
@@ -277,6 +352,7 @@ existing_annotations:
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: >-
       HSP104 binds ATP at both NBD1 and NBD2. This is supported by extensive
@@ -292,21 +368,24 @@ existing_annotations:
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: >-
       HSP104 shuttles between cytoplasm and nucleus. Nuclear localization
       is confirmed by immunoelectron microscopy (PMID:10467108) and is
       enhanced under heat stress. IEA is consistent with IDA evidence.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       Confirmed by IDA at PMID:10467108. UniProt subcellular location
-      mapping is accurate here.
+      mapping is accurate here, but the nuclear pool is stress-enhanced and
+      secondary to HSP104's predominant cytosolic disaggregase function.
 
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: >-
       Duplicate of IBA and IDA annotations for cytoplasm. The IEA from
@@ -321,6 +400,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: located_in
   review:
     summary: >-
       Cytosol annotation by ARBA machine learning. Consistent with IBA and
@@ -334,6 +414,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: >-
       ARBA annotation for protein folding. HSP104 participates in the
@@ -355,6 +436,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: >-
       IEA annotation for ATP hydrolysis activity from InterPro domain
@@ -369,6 +451,7 @@ existing_annotations:
     label: cellular response to heat
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: >-
       ARBA annotation for cellular response to heat. HSP104 is massively
@@ -384,6 +467,7 @@ existing_annotations:
     label: identical protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: enables
   review:
     summary: >-
       HSP104 forms a homohexamer, so identical protein binding is expected.
@@ -399,6 +483,7 @@ existing_annotations:
     label: protein unfolding
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: involved_in
   review:
     summary: >-
       IEA annotation for protein unfolding by ARBA. Consistent with IBA
@@ -413,6 +498,7 @@ existing_annotations:
     label: intracellular organelle lumen
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: located_in
   review:
     summary: >-
       ARBA annotation placing HSP104 in intracellular organelle lumen.
@@ -436,6 +522,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
+  qualifier: enables
   review:
     summary: >-
       High-throughput TAP-tag study identifying global protein complexes in
@@ -460,6 +547,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
+  qualifier: enables
   review:
     summary: >-
       Another high-throughput chaperone interaction study (TAP-tag based)
@@ -485,6 +573,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20850366
+  qualifier: enables
   review:
     summary: >-
       This study identified HSP104 as part of a chaperone cascade for
@@ -507,6 +596,7 @@ existing_annotations:
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:20404203
+  qualifier: enables
   review:
     summary: >-
       CryoEM structure of the HSP104 hexamer confirms self-association.
@@ -530,6 +620,7 @@ existing_annotations:
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:21474779
+  qualifier: enables
   review:
     summary: >-
       Species-specificity study using Hsp104/ClpB chimeras confirms
@@ -548,6 +639,7 @@ existing_annotations:
     label: cytosol
   evidence_type: NAS
   original_reference_id: PMID:20850366
+  qualifier: located_in
   review:
     summary: >-
       ComplexPortal annotation placing HSP104 in cytosol based on the TRC
@@ -562,6 +654,7 @@ existing_annotations:
     label: post-translational protein targeting to endoplasmic reticulum membrane
   evidence_type: NAS
   original_reference_id: PMID:20850366
+  qualifier: involved_in
   review:
     summary: >-
       ComplexPortal annotation based on HSP104's role in the TRC complex
@@ -588,6 +681,7 @@ existing_annotations:
     label: cellular response to heat
   evidence_type: IDA
   original_reference_id: PMID:24291094
+  qualifier: involved_in
   review:
     summary: >-
       Study demonstrating HSP104/Hsp70-dependent protein disaggregation
@@ -613,6 +707,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IDA
   original_reference_id: PMID:16135516
+  qualifier: enables
   review:
     summary: >-
       Direct biochemical demonstration of HSP104 ATPase activity and its
@@ -635,6 +730,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IMP
   original_reference_id: PMID:16135516
+  qualifier: enables
   review:
     summary: >-
       Mutant phenotype evidence for ATP hydrolysis. Walker A (K218T) and
@@ -657,6 +753,7 @@ existing_annotations:
     label: ATP hydrolysis activity
   evidence_type: IMP
   original_reference_id: PMID:9674429
+  qualifier: enables
   review:
     summary: >-
       Mutant phenotype evidence from the landmark Glover & Lindquist (1998)
@@ -679,6 +776,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:22842922
+  qualifier: located_in
   review:
     summary: >-
       High-throughput microscopy study of GFP-tagged proteins under DNA
@@ -699,6 +797,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IDA
   original_reference_id: PMID:9674429
+  qualifier: involved_in
   review:
     summary: >-
       PMID:9674429 demonstrates that HSP104 in concert with Hsp70/Hsp40
@@ -728,12 +827,13 @@ existing_annotations:
     label: nuclear periphery
   evidence_type: IDA
   original_reference_id: PMID:25817432
+  qualifier: located_in
   review:
     summary: >-
       PMID:25817432 identifies the intranuclear quality control compartment
       (INQ) where HSP104 colocalizes with Cmr1 and misfolded proteins at
       the nuclear periphery in response to genotoxic stress.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       PMID:25817432 provides direct evidence for HSP104 localization at
       the nuclear periphery as part of the INQ compartment, which
@@ -756,13 +856,14 @@ existing_annotations:
     label: stress granule disassembly
   evidence_type: IDA
   original_reference_id: PMID:24291094
+  qualifier: involved_in
   review:
     summary: >-
       PMID:24291094 demonstrates that HSP104 is required for stress granule
       disassembly during recovery from severe heat stress. Heat-SGs
       coassemble with protein aggregates, and their disassembly is coupled
       to Hsp104-dependent protein disaggregation.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       This is a well-supported secondary function of HSP104. Stress granule
       disassembly is mechanistically linked to its core disaggregase
@@ -784,6 +885,7 @@ existing_annotations:
     label: ATP binding
   evidence_type: IMP
   original_reference_id: PMID:11867765
+  qualifier: enables
   review:
     summary: >-
       Mutagenesis study of the AAA sensor-2 motif in NBD2. R826M mutation
@@ -807,11 +909,12 @@ existing_annotations:
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:10467108
+  qualifier: located_in
   review:
     summary: >-
       Immunoelectron microscopy demonstrating HSP104 presence in the
       nucleus. Nuclear accumulation is enhanced by heat shock.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       Direct immunoEM evidence for nuclear localization. PMID:10467108:
       "a small amount of Hsp104 was located in the cytoplasm and nucleus."
@@ -828,6 +931,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:10467108
+  qualifier: located_in
   review:
     summary: >-
       Same immunoelectron microscopy study confirming cytoplasmic
@@ -850,6 +954,7 @@ existing_annotations:
     label: trehalose metabolic process
   evidence_type: IMP
   original_reference_id: PMID:9797333
+  qualifier: involved_in
   review:
     summary: >-
       PMID:9797333 shows that HSP104 disruption affects trehalose
@@ -879,6 +984,7 @@ existing_annotations:
     label: protein folding in endoplasmic reticulum
   evidence_type: IMP
   original_reference_id: PMID:10931304
+  qualifier: involved_in
   review:
     summary: >-
       PMID:10931304 shows that HSP104 is required for conformational repair
@@ -906,6 +1012,7 @@ existing_annotations:
     label: protein unfolding
   evidence_type: IMP
   original_reference_id: PMID:7984243
+  qualifier: involved_in
   review:
     summary: >-
       The landmark Parsell et al. (1994) paper demonstrating that HSP104
@@ -929,6 +1036,7 @@ existing_annotations:
     label: ADP binding
   evidence_type: IMP
   original_reference_id: PMID:11867765
+  qualifier: enables
   review:
     summary: >-
       PMID:11867765 uses a site-specific fluorescent probe (Y819W) to
@@ -951,27 +1059,25 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:16135516
+  qualifier: enables
   review:
     summary: >-
       PMID:16135516 directly demonstrates ATP-dependent binding of HSP104
-      to the permanently unfolded substrate RCMLa. While the substrate
-      binding data is correct, the GO term "unfolded protein binding"
-      understates the mechanistic specificity of HSP104. The core function
-      is ATP-dependent protein disaggregation (GO:0140545), not passive
-      unfolded protein binding.
-    action: MODIFY
+      to RCMLa, a permanently unfolded model substrate. This directly supports
+      the biological claim represented by the original annotation, but
+      GO:0051082 is now obsolete.
+    action: UNDECIDED
     reason: >-
-      Same reasoning as for the IBA annotation of this term. HSP104 does
-      not merely bind unfolded proteins; it uses ATP hydrolysis to actively
-      thread and solubilize aggregated substrates. GO:0140545 "ATP-dependent
-      protein disaggregase activity" is the correct and specific term.
-      PMID:16135516: "the affinity of Hsp104 toward polypeptides is
-      regulated by nucleotides... the occupation of the N-terminally
-      located nucleotide-binding domain with ATP seems to be crucial for
-      substrate interaction."
-    proposed_replacement_terms:
-      - id: GO:0140545
-        label: ATP-dependent protein disaggregase activity
+      The cited experiment measures nucleotide-regulated binding to an
+      unfolded substrate; it does not assay disaggregation, refolding, or
+      prevention of aggregation during client escort. Consequently it cannot
+      support GO:0140545, and neither of GO:0051082's official consider targets
+      is an evidence-matched replacement: GO:0044183 adds folding assistance,
+      while GO:0140309 adds carrier/holdase semantics. The obsolete annotation
+      should not be accepted as a current term, but no replacement can be
+      asserted from PMID:16135516 alone. HSP104's disaggregase activity remains
+      captured separately by the NEW GO:0140545 annotation using direct
+      disaggregation sources.
     supported_by:
       - reference_id: PMID:16135516
         supporting_text: >-
@@ -980,17 +1086,13 @@ existing_annotations:
           adenosine-5' -O-(3-thiotriphosphate), the chaperone formed
           complexes with RCMLa, whereas no binding was observed in the
           presence of ADP.
-      - reference_id: PMID:7984243
-        supporting_text: >-
-          Hsp104 functions in a manner not previously described for other
-          heat-shock proteins: it mediates the resolubilization of
-          heat-inactivated luciferase from insoluble aggregates.
 
 - term:
     id: GO:0051087
     label: protein-folding chaperone binding
   evidence_type: IDA
   original_reference_id: PMID:9674429
+  qualifier: enables
   review:
     summary: >-
       PMID:9674429 demonstrates direct functional cooperation between
@@ -1015,6 +1117,7 @@ existing_annotations:
     label: cellular heat acclimation
   evidence_type: IMP
   original_reference_id: PMID:2188365
+  qualifier: involved_in
   review:
     summary: >-
       The foundational paper showing HSP104 is required for induced
@@ -1037,6 +1140,7 @@ existing_annotations:
     label: TRC complex
   evidence_type: IDA
   original_reference_id: PMID:20850366
+  qualifier: part_of
   review:
     summary: >-
       PMID:20850366 identifies HSP104 as a component of the TMD recognition
@@ -1064,6 +1168,7 @@ existing_annotations:
     label: ATP-dependent protein disaggregase activity
   evidence_type: IDA
   original_reference_id: PMID:7984243
+  qualifier: enables
   review:
     summary: >-
       HSP104 is the founding member of the ATP-dependent protein disaggregase
@@ -1411,13 +1516,6 @@ core_functions:
       Hsp70/Hsp40. HSP104 is essential for induced thermotolerance and
       mechanically unfolds aggregated polypeptides as part of disaggregation.
   - molecular_function:
-      id: GO:0016887
-      label: ATP hydrolysis activity
-    description: >-
-      ATP hydrolysis by two AAA ATPase domains (NBD1 and NBD2) per monomer
-      powers the disaggregation mechanism. NBD1 has low affinity/high turnover;
-      NBD2 has high affinity/slow hydrolysis.
-  - molecular_function:
       id: GO:0051087
       label: protein-folding chaperone binding
     description: >-
@@ -1425,7 +1523,23 @@ core_functions:
       chaperones, which are required for substrate delivery and downstream
       refolding.
 
-proposed_new_terms: []
+proposed_new_terms:
+  - proposed_name: prion fibril fragmentation activity
+    proposed_definition: >-
+      A molecular function that fragments a prion amyloid fibril into smaller
+      oligomeric seeds that can be transmitted to daughter cells and thereby
+      maintain cellular prion propagation.
+    justification: >-
+      HSP104-dependent fragmentation of prion fibrils is a directly established,
+      mechanistically distinct yeast function required to create infectious
+      seeds. Current GO lacks a term that represents prion fibril fragmentation;
+      the existing ATP-dependent protein disaggregase term does not capture the
+      propagation-producing outcome of partial fibril fragmentation.
+    supported_by:
+      - reference_id: PMID:18312264
+        supporting_text: >-
+          Prion propagation requires the Hsp104-dependent fragmentation of prion
+          fibrils to create infectious seeds.
 
 suggested_questions:
   - question: >-

--- a/genes/yeast/HSP104/HSP104-notes.md
+++ b/genes/yeast/HSP104/HSP104-notes.md
@@ -1,0 +1,75 @@
+# HSP104 review notes
+
+## 2026-08-28 annotation audit
+
+- HSP104 is the canonical cytosolic Hsp100/ClpB-family AAA+ disaggregase. Its
+  defining activity is ATP-dependent extraction of proteins from aggregates,
+  followed by Hsp70/Hsp40-dependent reactivation. The original resolubilization
+  study states that Hsp104 “mediates the resolubilization of heat-inactivated
+  luciferase from insoluble aggregates” [PMID:7984243, “Protein disaggregation
+  mediated by heat-shock protein Hsp104.”]. The reconstitution study further
+  reports that, with Hsp40 and Hsp70, Hsp104 reactivates proteins that were
+  denatured and allowed to aggregate [PMID:9674429, “Hsp104, Hsp70, and Hsp40:
+  a novel chaperone system that rescues previously aggregated proteins.”].
+  These data justify a NEW annotation to GO:0140545, ATP-dependent protein
+  disaggregase activity.
+
+- All 45 unique non-NEW GOA signatures were reconciled exactly by GO term,
+  evidence code, reference, and relation qualifier. The 67 GOA rows collapse to
+  45 signatures because the two high-throughput protein-binding publications
+  contain multiple WITH/FROM interaction partners. Those repeated partner rows
+  do not represent distinct GO assertions in this review.
+
+- The eight IBA rows were checked against the current PTHR11638 PAINT cache.
+  Cytoplasm and ATP hydrolysis are asserted at PTN000181243. Protein refolding,
+  protein unfolding, cytosol, unfolded protein binding, protein-folding
+  chaperone binding, and cellular heat acclimation are asserted at the fungal
+  node PTN007521008. S. cerevisiae HSP104 is itself an experimental descendant
+  seed for several of these assertions; this is valid PAINT grounding, not
+  circular evidence. The inherited biology is supported for HSP104. The
+  GO:0051082 IBA correctly propagates substrate-binding biology but the term is
+  obsolete. Neither official consider target preserves that assertion without
+  adding foldase or carrier/holdase semantics, so it is UNDECIDED rather than
+  branch-swapped to the separately established disaggregase activity.
+
+- The PMID:16135516 IDA row is treated separately. The paper directly assays
+  nucleotide-regulated binding to permanently unfolded RCMLa, but it does not
+  assay folding, aggregation prevention/escort, or disaggregation. Live QuickGO
+  records GO:0051082 as obsolete and offers GO:0044183 protein folding chaperone
+  and GO:0140309 unfolded protein holdase activity as `consider` targets. Neither
+  is evidence-matched to this assay, so the row is UNDECIDED rather than ACCEPT
+  on an obsolete term or MODIFY to an activity that this paper did not test. The
+  separate NEW GO:0140545 annotation retains direct disaggregation evidence.
+
+- Generic protein-binding annotations from the global TAP and chaperone-network
+  studies remain marked over-annotated. The full-text chaperone atlas explicitly
+  cautions that its TAP-tag interactions are indirect rather than binary
+  [PMID:19536198, “An atlas of chaperone-protein interactions in Saccharomyces
+  cerevisiae: implications to protein folding pathways in the cell.”]. Specific
+  homo-oligomerization and protein-folding-chaperone binding annotations are
+  retained separately.
+
+- Nuclear, nuclear-periphery, stress-granule, ER-folding, and TRC/ER-targeting
+  annotations are retained as non-core context. Direct microscopy supports a
+  nuclear pool [PMID:10467108, “At normal temperature (25 degrees C), a small
+  amount of Hsp104 was located in the cytoplasm and nucleus.”], and stress-granule
+  recovery requires Hsp104/Hsp70 activity [PMID:24291094, “Coordination of
+  translational control and protein homeostasis during severe heat stress.”].
+  These roles are credible consequences or specialized deployments of the core
+  disaggregation machinery rather than separate defining activities.
+
+- The trehalose-metabolism phenotype remains marked over-annotated: reduced
+  trehalose enzyme activities in an hsp104 mutant establish an indirect
+  proteostasis consequence, not a direct metabolic activity [PMID:9797333,
+  “The activities of trehalose-synthesizing and -hydrolyzing enzymes are low in
+  the HSP104 disruption mutant during heat shock.”]. The ARBA intracellular
+  organelle lumen annotation is likewise over-annotated because HSP104 is a
+  cytosolic/nuclear protein; an effect on repair within the ER does not establish
+  luminal localization.
+
+- Prion fibril fragmentation is a major yeast-specific function described by
+  UniProt and the literature, but a current QuickGO ontology search did not find
+  a GO term specifically representing prion propagation or fibril fragmentation.
+  A term request for “prion fibril fragmentation activity” is therefore captured
+  under `proposed_new_terms` without guessing an identifier; PMID:18312264 states
+  that Hsp104-dependent fibril fragmentation creates infectious seeds.


### PR DESCRIPTION
## Summary
- mark HSP104 COMPLETE after exact reconciliation of 45 qualifier-aware GOA assertion signatures
- audit all eight IBA rows against actual Hsp100/ClpB PAINT nodes with structured propagation metadata
- adjudicate the obsolete GO:0051082 binding rows without conflating binding evidence with disaggregation
- add a directly supported NEW GO:0140545 ATP-dependent protein disaggregase annotation
- propose prion fibril fragmentation activity without guessing an identifier

## Validation
- just validate yeast HSP104
- just validate-goa yeast HSP104
- just render yeast HSP104
- just deploy-browser
- git diff --check

No support-code changes or wrapper bypasses.