### PR TITLE
Re-review yeast TIM9 annotations

### DIFF
--- a/genes/yeast/TIM9/TIM9-ai-review.html
+++ b/genes/yeast/TIM9/TIM9-ai-review.html
@@ -830,7 +830,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TIM9 is a small mitochondrial intermembrane space (IMS) chaperone that forms a hexameric complex with TIM10 (the Tim9-Tim10 or TIM10 complex, composed of 3 copies of each subunit). This soluble 70 kDa complex functions as a carrier-holdase that escorts hydrophobic transmembrane protein precursors (carrier proteins, beta-barrel precursors) from the TOM complex across the aqueous IMS to the TIM22 complex for insertion into the inner membrane, or to the SAM complex for outer membrane beta-barrel assembly. TIM9 contains a twin CX3C motif that forms two intramolecular disulfide bonds in the IMS; during cytoplasmic transit these cysteines may coordinate zinc. TIM9 is essential for viability and plays both a structural role in complex assembly and a functional role in substrate recognition, with its N-terminal region required for efficient trapping of incoming substrates.</p>
+        <p>TIM9 is a small mitochondrial intermembrane space (IMS) chaperone that forms a hexameric complex with TIM10 (the Tim9-Tim10 or TIM10 complex, composed of 3 copies of each subunit). This soluble 70 kDa complex functions as a carrier-holdase that escorts hydrophobic transmembrane protein precursors, especially mitochondrial carriers, from the TOM complex across the aqueous IMS to the TIM22 complex for insertion into the inner membrane. Small Tim complexes have also been implicated in delivery of some beta-barrel precursors toward the SAM complex. TIM9 contains a twin CX3C motif that forms two intramolecular disulfide bonds in the IMS; during cytoplasmic transit these cysteines may coordinate zinc. TIM9 is essential for viability and plays both a structural role in complex assembly and a functional role in substrate recognition, with its N-terminal region required for efficient trapping of incoming substrates.</p>
     </div>
 
 
@@ -898,6 +898,74 @@
                             <strong>Reason:</strong> TIM9 is well-established as associated with the mitochondrial inner membrane, where a fraction of Tim9 is part of the membrane-associated 300 kDa TIM22 complex (PMID:9822593). The IBA annotation is phylogenetically sound and consistent with the IDA annotations.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">SOURCE STALE OR MISSING</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN004407763</span>
+
+                                    &middot; PANTHER:PTN004407763
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">GOA retains this location IBA, but current PAINT no longer carries GO:0005743 at PTN004407763; the node now carries GO:0042719 complex membership.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000007256</span>
+
+                                    &middot; TIM9
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Target experimental evidence validly grounded the earlier ancestral call.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q9Y5J6</span>
+
+                                    &middot; TIMM10B
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Human TIMM10B is a conserved small-Tim family component.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q9Y5J7</span>
+
+                                    &middot; TIMM9
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Human TIMM9 is the direct conserved ortholog.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -982,6 +1050,87 @@
                             <strong>Reason:</strong> This is the core biological process that TIM9 participates in. The Tim9-Tim10 complex mediates partial translocation of mitochondrial carrier proteins across the outer membrane and their subsequent insertion into the inner membrane via TIM22 (PMID:9889188). Multiple experimental evidence codes support this for yeast TIM9 directly.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">SOURCE STALE OR MISSING</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN004407763</span>
+
+                                    &middot; PANTHER:PTN004407763
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">GOA retains this process IBA, but current PAINT no longer carries GO:0045039 at PTN004407763; the target&#39;s direct evidence independently supports the process.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000007256</span>
+
+                                    &middot; TIM9
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Target experimental evidence directly supports the insertion pathway role.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">MGI:MGI:1353436</span>
+
+                                    &middot; MGI:MGI:1353436
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Mammalian ortholog evidence supports conservation of the pathway role.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q9Y5J7</span>
+
+                                    &middot; TIMM9
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Human TIMM9 supports the conserved small-Tim pathway assignment.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">WB:WBGene00006572</span>
+
+                                    &middot; WB:WBGene00006572
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Nematode ortholog evidence supports the conserved process.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1069,14 +1218,56 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TIM9 functions as part of the Tim9-Tim10 carrier complex that escorts hydrophobic precursors across the IMS. However, TIM9 is more precisely a carrier-holdase (it moves with its cargo) than a transporter (which facilitates movement without moving itself). GO:0140318 &#34;protein transporter activity&#34; may not be the optimal term; GO:0140309 &#34;unfolded protein carrier activity&#34; is more specific and accurate for TIM9 function. However, this IBA is not incorrect and the IDA annotations also use this term, so it is acceptable to keep.
+                            <strong>Summary:</strong> TIM9 functions in the Tim9-Tim10 shuttle that directly binds hydrophobic precursors and delivers them through the IMS. Live GO explicitly cites the soluble Tim9-Tim10 complex as an example of GO:0140318 protein transporter activity. GO:0140309 unfolded protein holdase activity adds the substrate-state and anti-aggregation dimension, but does not invalidate this transporter annotation.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> While GO:0140309 &#34;unfolded protein carrier activity&#34; would be more precise for TIM9 (as a carrier-holdase rather than a transporter), GO:0140318 is not incorrect -- TIM9 does facilitate protein delivery between compartments. The IBA annotation is phylogenetically sound. The more specific annotation to GO:0140309 is proposed as a NEW annotation below.
+                            <strong>Reason:</strong> GO:0140318 precisely captures TIM9&#39;s directed binding and delivery of precursor proteins between TOM-side intermediates and downstream insertases. It is retained as a core activity alongside the more specific holdase annotation.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">SOURCE STALE OR MISSING</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN004407763</span>
+
+                                    &middot; PANTHER:PTN004407763
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">GOA retains this MF IBA, but current PAINT no longer carries GO:0140318 at PTN004407763; direct target IDA and IGI rows independently support the activity.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000007256</span>
+
+                                    &middot; TIM9
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The target&#39;s own experimental annotation validly grounded the ancestral call; target-in-own-WITH/FROM is not circular.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1280,10 +1471,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O74700" data-a="GO:0015031" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O74700" data-a="GO:0015031" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1296,7 +1487,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> While broad, this IEA is not incorrect. TIM9 does participate in protein transport. The more specific annotations to GO:0045039 provide the necessary precision. Keeping this general IEA is fine alongside the specific experimental annotations.
+                            <strong>Reason:</strong> This umbrella is correct, but it is less informative than the reviewed transporter, holdase, and inner-membrane-insertion terms. It also accommodates the less directly documented SAM-directed route, so it is retained as non-core rather than narrowed to only one destination.
                         </div>
 
 
@@ -1549,7 +1740,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0005515 &#34;protein binding&#34; is too vague and does not capture the specific functional interaction. TIM9 interacts with TIM10 to form the functional hexameric chaperone complex, and also binds to substrate carrier proteins during transit. The specific functions (unfolded protein carrier activity, complex membership) are captured by other annotations. Per curation guidelines, &#34;protein binding&#34; should be avoided in favor of more informative MF terms. Falcon deep research notes that within the complex Tim10 provides the key substrate-binding elements (Tim9 alone does not bind the AAC carrier), and that the obligate Tim9-Tim10 partnership forms an essential heterohexamer -- the functionally meaningful interaction, not generic protein binding.
+                            <strong>Reason:</strong> GO:0005515 &#34;protein binding&#34; is too vague and does not capture the specific functional interaction. TIM9 interacts with TIM10 to form the functional hexameric chaperone complex, and also binds to substrate carrier proteins during transit. The specific functions (unfolded protein holdase activity, complex membership) are captured by other annotations. Per curation guidelines, &#34;protein binding&#34; should be avoided in favor of more informative MF terms. Falcon deep research notes that within the complex Tim10 provides the key substrate-binding elements (Tim9 alone does not bind the AAC carrier), and that the obligate Tim9-Tim10 partnership forms an essential heterohexamer -- the functionally meaningful interaction, not generic protein binding.
                         </div>
 
 
@@ -2318,7 +2509,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> TIM9 does facilitate protein delivery across the IMS. The term GO:0140318 captures the transporter aspect. While GO:0140309 &#34;unfolded protein carrier activity&#34; would be more precise (as TIM9 moves with its cargo rather than facilitating movement without moving), this annotation is not incorrect. The more specific GO:0140309 is proposed as a NEW annotation.
+                            <strong>Reason:</strong> GO:0140318 directly describes binding a protein and delivering it to a cellular location, and its live ontology comment explicitly names the soluble Tim9-Tim10 shuttle as an example. The complementary GO:0140309 NEW annotation captures the holdase/anti-aggregation dimension rather than replacing this transporter activity.
                         </div>
 
 
@@ -2818,12 +3009,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for TIM22 complex membership based on Sirrenberg et al. (1998), who showed that Tim10 and Tim12 (and by extension Tim9) interact with precursors and are part of a complex with Tim22 that mediates inner membrane insertion. While Tim9 was not directly characterized in this specific paper (it was not yet discovered), Tim9 was subsequently shown to be part of the TIM22 300 kDa complex (PMID:9822593, PMID:9889188).
+                            <strong>Summary:</strong> IDA annotation for TIM22 complex membership based on Sirrenberg et al. (1998), who showed that Tim10 and Tim12 (and by extension Tim9) interact with precursors and are part of a complex with Tim22 that mediates inner membrane insertion. While Tim9 is annotated to this complex. The cached paper is abstract-only and foregrounds Tim10 and Tim12 rather than Tim9, so it cannot by itself verify the TIM9 assay; subsequent direct studies place Tim9 in the TIM22-associated 300 kDa complex (PMID:9822593, PMID:9889188).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> TIM9 is a peripheral subunit of the TIM22 complex via its association with Tim10 and Tim12. The 300 kDa membrane complex containing Tim22, Tim54, Tim18, Tim12, Tim10, and Tim9 is well-established. ComplexPortal entry CPX-1629 lists TIM9 as a component.
+                            <strong>Reason:</strong> TIM9 is a peripheral TIM22-pathway component via its association with Tim10 and Tim12. The annotation is independently supported by PMID:9822593, while the abstract-only original reference is not overinterpreted or treated as disproving the curator&#39;s inaccessible full-text evidence.
                         </div>
 
 
@@ -3241,12 +3432,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for unfolded protein binding based on Vial et al. (2002), who demonstrated that the reconstituted Tim9-Tim10 complex binds to the physiological substrate ADP/ATP carrier (AAC) and displays chaperone activity in refolding the model substrate firefly luciferase. TIM9 is the canonical carrier-holdase: it binds unfolded/hydrophobic protein precursors AND escorts them across the mitochondrial IMS from the TOM complex to the TIM22 complex. GO:0051082 &#34;unfolded protein binding&#34; captures only the binding aspect but misses the essential carrier/escort function. GO:0140309 &#34;unfolded protein carrier activity&#34; was created specifically for this class of proteins (go-ontology#30552) and is the correct replacement term.
+                            <strong>Summary:</strong> IDA annotation for unfolded protein binding based on Vial et al. (2002), who demonstrated that the reconstituted Tim9-Tim10 complex binds to the physiological substrate ADP/ATP carrier (AAC) and displays chaperone activity in refolding the model substrate firefly luciferase. TIM9 contributes to the canonical carrier-holdase complex: it binds unfolded/hydrophobic protein precursors AND escorts them across the mitochondrial IMS from the TOM complex to the TIM22 complex. GO:0051082 &#34;unfolded protein binding&#34; captures only the binding aspect but misses the essential carrier/escort function. GO:0140309 &#34;unfolded protein holdase activity&#34; was created specifically for this class of proteins (go-ontology#30552) and is the correct replacement term.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> TIM9 (as part of the Tim9-Tim10 complex) is the textbook carrier-holdase: it binds unfolded hydrophobic precursor proteins AND escorts them between cellular compartments (from TOM to TIM22/SAM across the IMS). GO:0051082 &#34;unfolded protein binding&#34; captures only the binding aspect. GO:0140309 &#34;unfolded protein carrier activity&#34; was created in Nov 2025 specifically for TIM carrier-holdases (go-ontology#30552). Its definition -- &#34;A protein carrier activity that binds to a protein in an unfolded state and escorts it between two different cellular components. The unfolded protein carrier prevents aggregation of the target protein&#34; -- precisely describes TIM9 function. This is a child of GO:0140597 &#34;protein carrier chaperone&#34; and GO:0140104 &#34;molecular carrier activity.&#34; The Tim9-Tim10 complex acts as a &#34;chaperone-like protein that protects the hydrophobic precursors from aggregation and guides them through the mitochondrial intermembrane space&#34; (UniProt). PMID:12138093 shows the reconstituted complex is functional because it binds AAC and displays chaperone activity.
+                            <strong>Reason:</strong> TIM9 (as part of the Tim9-Tim10 complex) contributes to a textbook carrier-holdase: it binds unfolded hydrophobic precursor proteins AND escorts them between cellular compartments (principally from TOM to TIM22 across the IMS). GO:0051082 &#34;unfolded protein binding&#34; captures only the binding aspect. GO:0140309 &#34;unfolded protein holdase activity&#34; was created in Nov 2025 specifically for TIM carrier-holdases (go-ontology#30552). The current definition emphasizes binding an unfolded client, escorting it to an acceptor or location, and preventing aggregation. The Tim9-Tim10 complex acts as a chaperone-like protein that protects hydrophobic precursors from aggregation and guides them through the mitochondrial intermembrane space (UniProt). PMID:12138093 shows the reconstituted complex is functional because it binds AAC and displays chaperone activity.
                         </div>
 
 
@@ -3256,7 +3447,7 @@
 
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
-                                    unfolded protein carrier activity
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
 
@@ -3340,7 +3531,7 @@
                                     GO:0140309
                                 </a>
                             </span>
-                            <span class="term-label">unfolded protein carrier activity</span>
+                            <span class="term-label">unfolded protein holdase activity</span>
 
                         </div>
                     </td>
@@ -3380,12 +3571,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> NEW annotation. TIM9 (as part of the Tim9-Tim10 hexameric complex) is the canonical carrier-holdase for which GO:0140309 was created (go-ontology#30552). The Tim9-Tim10 complex binds unfolded hydrophobic transmembrane protein precursors and escorts them from the TOM complex across the IMS to the TIM22 complex (for inner membrane insertion) or to the SAM complex (for beta-barrel assembly). Vial et al. (2002, PMID:12138093) showed the reconstituted Tim9-Tim10 complex binds the ADP/ATP carrier substrate and displays chaperone activity. Multiple studies demonstrate the carrier/escort function: the complex guides hydrophobic proteins through the aqueous IMS (PMID:9822593), mediates partial translocation of carrier proteins (PMID:9889188), and can transfer substrates to multiple insertion sites (PMID:10469659).
+                            <strong>Summary:</strong> NEW annotation. TIM9 (as part of the Tim9-Tim10 hexameric complex) is the canonical carrier-holdase for which GO:0140309 was created (go-ontology#30552). The Tim9-Tim10 complex binds unfolded hydrophobic transmembrane protein precursors and escorts them from the TOM complex across the IMS to the TIM22 complex for inner membrane insertion. Small Tim complexes have also been implicated in some SAM-directed beta-barrel precursor delivery, but that is not required for this NEW assertion. Vial et al. (2002, PMID:12138093) showed the reconstituted Tim9-Tim10 complex binds the ADP/ATP carrier substrate and displays chaperone activity. Multiple studies demonstrate the carrier/escort function: the complex guides hydrophobic proteins through the aqueous IMS (PMID:9822593), mediates partial translocation of carrier proteins (PMID:9889188), and can transfer substrates to multiple insertion sites (PMID:10469659).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0140309 &#34;unfolded protein carrier activity&#34; was created specifically for TIM carrier-holdases. TIM9 is the founding member of this functional class. This term is not currently annotated to TIM9 in GOA despite being the most precise MF term for its chaperone function. It should be added as a new annotation.
+                            <strong>Reason:</strong> GO:0140309 &#34;unfolded protein holdase activity&#34; was created specifically for TIM carrier-holdases. TIM9 is the founding member of this functional class. This term is not currently annotated to TIM9 in GOA despite being the most precise MF term for its chaperone function. It should be added as a new annotation.
                         </div>
 
 
@@ -3486,7 +3677,7 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>TIM9 functions as part of the Tim9-Tim10 hexameric carrier-holdase complex that binds unfolded hydrophobic transmembrane protein precursors and escorts them from the TOM complex across the aqueous IMS to the TIM22 complex for inner membrane insertion, or to the SAM complex for outer membrane beta-barrel assembly. This carrier-holdase activity -- binding unfolded proteins AND transporting them between compartments -- is the core molecular function of TIM9.</h3>
+                <h3>TIM9 functions as part of the Tim9-Tim10 hexameric carrier-holdase complex that binds unfolded hydrophobic transmembrane protein precursors and escorts them from the TOM complex across the aqueous IMS to the TIM22 complex for inner membrane insertion. The substrate shielding/anti-aggregation dimension is the defining specificity of this holdase activity; a possible SAM-directed route is secondary and less directly documented in the cached TIM9 literature.</h3>
                 <span class="vote-buttons" data-g="O74700" data-a="FUNCTION: TIM9 functions as part of the Tim9-Tim10 hexameric..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -3550,6 +3741,129 @@
 
             </div>
 
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12138093" target="_blank" class="term-link">
+                                PMID:12138093
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the reconstituted TIM10 complex is functional because it bound to the physiological substrate ADP/ATP carrier and displayed chaperone activity in refolding the model substrate firefly luciferase.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9822593" target="_blank" class="term-link">
+                                PMID:9822593
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Tim9p is a new subunit of the TIM machinery that guides hydrophobic inner membrane proteins across the aqueous intermembrane space.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TIM9 contributes to the Tim9-Tim10 protein shuttle that directly binds mitochondrial carrier precursors at TOM-side intermediates and delivers them through the IMS toward downstream membrane insertion machinery. This directed delivery is a core activity distinct in emphasis from the substrate-state-specific holdase term.</h3>
+                <span class="vote-buttons" data-g="O74700" data-a="FUNCTION: TIM9 contributes to the Tim9-Tim10 protein shuttle..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140318" target="_blank" class="term-link">
+                            protein transporter activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045039" target="_blank" class="term-link">
+                                protein insertion into mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                mitochondrial intermembrane space
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042719" target="_blank" class="term-link">
+                            mitochondrial intermembrane space chaperone complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9822593" target="_blank" class="term-link">
+                                PMID:9822593
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Tim9p is a new subunit of the TIM machinery that guides hydrophobic inner membrane proteins across the aqueous intermembrane space.</div>
+
+                    </li>
+
+                </ul>
+            </div>
 
         </div>
 
@@ -4095,7 +4409,79 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
 
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What proportion of TIM9 client handling is directed to TIM22 versus SAM in vivo, and which individual beta-barrel precursors require the Tim9-Tim10 complex?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74700" data-a="Q: What proportion of TIM9 client handling is directe..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How do Tim9&#39;s structural contribution to the heterohexamer and Tim10&#39;s stronger isolated AAC-binding capacity partition client recognition within the intact complex?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O74700" data-a="Q: How do Tim9&#39;s structural contribution to the heter..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform time-resolved crosslinking of endogenous Tim9 and Tim10 during synchronized import of carrier and beta-barrel precursor panels, quantifying handoff to TIM22 or SAM.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Tim9-Tim10 directly handles both client classes, but TIM22-directed carrier delivery is the dominant and most robust TIM9-dependent route.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O74700" data-a="EXPERIMENT: Perform time-resolved crosslinking of endogenous T..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute Tim9-Tim10 complexes carrying interface-preserving Tim9 client-contact mutations and measure complex assembly, aggregation suppression, and precursor delivery.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Tim9 contributes client-contact surfaces beyond its structural role, even though isolated Tim10 shows stronger AAC binding than isolated Tim9.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O74700" data-a="EXPERIMENT: Reconstitute Tim9-Tim10 complexes carrying interfa..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
 
 
 
@@ -4464,6 +4850,91 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TIM9-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O74700" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tim9-review-notes">TIM9 review notes</h1>
+<h2 id="2026-08-28-dedicated-re-review">2026-08-28 dedicated re-review</h2>
+<ul>
+<li>
+<p>All 29 physical GOA rows correspond to 29 distinct term/evidence/reference/<br />
+  qualifier signatures and are represented in <code>existing_annotations</code>. One<br />
+  evidence-supported NEW annotation adds GO:0140309.</p>
+</li>
+<li>
+<p>TIM9 and TIM10 form the soluble IMS chaperone shuttle, but their roles are not<br />
+  assumed to be identical at the subunit level. The intact complex binds carrier<br />
+  precursor and exhibits chaperone activity [PMID:12138093, “the reconstituted<br />
+  TIM10 complex is functional because it bound to the physiological substrate<br />
+  ADP/ATP carrier and displayed chaperone activity in refolding the model<br />
+  substrate firefly luciferase.”]. Deep research notes that isolated Tim10 binds<br />
+  AAC more strongly than isolated Tim9, supporting a comparatively stronger<br />
+  structural contribution from Tim9 while retaining a functional role in the<br />
+  assembled holdase/transporter.</p>
+</li>
+<li>
+<p>Live QuickGO calls GO:0140309 <code>unfolded protein holdase activity</code>; the former<br />
+<code>unfolded protein carrier activity</code> is an exact synonym. The term covers binding<br />
+  an unfolded client, preventing its aggregation, and escorting it to an acceptor<br />
+  or location. GO:0140318 remains independently appropriate and core because its<br />
+  definition is direct protein binding plus delivery to a cellular location, and<br />
+  its ontology comment explicitly cites the soluble Tim9-Tim10 shuttle.</p>
+</li>
+<li>
+<p>All three GOA IBA rows use PTN004407763. The current cached PAINT table retains<br />
+  this node but now carries only GO:0042719 IMS chaperone-complex membership;<br />
+  GO:0005743, GO:0045039, and GO:0140318 are absent. Each GOA IBA therefore records<br />
+<code>SOURCE_STALE_OR_MISSING</code> for the PTN while retaining ACCEPT because direct TIM9<br />
+  experimental annotations independently support all three claims. The target<br />
+<code>SGD:S000007256</code> appearing in WITH/FROM is valid experimental grounding, not<br />
+  circularity.</p>
+</li>
+<li>
+<p>The single GO:0005515 IPI is marked over-annotated rather than removed: the<br />
+  Tim9-Tim10 interaction is real, but generic protein binding loses the informative<br />
+  IMS chaperone-complex and transporter context.</p>
+</li>
+<li>
+<p>Metal-ion and zinc-binding rows remain over-annotated for mature TIM9. UniProt<br />
+  says zinc coordination during cytoplasmic transit is probable, whereas the mature<br />
+  IMS protein contains two intramolecular disulfides; the RCA zinc-proteome row is<br />
+  motif-based rather than a direct TIM9 zinc-binding assay.</p>
+</li>
+<li>
+<p>TIM22-directed carrier delivery is the best directly supported route. UniProt and<br />
+  the deep-research synthesis implicate small Tims in some beta-barrel precursor<br />
+  delivery toward SAM, but the cached TIM9 primary literature reviewed here does not<br />
+  establish that route at the same resolution, so it is described as secondary and<br />
+  remains an experimental question.</p>
+</li>
+<li>
+<p>PMID:19037698 is a verified wrong identifier: its cached full text is an unrelated<br />
+  colorectal-surgery paper. The IMS localization is independently established, so<br />
+  the annotation remains ACCEPT while the reference is marked <code>WRONG_IDENTIFIER</code>;<br />
+  PMID:19037098 is the plausible transposed identifier.</p>
+</li>
+<li>
+<p>Twelve of the thirteen cached PMID records are abstract-only. Experimental rows<br />
+  were not rejected merely because their full assay details were unavailable.</p>
+</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4483,9 +4954,10 @@ description: &gt;-
   TIM9 is a small mitochondrial intermembrane space (IMS) chaperone that forms a hexameric
   complex with TIM10 (the Tim9-Tim10 or TIM10 complex, composed of 3 copies of each subunit).
   This soluble 70 kDa complex functions as a carrier-holdase that escorts hydrophobic
-  transmembrane protein precursors (carrier proteins, beta-barrel precursors) from the TOM
-  complex across the aqueous IMS to the TIM22 complex for insertion into the inner membrane,
-  or to the SAM complex for outer membrane beta-barrel assembly. TIM9 contains a twin CX3C
+  transmembrane protein precursors, especially mitochondrial carriers, from the TOM
+  complex across the aqueous IMS to the TIM22 complex for insertion into the inner membrane.
+  Small Tim complexes have also been implicated in delivery of some beta-barrel precursors
+  toward the SAM complex. TIM9 contains a twin CX3C
   motif that forms two intramolecular disulfide bonds in the IMS; during cytoplasmic transit
   these cysteines may coordinate zinc. TIM9 is essential for viability and plays both a
   structural role in complex assembly and a functional role in substrate recognition, with its
@@ -4511,6 +4983,27 @@ existing_annotations:
       TIM9 is well-established as associated with the mitochondrial inner membrane, where
       a fraction of Tim9 is part of the membrane-associated 300 kDa TIM22 complex (PMID:9822593).
       The IBA annotation is phylogenetically sound and consistent with the IDA annotations.
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      source_entities:
+      - source_id: PANTHER:PTN004407763
+        source_label: PANTHER:PTN004407763
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          GOA retains this location IBA, but current PAINT no longer carries GO:0005743
+          at PTN004407763; the node now carries GO:0042719 complex membership.
+      - source_id: SGD:S000007256
+        source_label: TIM9
+        source_status: SUPPORTS_TRANSFER
+        comment: Target experimental evidence validly grounded the earlier ancestral call.
+      - source_id: UniProtKB:Q9Y5J6
+        source_label: TIMM10B
+        source_status: SUPPORTS_TRANSFER
+        comment: Human TIMM10B is a conserved small-Tim family component.
+      - source_id: UniProtKB:Q9Y5J7
+        source_label: TIMM9
+        source_status: SUPPORTS_TRANSFER
+        comment: Human TIMM9 is the direct conserved ortholog.
     supported_by:
     - reference_id: PMID:9822593
       supporting_text: &gt;-
@@ -4538,6 +5031,31 @@ existing_annotations:
       mediates partial translocation of mitochondrial carrier proteins across the outer membrane
       and their subsequent insertion into the inner membrane via TIM22 (PMID:9889188). Multiple
       experimental evidence codes support this for yeast TIM9 directly.
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      source_entities:
+      - source_id: PANTHER:PTN004407763
+        source_label: PANTHER:PTN004407763
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          GOA retains this process IBA, but current PAINT no longer carries GO:0045039
+          at PTN004407763; the target&#39;s direct evidence independently supports the process.
+      - source_id: SGD:S000007256
+        source_label: TIM9
+        source_status: SUPPORTS_TRANSFER
+        comment: Target experimental evidence directly supports the insertion pathway role.
+      - source_id: MGI:MGI:1353436
+        source_label: MGI:MGI:1353436
+        source_status: SUPPORTS_TRANSFER
+        comment: Mammalian ortholog evidence supports conservation of the pathway role.
+      - source_id: UniProtKB:Q9Y5J7
+        source_label: TIMM9
+        source_status: SUPPORTS_TRANSFER
+        comment: Human TIMM9 supports the conserved small-Tim pathway assignment.
+      - source_id: WB:WBGene00006572
+        source_label: WB:WBGene00006572
+        source_status: SUPPORTS_TRANSFER
+        comment: Nematode ortholog evidence supports the conserved process.
     supported_by:
     - reference_id: PMID:9889188
       supporting_text: &gt;-
@@ -4558,19 +5076,31 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: &gt;-
-      TIM9 functions as part of the Tim9-Tim10 carrier complex that escorts hydrophobic
-      precursors across the IMS. However, TIM9 is more precisely a carrier-holdase (it moves
-      with its cargo) than a transporter (which facilitates movement without moving itself).
-      GO:0140318 &#34;protein transporter activity&#34; may not be the optimal term; GO:0140309
-      &#34;unfolded protein carrier activity&#34; is more specific and accurate for TIM9 function.
-      However, this IBA is not incorrect and the IDA annotations also use this term, so
-      it is acceptable to keep.
+      TIM9 functions in the Tim9-Tim10 shuttle that directly binds hydrophobic precursors
+      and delivers them through the IMS. Live GO explicitly cites the soluble Tim9-Tim10
+      complex as an example of GO:0140318 protein transporter activity. GO:0140309
+      unfolded protein holdase activity adds the substrate-state and anti-aggregation
+      dimension, but does not invalidate this transporter annotation.
     action: ACCEPT
     reason: &gt;-
-      While GO:0140309 &#34;unfolded protein carrier activity&#34; would be more precise for TIM9
-      (as a carrier-holdase rather than a transporter), GO:0140318 is not incorrect -- TIM9
-      does facilitate protein delivery between compartments. The IBA annotation is phylogenetically
-      sound. The more specific annotation to GO:0140309 is proposed as a NEW annotation below.
+      GO:0140318 precisely captures TIM9&#39;s directed binding and delivery of precursor
+      proteins between TOM-side intermediates and downstream insertases. It is retained
+      as a core activity alongside the more specific holdase annotation.
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      source_entities:
+      - source_id: PANTHER:PTN004407763
+        source_label: PANTHER:PTN004407763
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          GOA retains this MF IBA, but current PAINT no longer carries GO:0140318 at
+          PTN004407763; direct target IDA and IGI rows independently support the activity.
+      - source_id: SGD:S000007256
+        source_label: TIM9
+        source_status: SUPPORTS_TRANSFER
+        comment: &gt;-
+          The target&#39;s own experimental annotation validly grounded the ancestral call;
+          target-in-own-WITH/FROM is not circular.
     supported_by:
     - reference_id: PMID:9822593
       supporting_text: &gt;-
@@ -4632,11 +5162,12 @@ existing_annotations:
       Translocation). TIM9 participates in protein transport across the IMS. This is a
       general parent term; the more specific GO:0045039 (protein insertion into mitochondrial
       inner membrane) is also annotated.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      While broad, this IEA is not incorrect. TIM9 does participate in protein transport.
-      The more specific annotations to GO:0045039 provide the necessary precision. Keeping
-      this general IEA is fine alongside the specific experimental annotations.
+      This umbrella is correct, but it is less informative than the reviewed transporter,
+      holdase, and inner-membrane-insertion terms. It also accommodates the less directly
+      documented SAM-directed route, so it is retained as non-core rather than narrowed
+      to only one destination.
     supported_by:
     - reference_id: UniProt:O74700
       supporting_text: &gt;-
@@ -4721,7 +5252,7 @@ existing_annotations:
       GO:0005515 &#34;protein binding&#34; is too vague and does not capture the specific functional
       interaction. TIM9 interacts with TIM10 to form the functional hexameric chaperone
       complex, and also binds to substrate carrier proteins during transit. The specific
-      functions (unfolded protein carrier activity, complex membership) are captured by
+      functions (unfolded protein holdase activity, complex membership) are captured by
       other annotations. Per curation guidelines, &#34;protein binding&#34; should be avoided in
       favor of more informative MF terms. Falcon deep research notes that within the
       complex Tim10 provides the key substrate-binding elements (Tim9 alone does not bind
@@ -4938,11 +5469,10 @@ existing_annotations:
       carrier proteins and can be cross-linked to partly translocated carrier proteins.
     action: ACCEPT
     reason: &gt;-
-      TIM9 does facilitate protein delivery across the IMS. The term GO:0140318 captures
-      the transporter aspect. While GO:0140309 &#34;unfolded protein carrier activity&#34; would be
-      more precise (as TIM9 moves with its cargo rather than facilitating movement without
-      moving), this annotation is not incorrect. The more specific GO:0140309 is proposed
-      as a NEW annotation.
+      GO:0140318 directly describes binding a protein and delivering it to a cellular
+      location, and its live ontology comment explicitly names the soluble Tim9-Tim10
+      shuttle as an example. The complementary GO:0140309 NEW annotation captures the
+      holdase/anti-aggregation dimension rather than replacing this transporter activity.
     supported_by:
     - reference_id: PMID:9822593
       supporting_text: &gt;-
@@ -5067,14 +5597,16 @@ existing_annotations:
       IDA annotation for TIM22 complex membership based on Sirrenberg et al. (1998), who
       showed that Tim10 and Tim12 (and by extension Tim9) interact with precursors and
       are part of a complex with Tim22 that mediates inner membrane insertion. While Tim9
-      was not directly characterized in this specific paper (it was not yet discovered),
-      Tim9 was subsequently shown to be part of the TIM22 300 kDa complex (PMID:9822593,
-      PMID:9889188).
+      is annotated to this complex. The cached paper is abstract-only and foregrounds
+      Tim10 and Tim12 rather than Tim9, so it cannot by itself verify the TIM9 assay;
+      subsequent direct studies place Tim9 in the TIM22-associated 300 kDa complex
+      (PMID:9822593, PMID:9889188).
     action: ACCEPT
     reason: &gt;-
-      TIM9 is a peripheral subunit of the TIM22 complex via its association with Tim10 and
-      Tim12. The 300 kDa membrane complex containing Tim22, Tim54, Tim18, Tim12, Tim10,
-      and Tim9 is well-established. ComplexPortal entry CPX-1629 lists TIM9 as a component.
+      TIM9 is a peripheral TIM22-pathway component via its association with Tim10 and
+      Tim12. The annotation is independently supported by PMID:9822593, while the
+      abstract-only original reference is not overinterpreted or treated as disproving
+      the curator&#39;s inaccessible full-text evidence.
     supported_by:
     - reference_id: PMID:9495346
       supporting_text: &gt;-
@@ -5178,30 +5710,28 @@ existing_annotations:
       IDA annotation for unfolded protein binding based on Vial et al. (2002), who demonstrated
       that the reconstituted Tim9-Tim10 complex binds to the physiological substrate ADP/ATP
       carrier (AAC) and displays chaperone activity in refolding the model substrate firefly
-      luciferase. TIM9 is the canonical carrier-holdase: it binds unfolded/hydrophobic protein
+      luciferase. TIM9 contributes to the canonical carrier-holdase complex: it binds unfolded/hydrophobic protein
       precursors AND escorts them across the mitochondrial IMS from the TOM complex to the
       TIM22 complex. GO:0051082 &#34;unfolded protein binding&#34; captures only the binding aspect
-      but misses the essential carrier/escort function. GO:0140309 &#34;unfolded protein carrier
+      but misses the essential carrier/escort function. GO:0140309 &#34;unfolded protein holdase
       activity&#34; was created specifically for this class of proteins (go-ontology#30552) and
       is the correct replacement term.
     action: MODIFY
     reason: &gt;-
-      TIM9 (as part of the Tim9-Tim10 complex) is the textbook carrier-holdase: it binds
+      TIM9 (as part of the Tim9-Tim10 complex) contributes to a textbook carrier-holdase: it binds
       unfolded hydrophobic precursor proteins AND escorts them between cellular compartments
-      (from TOM to TIM22/SAM across the IMS). GO:0051082 &#34;unfolded protein binding&#34; captures
-      only the binding aspect. GO:0140309 &#34;unfolded protein carrier activity&#34; was created in
-      Nov 2025 specifically for TIM carrier-holdases (go-ontology#30552). Its definition --
-      &#34;A protein carrier activity that binds to a protein in an unfolded state and escorts it
-      between two different cellular components. The unfolded protein carrier prevents
-      aggregation of the target protein&#34; -- precisely describes TIM9 function. This is a
-      child of GO:0140597 &#34;protein carrier chaperone&#34; and GO:0140104 &#34;molecular carrier
-      activity.&#34; The Tim9-Tim10 complex acts as a &#34;chaperone-like protein that protects the
-      hydrophobic precursors from aggregation and guides them through the mitochondrial
-      intermembrane space&#34; (UniProt). PMID:12138093 shows the reconstituted complex is
+      (principally from TOM to TIM22 across the IMS). GO:0051082 &#34;unfolded protein binding&#34; captures
+      only the binding aspect. GO:0140309 &#34;unfolded protein holdase activity&#34; was created in
+      Nov 2025 specifically for TIM carrier-holdases (go-ontology#30552). The current
+      definition emphasizes binding an unfolded client, escorting it to an
+      acceptor or location, and preventing aggregation. The Tim9-Tim10 complex acts as a
+      chaperone-like protein that protects hydrophobic precursors from aggregation and
+      guides them through the mitochondrial
+      intermembrane space (UniProt). PMID:12138093 shows the reconstituted complex is
       functional because it binds AAC and displays chaperone activity.
     proposed_replacement_terms:
     - id: GO:0140309
-      label: unfolded protein carrier activity
+      label: unfolded protein holdase activity
     supported_by:
     - reference_id: PMID:12138093
       supporting_text: &gt;-
@@ -5223,10 +5753,10 @@ existing_annotations:
       supporting_text: |-
         TIM9·10 recognizes hydrophobic clients primarily through a **hydrophobic cleft** formed by chaperone helices
 
-# --- NEW annotation: unfolded protein carrier activity ---
+# --- NEW annotation: unfolded protein holdase activity ---
 - term:
     id: GO:0140309
-    label: unfolded protein carrier activity
+    label: unfolded protein holdase activity
   evidence_type: IDA
   original_reference_id: PMID:12138093
   review:
@@ -5234,8 +5764,10 @@ existing_annotations:
       NEW annotation. TIM9 (as part of the Tim9-Tim10 hexameric complex) is the canonical
       carrier-holdase for which GO:0140309 was created (go-ontology#30552). The Tim9-Tim10
       complex binds unfolded hydrophobic transmembrane protein precursors and escorts them
-      from the TOM complex across the IMS to the TIM22 complex (for inner membrane insertion)
-      or to the SAM complex (for beta-barrel assembly). Vial et al. (2002, PMID:12138093)
+      from the TOM complex across the IMS to the TIM22 complex for inner membrane insertion.
+      Small Tim complexes have also been implicated in some SAM-directed beta-barrel
+      precursor delivery, but that is not required for this NEW assertion. Vial et al.
+      (2002, PMID:12138093)
       showed the reconstituted Tim9-Tim10 complex binds the ADP/ATP carrier substrate and
       displays chaperone activity. Multiple studies demonstrate the carrier/escort function:
       the complex guides hydrophobic proteins through the aqueous IMS (PMID:9822593), mediates
@@ -5243,7 +5775,7 @@ existing_annotations:
       to multiple insertion sites (PMID:10469659).
     action: NEW
     reason: &gt;-
-      GO:0140309 &#34;unfolded protein carrier activity&#34; was created specifically for TIM
+      GO:0140309 &#34;unfolded protein holdase activity&#34; was created specifically for TIM
       carrier-holdases. TIM9 is the founding member of this functional class. This term
       is not currently annotated to TIM9 in GOA despite being the most precise MF term
       for its chaperone function. It should be added as a new annotation.
@@ -5341,6 +5873,14 @@ references:
 - id: PMID:19037698
   title: The Dutch multicenter experience of the endo-sponge treatment for anastomotic
     leakage after colorectal surgery.
+  is_invalid: true
+  reference_review:
+    relevance: NONE
+    correctness: WRONG_IDENTIFIER
+    review_notes: &gt;-
+      The cached full text is an unrelated colorectal-surgery paper and cannot support
+      TIM9 IMS localization. The term is independently correct; PMID:19037098 is the
+      plausible transposed identifier.
   findings:
   - statement: &gt;-
       NOTE: This PMID appears to be a data entry error in the GOA. It is about colorectal
@@ -5468,10 +6008,10 @@ core_functions:
   description: &gt;-
     TIM9 functions as part of the Tim9-Tim10 hexameric carrier-holdase complex that binds
     unfolded hydrophobic transmembrane protein precursors and escorts them from the TOM
-    complex across the aqueous IMS to the TIM22 complex for inner membrane insertion, or
-    to the SAM complex for outer membrane beta-barrel assembly. This carrier-holdase
-    activity -- binding unfolded proteins AND transporting them between compartments --
-    is the core molecular function of TIM9.
+    complex across the aqueous IMS to the TIM22 complex for inner membrane insertion.
+    The substrate shielding/anti-aggregation dimension is the defining specificity of
+    this holdase activity; a possible SAM-directed route is secondary and less directly
+    documented in the cached TIM9 literature.
   directly_involved_in:
   - id: GO:0045039
     label: protein insertion into mitochondrial inner membrane
@@ -5481,6 +6021,62 @@ core_functions:
   in_complex:
     id: GO:0042719
     label: mitochondrial intermembrane space chaperone complex
+  supported_by:
+  - reference_id: PMID:12138093
+    supporting_text: &gt;-
+      the reconstituted TIM10 complex is functional because it bound to the physiological
+      substrate ADP/ATP carrier and displayed chaperone activity in refolding the model
+      substrate firefly luciferase.
+  - reference_id: PMID:9822593
+    supporting_text: &gt;-
+      Tim9p is a new subunit of the TIM machinery that guides hydrophobic inner membrane
+      proteins across the aqueous intermembrane space.
+- molecular_function:
+    id: GO:0140318
+    label: protein transporter activity
+  description: &gt;-
+    TIM9 contributes to the Tim9-Tim10 protein shuttle that directly binds mitochondrial
+    carrier precursors at TOM-side intermediates and delivers them through the IMS toward
+    downstream membrane insertion machinery. This directed delivery is a core activity
+    distinct in emphasis from the substrate-state-specific holdase term.
+  directly_involved_in:
+  - id: GO:0045039
+    label: protein insertion into mitochondrial inner membrane
+  locations:
+  - id: GO:0005758
+    label: mitochondrial intermembrane space
+  in_complex:
+    id: GO:0042719
+    label: mitochondrial intermembrane space chaperone complex
+  supported_by:
+  - reference_id: PMID:9822593
+    supporting_text: &gt;-
+      Tim9p is a new subunit of the TIM machinery that guides hydrophobic inner membrane
+      proteins across the aqueous intermembrane space.
+
+proposed_new_terms: []
+
+suggested_questions:
+- question: &gt;-
+    What proportion of TIM9 client handling is directed to TIM22 versus SAM in vivo,
+    and which individual beta-barrel precursors require the Tim9-Tim10 complex?
+- question: &gt;-
+    How do Tim9&#39;s structural contribution to the heterohexamer and Tim10&#39;s stronger
+    isolated AAC-binding capacity partition client recognition within the intact complex?
+
+suggested_experiments:
+- description: &gt;-
+    Perform time-resolved crosslinking of endogenous Tim9 and Tim10 during synchronized
+    import of carrier and beta-barrel precursor panels, quantifying handoff to TIM22 or SAM.
+  hypothesis: &gt;-
+    Tim9-Tim10 directly handles both client classes, but TIM22-directed carrier delivery
+    is the dominant and most robust TIM9-dependent route.
+- description: &gt;-
+    Reconstitute Tim9-Tim10 complexes carrying interface-preserving Tim9 client-contact
+    mutations and measure complex assembly, aggregation suppression, and precursor delivery.
+  hypothesis: &gt;-
+    Tim9 contributes client-contact surfaces beyond its structural role, even though
+    isolated Tim10 shows stronger AAC binding than isolated Tim9.
 </code></pre>
             </div>
         </details>

--- a/genes/yeast/TIM9/TIM9-ai-review.yaml
+++ b/genes/yeast/TIM9/TIM9-ai-review.yaml
@@ -9,9 +9,10 @@ description: >-
   TIM9 is a small mitochondrial intermembrane space (IMS) chaperone that forms a hexameric
   complex with TIM10 (the Tim9-Tim10 or TIM10 complex, composed of 3 copies of each subunit).
   This soluble 70 kDa complex functions as a carrier-holdase that escorts hydrophobic
-  transmembrane protein precursors (carrier proteins, beta-barrel precursors) from the TOM
-  complex across the aqueous IMS to the TIM22 complex for insertion into the inner membrane,
-  or to the SAM complex for outer membrane beta-barrel assembly. TIM9 contains a twin CX3C
+  transmembrane protein precursors, especially mitochondrial carriers, from the TOM
+  complex across the aqueous IMS to the TIM22 complex for insertion into the inner membrane.
+  Small Tim complexes have also been implicated in delivery of some beta-barrel precursors
+  toward the SAM complex. TIM9 contains a twin CX3C
   motif that forms two intramolecular disulfide bonds in the IMS; during cytoplasmic transit
   these cysteines may coordinate zinc. TIM9 is essential for viability and plays both a
   structural role in complex assembly and a functional role in substrate recognition, with its
@@ -37,6 +38,27 @@ existing_annotations:
       TIM9 is well-established as associated with the mitochondrial inner membrane, where
       a fraction of Tim9 is part of the membrane-associated 300 kDa TIM22 complex (PMID:9822593).
       The IBA annotation is phylogenetically sound and consistent with the IDA annotations.
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      source_entities:
+      - source_id: PANTHER:PTN004407763
+        source_label: PANTHER:PTN004407763
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          GOA retains this location IBA, but current PAINT no longer carries GO:0005743
+          at PTN004407763; the node now carries GO:0042719 complex membership.
+      - source_id: SGD:S000007256
+        source_label: TIM9
+        source_status: SUPPORTS_TRANSFER
+        comment: Target experimental evidence validly grounded the earlier ancestral call.
+      - source_id: UniProtKB:Q9Y5J6
+        source_label: TIMM10B
+        source_status: SUPPORTS_TRANSFER
+        comment: Human TIMM10B is a conserved small-Tim family component.
+      - source_id: UniProtKB:Q9Y5J7
+        source_label: TIMM9
+        source_status: SUPPORTS_TRANSFER
+        comment: Human TIMM9 is the direct conserved ortholog.
     supported_by:
     - reference_id: PMID:9822593
       supporting_text: >-
@@ -64,6 +86,31 @@ existing_annotations:
       mediates partial translocation of mitochondrial carrier proteins across the outer membrane
       and their subsequent insertion into the inner membrane via TIM22 (PMID:9889188). Multiple
       experimental evidence codes support this for yeast TIM9 directly.
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      source_entities:
+      - source_id: PANTHER:PTN004407763
+        source_label: PANTHER:PTN004407763
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          GOA retains this process IBA, but current PAINT no longer carries GO:0045039
+          at PTN004407763; the target's direct evidence independently supports the process.
+      - source_id: SGD:S000007256
+        source_label: TIM9
+        source_status: SUPPORTS_TRANSFER
+        comment: Target experimental evidence directly supports the insertion pathway role.
+      - source_id: MGI:MGI:1353436
+        source_label: MGI:MGI:1353436
+        source_status: SUPPORTS_TRANSFER
+        comment: Mammalian ortholog evidence supports conservation of the pathway role.
+      - source_id: UniProtKB:Q9Y5J7
+        source_label: TIMM9
+        source_status: SUPPORTS_TRANSFER
+        comment: Human TIMM9 supports the conserved small-Tim pathway assignment.
+      - source_id: WB:WBGene00006572
+        source_label: WB:WBGene00006572
+        source_status: SUPPORTS_TRANSFER
+        comment: Nematode ortholog evidence supports the conserved process.
     supported_by:
     - reference_id: PMID:9889188
       supporting_text: >-
@@ -84,19 +131,31 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: >-
-      TIM9 functions as part of the Tim9-Tim10 carrier complex that escorts hydrophobic
-      precursors across the IMS. However, TIM9 is more precisely a carrier-holdase (it moves
-      with its cargo) than a transporter (which facilitates movement without moving itself).
-      GO:0140318 "protein transporter activity" may not be the optimal term; GO:0140309
-      "unfolded protein carrier activity" is more specific and accurate for TIM9 function.
-      However, this IBA is not incorrect and the IDA annotations also use this term, so
-      it is acceptable to keep.
+      TIM9 functions in the Tim9-Tim10 shuttle that directly binds hydrophobic precursors
+      and delivers them through the IMS. Live GO explicitly cites the soluble Tim9-Tim10
+      complex as an example of GO:0140318 protein transporter activity. GO:0140309
+      unfolded protein holdase activity adds the substrate-state and anti-aggregation
+      dimension, but does not invalidate this transporter annotation.
     action: ACCEPT
     reason: >-
-      While GO:0140309 "unfolded protein carrier activity" would be more precise for TIM9
-      (as a carrier-holdase rather than a transporter), GO:0140318 is not incorrect -- TIM9
-      does facilitate protein delivery between compartments. The IBA annotation is phylogenetically
-      sound. The more specific annotation to GO:0140309 is proposed as a NEW annotation below.
+      GO:0140318 precisely captures TIM9's directed binding and delivery of precursor
+      proteins between TOM-side intermediates and downstream insertases. It is retained
+      as a core activity alongside the more specific holdase annotation.
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      source_entities:
+      - source_id: PANTHER:PTN004407763
+        source_label: PANTHER:PTN004407763
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          GOA retains this MF IBA, but current PAINT no longer carries GO:0140318 at
+          PTN004407763; direct target IDA and IGI rows independently support the activity.
+      - source_id: SGD:S000007256
+        source_label: TIM9
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          The target's own experimental annotation validly grounded the ancestral call;
+          target-in-own-WITH/FROM is not circular.
     supported_by:
     - reference_id: PMID:9822593
       supporting_text: >-
@@ -158,11 +217,12 @@ existing_annotations:
       Translocation). TIM9 participates in protein transport across the IMS. This is a
       general parent term; the more specific GO:0045039 (protein insertion into mitochondrial
       inner membrane) is also annotated.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      While broad, this IEA is not incorrect. TIM9 does participate in protein transport.
-      The more specific annotations to GO:0045039 provide the necessary precision. Keeping
-      this general IEA is fine alongside the specific experimental annotations.
+      This umbrella is correct, but it is less informative than the reviewed transporter,
+      holdase, and inner-membrane-insertion terms. It also accommodates the less directly
+      documented SAM-directed route, so it is retained as non-core rather than narrowed
+      to only one destination.
     supported_by:
     - reference_id: UniProt:O74700
       supporting_text: >-
@@ -247,7 +307,7 @@ existing_annotations:
       GO:0005515 "protein binding" is too vague and does not capture the specific functional
       interaction. TIM9 interacts with TIM10 to form the functional hexameric chaperone
       complex, and also binds to substrate carrier proteins during transit. The specific
-      functions (unfolded protein carrier activity, complex membership) are captured by
+      functions (unfolded protein holdase activity, complex membership) are captured by
       other annotations. Per curation guidelines, "protein binding" should be avoided in
       favor of more informative MF terms. Falcon deep research notes that within the
       complex Tim10 provides the key substrate-binding elements (Tim9 alone does not bind
@@ -464,11 +524,10 @@ existing_annotations:
       carrier proteins and can be cross-linked to partly translocated carrier proteins.
     action: ACCEPT
     reason: >-
-      TIM9 does facilitate protein delivery across the IMS. The term GO:0140318 captures
-      the transporter aspect. While GO:0140309 "unfolded protein carrier activity" would be
-      more precise (as TIM9 moves with its cargo rather than facilitating movement without
-      moving), this annotation is not incorrect. The more specific GO:0140309 is proposed
-      as a NEW annotation.
+      GO:0140318 directly describes binding a protein and delivering it to a cellular
+      location, and its live ontology comment explicitly names the soluble Tim9-Tim10
+      shuttle as an example. The complementary GO:0140309 NEW annotation captures the
+      holdase/anti-aggregation dimension rather than replacing this transporter activity.
     supported_by:
     - reference_id: PMID:9822593
       supporting_text: >-
@@ -593,14 +652,16 @@ existing_annotations:
       IDA annotation for TIM22 complex membership based on Sirrenberg et al. (1998), who
       showed that Tim10 and Tim12 (and by extension Tim9) interact with precursors and
       are part of a complex with Tim22 that mediates inner membrane insertion. While Tim9
-      was not directly characterized in this specific paper (it was not yet discovered),
-      Tim9 was subsequently shown to be part of the TIM22 300 kDa complex (PMID:9822593,
-      PMID:9889188).
+      is annotated to this complex. The cached paper is abstract-only and foregrounds
+      Tim10 and Tim12 rather than Tim9, so it cannot by itself verify the TIM9 assay;
+      subsequent direct studies place Tim9 in the TIM22-associated 300 kDa complex
+      (PMID:9822593, PMID:9889188).
     action: ACCEPT
     reason: >-
-      TIM9 is a peripheral subunit of the TIM22 complex via its association with Tim10 and
-      Tim12. The 300 kDa membrane complex containing Tim22, Tim54, Tim18, Tim12, Tim10,
-      and Tim9 is well-established. ComplexPortal entry CPX-1629 lists TIM9 as a component.
+      TIM9 is a peripheral TIM22-pathway component via its association with Tim10 and
+      Tim12. The annotation is independently supported by PMID:9822593, while the
+      abstract-only original reference is not overinterpreted or treated as disproving
+      the curator's inaccessible full-text evidence.
     supported_by:
     - reference_id: PMID:9495346
       supporting_text: >-
@@ -704,30 +765,28 @@ existing_annotations:
       IDA annotation for unfolded protein binding based on Vial et al. (2002), who demonstrated
       that the reconstituted Tim9-Tim10 complex binds to the physiological substrate ADP/ATP
       carrier (AAC) and displays chaperone activity in refolding the model substrate firefly
-      luciferase. TIM9 is the canonical carrier-holdase: it binds unfolded/hydrophobic protein
+      luciferase. TIM9 contributes to the canonical carrier-holdase complex: it binds unfolded/hydrophobic protein
       precursors AND escorts them across the mitochondrial IMS from the TOM complex to the
       TIM22 complex. GO:0051082 "unfolded protein binding" captures only the binding aspect
-      but misses the essential carrier/escort function. GO:0140309 "unfolded protein carrier
+      but misses the essential carrier/escort function. GO:0140309 "unfolded protein holdase
       activity" was created specifically for this class of proteins (go-ontology#30552) and
       is the correct replacement term.
     action: MODIFY
     reason: >-
-      TIM9 (as part of the Tim9-Tim10 complex) is the textbook carrier-holdase: it binds
+      TIM9 (as part of the Tim9-Tim10 complex) contributes to a textbook carrier-holdase: it binds
       unfolded hydrophobic precursor proteins AND escorts them between cellular compartments
-      (from TOM to TIM22/SAM across the IMS). GO:0051082 "unfolded protein binding" captures
-      only the binding aspect. GO:0140309 "unfolded protein carrier activity" was created in
-      Nov 2025 specifically for TIM carrier-holdases (go-ontology#30552). Its definition --
-      "A protein carrier activity that binds to a protein in an unfolded state and escorts it
-      between two different cellular components. The unfolded protein carrier prevents
-      aggregation of the target protein" -- precisely describes TIM9 function. This is a
-      child of GO:0140597 "protein carrier chaperone" and GO:0140104 "molecular carrier
-      activity." The Tim9-Tim10 complex acts as a "chaperone-like protein that protects the
-      hydrophobic precursors from aggregation and guides them through the mitochondrial
-      intermembrane space" (UniProt). PMID:12138093 shows the reconstituted complex is
+      (principally from TOM to TIM22 across the IMS). GO:0051082 "unfolded protein binding" captures
+      only the binding aspect. GO:0140309 "unfolded protein holdase activity" was created in
+      Nov 2025 specifically for TIM carrier-holdases (go-ontology#30552). The current
+      definition emphasizes binding an unfolded client, escorting it to an
+      acceptor or location, and preventing aggregation. The Tim9-Tim10 complex acts as a
+      chaperone-like protein that protects hydrophobic precursors from aggregation and
+      guides them through the mitochondrial
+      intermembrane space (UniProt). PMID:12138093 shows the reconstituted complex is
       functional because it binds AAC and displays chaperone activity.
     proposed_replacement_terms:
     - id: GO:0140309
-      label: unfolded protein carrier activity
+      label: unfolded protein holdase activity
     supported_by:
     - reference_id: PMID:12138093
       supporting_text: >-
@@ -749,10 +808,10 @@ existing_annotations:
       supporting_text: |-
         TIM9·10 recognizes hydrophobic clients primarily through a **hydrophobic cleft** formed by chaperone helices
 
-# --- NEW annotation: unfolded protein carrier activity ---
+# --- NEW annotation: unfolded protein holdase activity ---
 - term:
     id: GO:0140309
-    label: unfolded protein carrier activity
+    label: unfolded protein holdase activity
   evidence_type: IDA
   original_reference_id: PMID:12138093
   review:
@@ -760,8 +819,10 @@ existing_annotations:
       NEW annotation. TIM9 (as part of the Tim9-Tim10 hexameric complex) is the canonical
       carrier-holdase for which GO:0140309 was created (go-ontology#30552). The Tim9-Tim10
       complex binds unfolded hydrophobic transmembrane protein precursors and escorts them
-      from the TOM complex across the IMS to the TIM22 complex (for inner membrane insertion)
-      or to the SAM complex (for beta-barrel assembly). Vial et al. (2002, PMID:12138093)
+      from the TOM complex across the IMS to the TIM22 complex for inner membrane insertion.
+      Small Tim complexes have also been implicated in some SAM-directed beta-barrel
+      precursor delivery, but that is not required for this NEW assertion. Vial et al.
+      (2002, PMID:12138093)
       showed the reconstituted Tim9-Tim10 complex binds the ADP/ATP carrier substrate and
       displays chaperone activity. Multiple studies demonstrate the carrier/escort function:
       the complex guides hydrophobic proteins through the aqueous IMS (PMID:9822593), mediates
@@ -769,7 +830,7 @@ existing_annotations:
       to multiple insertion sites (PMID:10469659).
     action: NEW
     reason: >-
-      GO:0140309 "unfolded protein carrier activity" was created specifically for TIM
+      GO:0140309 "unfolded protein holdase activity" was created specifically for TIM
       carrier-holdases. TIM9 is the founding member of this functional class. This term
       is not currently annotated to TIM9 in GOA despite being the most precise MF term
       for its chaperone function. It should be added as a new annotation.
@@ -867,6 +928,14 @@ references:
 - id: PMID:19037698
   title: The Dutch multicenter experience of the endo-sponge treatment for anastomotic
     leakage after colorectal surgery.
+  is_invalid: true
+  reference_review:
+    relevance: NONE
+    correctness: WRONG_IDENTIFIER
+    review_notes: >-
+      The cached full text is an unrelated colorectal-surgery paper and cannot support
+      TIM9 IMS localization. The term is independently correct; PMID:19037098 is the
+      plausible transposed identifier.
   findings:
   - statement: >-
       NOTE: This PMID appears to be a data entry error in the GOA. It is about colorectal
@@ -994,10 +1063,10 @@ core_functions:
   description: >-
     TIM9 functions as part of the Tim9-Tim10 hexameric carrier-holdase complex that binds
     unfolded hydrophobic transmembrane protein precursors and escorts them from the TOM
-    complex across the aqueous IMS to the TIM22 complex for inner membrane insertion, or
-    to the SAM complex for outer membrane beta-barrel assembly. This carrier-holdase
-    activity -- binding unfolded proteins AND transporting them between compartments --
-    is the core molecular function of TIM9.
+    complex across the aqueous IMS to the TIM22 complex for inner membrane insertion.
+    The substrate shielding/anti-aggregation dimension is the defining specificity of
+    this holdase activity; a possible SAM-directed route is secondary and less directly
+    documented in the cached TIM9 literature.
   directly_involved_in:
   - id: GO:0045039
     label: protein insertion into mitochondrial inner membrane
@@ -1007,3 +1076,59 @@ core_functions:
   in_complex:
     id: GO:0042719
     label: mitochondrial intermembrane space chaperone complex
+  supported_by:
+  - reference_id: PMID:12138093
+    supporting_text: >-
+      the reconstituted TIM10 complex is functional because it bound to the physiological
+      substrate ADP/ATP carrier and displayed chaperone activity in refolding the model
+      substrate firefly luciferase.
+  - reference_id: PMID:9822593
+    supporting_text: >-
+      Tim9p is a new subunit of the TIM machinery that guides hydrophobic inner membrane
+      proteins across the aqueous intermembrane space.
+- molecular_function:
+    id: GO:0140318
+    label: protein transporter activity
+  description: >-
+    TIM9 contributes to the Tim9-Tim10 protein shuttle that directly binds mitochondrial
+    carrier precursors at TOM-side intermediates and delivers them through the IMS toward
+    downstream membrane insertion machinery. This directed delivery is a core activity
+    distinct in emphasis from the substrate-state-specific holdase term.
+  directly_involved_in:
+  - id: GO:0045039
+    label: protein insertion into mitochondrial inner membrane
+  locations:
+  - id: GO:0005758
+    label: mitochondrial intermembrane space
+  in_complex:
+    id: GO:0042719
+    label: mitochondrial intermembrane space chaperone complex
+  supported_by:
+  - reference_id: PMID:9822593
+    supporting_text: >-
+      Tim9p is a new subunit of the TIM machinery that guides hydrophobic inner membrane
+      proteins across the aqueous intermembrane space.
+
+proposed_new_terms: []
+
+suggested_questions:
+- question: >-
+    What proportion of TIM9 client handling is directed to TIM22 versus SAM in vivo,
+    and which individual beta-barrel precursors require the Tim9-Tim10 complex?
+- question: >-
+    How do Tim9's structural contribution to the heterohexamer and Tim10's stronger
+    isolated AAC-binding capacity partition client recognition within the intact complex?
+
+suggested_experiments:
+- description: >-
+    Perform time-resolved crosslinking of endogenous Tim9 and Tim10 during synchronized
+    import of carrier and beta-barrel precursor panels, quantifying handoff to TIM22 or SAM.
+  hypothesis: >-
+    Tim9-Tim10 directly handles both client classes, but TIM22-directed carrier delivery
+    is the dominant and most robust TIM9-dependent route.
+- description: >-
+    Reconstitute Tim9-Tim10 complexes carrying interface-preserving Tim9 client-contact
+    mutations and measure complex assembly, aggregation suppression, and precursor delivery.
+  hypothesis: >-
+    Tim9 contributes client-contact surfaces beyond its structural role, even though
+    isolated Tim10 shows stronger AAC binding than isolated Tim9.

--- a/genes/yeast/TIM9/TIM9-notes.md
+++ b/genes/yeast/TIM9/TIM9-notes.md
@@ -1,0 +1,55 @@
+# TIM9 review notes
+
+## 2026-08-28 dedicated re-review
+
+- All 29 physical GOA rows correspond to 29 distinct term/evidence/reference/
+  qualifier signatures and are represented in `existing_annotations`. One
+  evidence-supported NEW annotation adds GO:0140309.
+
+- TIM9 and TIM10 form the soluble IMS chaperone shuttle, but their roles are not
+  assumed to be identical at the subunit level. The intact complex binds carrier
+  precursor and exhibits chaperone activity [PMID:12138093, “the reconstituted
+  TIM10 complex is functional because it bound to the physiological substrate
+  ADP/ATP carrier and displayed chaperone activity in refolding the model
+  substrate firefly luciferase.”]. Deep research notes that isolated Tim10 binds
+  AAC more strongly than isolated Tim9, supporting a comparatively stronger
+  structural contribution from Tim9 while retaining a functional role in the
+  assembled holdase/transporter.
+
+- Live QuickGO calls GO:0140309 `unfolded protein holdase activity`; the former
+  `unfolded protein carrier activity` is an exact synonym. The term covers binding
+  an unfolded client, preventing its aggregation, and escorting it to an acceptor
+  or location. GO:0140318 remains independently appropriate and core because its
+  definition is direct protein binding plus delivery to a cellular location, and
+  its ontology comment explicitly cites the soluble Tim9-Tim10 shuttle.
+
+- All three GOA IBA rows use PTN004407763. The current cached PAINT table retains
+  this node but now carries only GO:0042719 IMS chaperone-complex membership;
+  GO:0005743, GO:0045039, and GO:0140318 are absent. Each GOA IBA therefore records
+  `SOURCE_STALE_OR_MISSING` for the PTN while retaining ACCEPT because direct TIM9
+  experimental annotations independently support all three claims. The target
+  `SGD:S000007256` appearing in WITH/FROM is valid experimental grounding, not
+  circularity.
+
+- The single GO:0005515 IPI is marked over-annotated rather than removed: the
+  Tim9-Tim10 interaction is real, but generic protein binding loses the informative
+  IMS chaperone-complex and transporter context.
+
+- Metal-ion and zinc-binding rows remain over-annotated for mature TIM9. UniProt
+  says zinc coordination during cytoplasmic transit is probable, whereas the mature
+  IMS protein contains two intramolecular disulfides; the RCA zinc-proteome row is
+  motif-based rather than a direct TIM9 zinc-binding assay.
+
+- TIM22-directed carrier delivery is the best directly supported route. UniProt and
+  the deep-research synthesis implicate small Tims in some beta-barrel precursor
+  delivery toward SAM, but the cached TIM9 primary literature reviewed here does not
+  establish that route at the same resolution, so it is described as secondary and
+  remains an experimental question.
+
+- PMID:19037698 is a verified wrong identifier: its cached full text is an unrelated
+  colorectal-surgery paper. The IMS localization is independently established, so
+  the annotation remains ACCEPT while the reference is marked `WRONG_IDENTIFIER`;
+  PMID:19037098 is the plausible transposed identifier.
+
+- Twelve of the thirteen cached PMID records are abstract-only. Experimental rows
+  were not rejected merely because their full assay details were unavailable.


### PR DESCRIPTION
## Summary
- re-review all 29 physical TIM9 GOA annotation signatures and retain an evidence-supported NEW holdase annotation
- distinguish unfolded protein holdase activity from protein transporter activity as complementary core functions
- audit all three IBA rows against PTN004407763 and record their current PAINT sources as stale while retaining independently supported annotations
- flag PMID:19037698 as a wrong identifier, refine TIM22/SAM claims, and add review notes plus focused questions and experiments
- regenerate the TIM9 HTML review and browser payload

## Validation
- `just validate yeast TIM9`
- `just validate-goa yeast TIM9`
- `just render yeast TIM9`
- `just deploy-browser`
- `just refresh-bioreason-benchmark-sidecars`
- `just render-projects`
- targeted BioReason sidecar/publication parity tests (2 passed)
- `just test` (1793 unit tests, 154 doctests, mypy, Ruff)