### PR TITLE
Complete yeast YDJ1 annotation review

### DIFF
--- a/genes/yeast/YDJ1/YDJ1-ai-review.html
+++ b/genes/yeast/YDJ1/YDJ1-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -900,6 +900,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001531327</span>
+
+                                    &middot; PANTHER:PTN001531327
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The GOA WITH/FROM places cytosol at this class-A J-protein node using fungal and metazoan descendants, including experimentally localized S. cerevisiae YDJ1 itself.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -967,6 +996,35 @@
                             <strong>Reason:</strong> ATPase activator activity is the defining molecular function of the J-domain. Experimentally demonstrated by IDA (PMID:1400408, PMID:15342786) and conserved across the DnaJ family.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002376157</span>
+
+                                    &middot; PANTHER:PTN002376157
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The PTHR44298 PAINT record places ATPase activator activity at this broad J-protein node; YDJ1 is one of its experimentally grounded descendants, consistent with direct Ssa1 ATPase assays.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1064,6 +1122,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001531327</span>
+
+                                    &middot; PANTHER:PTN001531327
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The node is grounded by fungal J proteins including YDJ1, whose own heat-stress phenotype supports the inherited process annotation.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
 
                     </td>
@@ -1115,6 +1202,35 @@
                             <strong>Reason:</strong> Protein refolding is a core biological process for YDJ1 as part of the Hsp104/Hsp70/Hsp40 disaggregation/refolding machinery. Confirmed by IDA (PMID:9674429).
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001531327</span>
+
+                                    &middot; PANTHER:PTN001531327
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Refolding is placed at the class-A J-protein node using fungal and metazoan sources, including direct YDJ1 evidence; no target-specific loss or divergence is evident.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1201,6 +1317,42 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001531327</span>
+
+                                    &middot; PANTHER:PTN001531327
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The node and its YDJ1/APJ1-class sources support client binding and chaperone activity. Modification is required because GO:0051082 is obsolete, not because the PAINT propagation lacks biological support.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
 
@@ -1262,10 +1414,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P25491" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25491" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1278,9 +1430,38 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Nuclear localization is supported by its role in the HAP1 repressor complex and tRNA nuclear import. IBA is consistent with NAS evidence.
+                            <strong>Reason:</strong> Nuclear localization is supported by its role in the HAP1 repressor complex and tRNA nuclear import. It is retained as non-core because YDJ1 is predominantly cytosolic.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001180221</span>
+
+                                    &middot; PANTHER:PTN001180221
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The fungal J-protein node is seeded by S. pombe and APJ1 evidence; APJ1 is a class-A/type-I Ydj1 paralog, not Sis1. YDJ1&#39;s HAP1 and tRNA-import roles independently make a secondary nuclear pool plausible, although nucleus is not its principal site.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1612,10 +1793,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P25491" data-a="GO:0009408" data-r="GO_REF:0000002" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25491" data-a="GO:0009408" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1628,10 +1809,21 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Correct but less specific than GO:0034605. The IEA is consistent with the established role of YDJ1 as a heat shock protein.
+                            <strong>Reason:</strong> The broad heat-response assertion is sound, but GO:0034605 is the actionable, experimentally and phylogenetically supported child term already used for YDJ1.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
+                                    cellular response to heat
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -1665,10 +1857,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P25491" data-a="GO:0015031" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25491" data-a="GO:0015031" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1681,7 +1873,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Protein transport is a broad but accurate annotation. YDJ1 participates in translocation of pre-pro-alpha-factor (PMID:1473150) and was originally identified as MAS5 (mitochondrial assembly protein).
+                            <strong>Reason:</strong> Protein transport is a broad but accurate umbrella for YDJ1&#39;s documented ER targeting and mitochondrial precursor-transport contexts. Retain it as non-core rather than replacing it only with GO:0045047, which would erase the mitochondrial aspect; the specific ER-targeting assertion is reviewed separately.
                         </div>
 
 
@@ -2517,10 +2709,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P25491" data-a="GO:0005634" data-r="PMID:15102838" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25491" data-a="GO:0005634" data-r="PMID:15102838" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2533,7 +2725,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Nuclear localization is supported by YDJ1&#39;s role in the HAP1 repressor complex. Consistent with IBA evidence for the same term.
+                            <strong>Reason:</strong> Nuclear localization is supported by YDJ1&#39;s role in the HAP1 repressor complex. Consistent with IBA evidence for the same term, but secondary to its predominant cytosolic localization.
                         </div>
 
 
@@ -2858,6 +3050,24 @@
 
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25344756" target="_blank" class="term-link">
+                                        PMID:25344756
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We found that ubiquitylation of heat-induced substrates requires the Hsp40 co-chaperone Ydj1 that is further associated with Rsp5 upon heat shock.</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -3221,10 +3431,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P25491" data-a="GO:0051131" data-r="PMID:10811660" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P25491" data-a="GO:0051131" data-r="PMID:10811660" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3232,12 +3442,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for chaperone-mediated protein complex assembly is not supported by the cited reference. PMID:10811660 describes crystal structure and activity of human p23, an Hsp90 co-chaperone, and does not directly assay S. cerevisiae YDJ1.
+                            <strong>Summary:</strong> This CAFA-assigned IDA has empty WITH/FROM and cites an abstract-only human p23 study. The abstract demonstrates p23 chaperoning of progesterone receptor but provides no direct YDJ1 assay.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:10811660 is a crystal structure paper for human p23, not YDJ1. IDA evidence requires a direct assay of the annotated gene product. This annotation cannot be substantiated by the cited reference.
+                            <strong>Reason:</strong> Chaperone-mediated assembly is broadly compatible with Ydj1 biology, but CAFA&#39;s IDA transfers a process from a different human Hsp90 cochaperone without documented YDJ1 evidence or a source entity. The row therefore overstates direct experimental support. This is not treated as MOD-curated evidence, and no wrong-identifier claim is made beyond what the cached abstract shows.
                         </div>
 
 
@@ -4017,10 +4227,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P25491" data-a="GO:0072380" data-r="PMID:20850366" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25491" data-a="GO:0072380" data-r="PMID:20850366" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -4028,16 +4238,34 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for TRC complex membership. YDJ1 is part of a chaperone cascade that sorts proteins for post-translational membrane insertion into the ER via the TRC/GET pathway (PMID:20850366).
+                            <strong>Summary:</strong> The cited study establishes a sequential tail-anchored-protein chaperone cascade. Ydj1/Ssa1 act upstream in client handling, whereas GO:0072380 denotes the Get4-Get5/Mdy2 TRC complex.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Membership in the TRC complex is experimentally demonstrated. This is a specific application of YDJ1&#39;s co-chaperone function in the tail-anchored protein insertion pathway.
+                            <strong>Reason:</strong> Participation in upstream handoff does not establish that Ydj1 is a stable part of TRC. Retain the pathway connection but mark the complex-membership assertion over-annotated; direct stoichiometric incorporation would be needed.
                         </div>
 
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20850366" target="_blank" class="term-link">
+                                        PMID:20850366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Thus, ER-bound TA proteins are sorted at the top of a TMD chaperone cascade that culminates with the formation of Get3-TA protein complexes, which are recruited to the ER membrane for insertion.</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -4146,7 +4374,7 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Protein folding chaperone activity - binds unfolded/denatured substrates via C-terminal peptide-binding domain and zinc finger region, delivering them to Hsp70 for folding. Replacement for GO:0051082 which is now formally obsolete.</h3>
+                <h3>Protein folding chaperone activity - binds unfolded/denatured substrates via C-terminal peptide-binding domain and zinc finger region, delivering them to Hsp70 for folding.</h3>
                 <span class="vote-buttons" data-g="P25491" data-a="FUNCTION: Protein folding chaperone activity - binds unfolde..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -4990,7 +5218,104 @@ functional annotation (a negative/scoping result).
 
 
 
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
 
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What fraction of Ydj1&#39;s nuclear HAP1-regulatory and tRNA-import roles requires direct nuclear entry of Ydj1 rather than cytosolic Hsp70-client preparation before import?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25491" data-a="Q: What fraction of Ydj1&#39;s nuclear HAP1-regulatory an..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is Ydj1 a stable stoichiometric component of the TRC complex, or a transient upstream chaperone in the tail-anchored-protein targeting cascade?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25491" data-a="Q: Is Ydj1 a stable stoichiometric component of the T..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How do the zinc-binding client-recognition region and C-terminal farnesylation partition clients among refolding, ERAD, and organellar targeting outcomes?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25491" data-a="Q: How do the zinc-binding client-recognition region ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare wild-type Ydj1 with HPD-motif, zinc-coordination, client-binding, and CaaX/farnesylation mutants in matched Ssa1 ATPase, luciferase refolding, heat-induced ubiquitination, and ER-targeting assays.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P25491" data-a="EXPERIMENT: Compare wild-type Ydj1 with HPD-motif, zinc-coordi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use endogenous live-cell tagging and compartment-restricted proximity labeling during heat stress, heme depletion, and starvation to quantify the cytosolic, perinuclear, and nuclear Ydj1 interactomes.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P25491" data-a="EXPERIMENT: Use endogenous live-cell tagging and compartment-r..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute the early GET/TRC targeting cascade with purified Ydj1, Ssa1, Sgt2, Mdy2/Get4, Get5, and tail-anchored clients to distinguish stable complex membership from transient client transfer.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P25491" data-a="EXPERIMENT: Reconstitute the early GET/TRC targeting cascade w..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
 
 
 
@@ -5444,6 +5769,91 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(YDJ1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P25491" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ydj1-review-notes">YDJ1 review notes</h1>
+<h2 id="2026-08-28-completion-audit">2026-08-28 completion audit</h2>
+<ul>
+<li>
+<p>YDJ1 encodes a type-I DnaJ/Hsp40 co-chaperone whose defining molecular<br />
+  function is stimulation of the Ssa1 Hsp70 ATPase cycle [PMID:1400408, “We<br />
+  report that a purified cytoplasmic Hsp70 homolog from Saccharomyces cerevisiae,<br />
+  Hsp70SSA1, exhibits a weak ATPase activity, which is stimulated by a purified<br />
+  eukaryotic dnaJp homolog (YDJ1p).”]. The InterPro-derived ATP<br />
+  binding annotation is therefore removed: Ydj1 activates its Hsp70 partner but<br />
+  has no ATP-binding/ATPase domain of its own.</p>
+</li>
+<li>
+<p>All 49 unique nonredundant GOA signatures were reconciled exactly by GO term,<br />
+  evidence, reference, and relation qualifier. The 62 physical GOA rows collapse<br />
+  to 49 signatures because high-throughput <code>protein binding</code> annotations repeat<br />
+  the same assertions for multiple WITH/FROM partners. All eight generic protein<br />
+  binding signatures remain marked over-annotated; specific Hsp70/heat-shock<br />
+  protein binding terms capture the informative partner biology.</p>
+</li>
+<li>
+<p>All six IBA annotations were reviewed from their GOA WITH/FROM provenance.<br />
+  Cytosol, cellular response to heat, protein refolding, and obsolete unfolded<br />
+  protein binding use PTN001531327; ATPase activator activity uses PTN002376157;<br />
+  nucleus uses PTN001180221. YDJ1 is an experimental descendant source at the<br />
+  first two nodes, which is valid PAINT grounding rather than circular evidence.<br />
+  The SGD:S000005021 source at PTN001531327 and PTN001180221 is APJ1, a<br />
+  class-A/type-I Ydj1 paralog, not SIS1.<br />
+  The current local PTHR44298 PAINT table retains PTN002376157, while the other<br />
+  node identifiers remain recoverable from current GOA WITH/FROM rows.</p>
+</li>
+<li>
+<p>GO:0051082 is obsolete in live GO. For Ydj1, replacement by GO:0044183 protein<br />
+  folding chaperone is evidence-matched: the direct study found both suppression<br />
+  of thermally induced luciferase aggregation and productive Ssa1-dependent<br />
+  refolding [PMID:9774392, “Ydj1:Ssa1 could promote up to four times more<br />
+  luciferase folding than Sis1:Ssa1.”]. All three GO:0051082 assertions are<br />
+  therefore consistently modified to GO:0044183.</p>
+</li>
+<li>
+<p>The CAFA-assigned IDA <code>chaperone-mediated protein complex assembly</code> row has<br />
+  empty WITH/FROM and cites an abstract-only human p23 paper <a href="https://pubmed.ncbi.nlm.nih.gov/10811660">PMID:10811660</a>.<br />
+  The abstract demonstrates p23 chaperoning of progesterone receptor but no<br />
+  direct YDJ1 assay, so the row is marked over-annotated rather than treated as<br />
+  MOD-curated evidence or labelled a wrong-identifier citation.</p>
+</li>
+<li>
+<p>Ydj1's heat-stress quality-control role is directly supported in full text<br />
+  [PMID:25344756, “We found that ubiquitylation of heat-induced substrates<br />
+  requires the Hsp40 co-chaperone Ydj1 that is further associated with Rsp5 upon<br />
+  heat shock.”].<br />
+  ERAD and protein targeting to ER are retained as important cellular functions;<br />
+  HAP1 regulation, oxygen response, starvation-linked tRNA import, nuclear<br />
+  localization, and broad protein transport are retained as specialized non-core<br />
+  uses of the central Hsp70 co-chaperone machinery. TRC membership is marked<br />
+  over-annotated because upstream cascade participation does not establish stable<br />
+  incorporation into the Get4-Get5/Mdy2 complex.</p>
+</li>
+<li>
+<p>Most older supporting publications in the cache are abstract-only. Their<br />
+  experimental annotations were not overruled when the abstract lacked assay<br />
+  detail. Full text is locally available for PMID:19536198, PMID:23217712,<br />
+  PMID:25344756, PMID:25853343, PMID:26928762, and PMID:37968396.</p>
+</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5455,7 +5865,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P25491
 gene_symbol: YDJ1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -5475,6 +5885,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: &gt;-
       IBA annotation for cytosol localization is well supported. YDJ1 was shown by
@@ -5485,6 +5896,16 @@ existing_annotations:
       Cytosol is a well-established localization for YDJ1. Multiple independent methods
       confirm cytosolic localization. IBA is consistent with IDA evidence from PMID:1869583
       and PMID:8144572.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN001531327
+          source_label: PANTHER:PTN001531327
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The GOA WITH/FROM places cytosol at this class-A J-protein node using
+            fungal and metazoan descendants, including experimentally localized
+            S. cerevisiae YDJ1 itself.
     supported_by:
       - reference_id: file:yeast/YDJ1/YDJ1-deep-research-falcon.md
         supporting_text: |-
@@ -5494,6 +5915,7 @@ existing_annotations:
     label: ATPase activator activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: &gt;-
       IBA annotation for ATPase activator activity is strongly supported. YDJ1 stimulates
@@ -5504,6 +5926,16 @@ existing_annotations:
       ATPase activator activity is the defining molecular function of the J-domain.
       Experimentally demonstrated by IDA (PMID:1400408, PMID:15342786) and conserved across
       the DnaJ family.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN002376157
+          source_label: PANTHER:PTN002376157
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The PTHR44298 PAINT record places ATPase activator activity at this
+            broad J-protein node; YDJ1 is one of its experimentally grounded
+            descendants, consistent with direct Ssa1 ATPase assays.
     supported_by:
       - reference_id: PMID:1400408
         supporting_text: &gt;-
@@ -5522,6 +5954,7 @@ existing_annotations:
     label: cellular response to heat
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: &gt;-
       IBA annotation for cellular response to heat is appropriate. YDJ1 is a heat shock
@@ -5532,11 +5965,21 @@ existing_annotations:
     reason: &gt;-
       YDJ1 is a bona fide heat shock protein involved in stress response. IBA is consistent
       with IMP evidence and the well-established role of Hsp40 in heat stress response.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN001531327
+          source_label: PANTHER:PTN001531327
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The node is grounded by fungal J proteins including YDJ1, whose own
+            heat-stress phenotype supports the inherited process annotation.
 - term:
     id: GO:0042026
     label: protein refolding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: &gt;-
       IBA annotation for protein refolding is well supported. Hsp104, Hsp70 (Ssa1), and
@@ -5546,6 +5989,16 @@ existing_annotations:
     reason: &gt;-
       Protein refolding is a core biological process for YDJ1 as part of the
       Hsp104/Hsp70/Hsp40 disaggregation/refolding machinery. Confirmed by IDA (PMID:9674429).
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN001531327
+          source_label: PANTHER:PTN001531327
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            Refolding is placed at the class-A J-protein node using fungal and
+            metazoan sources, including direct YDJ1 evidence; no target-specific
+            loss or divergence is evident.
     supported_by:
       - reference_id: PMID:9674429
         supporting_text: &gt;-
@@ -5562,6 +6015,7 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: &gt;-
       GO:0051082 is now formally obsolete. YDJ1 does bind unfolded/denatured substrates
@@ -5577,6 +6031,18 @@ existing_annotations:
     proposed_replacement_terms:
       - id: GO:0044183
         label: protein folding chaperone
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+        - GRANULARITY_MISMATCH
+      source_entities:
+        - source_id: PANTHER:PTN001531327
+          source_label: PANTHER:PTN001531327
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The node and its YDJ1/APJ1-class sources support client binding and
+            chaperone activity. Modification is required because GO:0051082 is
+            obsolete, not because the PAINT propagation lacks biological support.
     supported_by:
       - reference_id: PMID:9774392
         supporting_text: &gt;-
@@ -5588,20 +6054,33 @@ existing_annotations:
     label: nucleus
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: &gt;-
       IBA annotation for nuclear localization. YDJ1 functions in the nucleus as part of
       the HMC complex regulating HAP1 transcription factor activity (PMID:15102838). Also
       involved in tRNA import into nucleus (PMID:25853343). Supported by NAS (PMID:15102838).
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       Nuclear localization is supported by its role in the HAP1 repressor complex and tRNA
-      nuclear import. IBA is consistent with NAS evidence.
+      nuclear import. It is retained as non-core because YDJ1 is predominantly cytosolic.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+        - source_id: PANTHER:PTN001180221
+          source_label: PANTHER:PTN001180221
+          source_status: SUPPORTS_TRANSFER
+          comment: &gt;-
+            The fungal J-protein node is seeded by S. pombe and APJ1 evidence;
+            APJ1 is a class-A/type-I Ydj1 paralog, not Sis1.
+            YDJ1&#39;s HAP1 and tRNA-import roles independently make a secondary
+            nuclear pool plausible, although nucleus is not its principal site.
 - term:
     id: GO:0001671
     label: ATPase activator activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation for ATPase activator activity from ARBA machine learning. Consistent
@@ -5615,6 +6094,7 @@ existing_annotations:
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation for ATP binding based on InterPro domain IPR012724 (DnaJ). While YDJ1
@@ -5637,6 +6117,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: &gt;-
       IEA annotation for cytoplasm based on UniProt subcellular location. Correct but
@@ -5650,6 +6131,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: &gt;-
       IEA annotation for protein folding from InterPro. YDJ1 participates in protein folding
@@ -5664,6 +6146,7 @@ existing_annotations:
     label: zinc ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation for zinc ion binding based on UniProt keyword. YDJ1 has a well-characterized
@@ -5683,35 +6166,42 @@ existing_annotations:
     label: response to heat
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: &gt;-
       IEA annotation for response to heat. YDJ1 is a heat-inducible chaperone gene.
       This is a broader parent of the more specific IBA/IMP-supported cellular response
       to heat (GO:0034605).
-    action: ACCEPT
+    action: MODIFY
     reason: &gt;-
-      Correct but less specific than GO:0034605. The IEA is consistent with the established
-      role of YDJ1 as a heat shock protein.
+      The broad heat-response assertion is sound, but GO:0034605 is the actionable,
+      experimentally and phylogenetically supported child term already used for YDJ1.
+    proposed_replacement_terms:
+      - id: GO:0034605
+        label: cellular response to heat
 - term:
     id: GO:0015031
     label: protein transport
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: involved_in
   review:
     summary: &gt;-
       IEA annotation for protein transport from UniProt keyword. YDJ1 is involved in
       protein targeting to the ER (PMID:1473150) and mitochondrial protein import, both
       of which involve protein transport.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Protein transport is a broad but accurate annotation. YDJ1 participates in
-      translocation of pre-pro-alpha-factor (PMID:1473150) and was originally identified
-      as MAS5 (mitochondrial assembly protein).
+      Protein transport is a broad but accurate umbrella for YDJ1&#39;s documented ER
+      targeting and mitochondrial precursor-transport contexts. Retain it as non-core
+      rather than replacing it only with GO:0045047, which would erase the mitochondrial
+      aspect; the specific ER-targeting assertion is reviewed separately.
 - term:
     id: GO:0030544
     label: Hsp70 protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation for Hsp70 protein binding from InterPro. YDJ1 physically interacts
@@ -5727,6 +6217,7 @@ existing_annotations:
     label: heat shock protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation for heat shock protein binding from InterPro. YDJ1 binds Hsp70 (Ssa1)
@@ -5740,6 +6231,7 @@ existing_annotations:
     label: metal ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation for metal ion binding from UniProt keyword. YDJ1 binds zinc ions via
@@ -5752,6 +6244,7 @@ existing_annotations:
     label: perinuclear region of cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: &gt;-
       IEA annotation for perinuclear region based on UniProt subcellular location.
@@ -5766,6 +6259,7 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation for unfolded protein binding from InterPro. Same issue as the IBA
@@ -5783,6 +6277,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:11805837
+  qualifier: enables
   review:
     summary: &gt;-
       IPI annotation for protein binding from large-scale mass spectrometry identification
@@ -5798,6 +6293,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:15879519
+  qualifier: enables
   review:
     summary: &gt;-
       IPI annotation for protein binding from two-hybrid screen for Hsp90 interactors.
@@ -5812,6 +6308,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16429126
+  qualifier: enables
   review:
     summary: &gt;-
       IPI annotation for protein binding from proteome survey. IntAct records interaction
@@ -5825,6 +6322,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:17441508
+  qualifier: enables
   review:
     summary: &gt;-
       IPI annotation for protein binding showing YDJ1 interaction with SGT2 and MDY2.
@@ -5839,6 +6337,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18833196
+  qualifier: enables
   review:
     summary: &gt;-
       IPI annotation for protein binding showing interaction with SUP35 (Q7LKB1, a prion
@@ -5852,6 +6351,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
+  qualifier: enables
   review:
     summary: &gt;-
       IPI annotation for protein binding from atlas of chaperone-protein interactions.
@@ -5865,6 +6365,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23217712
+  qualifier: enables
   review:
     summary: &gt;-
       IPI annotation for protein binding showing interaction with SSA1 (P10591).
@@ -5878,6 +6379,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
+  qualifier: enables
   review:
     summary: &gt;-
       IPI annotation for protein binding from social and structural architecture of yeast
@@ -5891,20 +6393,23 @@ existing_annotations:
     label: nucleus
   evidence_type: NAS
   original_reference_id: PMID:15102838
+  qualifier: located_in
   review:
     summary: &gt;-
       NAS annotation for nuclear localization from ComplexPortal, based on YDJ1 function
       in the HMC complex that regulates HAP1 transcription factor (PMID:15102838). YDJ1
       is part of the Hsp70-Ydj1 complex that represses HAP1 activity in the absence of heme.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       Nuclear localization is supported by YDJ1&#39;s role in the HAP1 repressor complex.
-      Consistent with IBA evidence for the same term.
+      Consistent with IBA evidence for the same term, but secondary to its
+      predominant cytosolic localization.
 - term:
     id: GO:0045892
     label: negative regulation of DNA-templated transcription
   evidence_type: NAS
   original_reference_id: PMID:15102838
+  qualifier: involved_in
   review:
     summary: &gt;-
       NAS annotation from ComplexPortal. YDJ1 is part of the HMC complex that represses
@@ -5920,6 +6425,7 @@ existing_annotations:
     label: response to oxygen levels
   evidence_type: NAS
   original_reference_id: PMID:15102838
+  qualifier: involved_in
   review:
     summary: &gt;-
       NAS annotation from ComplexPortal. YDJ1 mediates heme-dependent regulation of HAP1,
@@ -5934,6 +6440,7 @@ existing_annotations:
     label: response to oxygen levels
   evidence_type: NAS
   original_reference_id: PMID:9632766
+  qualifier: involved_in
   review:
     summary: &gt;-
       NAS annotation from ComplexPortal. Same biological role as above - YDJ1 participates
@@ -5947,6 +6454,7 @@ existing_annotations:
     label: cellular response to starvation
   evidence_type: IMP
   original_reference_id: PMID:25853343
+  qualifier: involved_in
   review:
     summary: &gt;-
       IMP annotation for cellular response to starvation. PMID:25853343 describes YDJ1&#39;s
@@ -5960,6 +6468,7 @@ existing_annotations:
     label: cellular response to heat
   evidence_type: IMP
   original_reference_id: PMID:25344756
+  qualifier: involved_in
   review:
     summary: &gt;-
       IMP annotation for cellular response to heat. YDJ1 is a heat-inducible co-chaperone
@@ -5969,11 +6478,17 @@ existing_annotations:
     reason: &gt;-
       Cellular response to heat is a core biological process for YDJ1. It is induced by
       heat stress and functions in the Hsp104/Hsp70/Hsp40 refolding system.
+    supported_by:
+      - reference_id: PMID:25344756
+        supporting_text: &gt;-
+          We found that ubiquitylation of heat-induced substrates requires the Hsp40
+          co-chaperone Ydj1 that is further associated with Rsp5 upon heat shock.
 - term:
     id: GO:0036503
     label: ERAD pathway
   evidence_type: IMP
   original_reference_id: PMID:15252059
+  qualifier: involved_in
   review:
     summary: &gt;-
       IMP annotation for ERAD pathway. YDJ1 is required for efficient ERAD of both
@@ -5987,6 +6502,7 @@ existing_annotations:
     label: ERAD pathway
   evidence_type: IMP
   original_reference_id: PMID:15342786
+  qualifier: involved_in
   review:
     summary: &gt;-
       IMP annotation for ERAD pathway. YDJ1 plays distinct roles from Hsp90 in CFTR
@@ -6001,6 +6517,7 @@ existing_annotations:
     label: zinc ion binding
   evidence_type: RCA
   original_reference_id: PMID:30358795
+  qualifier: enables
   review:
     summary: &gt;-
       RCA annotation for zinc ion binding from analysis of the yeast zinc proteome.
@@ -6015,6 +6532,7 @@ existing_annotations:
     label: cytosol
   evidence_type: HDA
   original_reference_id: PMID:26928762
+  qualifier: located_in
   review:
     summary: &gt;-
       HDA annotation for cytosol localization from large-scale yeast library creation
@@ -6028,6 +6546,7 @@ existing_annotations:
     label: ubiquitin-dependent protein catabolic process
   evidence_type: IMP
   original_reference_id: PMID:25344756
+  qualifier: involved_in
   review:
     summary: &gt;-
       IMP annotation for ubiquitin-dependent protein catabolic process. YDJ1 participates
@@ -6043,21 +6562,25 @@ existing_annotations:
     label: chaperone-mediated protein complex assembly
   evidence_type: IDA
   original_reference_id: PMID:10811660
+  qualifier: involved_in
   review:
     summary: &gt;-
-      IDA annotation for chaperone-mediated protein complex assembly is not supported by
-      the cited reference. PMID:10811660 describes crystal structure and activity of human
-      p23, an Hsp90 co-chaperone, and does not directly assay S. cerevisiae YDJ1.
-    action: REMOVE
+      This CAFA-assigned IDA has empty WITH/FROM and cites an abstract-only human p23
+      study. The abstract demonstrates p23 chaperoning of progesterone receptor but
+      provides no direct YDJ1 assay.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      PMID:10811660 is a crystal structure paper for human p23, not YDJ1. IDA evidence
-      requires a direct assay of the annotated gene product. This annotation cannot be
-      substantiated by the cited reference.
+      Chaperone-mediated assembly is broadly compatible with Ydj1 biology, but CAFA&#39;s
+      IDA transfers a process from a different human Hsp90 cochaperone without documented
+      YDJ1 evidence or a source entity. The row therefore overstates direct experimental
+      support. This is not treated as MOD-curated evidence, and no wrong-identifier claim
+      is made beyond what the cached abstract shows.
 - term:
     id: GO:0035719
     label: tRNA import into nucleus
   evidence_type: IMP
   original_reference_id: PMID:25853343
+  qualifier: involved_in
   review:
     summary: &gt;-
       IMP annotation for tRNA import into nucleus. Cytosolic Hsp70 and its co-chaperones
@@ -6073,6 +6596,7 @@ existing_annotations:
     label: ATPase activator activity
   evidence_type: IDA
   original_reference_id: PMID:1400408
+  qualifier: enables
   review:
     summary: &gt;-
       IDA annotation for ATPase activator activity. This is the foundational paper
@@ -6091,6 +6615,7 @@ existing_annotations:
     label: ATPase activator activity
   evidence_type: IDA
   original_reference_id: PMID:15342786
+  qualifier: enables
   review:
     summary: &gt;-
       IDA annotation for ATPase activator activity from study of Hsp40/Hsp90 roles in
@@ -6104,6 +6629,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IDA
   original_reference_id: PMID:1869583
+  qualifier: located_in
   review:
     summary: &gt;-
       IDA annotation for cytosol localization from the original characterization of YDJ1
@@ -6117,6 +6643,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IDA
   original_reference_id: PMID:8144572
+  qualifier: located_in
   review:
     summary: &gt;-
       IDA annotation for cytosol localization from differential regulation study of Hsp70
@@ -6129,6 +6656,7 @@ existing_annotations:
     label: &#34;&#39;de novo&#39; protein folding&#34;
   evidence_type: IMP
   original_reference_id: PMID:10567418
+  qualifier: involved_in
   review:
     summary: &gt;-
       IMP annotation for de novo protein folding. Mutations in YDJ1 cause defects in Axl1
@@ -6143,6 +6671,7 @@ existing_annotations:
     label: protein refolding
   evidence_type: IDA
   original_reference_id: PMID:9674429
+  qualifier: involved_in
   review:
     summary: &gt;-
       IDA annotation for protein refolding. Hsp104, Hsp70, and Hsp40 (YDJ1) cooperate to
@@ -6162,6 +6691,7 @@ existing_annotations:
     label: protein targeting to ER
   evidence_type: IMP
   original_reference_id: PMID:1473150
+  qualifier: involved_in
   review:
     summary: &gt;-
       IMP annotation for protein targeting to ER. YDJ1 is required for efficient
@@ -6179,6 +6709,7 @@ existing_annotations:
     label: perinuclear region of cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:1869583
+  qualifier: located_in
   review:
     summary: &gt;-
       IDA annotation for perinuclear region of cytoplasm. YDJ1 is concentrated in a
@@ -6192,6 +6723,7 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:9774392
+  qualifier: enables
   review:
     summary: &gt;-
       IDA annotation for unfolded protein binding based on direct binding assays showing
@@ -6220,16 +6752,23 @@ existing_annotations:
     label: TRC complex
   evidence_type: IDA
   original_reference_id: PMID:20850366
+  qualifier: part_of
   review:
     summary: &gt;-
-      IDA annotation for TRC complex membership. YDJ1 is part of a chaperone cascade that
-      sorts proteins for post-translational membrane insertion into the ER via the TRC/GET
-      pathway (PMID:20850366).
-    action: ACCEPT
+      The cited study establishes a sequential tail-anchored-protein chaperone cascade.
+      Ydj1/Ssa1 act upstream in client handling, whereas GO:0072380 denotes the
+      Get4-Get5/Mdy2 TRC complex.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Membership in the TRC complex is experimentally demonstrated. This is a specific
-      application of YDJ1&#39;s co-chaperone function in the tail-anchored protein insertion
-      pathway.
+      Participation in upstream handoff does not establish that Ydj1 is a stable part of
+      TRC. Retain the pathway connection but mark the complex-membership assertion
+      over-annotated; direct stoichiometric incorporation would be needed.
+    supported_by:
+      - reference_id: PMID:20850366
+        supporting_text: &gt;-
+          Thus, ER-bound TA proteins are sorted at the top of a TMD chaperone cascade that
+          culminates with the formation of Get3-TA protein complexes, which are recruited
+          to the ER membrane for insertion.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -6478,7 +7017,6 @@ core_functions:
 - description: &gt;-
     Protein folding chaperone activity - binds unfolded/denatured substrates via C-terminal
     peptide-binding domain and zinc finger region, delivering them to Hsp70 for folding.
-    Replacement for GO:0051082 which is now formally obsolete.
   molecular_function:
     id: GO:0044183
     label: protein folding chaperone
@@ -6488,6 +7026,36 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+
+proposed_new_terms: []
+
+suggested_questions:
+  - question: &gt;-
+      What fraction of Ydj1&#39;s nuclear HAP1-regulatory and tRNA-import roles
+      requires direct nuclear entry of Ydj1 rather than cytosolic Hsp70-client
+      preparation before import?
+  - question: &gt;-
+      Is Ydj1 a stable stoichiometric component of the TRC complex, or a
+      transient upstream chaperone in the tail-anchored-protein targeting
+      cascade?
+  - question: &gt;-
+      How do the zinc-binding client-recognition region and C-terminal
+      farnesylation partition clients among refolding, ERAD, and organellar
+      targeting outcomes?
+
+suggested_experiments:
+  - description: &gt;-
+      Compare wild-type Ydj1 with HPD-motif, zinc-coordination, client-binding,
+      and CaaX/farnesylation mutants in matched Ssa1 ATPase, luciferase
+      refolding, heat-induced ubiquitination, and ER-targeting assays.
+  - description: &gt;-
+      Use endogenous live-cell tagging and compartment-restricted proximity
+      labeling during heat stress, heme depletion, and starvation to quantify
+      the cytosolic, perinuclear, and nuclear Ydj1 interactomes.
+  - description: &gt;-
+      Reconstitute the early GET/TRC targeting cascade with purified Ydj1,
+      Ssa1, Sgt2, Mdy2/Get4, Get5, and tail-anchored clients to distinguish
+      stable complex membership from transient client transfer.
 </code></pre>
             </div>
         </details>

--- a/genes/yeast/YDJ1/YDJ1-ai-review.yaml
+++ b/genes/yeast/YDJ1/YDJ1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P25491
 gene_symbol: YDJ1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -21,6 +21,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: >-
       IBA annotation for cytosol localization is well supported. YDJ1 was shown by
@@ -31,6 +32,16 @@ existing_annotations:
       Cytosol is a well-established localization for YDJ1. Multiple independent methods
       confirm cytosolic localization. IBA is consistent with IDA evidence from PMID:1869583
       and PMID:8144572.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN001531327
+          source_label: PANTHER:PTN001531327
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The GOA WITH/FROM places cytosol at this class-A J-protein node using
+            fungal and metazoan descendants, including experimentally localized
+            S. cerevisiae YDJ1 itself.
     supported_by:
       - reference_id: file:yeast/YDJ1/YDJ1-deep-research-falcon.md
         supporting_text: |-
@@ -40,6 +51,7 @@ existing_annotations:
     label: ATPase activator activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: >-
       IBA annotation for ATPase activator activity is strongly supported. YDJ1 stimulates
@@ -50,6 +62,16 @@ existing_annotations:
       ATPase activator activity is the defining molecular function of the J-domain.
       Experimentally demonstrated by IDA (PMID:1400408, PMID:15342786) and conserved across
       the DnaJ family.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN002376157
+          source_label: PANTHER:PTN002376157
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The PTHR44298 PAINT record places ATPase activator activity at this
+            broad J-protein node; YDJ1 is one of its experimentally grounded
+            descendants, consistent with direct Ssa1 ATPase assays.
     supported_by:
       - reference_id: PMID:1400408
         supporting_text: >-
@@ -68,6 +90,7 @@ existing_annotations:
     label: cellular response to heat
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: >-
       IBA annotation for cellular response to heat is appropriate. YDJ1 is a heat shock
@@ -78,11 +101,21 @@ existing_annotations:
     reason: >-
       YDJ1 is a bona fide heat shock protein involved in stress response. IBA is consistent
       with IMP evidence and the well-established role of Hsp40 in heat stress response.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN001531327
+          source_label: PANTHER:PTN001531327
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The node is grounded by fungal J proteins including YDJ1, whose own
+            heat-stress phenotype supports the inherited process annotation.
 - term:
     id: GO:0042026
     label: protein refolding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: involved_in
   review:
     summary: >-
       IBA annotation for protein refolding is well supported. Hsp104, Hsp70 (Ssa1), and
@@ -92,6 +125,16 @@ existing_annotations:
     reason: >-
       Protein refolding is a core biological process for YDJ1 as part of the
       Hsp104/Hsp70/Hsp40 disaggregation/refolding machinery. Confirmed by IDA (PMID:9674429).
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+        - source_id: PANTHER:PTN001531327
+          source_label: PANTHER:PTN001531327
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            Refolding is placed at the class-A J-protein node using fungal and
+            metazoan sources, including direct YDJ1 evidence; no target-specific
+            loss or divergence is evident.
     supported_by:
       - reference_id: PMID:9674429
         supporting_text: >-
@@ -108,6 +151,7 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: enables
   review:
     summary: >-
       GO:0051082 is now formally obsolete. YDJ1 does bind unfolded/denatured substrates
@@ -123,6 +167,18 @@ existing_annotations:
     proposed_replacement_terms:
       - id: GO:0044183
         label: protein folding chaperone
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+        - GRANULARITY_MISMATCH
+      source_entities:
+        - source_id: PANTHER:PTN001531327
+          source_label: PANTHER:PTN001531327
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The node and its YDJ1/APJ1-class sources support client binding and
+            chaperone activity. Modification is required because GO:0051082 is
+            obsolete, not because the PAINT propagation lacks biological support.
     supported_by:
       - reference_id: PMID:9774392
         supporting_text: >-
@@ -134,20 +190,33 @@ existing_annotations:
     label: nucleus
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
   review:
     summary: >-
       IBA annotation for nuclear localization. YDJ1 functions in the nucleus as part of
       the HMC complex regulating HAP1 transcription factor activity (PMID:15102838). Also
       involved in tRNA import into nucleus (PMID:25853343). Supported by NAS (PMID:15102838).
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       Nuclear localization is supported by its role in the HAP1 repressor complex and tRNA
-      nuclear import. IBA is consistent with NAS evidence.
+      nuclear import. It is retained as non-core because YDJ1 is predominantly cytosolic.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+        - source_id: PANTHER:PTN001180221
+          source_label: PANTHER:PTN001180221
+          source_status: SUPPORTS_TRANSFER
+          comment: >-
+            The fungal J-protein node is seeded by S. pombe and APJ1 evidence;
+            APJ1 is a class-A/type-I Ydj1 paralog, not Sis1.
+            YDJ1's HAP1 and tRNA-import roles independently make a secondary
+            nuclear pool plausible, although nucleus is not its principal site.
 - term:
     id: GO:0001671
     label: ATPase activator activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: enables
   review:
     summary: >-
       IEA annotation for ATPase activator activity from ARBA machine learning. Consistent
@@ -161,6 +230,7 @@ existing_annotations:
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: >-
       IEA annotation for ATP binding based on InterPro domain IPR012724 (DnaJ). While YDJ1
@@ -183,6 +253,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: >-
       IEA annotation for cytoplasm based on UniProt subcellular location. Correct but
@@ -196,6 +267,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: >-
       IEA annotation for protein folding from InterPro. YDJ1 participates in protein folding
@@ -210,6 +282,7 @@ existing_annotations:
     label: zinc ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: >-
       IEA annotation for zinc ion binding based on UniProt keyword. YDJ1 has a well-characterized
@@ -229,35 +302,42 @@ existing_annotations:
     label: response to heat
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: >-
       IEA annotation for response to heat. YDJ1 is a heat-inducible chaperone gene.
       This is a broader parent of the more specific IBA/IMP-supported cellular response
       to heat (GO:0034605).
-    action: ACCEPT
+    action: MODIFY
     reason: >-
-      Correct but less specific than GO:0034605. The IEA is consistent with the established
-      role of YDJ1 as a heat shock protein.
+      The broad heat-response assertion is sound, but GO:0034605 is the actionable,
+      experimentally and phylogenetically supported child term already used for YDJ1.
+    proposed_replacement_terms:
+      - id: GO:0034605
+        label: cellular response to heat
 - term:
     id: GO:0015031
     label: protein transport
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: involved_in
   review:
     summary: >-
       IEA annotation for protein transport from UniProt keyword. YDJ1 is involved in
       protein targeting to the ER (PMID:1473150) and mitochondrial protein import, both
       of which involve protein transport.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Protein transport is a broad but accurate annotation. YDJ1 participates in
-      translocation of pre-pro-alpha-factor (PMID:1473150) and was originally identified
-      as MAS5 (mitochondrial assembly protein).
+      Protein transport is a broad but accurate umbrella for YDJ1's documented ER
+      targeting and mitochondrial precursor-transport contexts. Retain it as non-core
+      rather than replacing it only with GO:0045047, which would erase the mitochondrial
+      aspect; the specific ER-targeting assertion is reviewed separately.
 - term:
     id: GO:0030544
     label: Hsp70 protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: >-
       IEA annotation for Hsp70 protein binding from InterPro. YDJ1 physically interacts
@@ -273,6 +353,7 @@ existing_annotations:
     label: heat shock protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: >-
       IEA annotation for heat shock protein binding from InterPro. YDJ1 binds Hsp70 (Ssa1)
@@ -286,6 +367,7 @@ existing_annotations:
     label: metal ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: >-
       IEA annotation for metal ion binding from UniProt keyword. YDJ1 binds zinc ions via
@@ -298,6 +380,7 @@ existing_annotations:
     label: perinuclear region of cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
+  qualifier: located_in
   review:
     summary: >-
       IEA annotation for perinuclear region based on UniProt subcellular location.
@@ -312,6 +395,7 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: >-
       IEA annotation for unfolded protein binding from InterPro. Same issue as the IBA
@@ -329,6 +413,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:11805837
+  qualifier: enables
   review:
     summary: >-
       IPI annotation for protein binding from large-scale mass spectrometry identification
@@ -344,6 +429,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:15879519
+  qualifier: enables
   review:
     summary: >-
       IPI annotation for protein binding from two-hybrid screen for Hsp90 interactors.
@@ -358,6 +444,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16429126
+  qualifier: enables
   review:
     summary: >-
       IPI annotation for protein binding from proteome survey. IntAct records interaction
@@ -371,6 +458,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:17441508
+  qualifier: enables
   review:
     summary: >-
       IPI annotation for protein binding showing YDJ1 interaction with SGT2 and MDY2.
@@ -385,6 +473,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18833196
+  qualifier: enables
   review:
     summary: >-
       IPI annotation for protein binding showing interaction with SUP35 (Q7LKB1, a prion
@@ -398,6 +487,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
+  qualifier: enables
   review:
     summary: >-
       IPI annotation for protein binding from atlas of chaperone-protein interactions.
@@ -411,6 +501,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23217712
+  qualifier: enables
   review:
     summary: >-
       IPI annotation for protein binding showing interaction with SSA1 (P10591).
@@ -424,6 +515,7 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
+  qualifier: enables
   review:
     summary: >-
       IPI annotation for protein binding from social and structural architecture of yeast
@@ -437,20 +529,23 @@ existing_annotations:
     label: nucleus
   evidence_type: NAS
   original_reference_id: PMID:15102838
+  qualifier: located_in
   review:
     summary: >-
       NAS annotation for nuclear localization from ComplexPortal, based on YDJ1 function
       in the HMC complex that regulates HAP1 transcription factor (PMID:15102838). YDJ1
       is part of the Hsp70-Ydj1 complex that represses HAP1 activity in the absence of heme.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       Nuclear localization is supported by YDJ1's role in the HAP1 repressor complex.
-      Consistent with IBA evidence for the same term.
+      Consistent with IBA evidence for the same term, but secondary to its
+      predominant cytosolic localization.
 - term:
     id: GO:0045892
     label: negative regulation of DNA-templated transcription
   evidence_type: NAS
   original_reference_id: PMID:15102838
+  qualifier: involved_in
   review:
     summary: >-
       NAS annotation from ComplexPortal. YDJ1 is part of the HMC complex that represses
@@ -466,6 +561,7 @@ existing_annotations:
     label: response to oxygen levels
   evidence_type: NAS
   original_reference_id: PMID:15102838
+  qualifier: involved_in
   review:
     summary: >-
       NAS annotation from ComplexPortal. YDJ1 mediates heme-dependent regulation of HAP1,
@@ -480,6 +576,7 @@ existing_annotations:
     label: response to oxygen levels
   evidence_type: NAS
   original_reference_id: PMID:9632766
+  qualifier: involved_in
   review:
     summary: >-
       NAS annotation from ComplexPortal. Same biological role as above - YDJ1 participates
@@ -493,6 +590,7 @@ existing_annotations:
     label: cellular response to starvation
   evidence_type: IMP
   original_reference_id: PMID:25853343
+  qualifier: involved_in
   review:
     summary: >-
       IMP annotation for cellular response to starvation. PMID:25853343 describes YDJ1's
@@ -506,6 +604,7 @@ existing_annotations:
     label: cellular response to heat
   evidence_type: IMP
   original_reference_id: PMID:25344756
+  qualifier: involved_in
   review:
     summary: >-
       IMP annotation for cellular response to heat. YDJ1 is a heat-inducible co-chaperone
@@ -515,11 +614,17 @@ existing_annotations:
     reason: >-
       Cellular response to heat is a core biological process for YDJ1. It is induced by
       heat stress and functions in the Hsp104/Hsp70/Hsp40 refolding system.
+    supported_by:
+      - reference_id: PMID:25344756
+        supporting_text: >-
+          We found that ubiquitylation of heat-induced substrates requires the Hsp40
+          co-chaperone Ydj1 that is further associated with Rsp5 upon heat shock.
 - term:
     id: GO:0036503
     label: ERAD pathway
   evidence_type: IMP
   original_reference_id: PMID:15252059
+  qualifier: involved_in
   review:
     summary: >-
       IMP annotation for ERAD pathway. YDJ1 is required for efficient ERAD of both
@@ -533,6 +638,7 @@ existing_annotations:
     label: ERAD pathway
   evidence_type: IMP
   original_reference_id: PMID:15342786
+  qualifier: involved_in
   review:
     summary: >-
       IMP annotation for ERAD pathway. YDJ1 plays distinct roles from Hsp90 in CFTR
@@ -547,6 +653,7 @@ existing_annotations:
     label: zinc ion binding
   evidence_type: RCA
   original_reference_id: PMID:30358795
+  qualifier: enables
   review:
     summary: >-
       RCA annotation for zinc ion binding from analysis of the yeast zinc proteome.
@@ -561,6 +668,7 @@ existing_annotations:
     label: cytosol
   evidence_type: HDA
   original_reference_id: PMID:26928762
+  qualifier: located_in
   review:
     summary: >-
       HDA annotation for cytosol localization from large-scale yeast library creation
@@ -574,6 +682,7 @@ existing_annotations:
     label: ubiquitin-dependent protein catabolic process
   evidence_type: IMP
   original_reference_id: PMID:25344756
+  qualifier: involved_in
   review:
     summary: >-
       IMP annotation for ubiquitin-dependent protein catabolic process. YDJ1 participates
@@ -589,21 +698,25 @@ existing_annotations:
     label: chaperone-mediated protein complex assembly
   evidence_type: IDA
   original_reference_id: PMID:10811660
+  qualifier: involved_in
   review:
     summary: >-
-      IDA annotation for chaperone-mediated protein complex assembly is not supported by
-      the cited reference. PMID:10811660 describes crystal structure and activity of human
-      p23, an Hsp90 co-chaperone, and does not directly assay S. cerevisiae YDJ1.
-    action: REMOVE
+      This CAFA-assigned IDA has empty WITH/FROM and cites an abstract-only human p23
+      study. The abstract demonstrates p23 chaperoning of progesterone receptor but
+      provides no direct YDJ1 assay.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      PMID:10811660 is a crystal structure paper for human p23, not YDJ1. IDA evidence
-      requires a direct assay of the annotated gene product. This annotation cannot be
-      substantiated by the cited reference.
+      Chaperone-mediated assembly is broadly compatible with Ydj1 biology, but CAFA's
+      IDA transfers a process from a different human Hsp90 cochaperone without documented
+      YDJ1 evidence or a source entity. The row therefore overstates direct experimental
+      support. This is not treated as MOD-curated evidence, and no wrong-identifier claim
+      is made beyond what the cached abstract shows.
 - term:
     id: GO:0035719
     label: tRNA import into nucleus
   evidence_type: IMP
   original_reference_id: PMID:25853343
+  qualifier: involved_in
   review:
     summary: >-
       IMP annotation for tRNA import into nucleus. Cytosolic Hsp70 and its co-chaperones
@@ -619,6 +732,7 @@ existing_annotations:
     label: ATPase activator activity
   evidence_type: IDA
   original_reference_id: PMID:1400408
+  qualifier: enables
   review:
     summary: >-
       IDA annotation for ATPase activator activity. This is the foundational paper
@@ -637,6 +751,7 @@ existing_annotations:
     label: ATPase activator activity
   evidence_type: IDA
   original_reference_id: PMID:15342786
+  qualifier: enables
   review:
     summary: >-
       IDA annotation for ATPase activator activity from study of Hsp40/Hsp90 roles in
@@ -650,6 +765,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IDA
   original_reference_id: PMID:1869583
+  qualifier: located_in
   review:
     summary: >-
       IDA annotation for cytosol localization from the original characterization of YDJ1
@@ -663,6 +779,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IDA
   original_reference_id: PMID:8144572
+  qualifier: located_in
   review:
     summary: >-
       IDA annotation for cytosol localization from differential regulation study of Hsp70
@@ -675,6 +792,7 @@ existing_annotations:
     label: "'de novo' protein folding"
   evidence_type: IMP
   original_reference_id: PMID:10567418
+  qualifier: involved_in
   review:
     summary: >-
       IMP annotation for de novo protein folding. Mutations in YDJ1 cause defects in Axl1
@@ -689,6 +807,7 @@ existing_annotations:
     label: protein refolding
   evidence_type: IDA
   original_reference_id: PMID:9674429
+  qualifier: involved_in
   review:
     summary: >-
       IDA annotation for protein refolding. Hsp104, Hsp70, and Hsp40 (YDJ1) cooperate to
@@ -708,6 +827,7 @@ existing_annotations:
     label: protein targeting to ER
   evidence_type: IMP
   original_reference_id: PMID:1473150
+  qualifier: involved_in
   review:
     summary: >-
       IMP annotation for protein targeting to ER. YDJ1 is required for efficient
@@ -725,6 +845,7 @@ existing_annotations:
     label: perinuclear region of cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:1869583
+  qualifier: located_in
   review:
     summary: >-
       IDA annotation for perinuclear region of cytoplasm. YDJ1 is concentrated in a
@@ -738,6 +859,7 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:9774392
+  qualifier: enables
   review:
     summary: >-
       IDA annotation for unfolded protein binding based on direct binding assays showing
@@ -766,16 +888,23 @@ existing_annotations:
     label: TRC complex
   evidence_type: IDA
   original_reference_id: PMID:20850366
+  qualifier: part_of
   review:
     summary: >-
-      IDA annotation for TRC complex membership. YDJ1 is part of a chaperone cascade that
-      sorts proteins for post-translational membrane insertion into the ER via the TRC/GET
-      pathway (PMID:20850366).
-    action: ACCEPT
+      The cited study establishes a sequential tail-anchored-protein chaperone cascade.
+      Ydj1/Ssa1 act upstream in client handling, whereas GO:0072380 denotes the
+      Get4-Get5/Mdy2 TRC complex.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Membership in the TRC complex is experimentally demonstrated. This is a specific
-      application of YDJ1's co-chaperone function in the tail-anchored protein insertion
-      pathway.
+      Participation in upstream handoff does not establish that Ydj1 is a stable part of
+      TRC. Retain the pathway connection but mark the complex-membership assertion
+      over-annotated; direct stoichiometric incorporation would be needed.
+    supported_by:
+      - reference_id: PMID:20850366
+        supporting_text: >-
+          Thus, ER-bound TA proteins are sorted at the top of a TMD chaperone cascade that
+          culminates with the formation of Get3-TA protein complexes, which are recruited
+          to the ER membrane for insertion.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -1024,7 +1153,6 @@ core_functions:
 - description: >-
     Protein folding chaperone activity - binds unfolded/denatured substrates via C-terminal
     peptide-binding domain and zinc finger region, delivering them to Hsp70 for folding.
-    Replacement for GO:0051082 which is now formally obsolete.
   molecular_function:
     id: GO:0044183
     label: protein folding chaperone
@@ -1034,3 +1162,33 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+
+proposed_new_terms: []
+
+suggested_questions:
+  - question: >-
+      What fraction of Ydj1's nuclear HAP1-regulatory and tRNA-import roles
+      requires direct nuclear entry of Ydj1 rather than cytosolic Hsp70-client
+      preparation before import?
+  - question: >-
+      Is Ydj1 a stable stoichiometric component of the TRC complex, or a
+      transient upstream chaperone in the tail-anchored-protein targeting
+      cascade?
+  - question: >-
+      How do the zinc-binding client-recognition region and C-terminal
+      farnesylation partition clients among refolding, ERAD, and organellar
+      targeting outcomes?
+
+suggested_experiments:
+  - description: >-
+      Compare wild-type Ydj1 with HPD-motif, zinc-coordination, client-binding,
+      and CaaX/farnesylation mutants in matched Ssa1 ATPase, luciferase
+      refolding, heat-induced ubiquitination, and ER-targeting assays.
+  - description: >-
+      Use endogenous live-cell tagging and compartment-restricted proximity
+      labeling during heat stress, heme depletion, and starvation to quantify
+      the cytosolic, perinuclear, and nuclear Ydj1 interactomes.
+  - description: >-
+      Reconstitute the early GET/TRC targeting cascade with purified Ydj1,
+      Ssa1, Sgt2, Mdy2/Get4, Get5, and tail-anchored clients to distinguish
+      stable complex membership from transient client transfer.

--- a/genes/yeast/YDJ1/YDJ1-notes.md
+++ b/genes/yeast/YDJ1/YDJ1-notes.md
@@ -1,0 +1,57 @@
+# YDJ1 review notes
+
+## 2026-08-28 completion audit
+
+- YDJ1 encodes a type-I DnaJ/Hsp40 co-chaperone whose defining molecular
+  function is stimulation of the Ssa1 Hsp70 ATPase cycle [PMID:1400408, “We
+  report that a purified cytoplasmic Hsp70 homolog from Saccharomyces cerevisiae,
+  Hsp70SSA1, exhibits a weak ATPase activity, which is stimulated by a purified
+  eukaryotic dnaJp homolog (YDJ1p).”]. The InterPro-derived ATP
+  binding annotation is therefore removed: Ydj1 activates its Hsp70 partner but
+  has no ATP-binding/ATPase domain of its own.
+
+- All 49 unique nonredundant GOA signatures were reconciled exactly by GO term,
+  evidence, reference, and relation qualifier. The 62 physical GOA rows collapse
+  to 49 signatures because high-throughput `protein binding` annotations repeat
+  the same assertions for multiple WITH/FROM partners. All eight generic protein
+  binding signatures remain marked over-annotated; specific Hsp70/heat-shock
+  protein binding terms capture the informative partner biology.
+
+- All six IBA annotations were reviewed from their GOA WITH/FROM provenance.
+  Cytosol, cellular response to heat, protein refolding, and obsolete unfolded
+  protein binding use PTN001531327; ATPase activator activity uses PTN002376157;
+  nucleus uses PTN001180221. YDJ1 is an experimental descendant source at the
+  first two nodes, which is valid PAINT grounding rather than circular evidence.
+  The SGD:S000005021 source at PTN001531327 and PTN001180221 is APJ1, a
+  class-A/type-I Ydj1 paralog, not SIS1.
+  The current local PTHR44298 PAINT table retains PTN002376157, while the other
+  node identifiers remain recoverable from current GOA WITH/FROM rows.
+
+- GO:0051082 is obsolete in live GO. For Ydj1, replacement by GO:0044183 protein
+  folding chaperone is evidence-matched: the direct study found both suppression
+  of thermally induced luciferase aggregation and productive Ssa1-dependent
+  refolding [PMID:9774392, “Ydj1:Ssa1 could promote up to four times more
+  luciferase folding than Sis1:Ssa1.”]. All three GO:0051082 assertions are
+  therefore consistently modified to GO:0044183.
+
+- The CAFA-assigned IDA `chaperone-mediated protein complex assembly` row has
+  empty WITH/FROM and cites an abstract-only human p23 paper [PMID:10811660].
+  The abstract demonstrates p23 chaperoning of progesterone receptor but no
+  direct YDJ1 assay, so the row is marked over-annotated rather than treated as
+  MOD-curated evidence or labelled a wrong-identifier citation.
+
+- Ydj1's heat-stress quality-control role is directly supported in full text
+  [PMID:25344756, “We found that ubiquitylation of heat-induced substrates
+  requires the Hsp40 co-chaperone Ydj1 that is further associated with Rsp5 upon
+  heat shock.”].
+  ERAD and protein targeting to ER are retained as important cellular functions;
+  HAP1 regulation, oxygen response, starvation-linked tRNA import, nuclear
+  localization, and broad protein transport are retained as specialized non-core
+  uses of the central Hsp70 co-chaperone machinery. TRC membership is marked
+  over-annotated because upstream cascade participation does not establish stable
+  incorporation into the Get4-Get5/Mdy2 complex.
+
+- Most older supporting publications in the cache are abstract-only. Their
+  experimental annotations were not overruled when the abstract lacked assay
+  detail. Full text is locally available for PMID:19536198, PMID:23217712,
+  PMID:25344756, PMID:25853343, PMID:26928762, and PMID:37968396.


### PR DESCRIPTION
## Summary
- mark YDJ1 COMPLETE after exact reconciliation of 49 qualifier-aware GOA assertion signatures
- audit all six IBA rows against their actual PAINT PTN provenance
- remove the erroneous InterPro-derived ATP-binding assertion while retaining direct Hsp70 ATPase-activator biology
- consistently replace obsolete GO:0051082 with evidence-matched GO:0044183
- retain unverifiable abstract-only experimental evidence as UNDECIDED rather than overruling the curator
- synthesize core functions, focused notes, questions, and experiments

## Validation
- just validate yeast YDJ1
- just validate-goa yeast YDJ1
- just render yeast YDJ1
- just deploy-browser
- git diff --check

No support-code changes or wrapper bypasses.