### PR TITLE
Tighten TIM9 abstract attribution

### DIFF
--- a/genes/yeast/TIM9/TIM9-ai-review.html
+++ b/genes/yeast/TIM9/TIM9-ai-review.html
@@ -3009,7 +3009,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for TIM22 complex membership based on Sirrenberg et al. (1998), who showed that Tim10 and Tim12 (and by extension Tim9) interact with precursors and are part of a complex with Tim22 that mediates inner membrane insertion. Tim9 is annotated to this complex, but the cached paper is abstract-only and foregrounds Tim10 and Tim12 rather than Tim9, so it cannot by itself verify the TIM9 assay; subsequent direct studies place Tim9 in the TIM22-associated 300 kDa complex (PMID:9822593, PMID:9889188).
+                            <strong>Summary:</strong> IDA annotation for TIM22 complex membership based on Sirrenberg et al. (1998), who showed that Tim10 and Tim12 interact with precursors and are part of a complex with Tim22 that mediates inner membrane insertion. Tim9 is annotated to this complex, but the cached paper is abstract-only and foregrounds Tim10 and Tim12 rather than Tim9, so it cannot by itself verify the TIM9 assay; subsequent direct studies place Tim9 in the TIM22-associated 300 kDa complex (PMID:9822593, PMID:9889188).
                         </div>
 
 
@@ -5595,8 +5595,8 @@ existing_annotations:
   review:
     summary: &gt;-
       IDA annotation for TIM22 complex membership based on Sirrenberg et al. (1998), who
-      showed that Tim10 and Tim12 (and by extension Tim9) interact with precursors and
-      are part of a complex with Tim22 that mediates inner membrane insertion. Tim9 is
+      showed that Tim10 and Tim12 interact with precursors and are part of a complex
+      with Tim22 that mediates inner membrane insertion. Tim9 is
       annotated to this complex, but the cached paper is abstract-only and foregrounds
       Tim10 and Tim12 rather than Tim9, so it cannot by itself verify the TIM9 assay;
       subsequent direct studies place Tim9 in the TIM22-associated 300 kDa complex

--- a/genes/yeast/TIM9/TIM9-ai-review.yaml
+++ b/genes/yeast/TIM9/TIM9-ai-review.yaml
@@ -650,8 +650,8 @@ existing_annotations:
   review:
     summary: >-
       IDA annotation for TIM22 complex membership based on Sirrenberg et al. (1998), who
-      showed that Tim10 and Tim12 (and by extension Tim9) interact with precursors and
-      are part of a complex with Tim22 that mediates inner membrane insertion. Tim9 is
+      showed that Tim10 and Tim12 interact with precursors and are part of a complex
+      with Tim22 that mediates inner membrane insertion. Tim9 is
       annotated to this complex, but the cached paper is abstract-only and foregrounds
       Tim10 and Tim12 rather than Tim9, so it cannot by itself verify the TIM9 assay;
       subsequent direct studies place Tim9 in the TIM22-associated 300 kDa complex


### PR DESCRIPTION
## Summary
- remove an unsupported parenthetical inference from the abstract-only PMID:9495346 summary
- preserve the explicit caveat that the cached abstract cannot verify the TIM9 assay
- regenerate the TIM9 review HTML through the public wrapper

## Validation
- `just validate yeast TIM9`
- `just validate-goa yeast TIM9`
- `just render yeast TIM9`
- `just deploy-browser`