### PR TITLE
Complete yeast TIM10 annotation review

### DIFF
--- a/genes/yeast/TIM10/TIM10-ai-review.html
+++ b/genes/yeast/TIM10/TIM10-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -841,7 +841,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TIM10 is an essential mitochondrial intermembrane space (IMS) chaperone protein in Saccharomyces cerevisiae. It forms a heterohexameric complex with TIM9 (3x TIM9 + 3x TIM10), known as the TIM9-TIM10 complex or soluble 70 kDa complex. This complex functions as an ATP-independent holdase chaperone that escorts hydrophobic multi-pass transmembrane precursor proteins (such as the ADP/ATP carrier and other members of the mitochondrial carrier family) across the aqueous IMS from the TOM complex at the outer membrane to the TIM22 complex at the inner membrane, where they are inserted. TIM10 acts as a substrate sensor within the complex, recognizing the transmembrane domains of carrier precursors. The protein contains a characteristic twin CX3C motif with four conserved cysteines that form two intramolecular disulfide bonds in the oxidizing IMS environment; during cytoplasmic transit, these cysteines coordinate zinc to maintain an import-competent reduced state. TIM10 also participates in the transfer of beta-barrel outer membrane protein precursors to the SAM complex. The TIM9-TIM10 complex associates with TIM12 to dock at the TIM22 translocase for precursor handoff and inner membrane insertion.</p>
+        <p>TIM10 is an essential mitochondrial intermembrane space (IMS) chaperone protein in Saccharomyces cerevisiae. It forms a heterohexameric complex with TIM9 (3x TIM9 + 3x TIM10), known as the TIM9-TIM10 complex or soluble 70 kDa complex. This complex functions as an ATP-independent holdase chaperone that escorts hydrophobic multi-pass transmembrane precursor proteins (such as the ADP/ATP carrier and other members of the mitochondrial carrier family) across the aqueous IMS from the TOM complex at the outer membrane to the TIM22 complex at the inner membrane, where they are inserted. TIM10 acts as a substrate sensor within the complex, recognizing the transmembrane domains of carrier precursors. The protein contains a characteristic twin CX3C motif with four conserved cysteines that form two intramolecular disulfide bonds in the oxidizing IMS environment; during cytoplasmic transit, these cysteines coordinate zinc to maintain an import-competent reduced state. TIM10 has also been implicated in transfer of beta-barrel outer membrane protein precursors toward the SAM complex. The TIM9-TIM10 complex associates with TIM12 to dock at the TIM22 translocase for precursor handoff and inner membrane insertion.</p>
     </div>
 
 
@@ -906,9 +906,77 @@
 
 
                         <div>
-                            <strong>Reason:</strong> TIM10 is a bona fide component of the TIM22 complex. It forms part of the peripheral chaperone subcomplex (TIM9-TIM10-TIM12) that is stably associated with the membrane-integral TIM22 complex. The IBA annotation is consistent with extensive experimental evidence.
+                            <strong>Reason:</strong> TIM10 is a bona fide component of the TIM22 complex. It forms part of the peripheral chaperone subcomplex (TIM9-TIM10-TIM12) that associates with the membrane-integral TIM22 complex. The IBA annotation is consistent with extensive experimental evidence.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000113167</span>
+
+                                    &middot; PANTHER:PTN000113167
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Current PAINT retains the GO:0042721 IBD at this eukaryotic small-Tim node.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000000295</span>
+
+                                    &middot; TIM12
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Yeast Tim12 is a peripheral TIM22-pathway small-Tim component.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000003530</span>
+
+                                    &middot; TIM10
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Target TIM10 has direct complex-association evidence; its appearance as a seed is valid.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P62072</span>
+
+                                    &middot; TIMM10
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Human TIMM10 is the conserved orthologous small-Tim component.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -925,19 +993,6 @@
                                 </span>
 
                                 <div class="support-text">A small fraction of Tim9p is bound to the outer face of the inner membrane in a 300 kDa complex whose other subunits include Tim54p, Tim22p, Tim12p and Tim10p.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12637749" target="_blank" class="term-link">
-                                        PMID:12637749
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">Protein insertion into the mitochondrial inner membrane by a twin-pore translocase.</div>
 
                             </div>
 
@@ -1001,9 +1056,58 @@
 
 
                         <div>
-                            <strong>Reason:</strong> TIM10 does not have insertase activity. Tim22 is the insertase that mediates membrane-potential-dependent insertion of carrier proteins into the inner membrane. TIM10 is a soluble IMS chaperone that escorts precursors to TIM22. The correct molecular function is unfolded protein carrier activity (GO:0140309), which captures the escort/holdase function of TIM10. Koehler et al. explicitly stated that Tim10p was required to transport carrier precursors across the outer membrane, while Tim12p and Tim22p mediated insertion (PMID:9430585).
+                            <strong>Reason:</strong> TIM10 does not have insertase activity. Tim22 is the insertase that mediates membrane-potential-dependent insertion of carrier proteins into the inner membrane. TIM10 is a soluble IMS chaperone that escorts precursors to TIM22. The correct molecular function is unfolded protein holdase activity (GO:0140309), which captures the escort/holdase function of TIM10. Koehler et al. explicitly stated that Tim10p was required to transport carrier precursors across the outer membrane, while Tim12p and Tim22p mediated insertion (PMID:9430585).
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">SOURCE STALE OR MISSING</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">ROLE CONFLATION</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000113167</span>
+
+                                    &middot; PANTHER:PTN000113167
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">GOA still carries GO:0032977 from this node, but the current cached PAINT table no longer contains an insertase IBD at PTN000113167.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P62072</span>
+
+                                    &middot; TIMM10
+
+
+                                    <span class="badge">SOURCE BAD</span>
+
+
+                                    <div class="propagation-comment">Human TIMM10 is a soluble small-Tim chaperone/carrier, not the membrane-embedded insertase; using it to seed insertase activity conflates delivery with insertion.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
                         <div style="margin-top: 0.5rem;">
@@ -1011,7 +1115,7 @@
 
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
-                                    unfolded protein carrier activity
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
 
@@ -1110,6 +1214,100 @@
                             <strong>Reason:</strong> This biological process annotation is appropriate. TIM10 is directly involved in the protein insertion pathway even though it functions at the chaperoning step rather than the insertion step per se. The IBA annotation is well supported by extensive experimental evidence across multiple publications showing TIM10 is essential for this process.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000113167</span>
+
+                                    &middot; PANTHER:PTN000113167
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Current PAINT retains the GO:0045039 IBD at this conserved small-Tim node.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000000295</span>
+
+                                    &middot; TIM12
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Yeast Tim12 experimentally supports participation in the TIM22 pathway.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000003530</span>
+
+                                    &middot; TIM10
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Target experimental evidence validly grounds the ancestral process assertion.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">MGI:MGI:1353429</span>
+
+                                    &middot; mouse Timm10
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Mammalian ortholog evidence supports the conserved insertion pathway role.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P62072</span>
+
+                                    &middot; TIMM10
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Human TIMM10 supports conservation of the carrier-delivery pathway.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">WB:WBGene00006573</span>
+
+                                    &middot; worm tim-10
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Nematode ortholog evidence supports the conserved process assertion.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1339,10 +1537,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P87108" data-a="GO:0015031" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P87108" data-a="GO:0015031" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1355,7 +1553,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> While this is a very broad term, it is not incorrect. TIM10 is fundamentally a protein transporter in the IMS. The IEA is acceptable as a broader classification that complements the more specific annotations to GO:0045039.
+                            <strong>Reason:</strong> This broad umbrella is correct and covers both TIM22-directed carrier delivery and the reported SAM-directed beta-barrel precursor route, but it is less informative than the reviewed pathway and carrier activities and is therefore non-core.
                         </div>
 
 
@@ -1563,10 +1761,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P87108" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P87108" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1579,7 +1777,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> TIM10 does bind metal ions (specifically zinc) via its CX3C motifs, though this occurs in the cytoplasm rather than in its functional IMS location. The IEA annotation to this general term is not wrong, and the more specific zinc ion binding annotation (GO:0008270) provides better specificity.
+                            <strong>Reason:</strong> TIM10 does bind metal ions (specifically zinc) via its CX3C motifs, though this occurs in the cytoplasm rather than in its functional IMS location. The IEA annotation to this general term is not wrong, but transient metal coordination during biogenesis is secondary to the mature IMS chaperone/carrier function.
                         </div>
 
 
@@ -1645,10 +1843,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P87108" data-a="GO:0005515" data-r="PMID:11483513" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P87108" data-a="GO:0005515" data-r="PMID:11483513" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1661,7 +1859,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Per curation guidelines, protein binding (GO:0005515) is uninformative and should be replaced by more specific molecular function terms. The interaction between TIM10 and TIM9 is captured by the complex membership annotations (GO:0042719 and GO:0042721) and by the more informative unfolded protein carrier activity (GO:0140309) proposed as a replacement for GO:0051082.
+                            <strong>Reason:</strong> Per curation guidelines, protein binding (GO:0005515) is uninformative and should be replaced by more specific molecular function terms. The interaction between TIM10 and TIM9 is captured by the complex membership annotations (GO:0042719 and GO:0042721) and by the more informative unfolded protein holdase activity (GO:0140309) proposed as a replacement for GO:0051082.
                         </div>
 
 
@@ -1727,10 +1925,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P87108" data-a="GO:0005515" data-r="PMID:12637749" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P87108" data-a="GO:0005515" data-r="PMID:12637749" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1738,34 +1936,16 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This annotation records the physical interaction of TIM10 with TIM18 (Q08749) as detected in PMID:12637749. Rehling et al. identified TIM10 as part of the TIM22 complex which includes TIM18.
+                            <strong>Summary:</strong> This annotation records the physical interaction of TIM10 with TIM18 (Q08749) as detected in PMID:12637749. The cached abstract establishes a purified TIM22 twin-pore translocase but does not name Tim10, Tim18, or their specific interaction; no evidence-matched quote for the IPI can therefore be supplied from this cache.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Protein binding is uninformative. The interaction of TIM10 with TIM18 is better captured by the annotation to TIM22 complex membership (GO:0042721).
+                            <strong>Reason:</strong> Protein binding is uninformative, and the abstract-only cache cannot verify the partner-level assay. The independently established pathway relationship is better captured by TIM22 complex membership (GO:0042721); this does not assert that the curator&#39;s inaccessible full-text evidence was wrong.
                         </div>
 
 
 
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12637749" target="_blank" class="term-link">
-                                        PMID:12637749
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">Protein insertion into the mitochondrial inner membrane by a twin-pore translocase.</div>
-
-                            </div>
-
-                        </div>
 
 
                     </td>
@@ -1809,10 +1989,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P87108" data-a="GO:0005515" data-r="PMID:17882259" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P87108" data-a="GO:0005515" data-r="PMID:17882259" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1873,10 +2053,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P87108" data-a="GO:0005515" data-r="PMID:23267104" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P87108" data-a="GO:0005515" data-r="PMID:23267104" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1884,12 +2064,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This annotation records a physical interaction of TIM10 with TIM12 (P32830) from PMID:23267104 (proteome-wide protein interaction measurements of bacterial proteins of unknown function). This appears to be a cross-species or high-throughput interaction study.
+                            <strong>Summary:</strong> This annotation records a physical interaction of TIM10 with TIM12 (P32830) from PMID:23267104. Inspection of the cached full text verifies that the study is restricted to Escherichia coli proteins and contains no yeast, Tim10, or Tim12 mention, so the citation does not support this interaction.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Protein binding is uninformative. The TIM10-TIM12 interaction is well established and captured by the complex membership annotations (GO:0042721, GO:0042719). There is no need for a separate generic protein binding annotation.
+                            <strong>Reason:</strong> The cited full text is a verified identifier mismatch for this yeast interaction. The TIM10-TIM12 association is independently established and captured by complex membership annotations, but this generic protein-binding row overstates what its original reference supports.
                         </div>
 
 
@@ -1971,7 +2151,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Protein binding is uninformative. Furthermore, this cross-species interaction with human MAGEA2B has no known physiological relevance for yeast TIM10 and likely reflects in vitro assay artifacts.
+                            <strong>Reason:</strong> The intentionally cross-species interaction with human MAGEA2B has no physiological relevance to yeast TIM10 function. A generic protein-binding annotation derived from this heterologous assay should not be retained as yeast biology.
                         </div>
 
 
@@ -2035,7 +2215,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Protein binding is uninformative. Furthermore, this cross-species interaction with human TEX11 has no known physiological relevance for yeast TIM10 and likely reflects in vitro assay artifacts.
+                            <strong>Reason:</strong> The intentionally cross-species interaction with human TEX11 has no physiological relevance to yeast TIM10 function. A generic protein-binding annotation derived from this heterologous assay should not be retained as yeast biology.
                         </div>
 
 
@@ -2083,10 +2263,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P87108" data-a="GO:0005515" data-r="PMID:9495346" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P87108" data-a="GO:0005515" data-r="PMID:9495346" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2099,7 +2279,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Protein binding is uninformative. The TIM10-TIM12 interaction is better represented by the complex membership annotations (GO:0042721, GO:0042719). The more informative molecular function is protein transporter activity (GO:0140318) or unfolded protein carrier activity (GO:0140309).
+                            <strong>Reason:</strong> Protein binding is uninformative. The TIM10-TIM12 interaction is better represented by the complex membership annotations (GO:0042721, GO:0042719). The more informative molecular function is protein transporter activity (GO:0140318) or unfolded protein holdase activity (GO:0140309).
                         </div>
 
 
@@ -2657,10 +2837,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P87108" data-a="GO:0008270" data-r="PMID:30358795" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P87108" data-a="GO:0008270" data-r="PMID:30358795" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2673,7 +2853,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> TIM10 does bind zinc via its CX3C motifs, though this occurs in the cytoplasmic reduced state rather than in the functional IMS oxidized state. The annotation is not incorrect -- TIM10 is part of the zinc proteome -- but the zinc binding is transient and occurs during biogenesis rather than function.
+                            <strong>Reason:</strong> TIM10 does bind zinc via its CX3C motifs, though this occurs in the cytoplasmic reduced state rather than in the functional IMS oxidized state. The annotation is not incorrect -- TIM10 is part of the zinc proteome -- but the zinc binding is transient during biogenesis and is not its core mature activity.
                         </div>
 
 
@@ -3532,12 +3712,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Vial et al. (PMID:12138093) demonstrated that the reconstituted TIM10 complex binds to the physiological substrate ADP/ATP carrier and displays chaperone activity in refolding model substrate firefly luciferase. While TIM10 does bind unfolded proteins, the term GO:0051082 (unfolded protein binding) fails to capture the critical carrier/escort function of TIM10. TIM10 does not merely bind unfolded proteins -- it actively escorts them across the aqueous IMS from the TOM complex to the TIM22 complex, functioning as a true protein carrier chaperone. GO:0140309 (unfolded protein carrier activity) is defined as &#34;A protein carrier activity that binds to a protein in an unfolded state and escorts it between two different cellular components. The unfolded protein carrier prevents aggregation of the target protein.&#34; This precisely describes TIM10 function.
+                            <strong>Summary:</strong> Vial et al. (PMID:12138093) demonstrated that the reconstituted TIM10 complex binds to the physiological substrate ADP/ATP carrier and displays chaperone activity in refolding model substrate firefly luciferase. While TIM10 does bind unfolded proteins, the term GO:0051082 (unfolded protein binding) fails to capture the critical carrier/escort function of TIM10. TIM10 does not merely bind unfolded proteins -- it actively escorts them across the aqueous IMS from the TOM complex to the TIM22 complex, functioning as a true protein carrier chaperone. Live GO names GO:0140309 &#34;unfolded protein holdase activity&#34; and defines it as binding an unfolded protein, escorting it to an acceptor or location, and preventing its aggregation. This precisely describes TIM10 function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0051082 (unfolded protein binding) is too generic and misses the essential carrier/escort function of TIM10. The TIM9-TIM10 complex is a quintessential unfolded protein carrier: it binds hydrophobic unfolded precursors in the IMS, prevents their aggregation, and escorts them between two cellular compartments (from the TOM complex at the outer membrane to the TIM22 complex at the inner membrane). GO:0140309 (unfolded protein carrier activity) captures this complete function. The reconstituted complex not only bound substrate but also &#34;facilitated passage of AAC across the outer membrane&#34; and &#34;ensured its accurate membrane insertion&#34; (PMID:11483513), confirming active escort rather than passive binding.
+                            <strong>Reason:</strong> GO:0051082 (unfolded protein binding) is too generic and misses the essential carrier/escort function of TIM10. The TIM9-TIM10 complex is a quintessential unfolded protein carrier: it binds hydrophobic unfolded precursors in the IMS, prevents their aggregation, and escorts them between two cellular compartments (from the TOM complex at the outer membrane to the TIM22 complex at the inner membrane). GO:0140309 (unfolded protein holdase activity) captures this complete function. The reconstituted complex not only bound substrate but also &#34;facilitated passage of AAC across the outer membrane&#34; and &#34;ensured its accurate membrane insertion&#34; (PMID:11483513), confirming active escort rather than passive binding.
                         </div>
 
 
@@ -3547,7 +3727,7 @@
 
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
-                                    unfolded protein carrier activity
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
 
@@ -3625,8 +3805,8 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>TIM10 functions as an unfolded protein carrier in the mitochondrial intermembrane space (IMS). As part of the hexameric TIM9-TIM10 chaperone complex, it binds hydrophobic unfolded precursor proteins (primarily mitochondrial carrier family members) exiting the TOM translocase and escorts them across the aqueous IMS to the TIM22 insertase complex at the inner membrane. TIM10 acts as a substrate sensor within the complex. This is an ATP-independent holdase/carrier function that prevents aggregation of highly hydrophobic transmembrane precursors.</h3>
-                <span class="vote-buttons" data-g="P87108" data-a="FUNCTION: TIM10 functions as an unfolded protein carrier in ..." data-r="" data-act="CORE_FUNCTION">
+                <h3>TIM10 functions as an unfolded protein holdase/carrier in the mitochondrial intermembrane space (IMS). As part of the hexameric TIM9-TIM10 chaperone complex, it binds hydrophobic unfolded precursor proteins (primarily mitochondrial carrier family members) exiting the TOM translocase and escorts them across the aqueous IMS to the TIM22 insertase complex at the inner membrane. TIM10 acts as a substrate sensor within the complex. This is an ATP-independent holdase/carrier function that prevents aggregation of highly hydrophobic transmembrane precursors.</h3>
+                <span class="vote-buttons" data-g="P87108" data-a="FUNCTION: TIM10 functions as an unfolded protein holdase/car..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -3741,8 +3921,8 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>TIM10 has protein transporter activity, directly binding to and delivering mitochondrial carrier protein precursors from the TOM complex to the TIM22 complex. This transporter function overlaps with but is distinct from the unfolded protein carrier activity, emphasizing the directed delivery aspect of TIM10 function.</h3>
-                <span class="vote-buttons" data-g="P87108" data-a="FUNCTION: TIM10 has protein transporter activity, directly b..." data-r="" data-act="CORE_FUNCTION">
+                <h3>TIM10 has protein transporter activity: it directly engages mitochondrial carrier precursors released from TOM-side intermediates and delivers them through the IMS to the TIM22 pathway. This directed delivery is retained separately from the substrate-state-specific holdase term because it is supported by direct IDA and mutant evidence and emphasizes transport between pathway stations.</h3>
+                <span class="vote-buttons" data-g="P87108" data-a="FUNCTION: TIM10 has protein transporter activity: it directl..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -4413,7 +4593,79 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
 
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What fraction of TIM10 is stably incorporated into the membrane-associated TIM22 assembly versus cycling transiently between the soluble Tim9-Tim10 pool and TIM22 during client handoff?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P87108" data-a="Q: What fraction of TIM10 is stably incorporated into..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do any yeast beta-barrel outer-membrane precursors depend directly on TIM10, and is their delivery to SAM mediated by the same Tim9-Tim10 client-binding surface used for mitochondrial carriers?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P87108" data-a="Q: Do any yeast beta-barrel outer-membrane precursors..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use time-resolved crosslinking and quantitative native-complex analysis during a synchronized carrier-import reaction to measure TIM10 occupancy in soluble Tim9-Tim10, TIM22-associated, and precursor-bound states.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TIM10 cycles between a major soluble IMS chaperone pool and a smaller transiently TIM22-associated handoff state rather than functioning as the membrane insertase.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P87108" data-a="EXPERIMENT: Use time-resolved crosslinking and quantitative na..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare import and SAM assembly of a panel of beta-barrel precursors in conditional tim10 mutants, followed by rescue with client-binding-surface mutants that preserve Tim9-Tim10 hexamer assembly.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TIM10 may chaperone a defined subset of beta-barrel precursors toward SAM through the same hydrophobic-client recognition surface used in the TIM22 carrier pathway.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P87108" data-a="EXPERIMENT: Compare import and SAM assembly of a panel of beta..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
 
 
 
@@ -4780,6 +5032,108 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TIM10-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P87108" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tim10-review-notes">TIM10 review notes</h1>
+<h2 id="2026-08-28-completion-audit">2026-08-28 completion audit</h2>
+<ul>
+<li>
+<p>TIM10 is a small-Tim mitochondrial intermembrane-space chaperone. Its core<br />
+  activity is best represented by GO:0140309, unfolded protein holdase activity<br />
+  (the current official label; “unfolded protein carrier activity” is an exact synonym):<br />
+  the reconstituted Tim9-Tim10 complex “bound to the physiological substrate<br />
+  ADP/ATP carrier and displayed chaperone activity in refolding the model<br />
+  substrate firefly luciferase” <a href="https://pubmed.ncbi.nlm.nih.gov/12138093">PMID:12138093</a>. This supports directed client<br />
+  shielding and delivery, not membrane insertase activity.</p>
+</li>
+<li>
+<p>The two direct GO:0140318 protein-transporter rows remain ACCEPT and are<br />
+  represented as a second core function. GO:0140309 captures the substrate-state-<br />
+  specific holdase behavior (maintaining hydrophobic clients without aggregation),<br />
+  whereas GO:0140318 records directed delivery between TOM-side intermediates and<br />
+  the TIM22 pathway. These claims overlap but emphasize experimentally supported<br />
+  mechanistic dimensions rather than contradicting one another.</p>
+</li>
+<li>
+<p>All 34 physical GOA rows are represented by 34 review entries. When grouped only<br />
+  by term, evidence, reference, and qualifier they comprise 33 signatures; the sole<br />
+  repeated signature is the pair of GO:0005515 / IPI / PMID:27107014 / <code>enables</code><br />
+  rows distinguished by their WITH/FROM human partners. Five generic protein-binding<br />
+  rows are retained as over-annotated interaction statements, while the two intentional<br />
+  cross-species human-partner rows are removed as nonphysiological yeast annotations;<br />
+  the informative biology is captured by Tim9-Tim10 chaperone-complex membership,<br />
+  TIM22-pathway participation, and unfolded-protein carrier activity.</p>
+</li>
+<li>
+<p>All three IBA rows use PTN000113167. Current cached PAINT retains the<br />
+  GO:0042721 complex-membership and GO:0045039 inner-membrane-insertion-process<br />
+  IBDs. Their WITH/FROM seeds are conserved small-Tim/TIM22-pathway components,<br />
+  including TIM12 (<code>SGD:S000000295</code>), the target TIM10<br />
+  (<code>SGD:S000003530</code>), human TIMM10 (<code>UniProtKB:P62072</code>), and orthologous mouse<br />
+  and worm sources for the process term. Target-in-own-WITH/FROM is valid<br />
+  experimental grounding, not circularity.</p>
+</li>
+<li>
+<p>GOA also carries GO:0032977 membrane insertase activity from PTN000113167 and<br />
+  human TIMM10, but that assertion is absent from the current cached PAINT table.<br />
+  It also conflates the small-Tim delivery role with the membrane-embedded Tim22<br />
+  insertase. The row is therefore modified to GO:0140309 and recorded as stale<br />
+  PAINT provenance plus role conflation. Direct work instead states that Tim10<br />
+  transports carrier precursors while Tim12/Tim22 mediate insertion<br />
+  [PMID:9430585, “Tim10p readily dissociated from the complex and was required<br />
+  to transport carrier precursors across the outer membrane; Tim12p was firmly<br />
+  bound to Tim22p and mediated the insertion of carriers into the inner<br />
+  membrane.”].</p>
+</li>
+<li>
+<p>Metal and zinc binding are retained as non-core. The reduced twin-CX3C motif<br />
+  can bind zinc [PMID:9495346, “Both proteins contain a zinc-finger-like motif<br />
+  with four cysteines and bind equimolar amounts of zinc ions.”], whereas the<br />
+  mature IMS protein uses those cysteines in intramolecular disulfide bonds.</p>
+</li>
+<li>
+<p>PMID:19037698 is a verified wrong identifier for the ComplexPortal IMS row:<br />
+  its cached full text concerns colorectal anastomotic leakage. The biological<br />
+  localization is independently established by multiple TIM10 papers, so the<br />
+  annotation is accepted while the reference is explicitly marked<br />
+<code>WRONG_IDENTIFIER</code>; PMID:19037098 is the plausible transposed identifier.</p>
+</li>
+<li>
+<p>PMID:23267104 is also a verified wrong identifier for its TIM10-TIM12 IPI row.<br />
+  Full-text inspection found an E. coli-only study with no yeast, Tim10, or Tim12<br />
+  mention. The physiological TIM10-TIM12 association is independently supported,<br />
+  but this citation cannot support the generic interaction row.</p>
+</li>
+<li>
+<p>PMID:12637749 is abstract-only. Its abstract supports the TIM22 complex as a<br />
+  twin-pore translocase but does not name Tim10, Tim18, or their partner-level IPI,<br />
+  so no title or non-supporting abstract sentence was used as evidence for that row.</p>
+</li>
+<li>
+<p>Thirteen of the sixteen cached PMID records are abstract-only. The only cached<br />
+  full texts are the unrelated PMID:19037698 paper, PMID:23267104, and<br />
+  PMID:27107014. Experimental annotations were not rejected merely because assay<br />
+  detail was unavailable from an abstract.</p>
+</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4791,7 +5145,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P87108
 gene_symbol: TIM10
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -4810,8 +5164,8 @@ description: &gt;-
   domains of carrier precursors. The protein contains a characteristic twin CX3C motif
   with four conserved cysteines that form two intramolecular disulfide bonds in the
   oxidizing IMS environment; during cytoplasmic transit, these cysteines coordinate
-  zinc to maintain an import-competent reduced state. TIM10 also participates in the
-  transfer of beta-barrel outer membrane protein precursors to the SAM complex. The
+  zinc to maintain an import-competent reduced state. TIM10 has also been implicated in
+  transfer of beta-barrel outer membrane protein precursors toward the SAM complex. The
   TIM9-TIM10 complex associates with TIM12 to dock at the TIM22 translocase for
   precursor handoff and inner membrane insertion.
 existing_annotations:
@@ -4830,17 +5184,34 @@ existing_annotations:
     action: ACCEPT
     reason: &gt;-
       TIM10 is a bona fide component of the TIM22 complex. It forms part of the
-      peripheral chaperone subcomplex (TIM9-TIM10-TIM12) that is stably associated
-      with the membrane-integral TIM22 complex. The IBA annotation is consistent
+      peripheral chaperone subcomplex (TIM9-TIM10-TIM12) that associates with the
+      membrane-integral TIM22 complex. The IBA annotation is consistent
       with extensive experimental evidence.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000113167
+        source_label: PANTHER:PTN000113167
+        source_status: SUPPORTS_TRANSFER
+        comment: &gt;-
+          Current PAINT retains the GO:0042721 IBD at this eukaryotic small-Tim node.
+      - source_id: SGD:S000000295
+        source_label: TIM12
+        source_status: SUPPORTS_TRANSFER
+        comment: Yeast Tim12 is a peripheral TIM22-pathway small-Tim component.
+      - source_id: SGD:S000003530
+        source_label: TIM10
+        source_status: SUPPORTS_TRANSFER
+        comment: Target TIM10 has direct complex-association evidence; its appearance as a seed is valid.
+      - source_id: UniProtKB:P62072
+        source_label: TIMM10
+        source_status: SUPPORTS_TRANSFER
+        comment: Human TIMM10 is the conserved orthologous small-Tim component.
     supported_by:
     - reference_id: PMID:9822593
       supporting_text: &gt;-
         A small fraction of Tim9p is bound to the outer face of the inner membrane in a
         300 kDa complex whose other subunits include Tim54p, Tim22p, Tim12p and Tim10p.
-    - reference_id: PMID:12637749
-      supporting_text: &gt;-
-        Protein insertion into the mitochondrial inner membrane by a twin-pore translocase.
     - reference_id: file:yeast/TIM10/TIM10-deep-research-falcon.md
       supporting_text: |-
         a TIM22-associated assembly often described as **Tim9–Tim10–Tim12** (review-level stoichiometry cited as **3:2:1**) that is positioned at the IMS face of TIM22 to receive precursors.
@@ -4862,13 +5233,30 @@ existing_annotations:
       TIM10 does not have insertase activity. Tim22 is the insertase that mediates
       membrane-potential-dependent insertion of carrier proteins into the inner membrane.
       TIM10 is a soluble IMS chaperone that escorts precursors to TIM22. The correct
-      molecular function is unfolded protein carrier activity (GO:0140309), which
+      molecular function is unfolded protein holdase activity (GO:0140309), which
       captures the escort/holdase function of TIM10. Koehler et al. explicitly stated
       that Tim10p was required to transport carrier precursors across the outer membrane,
       while Tim12p and Tim22p mediated insertion (PMID:9430585).
     proposed_replacement_terms:
-    - id: GO:0140309
-      label: unfolded protein carrier activity
+      - id: GO:0140309
+        label: unfolded protein holdase activity
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      failure_modes:
+      - ROLE_CONFLATION
+      source_entities:
+      - source_id: PANTHER:PTN000113167
+        source_label: PANTHER:PTN000113167
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          GOA still carries GO:0032977 from this node, but the current cached PAINT
+          table no longer contains an insertase IBD at PTN000113167.
+      - source_id: UniProtKB:P62072
+        source_label: TIMM10
+        source_status: SOURCE_BAD
+        comment: &gt;-
+          Human TIMM10 is a soluble small-Tim chaperone/carrier, not the membrane-embedded
+          insertase; using it to seed insertase activity conflates delivery with insertion.
     supported_by:
     - reference_id: PMID:9430585
       supporting_text: &gt;-
@@ -4902,6 +5290,33 @@ existing_annotations:
       rather than the insertion step per se. The IBA annotation is well supported by
       extensive experimental evidence across multiple publications showing TIM10 is
       essential for this process.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000113167
+        source_label: PANTHER:PTN000113167
+        source_status: SUPPORTS_TRANSFER
+        comment: Current PAINT retains the GO:0045039 IBD at this conserved small-Tim node.
+      - source_id: SGD:S000000295
+        source_label: TIM12
+        source_status: SUPPORTS_TRANSFER
+        comment: Yeast Tim12 experimentally supports participation in the TIM22 pathway.
+      - source_id: SGD:S000003530
+        source_label: TIM10
+        source_status: SUPPORTS_TRANSFER
+        comment: Target experimental evidence validly grounds the ancestral process assertion.
+      - source_id: MGI:MGI:1353429
+        source_label: mouse Timm10
+        source_status: SUPPORTS_TRANSFER
+        comment: Mammalian ortholog evidence supports the conserved insertion pathway role.
+      - source_id: UniProtKB:P62072
+        source_label: TIMM10
+        source_status: SUPPORTS_TRANSFER
+        comment: Human TIMM10 supports conservation of the carrier-delivery pathway.
+      - source_id: WB:WBGene00006573
+        source_label: worm tim-10
+        source_status: SUPPORTS_TRANSFER
+        comment: Nematode ortholog evidence supports the conserved process assertion.
     supported_by:
     - reference_id: PMID:9430585
       supporting_text: &gt;-
@@ -4973,11 +5388,11 @@ existing_annotations:
       This IEA from UniProt keyword mapping is correct but overly general compared
       to the more specific GO:0045039 (protein insertion into mitochondrial inner
       membrane) annotations already present.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      While this is a very broad term, it is not incorrect. TIM10 is fundamentally a
-      protein transporter in the IMS. The IEA is acceptable as a broader classification
-      that complements the more specific annotations to GO:0045039.
+      This broad umbrella is correct and covers both TIM22-directed carrier delivery and
+      the reported SAM-directed beta-barrel precursor route, but it is less informative
+      than the reviewed pathway and carrier activities and is therefore non-core.
     supported_by:
     - reference_id: PMID:9430585
       supporting_text: &gt;-
@@ -5040,12 +5455,12 @@ existing_annotations:
       coordinating zinc (PMID:9495346, UniProt). The IEA from UniProt keyword mapping
       to the general metal ion binding term is acceptable but the zinc binding is
       transient and context-dependent.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       TIM10 does bind metal ions (specifically zinc) via its CX3C motifs, though this
       occurs in the cytoplasm rather than in its functional IMS location. The IEA
-      annotation to this general term is not wrong, and the more specific zinc ion
-      binding annotation (GO:0008270) provides better specificity.
+      annotation to this general term is not wrong, but transient metal coordination
+      during biogenesis is secondary to the mature IMS chaperone/carrier function.
     supported_by:
     - reference_id: PMID:9495346
       supporting_text: &gt;-
@@ -5061,12 +5476,12 @@ existing_annotations:
       This annotation records the physical interaction of TIM10 with TIM9 (O74700)
       as detected in PMID:11483513. Luciano et al. showed that Tim9 and Tim10 purified
       from E. coli can form a complex of the same size as the endogenous complex.
-    action: REMOVE
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Per curation guidelines, protein binding (GO:0005515) is uninformative and should
       be replaced by more specific molecular function terms. The interaction between
       TIM10 and TIM9 is captured by the complex membership annotations (GO:0042719
-      and GO:0042721) and by the more informative unfolded protein carrier activity
+      and GO:0042721) and by the more informative unfolded protein holdase activity
       (GO:0140309) proposed as a replacement for GO:0051082.
     supported_by:
     - reference_id: PMID:11483513
@@ -5081,16 +5496,15 @@ existing_annotations:
   review:
     summary: &gt;-
       This annotation records the physical interaction of TIM10 with TIM18 (Q08749)
-      as detected in PMID:12637749. Rehling et al. identified TIM10 as part of the
-      TIM22 complex which includes TIM18.
-    action: REMOVE
+      as detected in PMID:12637749. The cached abstract establishes a purified TIM22
+      twin-pore translocase but does not name Tim10, Tim18, or their specific interaction;
+      no evidence-matched quote for the IPI can therefore be supplied from this cache.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Protein binding is uninformative. The interaction of TIM10 with TIM18 is better
-      captured by the annotation to TIM22 complex membership (GO:0042721).
-    supported_by:
-    - reference_id: PMID:12637749
-      supporting_text: &gt;-
-        Protein insertion into the mitochondrial inner membrane by a twin-pore translocase.
+      Protein binding is uninformative, and the abstract-only cache cannot verify the
+      partner-level assay. The independently established pathway relationship is better
+      captured by TIM22 complex membership (GO:0042721); this does not assert that the
+      curator&#39;s inaccessible full-text evidence was wrong.
 - term:
     id: GO:0005515
     label: protein binding
@@ -5101,7 +5515,7 @@ existing_annotations:
       This annotation records a physical interaction between TIM10 and TIM18 (Q08749)
       from PMID:17882259 (Shy1 couples Cox1 translational regulation to cytochrome c
       oxidase assembly). This is a large-scale interaction study.
-    action: REMOVE
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Protein binding is uninformative. This interaction is better captured by the
       complex membership annotations. The specific paper is about Shy1/Cox1 regulation
@@ -5115,14 +5529,15 @@ existing_annotations:
   review:
     summary: &gt;-
       This annotation records a physical interaction of TIM10 with TIM12 (P32830)
-      from PMID:23267104 (proteome-wide protein interaction measurements of bacterial
-      proteins of unknown function). This appears to be a cross-species or
-      high-throughput interaction study.
-    action: REMOVE
+      from PMID:23267104. Inspection of the cached full text verifies that the study
+      is restricted to Escherichia coli proteins and contains no yeast, Tim10, or
+      Tim12 mention, so the citation does not support this interaction.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Protein binding is uninformative. The TIM10-TIM12 interaction is well
-      established and captured by the complex membership annotations (GO:0042721,
-      GO:0042719). There is no need for a separate generic protein binding annotation.
+      The cited full text is a verified identifier mismatch for this yeast interaction.
+      The TIM10-TIM12 association is independently established and captured by complex
+      membership annotations, but this generic protein-binding row overstates what its
+      original reference supports.
     supported_by:
     - reference_id: PMID:9822593
       supporting_text: &gt;-
@@ -5141,9 +5556,9 @@ existing_annotations:
       relevance for yeast TIM10 function.
     action: REMOVE
     reason: &gt;-
-      Protein binding is uninformative. Furthermore, this cross-species interaction
-      with human MAGEA2B has no known physiological relevance for yeast TIM10 and
-      likely reflects in vitro assay artifacts.
+      The intentionally cross-species interaction with human MAGEA2B has no physiological
+      relevance to yeast TIM10 function. A generic protein-binding annotation derived
+      from this heterologous assay should not be retained as yeast biology.
 - term:
     id: GO:0005515
     label: protein binding
@@ -5157,9 +5572,9 @@ existing_annotations:
       relevance for yeast TIM10 function.
     action: REMOVE
     reason: &gt;-
-      Protein binding is uninformative. Furthermore, this cross-species interaction
-      with human TEX11 has no known physiological relevance for yeast TIM10 and
-      likely reflects in vitro assay artifacts.
+      The intentionally cross-species interaction with human TEX11 has no physiological
+      relevance to yeast TIM10 function. A generic protein-binding annotation derived
+      from this heterologous assay should not be retained as yeast biology.
 - term:
     id: GO:0005515
     label: protein binding
@@ -5170,12 +5585,12 @@ existing_annotations:
       This annotation records a physical interaction of TIM10 with TIM12 (P32830)
       from PMID:9495346. Sirrenberg et al. showed Tim10 and Tim12 interact
       sequentially with carrier precursors and form a complex with Tim22.
-    action: REMOVE
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Protein binding is uninformative. The TIM10-TIM12 interaction is better
       represented by the complex membership annotations (GO:0042721, GO:0042719).
       The more informative molecular function is protein transporter activity
-      (GO:0140318) or unfolded protein carrier activity (GO:0140309).
+      (GO:0140318) or unfolded protein holdase activity (GO:0140309).
     supported_by:
     - reference_id: PMID:9495346
       supporting_text: &gt;-
@@ -5331,12 +5746,12 @@ existing_annotations:
       bonds rather than coordinating zinc (PMID:9495346, UniProt). The RCA annotation
       from a zinc proteome study (PMID:30358795) is acceptable but should be
       understood in context.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       TIM10 does bind zinc via its CX3C motifs, though this occurs in the cytoplasmic
       reduced state rather than in the functional IMS oxidized state. The annotation
       is not incorrect -- TIM10 is part of the zinc proteome -- but the zinc binding
-      is transient and occurs during biogenesis rather than function.
+      is transient during biogenesis and is not its core mature activity.
     supported_by:
     - reference_id: PMID:9495346
       supporting_text: &gt;-
@@ -5548,11 +5963,9 @@ existing_annotations:
       capture the critical carrier/escort function of TIM10. TIM10 does not merely
       bind unfolded proteins -- it actively escorts them across the aqueous IMS from
       the TOM complex to the TIM22 complex, functioning as a true protein carrier
-      chaperone. GO:0140309 (unfolded protein carrier activity) is defined as &#34;A
-      protein carrier activity that binds to a protein in an unfolded state and
-      escorts it between two different cellular components. The unfolded protein
-      carrier prevents aggregation of the target protein.&#34; This precisely describes
-      TIM10 function.
+      chaperone. Live GO names GO:0140309 &#34;unfolded protein holdase activity&#34; and
+      defines it as binding an unfolded protein, escorting it to an acceptor or location,
+      and preventing its aggregation. This precisely describes TIM10 function.
     action: MODIFY
     reason: &gt;-
       GO:0051082 (unfolded protein binding) is too generic and misses the essential
@@ -5560,13 +5973,13 @@ existing_annotations:
       unfolded protein carrier: it binds hydrophobic unfolded precursors in the IMS,
       prevents their aggregation, and escorts them between two cellular compartments
       (from the TOM complex at the outer membrane to the TIM22 complex at the inner
-      membrane). GO:0140309 (unfolded protein carrier activity) captures this complete
+      membrane). GO:0140309 (unfolded protein holdase activity) captures this complete
       function. The reconstituted complex not only bound substrate but also &#34;facilitated
       passage of AAC across the outer membrane&#34; and &#34;ensured its accurate membrane
       insertion&#34; (PMID:11483513), confirming active escort rather than passive binding.
     proposed_replacement_terms:
     - id: GO:0140309
-      label: unfolded protein carrier activity
+      label: unfolded protein holdase activity
     supported_by:
     - reference_id: PMID:12138093
       supporting_text: &gt;-
@@ -5704,6 +6117,13 @@ references:
   title: The Dutch multicenter experience of the endo-sponge treatment for anastomotic
     leakage after colorectal surgery.
   is_invalid: true
+  reference_review:
+    relevance: NONE
+    correctness: WRONG_IDENTIFIER
+    review_notes: &gt;-
+      The cached full text is an unrelated colorectal-surgery article. The GO term is
+      independently correct for TIM10, but this identifier cannot support it and may be
+      a transposition of PMID:19037098.
   findings:
   - statement: &gt;-
       This publication is about colorectal surgery and has no relevance to TIM10 or
@@ -5713,6 +6133,12 @@ references:
 - id: PMID:23267104
   title: Proteome-wide protein interaction measurements of bacterial proteins of unknown
     function.
+  reference_review:
+    relevance: NONE
+    correctness: WRONG_IDENTIFIER
+    review_notes: &gt;-
+      Full-text inspection found an E. coli-only interaction study with no yeast,
+      Tim10, or Tim12 mention; it cannot support the TIM10-TIM12 IPI row.
   findings: []
 - id: PMID:24769239
   title: Quantitative variations of the mitochondrial proteome and phosphoproteome
@@ -5780,7 +6206,7 @@ references:
   findings: []
 core_functions:
 - description: &gt;-
-    TIM10 functions as an unfolded protein carrier in the mitochondrial intermembrane
+    TIM10 functions as an unfolded protein holdase/carrier in the mitochondrial intermembrane
     space (IMS). As part of the hexameric TIM9-TIM10 chaperone complex, it binds
     hydrophobic unfolded precursor proteins (primarily mitochondrial carrier family
     members) exiting the TOM translocase and escorts them across the aqueous IMS to
@@ -5814,10 +6240,11 @@ core_functions:
       The reconstituted TIM10 complex not only facilitated passage of AAC across the
       outer membrane but also ensured its accurate membrane insertion.
 - description: &gt;-
-    TIM10 has protein transporter activity, directly binding to and delivering
-    mitochondrial carrier protein precursors from the TOM complex to the TIM22
-    complex. This transporter function overlaps with but is distinct from the unfolded
-    protein carrier activity, emphasizing the directed delivery aspect of TIM10 function.
+    TIM10 has protein transporter activity: it directly engages mitochondrial carrier
+    precursors released from TOM-side intermediates and delivers them through the IMS
+    to the TIM22 pathway. This directed delivery is retained separately from the
+    substrate-state-specific holdase term because it is supported by direct IDA and
+    mutant evidence and emphasizes transport between pathway stations.
   molecular_function:
     id: GO:0140318
     label: protein transporter activity
@@ -5840,6 +6267,33 @@ core_functions:
       Two related proteins in the intermembrane space, Tim10/Mrs11 and Tim12/Mrs5,
       interact sequentially with these precursors and facilitate their translocation
       across the outer membrane, irrespective of the membrane potential.
+proposed_new_terms: []
+
+suggested_questions:
+- question: &gt;-
+    What fraction of TIM10 is stably incorporated into the membrane-associated TIM22
+    assembly versus cycling transiently between the soluble Tim9-Tim10 pool and TIM22
+    during client handoff?
+- question: &gt;-
+    Do any yeast beta-barrel outer-membrane precursors depend directly on TIM10, and is
+    their delivery to SAM mediated by the same Tim9-Tim10 client-binding surface used
+    for mitochondrial carriers?
+
+suggested_experiments:
+- description: &gt;-
+    Use time-resolved crosslinking and quantitative native-complex analysis during a
+    synchronized carrier-import reaction to measure TIM10 occupancy in soluble Tim9-Tim10,
+    TIM22-associated, and precursor-bound states.
+  hypothesis: &gt;-
+    TIM10 cycles between a major soluble IMS chaperone pool and a smaller transiently
+    TIM22-associated handoff state rather than functioning as the membrane insertase.
+- description: &gt;-
+    Compare import and SAM assembly of a panel of beta-barrel precursors in conditional
+    tim10 mutants, followed by rescue with client-binding-surface mutants that preserve
+    Tim9-Tim10 hexamer assembly.
+  hypothesis: &gt;-
+    TIM10 may chaperone a defined subset of beta-barrel precursors toward SAM through
+    the same hydrophobic-client recognition surface used in the TIM22 carrier pathway.
 </code></pre>
             </div>
         </details>

--- a/genes/yeast/TIM10/TIM10-ai-review.yaml
+++ b/genes/yeast/TIM10/TIM10-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P87108
 gene_symbol: TIM10
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -20,8 +20,8 @@ description: >-
   domains of carrier precursors. The protein contains a characteristic twin CX3C motif
   with four conserved cysteines that form two intramolecular disulfide bonds in the
   oxidizing IMS environment; during cytoplasmic transit, these cysteines coordinate
-  zinc to maintain an import-competent reduced state. TIM10 also participates in the
-  transfer of beta-barrel outer membrane protein precursors to the SAM complex. The
+  zinc to maintain an import-competent reduced state. TIM10 has also been implicated in
+  transfer of beta-barrel outer membrane protein precursors toward the SAM complex. The
   TIM9-TIM10 complex associates with TIM12 to dock at the TIM22 translocase for
   precursor handoff and inner membrane insertion.
 existing_annotations:
@@ -40,17 +40,34 @@ existing_annotations:
     action: ACCEPT
     reason: >-
       TIM10 is a bona fide component of the TIM22 complex. It forms part of the
-      peripheral chaperone subcomplex (TIM9-TIM10-TIM12) that is stably associated
-      with the membrane-integral TIM22 complex. The IBA annotation is consistent
+      peripheral chaperone subcomplex (TIM9-TIM10-TIM12) that associates with the
+      membrane-integral TIM22 complex. The IBA annotation is consistent
       with extensive experimental evidence.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000113167
+        source_label: PANTHER:PTN000113167
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          Current PAINT retains the GO:0042721 IBD at this eukaryotic small-Tim node.
+      - source_id: SGD:S000000295
+        source_label: TIM12
+        source_status: SUPPORTS_TRANSFER
+        comment: Yeast Tim12 is a peripheral TIM22-pathway small-Tim component.
+      - source_id: SGD:S000003530
+        source_label: TIM10
+        source_status: SUPPORTS_TRANSFER
+        comment: Target TIM10 has direct complex-association evidence; its appearance as a seed is valid.
+      - source_id: UniProtKB:P62072
+        source_label: TIMM10
+        source_status: SUPPORTS_TRANSFER
+        comment: Human TIMM10 is the conserved orthologous small-Tim component.
     supported_by:
     - reference_id: PMID:9822593
       supporting_text: >-
         A small fraction of Tim9p is bound to the outer face of the inner membrane in a
         300 kDa complex whose other subunits include Tim54p, Tim22p, Tim12p and Tim10p.
-    - reference_id: PMID:12637749
-      supporting_text: >-
-        Protein insertion into the mitochondrial inner membrane by a twin-pore translocase.
     - reference_id: file:yeast/TIM10/TIM10-deep-research-falcon.md
       supporting_text: |-
         a TIM22-associated assembly often described as **Tim9–Tim10–Tim12** (review-level stoichiometry cited as **3:2:1**) that is positioned at the IMS face of TIM22 to receive precursors.
@@ -72,13 +89,30 @@ existing_annotations:
       TIM10 does not have insertase activity. Tim22 is the insertase that mediates
       membrane-potential-dependent insertion of carrier proteins into the inner membrane.
       TIM10 is a soluble IMS chaperone that escorts precursors to TIM22. The correct
-      molecular function is unfolded protein carrier activity (GO:0140309), which
+      molecular function is unfolded protein holdase activity (GO:0140309), which
       captures the escort/holdase function of TIM10. Koehler et al. explicitly stated
       that Tim10p was required to transport carrier precursors across the outer membrane,
       while Tim12p and Tim22p mediated insertion (PMID:9430585).
     proposed_replacement_terms:
-    - id: GO:0140309
-      label: unfolded protein carrier activity
+      - id: GO:0140309
+        label: unfolded protein holdase activity
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      failure_modes:
+      - ROLE_CONFLATION
+      source_entities:
+      - source_id: PANTHER:PTN000113167
+        source_label: PANTHER:PTN000113167
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          GOA still carries GO:0032977 from this node, but the current cached PAINT
+          table no longer contains an insertase IBD at PTN000113167.
+      - source_id: UniProtKB:P62072
+        source_label: TIMM10
+        source_status: SOURCE_BAD
+        comment: >-
+          Human TIMM10 is a soluble small-Tim chaperone/carrier, not the membrane-embedded
+          insertase; using it to seed insertase activity conflates delivery with insertion.
     supported_by:
     - reference_id: PMID:9430585
       supporting_text: >-
@@ -112,6 +146,33 @@ existing_annotations:
       rather than the insertion step per se. The IBA annotation is well supported by
       extensive experimental evidence across multiple publications showing TIM10 is
       essential for this process.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000113167
+        source_label: PANTHER:PTN000113167
+        source_status: SUPPORTS_TRANSFER
+        comment: Current PAINT retains the GO:0045039 IBD at this conserved small-Tim node.
+      - source_id: SGD:S000000295
+        source_label: TIM12
+        source_status: SUPPORTS_TRANSFER
+        comment: Yeast Tim12 experimentally supports participation in the TIM22 pathway.
+      - source_id: SGD:S000003530
+        source_label: TIM10
+        source_status: SUPPORTS_TRANSFER
+        comment: Target experimental evidence validly grounds the ancestral process assertion.
+      - source_id: MGI:MGI:1353429
+        source_label: mouse Timm10
+        source_status: SUPPORTS_TRANSFER
+        comment: Mammalian ortholog evidence supports the conserved insertion pathway role.
+      - source_id: UniProtKB:P62072
+        source_label: TIMM10
+        source_status: SUPPORTS_TRANSFER
+        comment: Human TIMM10 supports conservation of the carrier-delivery pathway.
+      - source_id: WB:WBGene00006573
+        source_label: worm tim-10
+        source_status: SUPPORTS_TRANSFER
+        comment: Nematode ortholog evidence supports the conserved process assertion.
     supported_by:
     - reference_id: PMID:9430585
       supporting_text: >-
@@ -183,11 +244,11 @@ existing_annotations:
       This IEA from UniProt keyword mapping is correct but overly general compared
       to the more specific GO:0045039 (protein insertion into mitochondrial inner
       membrane) annotations already present.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      While this is a very broad term, it is not incorrect. TIM10 is fundamentally a
-      protein transporter in the IMS. The IEA is acceptable as a broader classification
-      that complements the more specific annotations to GO:0045039.
+      This broad umbrella is correct and covers both TIM22-directed carrier delivery and
+      the reported SAM-directed beta-barrel precursor route, but it is less informative
+      than the reviewed pathway and carrier activities and is therefore non-core.
     supported_by:
     - reference_id: PMID:9430585
       supporting_text: >-
@@ -250,12 +311,12 @@ existing_annotations:
       coordinating zinc (PMID:9495346, UniProt). The IEA from UniProt keyword mapping
       to the general metal ion binding term is acceptable but the zinc binding is
       transient and context-dependent.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       TIM10 does bind metal ions (specifically zinc) via its CX3C motifs, though this
       occurs in the cytoplasm rather than in its functional IMS location. The IEA
-      annotation to this general term is not wrong, and the more specific zinc ion
-      binding annotation (GO:0008270) provides better specificity.
+      annotation to this general term is not wrong, but transient metal coordination
+      during biogenesis is secondary to the mature IMS chaperone/carrier function.
     supported_by:
     - reference_id: PMID:9495346
       supporting_text: >-
@@ -271,12 +332,12 @@ existing_annotations:
       This annotation records the physical interaction of TIM10 with TIM9 (O74700)
       as detected in PMID:11483513. Luciano et al. showed that Tim9 and Tim10 purified
       from E. coli can form a complex of the same size as the endogenous complex.
-    action: REMOVE
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Per curation guidelines, protein binding (GO:0005515) is uninformative and should
       be replaced by more specific molecular function terms. The interaction between
       TIM10 and TIM9 is captured by the complex membership annotations (GO:0042719
-      and GO:0042721) and by the more informative unfolded protein carrier activity
+      and GO:0042721) and by the more informative unfolded protein holdase activity
       (GO:0140309) proposed as a replacement for GO:0051082.
     supported_by:
     - reference_id: PMID:11483513
@@ -291,16 +352,15 @@ existing_annotations:
   review:
     summary: >-
       This annotation records the physical interaction of TIM10 with TIM18 (Q08749)
-      as detected in PMID:12637749. Rehling et al. identified TIM10 as part of the
-      TIM22 complex which includes TIM18.
-    action: REMOVE
+      as detected in PMID:12637749. The cached abstract establishes a purified TIM22
+      twin-pore translocase but does not name Tim10, Tim18, or their specific interaction;
+      no evidence-matched quote for the IPI can therefore be supplied from this cache.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Protein binding is uninformative. The interaction of TIM10 with TIM18 is better
-      captured by the annotation to TIM22 complex membership (GO:0042721).
-    supported_by:
-    - reference_id: PMID:12637749
-      supporting_text: >-
-        Protein insertion into the mitochondrial inner membrane by a twin-pore translocase.
+      Protein binding is uninformative, and the abstract-only cache cannot verify the
+      partner-level assay. The independently established pathway relationship is better
+      captured by TIM22 complex membership (GO:0042721); this does not assert that the
+      curator's inaccessible full-text evidence was wrong.
 - term:
     id: GO:0005515
     label: protein binding
@@ -311,7 +371,7 @@ existing_annotations:
       This annotation records a physical interaction between TIM10 and TIM18 (Q08749)
       from PMID:17882259 (Shy1 couples Cox1 translational regulation to cytochrome c
       oxidase assembly). This is a large-scale interaction study.
-    action: REMOVE
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Protein binding is uninformative. This interaction is better captured by the
       complex membership annotations. The specific paper is about Shy1/Cox1 regulation
@@ -325,14 +385,15 @@ existing_annotations:
   review:
     summary: >-
       This annotation records a physical interaction of TIM10 with TIM12 (P32830)
-      from PMID:23267104 (proteome-wide protein interaction measurements of bacterial
-      proteins of unknown function). This appears to be a cross-species or
-      high-throughput interaction study.
-    action: REMOVE
+      from PMID:23267104. Inspection of the cached full text verifies that the study
+      is restricted to Escherichia coli proteins and contains no yeast, Tim10, or
+      Tim12 mention, so the citation does not support this interaction.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Protein binding is uninformative. The TIM10-TIM12 interaction is well
-      established and captured by the complex membership annotations (GO:0042721,
-      GO:0042719). There is no need for a separate generic protein binding annotation.
+      The cited full text is a verified identifier mismatch for this yeast interaction.
+      The TIM10-TIM12 association is independently established and captured by complex
+      membership annotations, but this generic protein-binding row overstates what its
+      original reference supports.
     supported_by:
     - reference_id: PMID:9822593
       supporting_text: >-
@@ -351,9 +412,9 @@ existing_annotations:
       relevance for yeast TIM10 function.
     action: REMOVE
     reason: >-
-      Protein binding is uninformative. Furthermore, this cross-species interaction
-      with human MAGEA2B has no known physiological relevance for yeast TIM10 and
-      likely reflects in vitro assay artifacts.
+      The intentionally cross-species interaction with human MAGEA2B has no physiological
+      relevance to yeast TIM10 function. A generic protein-binding annotation derived
+      from this heterologous assay should not be retained as yeast biology.
 - term:
     id: GO:0005515
     label: protein binding
@@ -367,9 +428,9 @@ existing_annotations:
       relevance for yeast TIM10 function.
     action: REMOVE
     reason: >-
-      Protein binding is uninformative. Furthermore, this cross-species interaction
-      with human TEX11 has no known physiological relevance for yeast TIM10 and
-      likely reflects in vitro assay artifacts.
+      The intentionally cross-species interaction with human TEX11 has no physiological
+      relevance to yeast TIM10 function. A generic protein-binding annotation derived
+      from this heterologous assay should not be retained as yeast biology.
 - term:
     id: GO:0005515
     label: protein binding
@@ -380,12 +441,12 @@ existing_annotations:
       This annotation records a physical interaction of TIM10 with TIM12 (P32830)
       from PMID:9495346. Sirrenberg et al. showed Tim10 and Tim12 interact
       sequentially with carrier precursors and form a complex with Tim22.
-    action: REMOVE
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Protein binding is uninformative. The TIM10-TIM12 interaction is better
       represented by the complex membership annotations (GO:0042721, GO:0042719).
       The more informative molecular function is protein transporter activity
-      (GO:0140318) or unfolded protein carrier activity (GO:0140309).
+      (GO:0140318) or unfolded protein holdase activity (GO:0140309).
     supported_by:
     - reference_id: PMID:9495346
       supporting_text: >-
@@ -541,12 +602,12 @@ existing_annotations:
       bonds rather than coordinating zinc (PMID:9495346, UniProt). The RCA annotation
       from a zinc proteome study (PMID:30358795) is acceptable but should be
       understood in context.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       TIM10 does bind zinc via its CX3C motifs, though this occurs in the cytoplasmic
       reduced state rather than in the functional IMS oxidized state. The annotation
       is not incorrect -- TIM10 is part of the zinc proteome -- but the zinc binding
-      is transient and occurs during biogenesis rather than function.
+      is transient during biogenesis and is not its core mature activity.
     supported_by:
     - reference_id: PMID:9495346
       supporting_text: >-
@@ -758,11 +819,9 @@ existing_annotations:
       capture the critical carrier/escort function of TIM10. TIM10 does not merely
       bind unfolded proteins -- it actively escorts them across the aqueous IMS from
       the TOM complex to the TIM22 complex, functioning as a true protein carrier
-      chaperone. GO:0140309 (unfolded protein carrier activity) is defined as "A
-      protein carrier activity that binds to a protein in an unfolded state and
-      escorts it between two different cellular components. The unfolded protein
-      carrier prevents aggregation of the target protein." This precisely describes
-      TIM10 function.
+      chaperone. Live GO names GO:0140309 "unfolded protein holdase activity" and
+      defines it as binding an unfolded protein, escorting it to an acceptor or location,
+      and preventing its aggregation. This precisely describes TIM10 function.
     action: MODIFY
     reason: >-
       GO:0051082 (unfolded protein binding) is too generic and misses the essential
@@ -770,13 +829,13 @@ existing_annotations:
       unfolded protein carrier: it binds hydrophobic unfolded precursors in the IMS,
       prevents their aggregation, and escorts them between two cellular compartments
       (from the TOM complex at the outer membrane to the TIM22 complex at the inner
-      membrane). GO:0140309 (unfolded protein carrier activity) captures this complete
+      membrane). GO:0140309 (unfolded protein holdase activity) captures this complete
       function. The reconstituted complex not only bound substrate but also "facilitated
       passage of AAC across the outer membrane" and "ensured its accurate membrane
       insertion" (PMID:11483513), confirming active escort rather than passive binding.
     proposed_replacement_terms:
     - id: GO:0140309
-      label: unfolded protein carrier activity
+      label: unfolded protein holdase activity
     supported_by:
     - reference_id: PMID:12138093
       supporting_text: >-
@@ -914,6 +973,13 @@ references:
   title: The Dutch multicenter experience of the endo-sponge treatment for anastomotic
     leakage after colorectal surgery.
   is_invalid: true
+  reference_review:
+    relevance: NONE
+    correctness: WRONG_IDENTIFIER
+    review_notes: >-
+      The cached full text is an unrelated colorectal-surgery article. The GO term is
+      independently correct for TIM10, but this identifier cannot support it and may be
+      a transposition of PMID:19037098.
   findings:
   - statement: >-
       This publication is about colorectal surgery and has no relevance to TIM10 or
@@ -923,6 +989,12 @@ references:
 - id: PMID:23267104
   title: Proteome-wide protein interaction measurements of bacterial proteins of unknown
     function.
+  reference_review:
+    relevance: NONE
+    correctness: WRONG_IDENTIFIER
+    review_notes: >-
+      Full-text inspection found an E. coli-only interaction study with no yeast,
+      Tim10, or Tim12 mention; it cannot support the TIM10-TIM12 IPI row.
   findings: []
 - id: PMID:24769239
   title: Quantitative variations of the mitochondrial proteome and phosphoproteome
@@ -990,7 +1062,7 @@ references:
   findings: []
 core_functions:
 - description: >-
-    TIM10 functions as an unfolded protein carrier in the mitochondrial intermembrane
+    TIM10 functions as an unfolded protein holdase/carrier in the mitochondrial intermembrane
     space (IMS). As part of the hexameric TIM9-TIM10 chaperone complex, it binds
     hydrophobic unfolded precursor proteins (primarily mitochondrial carrier family
     members) exiting the TOM translocase and escorts them across the aqueous IMS to
@@ -1024,10 +1096,11 @@ core_functions:
       The reconstituted TIM10 complex not only facilitated passage of AAC across the
       outer membrane but also ensured its accurate membrane insertion.
 - description: >-
-    TIM10 has protein transporter activity, directly binding to and delivering
-    mitochondrial carrier protein precursors from the TOM complex to the TIM22
-    complex. This transporter function overlaps with but is distinct from the unfolded
-    protein carrier activity, emphasizing the directed delivery aspect of TIM10 function.
+    TIM10 has protein transporter activity: it directly engages mitochondrial carrier
+    precursors released from TOM-side intermediates and delivers them through the IMS
+    to the TIM22 pathway. This directed delivery is retained separately from the
+    substrate-state-specific holdase term because it is supported by direct IDA and
+    mutant evidence and emphasizes transport between pathway stations.
   molecular_function:
     id: GO:0140318
     label: protein transporter activity
@@ -1050,3 +1123,30 @@ core_functions:
       Two related proteins in the intermembrane space, Tim10/Mrs11 and Tim12/Mrs5,
       interact sequentially with these precursors and facilitate their translocation
       across the outer membrane, irrespective of the membrane potential.
+proposed_new_terms: []
+
+suggested_questions:
+- question: >-
+    What fraction of TIM10 is stably incorporated into the membrane-associated TIM22
+    assembly versus cycling transiently between the soluble Tim9-Tim10 pool and TIM22
+    during client handoff?
+- question: >-
+    Do any yeast beta-barrel outer-membrane precursors depend directly on TIM10, and is
+    their delivery to SAM mediated by the same Tim9-Tim10 client-binding surface used
+    for mitochondrial carriers?
+
+suggested_experiments:
+- description: >-
+    Use time-resolved crosslinking and quantitative native-complex analysis during a
+    synchronized carrier-import reaction to measure TIM10 occupancy in soluble Tim9-Tim10,
+    TIM22-associated, and precursor-bound states.
+  hypothesis: >-
+    TIM10 cycles between a major soluble IMS chaperone pool and a smaller transiently
+    TIM22-associated handoff state rather than functioning as the membrane insertase.
+- description: >-
+    Compare import and SAM assembly of a panel of beta-barrel precursors in conditional
+    tim10 mutants, followed by rescue with client-binding-surface mutants that preserve
+    Tim9-Tim10 hexamer assembly.
+  hypothesis: >-
+    TIM10 may chaperone a defined subset of beta-barrel precursors toward SAM through
+    the same hydrophobic-client recognition surface used in the TIM22 carrier pathway.

--- a/genes/yeast/TIM10/TIM10-notes.md
+++ b/genes/yeast/TIM10/TIM10-notes.md
@@ -1,0 +1,71 @@
+# TIM10 review notes
+
+## 2026-08-28 completion audit
+
+- TIM10 is a small-Tim mitochondrial intermembrane-space chaperone. Its core
+  activity is best represented by GO:0140309, unfolded protein holdase activity
+  (the current official label; “unfolded protein carrier activity” is an exact synonym):
+  the reconstituted Tim9-Tim10 complex “bound to the physiological substrate
+  ADP/ATP carrier and displayed chaperone activity in refolding the model
+  substrate firefly luciferase” [PMID:12138093]. This supports directed client
+  shielding and delivery, not membrane insertase activity.
+
+- The two direct GO:0140318 protein-transporter rows remain ACCEPT and are
+  represented as a second core function. GO:0140309 captures the substrate-state-
+  specific holdase behavior (maintaining hydrophobic clients without aggregation),
+  whereas GO:0140318 records directed delivery between TOM-side intermediates and
+  the TIM22 pathway. These claims overlap but emphasize experimentally supported
+  mechanistic dimensions rather than contradicting one another.
+
+- All 34 physical GOA rows are represented by 34 review entries. When grouped only
+  by term, evidence, reference, and qualifier they comprise 33 signatures; the sole
+  repeated signature is the pair of GO:0005515 / IPI / PMID:27107014 / `enables`
+  rows distinguished by their WITH/FROM human partners. Five generic protein-binding
+  rows are retained as over-annotated interaction statements, while the two intentional
+  cross-species human-partner rows are removed as nonphysiological yeast annotations;
+  the informative biology is captured by Tim9-Tim10 chaperone-complex membership,
+  TIM22-pathway participation, and unfolded-protein carrier activity.
+
+- All three IBA rows use PTN000113167. Current cached PAINT retains the
+  GO:0042721 complex-membership and GO:0045039 inner-membrane-insertion-process
+  IBDs. Their WITH/FROM seeds are conserved small-Tim/TIM22-pathway components,
+  including TIM12 (`SGD:S000000295`), the target TIM10
+  (`SGD:S000003530`), human TIMM10 (`UniProtKB:P62072`), and orthologous mouse
+  and worm sources for the process term. Target-in-own-WITH/FROM is valid
+  experimental grounding, not circularity.
+
+- GOA also carries GO:0032977 membrane insertase activity from PTN000113167 and
+  human TIMM10, but that assertion is absent from the current cached PAINT table.
+  It also conflates the small-Tim delivery role with the membrane-embedded Tim22
+  insertase. The row is therefore modified to GO:0140309 and recorded as stale
+  PAINT provenance plus role conflation. Direct work instead states that Tim10
+  transports carrier precursors while Tim12/Tim22 mediate insertion
+  [PMID:9430585, “Tim10p readily dissociated from the complex and was required
+  to transport carrier precursors across the outer membrane; Tim12p was firmly
+  bound to Tim22p and mediated the insertion of carriers into the inner
+  membrane.”].
+
+- Metal and zinc binding are retained as non-core. The reduced twin-CX3C motif
+  can bind zinc [PMID:9495346, “Both proteins contain a zinc-finger-like motif
+  with four cysteines and bind equimolar amounts of zinc ions.”], whereas the
+  mature IMS protein uses those cysteines in intramolecular disulfide bonds.
+
+- PMID:19037698 is a verified wrong identifier for the ComplexPortal IMS row:
+  its cached full text concerns colorectal anastomotic leakage. The biological
+  localization is independently established by multiple TIM10 papers, so the
+  annotation is accepted while the reference is explicitly marked
+  `WRONG_IDENTIFIER`; PMID:19037098 is the plausible transposed identifier.
+
+- PMID:23267104 is also a verified wrong identifier for its TIM10-TIM12 IPI row.
+  Full-text inspection found an E. coli-only study with no yeast, Tim10, or Tim12
+  mention. The physiological TIM10-TIM12 association is independently supported,
+  but this citation cannot support the generic interaction row.
+
+- PMID:12637749 is abstract-only. Its abstract supports the TIM22 complex as a
+  twin-pore translocase but does not name Tim10, Tim18, or their partner-level IPI,
+  so no title or non-supporting abstract sentence was used as evidence for that row.
+
+- Thirteen of the sixteen cached PMID records are abstract-only. The only cached
+  full texts are the unrelated PMID:19037698 paper, PMID:23267104, and
+  PMID:27107014. Experimental annotations were not rejected merely because assay
+  detail was unavailable from an abstract.


### PR DESCRIPTION
## Summary
- mark TIM10 COMPLETE after exact reconciliation of 33 qualifier-aware GOA assertion signatures
- audit all three IBA rows against PTN000113167 and current PAINT source data
- replace stale small-Tim membrane-insertase activity with evidence-matched unfolded-protein carrier activity
- retain generic interaction rows as over-annotated rather than deleting their underlying observations
- record PMID:19037698 as a verified wrong identifier while preserving independently established IMS localization
- synthesize the specific Tim9-Tim10 carrier/chaperone core function and focused follow-up experiments

## Validation
- just validate yeast TIM10
- just validate-goa yeast TIM10
- just render yeast TIM10
- just deploy-browser
- git diff --check

No support-code changes or wrapper bypasses.