### PR TITLE
Re-review yeast TSA1 annotations

### DIFF
--- a/genes/yeast/TSA1/TSA1-ai-review.html
+++ b/genes/yeast/TSA1/TSA1-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -836,6 +836,51 @@
 
 
 
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>in-situ holdase chaperone activity</h3>
+                <span class="vote-buttons" data-g="P34760" data-a="in-situ holdase chaperone activity" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> Binding to an unfolded or misfolded protein to prevent its aggregation at the site where the client is encountered, without requiring escort to an acceptor molecule or another cellular location.</p>
+
+
+
+            <p><strong>Justification:</strong> TSA1 is an ATP-independent, stress-activated holdase whose higher-order oligomers prevent aggregation. GO:0051082 is obsolete; GO:0044183 captures its participation in folding/proteostasis but not the holdase mechanism, while GO:0140309 specifically requires carrier-mediated escort and therefore does not fit TSA1. This is the general ontology gap documented by the UNFOLDED_PROTEIN_BINDING project.</p>
+
+
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/16251355" target="_blank" class="term-link">
+                        PMID:16251355
+                    </a>
+
+
+                    : We propose that Tsa1 normally functions to chaperone misassembled ribosomal proteins, preventing the toxicity that arises from their aggregation.
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
 
 
 
@@ -901,6 +946,37 @@ Consistent with IDA evidence (PMID:18271751) and falcon synthesis.
 acts as the primary cytosolic peroxide sink.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000073874</span>
+
+                                    &middot; PANTHER:PTN000073874
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Current PTHR10681 PAINT places cytosol at this ancestral node. Its
+experimental seeds span bacterial, fungal, fly, mouse and human
+peroxiredoxins; SGD:S000004490 (TSA1) is itself a valid direct seed.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -973,6 +1049,38 @@ hydrogen peroxide catabolic process) better capture the core function.
 annotations represent the precise antioxidant function.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE NON CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000073874</span>
+
+                                    &middot; PANTHER:PTN000073874
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Current PTHR10681 PAINT places this broad stress-response term at the
+same ancestral peroxiredoxin node. The diverse experimental seed set
+includes TSA1 and its yeast paralog TSA2, so transfer is sound but
+less informative than the peroxide-specific processes.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1048,6 +1156,38 @@ inference, biochemistry and structural data.
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000073874</span>
+
+                                    &middot; PANTHER:PTN000073874
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Current PTHR10681 PAINT retains thioredoxin peroxidase activity at
+this node. The seed set includes TSA1, TSA2, fission-yeast Tpx1 and
+experimentally characterized metazoan/protist peroxiredoxins; TSA1&#39;s
+own biochemical evidence correctly grounds the ancestral assertion.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1117,6 +1257,38 @@ Tsa1 is responsible for decomposing the bulk of cellular H2O2.
 function.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000073874</span>
+
+                                    &middot; PANTHER:PTN000073874
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Current PTHR10681 PAINT retains hydrogen peroxide catabolism at this
+node using broad experimental support across peroxiredoxins. TSA1 is
+not listed as a seed for this particular call, but its conserved
+catalytic mechanism and direct assays independently support transfer.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1191,6 +1363,38 @@ thioredoxin-peroxiredoxin redox network.
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000073874</span>
+
+                                    &middot; PANTHER:PTN000073874
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Current PTHR10681 PAINT retains cell redox homeostasis at this node.
+The GOA seed identifiers for the two Arabidopsis loci use older TAIR
+syntax than current PAINT, but the node and biological evidence are
+unchanged; TSA1 is also an experimental seed.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1250,12 +1454,12 @@ thioredoxin-peroxiredoxin redox network.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cellular oxidant detoxification may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> This combined IEA parent term is correct because TSA1 enzymatically removes hydroperoxides.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Retained as a broad non-core parent of the more precise hydrogen peroxide catabolism annotation.
                         </div>
 
 
@@ -1375,12 +1579,12 @@ GO_REF:0000043 SPKW keyword annotations are being retired upstream.)
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> UniProt subcellular-location mapping agrees with multiple direct cytosol/cytoplasm experiments.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Correct core localization; GO:0005829 cytosol supplies the more precise child term.
                         </div>
 
 
@@ -1428,12 +1632,12 @@ GO_REF:0000043 SPKW keyword annotations are being retired upstream.)
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> The ARBA prediction matches TSA1&#39;s directly measured thioredoxin-dependent peroxide reductase activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Correct core molecular function, independently grounded by PMID:7961686.
                         </div>
 
 
@@ -1481,12 +1685,12 @@ GO_REF:0000043 SPKW keyword annotations are being retired upstream.)
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: antioxidant activity may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> InterPro/keyword mapping correctly captures TSA1&#39;s antioxidant role but is less specific than peroxiredoxin activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Broad umbrella activity retained as non-core because catalytic child terms are available.
                         </div>
 
 
@@ -1534,12 +1738,12 @@ GO_REF:0000043 SPKW keyword annotations are being retired upstream.)
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: oxidoreductase activity may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> Oxidoreductase activity is chemically correct but very broad for a characterized thioredoxin-dependent peroxiredoxin.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Retain as a non-core parent rather than obscuring the precise catalytic function.
                         </div>
 
 
@@ -1731,12 +1935,12 @@ MF and protein folding process capture the mechanism more directly.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cell redox homeostasis is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> ARBA inference is concordant with extensive direct evidence for TSA1-dependent peroxide/redox control.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Correct core process of the thioredoxin-peroxiredoxin system.
                         </div>
 
 
@@ -1784,12 +1988,12 @@ MF and protein folding process capture the mechanism more directly.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein stabilization may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> ARBA captures the aggregation-prevention consequence of TSA1&#39;s stress-activated chaperone state.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Correct but less mechanistically informative than protein folding chaperone activity.
                         </div>
 
 
@@ -1992,11 +2196,9 @@ the experimentally characterized thioredoxin-coupled peroxidase activity
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic protein-binding annotation. Tsa1 does form extensive (often
-transient, redox-based) interactions with client proteins - it forms
-mixed-disulfide intermediates (peroxiredoxinylation) with hundreds of
-targets - but the bare &#34;protein binding&#34; term is uninformative and these
-interactions are better captured by the redox/chaperone functions.
+                            <strong>Summary:</strong> The yeast two-hybrid study directly detected TSA1 as a thioredoxin target;
+GOA identifies the partner as TRX2 (P22803). This validates the physical
+interaction but not generic protein binding as a useful function.
                         </div>
 
 
@@ -2014,11 +2216,13 @@ redox-relay/chaperone biology better described by specific MF terms.
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:yeast/TSA1/TSA1-deep-research-falcon.md
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16272220" target="_blank" class="term-link">
+                                        PMID:16272220
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">A 2023 bioRxiv preprint reports that Tsa1 forms widespread covalent mixed disulfide intermediates with cellular proteins, termed **Tsa1-Induced Mixed Disulfide Intermediates (TIMDIs)**, and frames this as a bona fide redox-linked post-translational modification termed **peroxiredoxinylation**.</div>
+                                <div class="support-text">We demonstrate here that, in the CY306 strain, yeast TRX1 and TRX2, as well as Arabidopsis TRX introduced as bait, interact with known TRX targets or putative partners such as yeast peroxiredoxins AHP1 and TSA1, whereas the same interactions cannot be detected in classical Y2H strains.</div>
 
                             </div>
 
@@ -2077,12 +2281,14 @@ redox-relay/chaperone biology better described by specific MF terms.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for TSA1.
+                            <strong>Summary:</strong> The high-throughput complex map reports association with TSA2 (Q04120),
+consistent with peroxiredoxin oligomerization, but GO:0005515 does not
+distinguish this structural association from TSA1&#39;s catalytic activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Retain the interaction evidence while flagging the generic binding term as mechanistically uninformative.
                         </div>
 
 
@@ -2141,12 +2347,14 @@ redox-relay/chaperone biology better described by specific MF terms.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for TSA1.
+                            <strong>Summary:</strong> This binary-interactome row also records TSA2 (Q04120) as partner. The
+interaction can be valid while the generic binding MF remains unsuitable
+as a representation of TSA1&#39;s evolved function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Preserve the experimental interaction but do not elevate generic protein binding to a core function.
                         </div>
 
 
@@ -2205,12 +2413,14 @@ redox-relay/chaperone biology better described by specific MF terms.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for TSA1.
+                            <strong>Summary:</strong> Two physical GOA rows collapse to this signature, with TRX2 (P22803) and
+TSA2 (Q04120) as distinct partners. Both are biologically plausible, but
+GO:0005515 obscures the redox-cycle and oligomerization mechanisms.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Retain both physical observations while treating the generic MF as over-annotated.
                         </div>
 
 
@@ -2638,12 +2848,14 @@ aggregation (PMID:15163410). Selected as one of the core functions.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> tsa1 deletion causes accumulation of aggregated, predominantly ribosomal
+proteins, and the cached abstract attributes protection to Tsa1&#39;s
+chaperone rather than peroxidase function (PMID:16251355).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct genetic evidence supports a core role in protein-folding proteostasis.
                         </div>
 
 
@@ -2702,12 +2914,12 @@ aggregation (PMID:15163410). Selected as one of the core functions.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> The paper directly shows oxidative stress drives Tsa1&#39;s structural and functional switch (PMID:15163410).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Oxidative stress is both substrate context for peroxidase activity and trigger for the chaperone switch.
                         </div>
 
 
@@ -2766,12 +2978,12 @@ aggregation (PMID:15163410). Selected as one of the core functions.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cellular response to heat may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> Heat shock induces high-MW chaperone complexes and Tsa1 enhances heat resistance (PMID:15163410).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Correct stress context, but secondary to the molecular chaperone function it elicits.
                         </div>
 
 
@@ -2830,15 +3042,17 @@ aggregation (PMID:15163410). Selected as one of the core functions.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Tsa1&#39;s holdase activity involves binding unfolded/misfolded proteins. The
-activity-style term protein folding chaperone (GO:0044183) is more
-informative than the simple binding term for this moonlighting function.
+                            <strong>Summary:</strong> The paper directly demonstrates a stress-induced peroxiredoxin-to-chaperone
+switch. GO:0051082 is now obsolete; GO:0044183 accurately captures binding
+that assists protein folding, whereas GO:0140309 is inappropriate because
+Tsa1 prevents aggregation in situ and does not escort clients to a destination.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Replace with the more specific chaperone activity term; both are MF so this
-is a same-aspect refinement, not a cross-aspect change.
+                            <strong>Reason:</strong> Replace the obsolete binding term with protein folding chaperone. The
+experimental annotation is not rejected: its underlying chaperone/holdase
+biology is sound and is represented by the current activity term.
                         </div>
 
 
@@ -2861,11 +3075,13 @@ is a same-aspect refinement, not a cross-aspect change.
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:yeast/TSA1/TSA1-deep-research-falcon.md
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15163410" target="_blank" class="term-link">
+                                        PMID:15163410
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">This supports a functional switch where hyperoxidized Tsa1 acts as a **stress-activated chaperone adaptor** to recruit the protein quality control machinery.</div>
+                                <div class="support-text">We show here that two cytosolic yeast Prxs, cPrxI and II, which display diversity in structure and apparent molecular weights (MW), can act alternatively as peroxidases and molecular chaperones.</div>
 
                             </div>
 
@@ -2924,12 +3140,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cellular response to dithiothreitol may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> tsa1 mutants are DTT-sensitive and accumulate ribosomal-protein aggregates under DTT stress (PMID:16251355).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Experimentally supported reductive-stress context, not a defining core function.
                         </div>
 
 
@@ -2988,12 +3204,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> High-MW Tsa1 complexes display molecular-chaperone activity during oxidative or heat stress (PMID:15163410).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> This CAFA-assigned IMP signature is biologically consistent with the paper&#39;s direct chaperone evidence.
                         </div>
 
 
@@ -3052,12 +3268,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> The paper demonstrates the low-MW Tsa1 state is the peroxidase-dominant form (PMID:15163410).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Core catalytic activity independently established by direct biochemical studies.
                         </div>
 
 
@@ -3116,12 +3332,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cellular response to heat may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> Heat shock triggers the peroxidase-to-chaperone switch and Tsa1-dependent resistance (PMID:15163410).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Valid contextual phenotype, subordinate to the core chaperone activity.
                         </div>
 
 
@@ -3180,12 +3396,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: identical protein binding is too generic or over-extended for TSA1.
+                            <strong>Summary:</strong> Tsa1 forms high-MW homo-oligomeric assemblies, but an IMP code does not directly assay identical-protein binding.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Oligomerization is real, yet the generic binding term and evidence assignment do not capture the chaperone switch.
                         </div>
 
 
@@ -3244,12 +3460,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cell redox homeostasis is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> Tsa1&#39;s peroxide-sensing catalytic cysteine couples redox state to a reversible functional switch (PMID:15163410).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Consistent with TSA1&#39;s core role in the thioredoxin-peroxiredoxin redox network.
                         </div>
 
 
@@ -3308,12 +3524,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein stabilization may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> The stress-induced high-MW chaperone state stabilizes aggregation-prone proteins (PMID:15163410).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Valid downstream consequence of holdase activity, but less mechanistically specific.
                         </div>
 
 
@@ -3372,12 +3588,15 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for TSA1.
+                            <strong>Summary:</strong> The genetic evidence supports Tsa1&#39;s aggregation-preventing chaperone role,
+but GO:0051082 is obsolete. GO:0044183 is the current evidence-matched
+activity term; GO:0140309 would incorrectly imply carrier-mediated escort.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Preserve the experimentally supported chaperone biology while replacing
+the obsolete binding term with protein folding chaperone.
                         </div>
 
 
@@ -3393,6 +3612,24 @@ is a same-aspect refinement, not a cross-aspect change.
 
                         </div>
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15163410" target="_blank" class="term-link">
+                                        PMID:15163410
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The chaperone function of these proteins enhances yeast resistance to heat shock.</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -3447,12 +3684,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein polymerization may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> Oxidative stress and heat drive formation of high-MW Tsa1 complexes (PMID:15163410).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Describes the regulatory oligomerization state rather than TSA1&#39;s core catalytic or chaperone activity.
                         </div>
 
 
@@ -3511,12 +3748,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cellular response to hydroperoxide may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> The peroxidatic cysteine acts as an H2O2 sensor that drives Tsa1&#39;s stress-dependent switch (PMID:15163410).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Correct peroxide-specific stress response, but subordinate to peroxidase and chaperone functions.
                         </div>
 
 
@@ -3575,12 +3812,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> A chaperone-only Tsa1 allele rescues zinc-deficient growth, and holdase overexpression phenocopies rescue (PMID:24022485 abstract).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct physiological genetic evidence supports the core chaperone/proteostasis role.
                         </div>
 
 
@@ -3639,12 +3876,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: DNA damage checkpoint signaling may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> tsa1 loss activates the DNA-damage checkpoint and alters dNTP homeostasis (PMID:19851444).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Valid downstream consequence of genome instability, not a direct checkpoint activity of Tsa1.
                         </div>
 
 
@@ -3703,12 +3940,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> The isoenzyme study explicitly identifies TSA1/cTPxI as a cytoplasmic thiol peroxidase (PMID:10681558).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct localization evidence supports the core cytoplasmic compartment.
                         </div>
 
 
@@ -3767,12 +4004,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> Cytosolic and mitochondrial fractionation identifies TSA1 as cytosolic (PMID:8344960).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct experimental localization agrees with UniProt and the cytosol IBA.
                         </div>
 
 
@@ -3831,12 +4068,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytosol is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> Tsa1 is present in the cytosol and additionally associates with actively translating ribosomes (PMID:18271751).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Core localization supported by direct fractionation/localization work.
                         </div>
 
 
@@ -3895,12 +4132,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> Purified TSA1 reduces H2O2 and alkyl hydroperoxides using thioredoxin, thioredoxin reductase and NADPH (PMID:7961686).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct biochemical demonstration of TSA1&#39;s defining molecular function.
                         </div>
 
 
@@ -3959,12 +4196,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> Loss-of-function catalytic-cysteine analysis complements the purified-enzyme evidence for thioredoxin peroxidase activity (PMID:7961686).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Mutant phenotype/mechanism supports the same core catalytic function.
                         </div>
 
 
@@ -4023,12 +4260,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> The study characterizes TSA1 as an NADPH/thioredoxin-dependent peroxidase in cellular heat-stress defense (PMID:9799566).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Experimental enzymology and phenotype support the core activity.
                         </div>
 
 
@@ -4087,12 +4324,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> tsa1 disruption causes thermosensitivity and excess peroxide/protein oxidation, supporting its peroxidase role (PMID:9799566).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Genetic evidence independently supports the core enzymatic function.
                         </div>
 
 
@@ -4151,12 +4388,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: response to hydroperoxide may be context-dependent or peripheral for TSA1.
+                            <strong>Summary:</strong> tsa1 deletion is sensitive to both organic hydroperoxide and H2O2, and purified Tsa1 removes both substrates (PMID:15210711).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Correct general stress response, but less specific than peroxide catabolism and cellular response to oxidative stress.
                         </div>
 
 
@@ -4215,12 +4452,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> Peroxiredoxin-null cells are oxidant-sensitive, and TSA1 rescues the mutator phenotype in a catalytic-site-dependent manner (PMID:15051715).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct genetic evidence supports TSA1 as a core oxidative-stress effector.
                         </div>
 
 
@@ -4279,12 +4516,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> Tsa1 protects cytosol and active ribosomes from endogenous ROS and shifts toward chaperone function under peroxide stress (PMID:18271751).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Central experimentally supported oxidative-stress role.
                         </div>
 
 
@@ -4343,12 +4580,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> tsa1 disruption impairs aerobic growth and peroxide resistance, demonstrating an antioxidant-stress role (PMID:8344960).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Foundational direct evidence for TSA1&#39;s core oxidative-stress function.
                         </div>
 
 
@@ -4407,12 +4644,12 @@ is a same-aspect refinement, not a cross-aspect change.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> The tsa1 mutant&#39;s oxidant-sensitive phenotype supports a required cellular response to oxidative stress (PMID:8344960).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Core process directly linked to loss of TSA1.
                         </div>
 
 
@@ -4639,12 +4876,12 @@ cytosolic peroxidase/chaperone activities.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cell redox homeostasis is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> TSA1 is a cytosolic thiol-specific antioxidant required for peroxide defense (PMID:8344960).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct evidence is consistent with its core role in cellular redox homeostasis.
                         </div>
 
 
@@ -4703,12 +4940,12 @@ cytosolic peroxidase/chaperone activities.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cell redox homeostasis is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> Disruption of TSA1 perturbs oxidant resistance, genetically supporting redox homeostasis (PMID:8344960).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Core downstream process of the thioredoxin-dependent peroxidase reaction.
                         </div>
 
 
@@ -4767,12 +5004,12 @@ cytosolic peroxidase/chaperone activities.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cell redox homeostasis is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> tsa1 mutants accumulate peroxide and oxidatively damaged proteins during heat stress (PMID:9799566).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Genetic evidence supports the core redox-homeostasis process.
                         </div>
 
 
@@ -4831,12 +5068,15 @@ cytosolic peroxidase/chaperone activities.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for TSA1.
+                            <strong>Summary:</strong> The cached abstract directly attributes aggregate prevention to Tsa1&#39;s
+chaperone function. Because GO:0051082 is obsolete, GO:0044183 is the best
+current activity term; the carrier-specific GO:0140309 does not fit.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> The experiment supports chaperone-assisted proteostasis, so retain the
+biological assertion through an evidence-matched same-aspect replacement.
                         </div>
 
 
@@ -4852,6 +5092,24 @@ cytosolic peroxidase/chaperone activities.
 
                         </div>
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16251355" target="_blank" class="term-link">
+                                        PMID:16251355
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We propose that Tsa1 normally functions to chaperone misassembled ribosomal proteins, preventing the toxicity that arises from their aggregation.</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -4906,12 +5164,12 @@ cytosolic peroxidase/chaperone activities.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: peroxiredoxin activity is consistent with known biology of TSA1.
+                            <strong>Summary:</strong> Competitive kinetics directly measure rapid Tsa1 reactions with H2O2 and peroxynitrite (PMID:17210445).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct kinetic evidence supports peroxiredoxin activity as a core function.
                         </div>
 
 
@@ -5264,6 +5522,17 @@ damaged aggregates; reactivation requires reduction by sulfiredoxin Srx1.</h3>
                 <div class="reference-title">Two enzymes in one; two yeast peroxiredoxins display oxidative stress-dependent switching from a peroxidase to a molecular chaperone function.</div>
 
 
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Oxidative stress and heat shock switch yeast cytosolic peroxiredoxins from peroxidase to molecular-chaperone function.</div>
+
+                        <div class="finding-text">"Oxidative stress and heat shock exposure of yeasts causes the protein structures of cPrxI and II to shift from low MW species to high MW complexes. This triggers a peroxidase-to-chaperone functional switch."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
 
             <div class="reference-item">
@@ -5295,6 +5564,17 @@ damaged aggregates; reactivation requires reduction by sulfiredoxin Srx1.</h3>
 
                 <div class="reference-title">The thioredoxin system protects ribosomes against stress-induced aggregation.</div>
 
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Tsa1&#39;s chaperone function prevents aggregation of misassembled ribosomal proteins during reductive stress.</div>
+
+                        <div class="finding-text">"We propose that Tsa1 normally functions to chaperone misassembled ribosomal proteins, preventing the toxicity that arises from their aggregation."</div>
+
+                    </li>
+
+                </ul>
 
             </div>
 
@@ -5439,6 +5719,17 @@ damaged aggregates; reactivation requires reduction by sulfiredoxin Srx1.</h3>
 
                 <div class="reference-title">Peroxiredoxin chaperone activity is critical for protein homeostasis in zinc-deficient yeast.</div>
 
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Tsa1 chaperone activity, rather than peroxidase activity, is critical for proteostasis in zinc-deficient yeast.</div>
+
+                        <div class="finding-text">"In this report, we show that Tsa1 chaperone, and not peroxidase, activity is the more critical function in zinc-deficient cells."</div>
+
+                    </li>
+
+                </ul>
 
             </div>
 
@@ -5639,11 +5930,92 @@ thioredoxin-peroxiredoxin system into a proteome-thiol buffering circuit.</div>
 
 
 
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which endogenous client proteins are directly bound by the high-molecular-weight Tsa1 holdase, and which contacts instead reflect redox-linked mixed disulfides?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P34760" data-a="Q: Which endogenous client proteins are directly boun..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Tsa1 merely hold aggregation-prone clients for Hsp70/Hsp104, or can it directly promote productive folding of particular substrates?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P34760" data-a="Q: Does Tsa1 merely hold aggregation-prone clients fo..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare wild-type Tsa1 with peroxidase-only and chaperone-only separation-of-function alleles using stress-resolved client crosslinking, aggregation assays and recovery of native client activity.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: High-molecular-weight Tsa1 directly stabilizes a defined client set without catalyzing refolding, and productive recovery requires downstream Hsp70/Hsp104.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P34760" data-a="EXPERIMENT: Compare wild-type Tsa1 with peroxidase-only and ch..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute Tsa1-client complexes in vitro and separately measure aggregation suppression, spontaneous refolding and transfer to Ssa1/Hsp104.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Tsa1 behaves as an in-situ holdase rather than the carrier/escort activity defined by GO:0140309.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P34760" data-a="EXPERIMENT: Reconstitute Tsa1-client complexes in vitro and se..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
 
 
 
 
 
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">UPB</span>
+
+        </div>
+    </div>
 
 
     <!-- Computational Predictions Section -->
@@ -5984,6 +6356,93 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TSA1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P34760" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tsa1-annotation-re-review-notes">TSA1 annotation re-review notes</h1>
+<h2 id="2026-08-28-dedicated-re-review">2026-08-28 dedicated re-review</h2>
+<p>TSA1 (P34760; SGD:S000004490) is the major cytosolic typical 2-Cys<br />
+peroxiredoxin in budding yeast. Its primary catalytic function is reduction of<br />
+hydrogen peroxide and organic hydroperoxides with reducing equivalents supplied<br />
+by thioredoxin [PMID:7961686, "The 25-kDa enzyme is now shown to be a peroxidase<br />
+that reduces H2O2 and alkyl hydroperoxides with the use of hydrogens provided by<br />
+thioredoxin, thioredoxin reductase, and NADPH."].</p>
+<p>Tsa1 also has a stress-dependent chaperone function. Oxidative stress and heat<br />
+shock shift the protein into high-molecular-weight assemblies and switch the<br />
+dominant activity from peroxidase to chaperone [PMID:15163410, "Oxidative stress<br />
+and heat shock exposure of yeasts causes the protein structures of cPrxI and II<br />
+to shift from low MW species to high MW complexes. This triggers a<br />
+peroxidase-to-chaperone functional switch."]. Genetic evidence connects that<br />
+activity to prevention of ribosomal-protein aggregation [PMID:16251355, "We<br />
+propose that Tsa1 normally functions to chaperone misassembled ribosomal<br />
+proteins, preventing the toxicity that arises from their aggregation."], and a<br />
+separate study establishes that chaperone activity is especially important in<br />
+zinc-deficient cells [PMID:24022485, "In this report, we show that Tsa1<br />
+chaperone, and not peroxidase, activity is the more critical function in<br />
+zinc-deficient cells."]. All three cached records are abstract-only, so the<br />
+review accepts their explicit abstract-level conclusions without inventing<br />
+assay details from inaccessible full text.</p>
+<h3 id="goa-reconciliation">GOA reconciliation</h3>
+<p>The cached GOA contains 68 physical rows and 60 qualifier-aware signatures<br />
+(qualifier + GO term + evidence code + reference). Four signatures collapse<br />
+multiple physical rows: PMID:37968396 protein binding has two interaction<br />
+partners, PMID:15163410 protein folding IDA occurs twice, and the IGI rows for<br />
+PMID:19851444 and PMID:15051715 each have four distinct WITH/FROM partners. The<br />
+review represents each exact signature once, as required by the current review<br />
+schema; <code>just validate-goa yeast TSA1</code> checks this reconciliation. All physical<br />
+rows use positive relation qualifiers (enables, involved_in, located_in,<br />
+is_active_in); there are no NOT annotations or isoform-specific rows.</p>
+<p>The four IPI protein-binding signatures were retained only as<br />
+MARK_AS_OVER_ANNOTATED because the generic term does not describe Tsa1's<br />
+peroxidase, redox-transfer or chaperone mechanisms. The two PMID:37968396 rows<br />
+correspond separately to TRX2 (P22803) and TSA2 (Q04120), rather than a duplicate<br />
+curation accident.</p>
+<h3 id="paint-audit">PAINT audit</h3>
+<p>All five IBA annotations descend from PTHR10681 node PTN000073874. Current<br />
+<code>PTHR10681-paint.tsv</code> retains that same node for cytosol (GO:0005829),<br />
+thioredoxin peroxidase activity (GO:0008379), response to oxidative stress<br />
+(GO:0006979), hydrogen peroxide catabolic process (GO:0042744), and cell redox<br />
+homeostasis (GO:0045454). TSA1 itself is an experimental seed for four of these<br />
+five calls; this is valid target-grounded IBD evidence, not circularity. The<br />
+hydrogen-peroxide-catabolism call is seeded by other experimentally<br />
+characterized peroxiredoxins and is independently supported by TSA1<br />
+biochemistry. The only source-format drift is that current PAINT writes the two<br />
+Arabidopsis redox-homeostasis seeds as AGI_LocusCode identifiers whereas cached<br />
+GOA writes TAIR:locus identifiers. No node-placement failure or target-specific<br />
+loss/divergence was found.</p>
+<h3 id="obsolete-unfolded-protein-term">Obsolete unfolded-protein term</h3>
+<p>Live QuickGO was checked on 2026-08-28. GO:0051082 is obsolete. GO:0044183 is<br />
+current and defined as binding a protein or complex to assist protein folding;<br />
+it is therefore an evidence-matched replacement for the papers that explicitly<br />
+call Tsa1 a molecular chaperone and annotate protein folding. GO:0140309 is<br />
+currently labelled "unfolded protein holdase activity," but its unchanged<br />
+definition requires escorting the client to an acceptor or specific location.<br />
+Tsa1 prevents aggregation in situ and is not a carrier, so GO:0140309 was not<br />
+used. A general in-situ holdase activity remains an ontology gap; the review<br />
+records this as a proposed new term while retaining GO:0044183 as the available<br />
+current chaperone activity.</p>
+<p>The final synthesis treats thioredoxin-dependent peroxiredoxin activity and the<br />
+stress-activated chaperone/holdase switch as TSA1's two core functions. Broad<br />
+parents, heat/zinc/DTT contexts, genome protection, gluconeogenic regulation,<br />
+ribosome association and generic binding are retained as non-core or<br />
+over-annotated rather than promoted into the core-function summary.</p>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5995,7 +6454,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P34760
 gene_symbol: TSA1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -6015,6 +6474,8 @@ description: &gt;-
   ribosomes as an antioxidant, protects against oxidative damage caused by
   nascent-protein misfolding, and is required for telomere length maintenance.
   Orthologous to human PRDX1/PRDX2.
+tags:
+- UPB
 existing_annotations:
 - term:
     id: GO:0005829
@@ -6030,6 +6491,16 @@ existing_annotations:
     reason: |-
       Core localization. Tsa1 is one of the most abundant cytosolic proteins and
       acts as the primary cytosolic peroxide sink.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000073874
+        source_label: PANTHER:PTN000073874
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          Current PTHR10681 PAINT places cytosol at this ancestral node. Its
+          experimental seeds span bacterial, fungal, fly, mouse and human
+          peroxiredoxins; SGD:S000004490 (TSA1) is itself a valid direct seed.
     additional_reference_ids:
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
@@ -6050,6 +6521,17 @@ existing_annotations:
     reason: |-
       Correct but general parent term; retained as non-core because more specific
       annotations represent the precise antioxidant function.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000073874
+        source_label: PANTHER:PTN000073874
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          Current PTHR10681 PAINT places this broad stress-response term at the
+          same ancestral peroxiredoxin node. The diverse experimental seed set
+          includes TSA1 and its yeast paralog TSA2, so transfer is sound but
+          less informative than the peroxide-specific processes.
     additional_reference_ids:
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
@@ -6071,6 +6553,17 @@ existing_annotations:
     reason: |-
       Defining enzymatic activity of TSA1, well supported across phylogenetic
       inference, biochemistry and structural data.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000073874
+        source_label: PANTHER:PTN000073874
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          Current PTHR10681 PAINT retains thioredoxin peroxidase activity at
+          this node. The seed set includes TSA1, TSA2, fission-yeast Tpx1 and
+          experimentally characterized metazoan/protist peroxiredoxins; TSA1&#39;s
+          own biochemical evidence correctly grounds the ancestral assertion.
     additional_reference_ids:
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
@@ -6090,6 +6583,17 @@ existing_annotations:
     reason: |-
       Direct downstream process of the peroxidase activity; central to TSA1
       function.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000073874
+        source_label: PANTHER:PTN000073874
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          Current PTHR10681 PAINT retains hydrogen peroxide catabolism at this
+          node using broad experimental support across peroxiredoxins. TSA1 is
+          not listed as a seed for this particular call, but its conserved
+          catalytic mechanism and direct assays independently support transfer.
     additional_reference_ids:
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
@@ -6110,6 +6614,17 @@ existing_annotations:
     reason: |-
       Well supported as a core function; Tsa1 is a central node of the cytosolic
       thioredoxin-peroxiredoxin redox network.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000073874
+        source_label: PANTHER:PTN000073874
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          Current PTHR10681 PAINT retains cell redox homeostasis at this node.
+          The GOA seed identifiers for the two Arabidopsis loci use older TAIR
+          syntax than current PAINT, but the node and biological evidence are
+          unchanged; TSA1 is also an experimental seed.
     additional_reference_ids:
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
@@ -6122,9 +6637,9 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: cellular oxidant detoxification may be context-dependent or peripheral for TSA1.&#39;
+    summary: This combined IEA parent term is correct because TSA1 enzymatically removes hydroperoxides.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Retained as a broad non-core parent of the more precise hydrogen peroxide catabolism annotation.
 - term:
     id: GO:0004601
     label: peroxidase activity
@@ -6151,36 +6666,36 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of TSA1.&#39;
+    summary: UniProt subcellular-location mapping agrees with multiple direct cytosol/cytoplasm experiments.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Correct core localization; GO:0005829 cytosol supplies the more precise child term.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.&#39;
+    summary: The ARBA prediction matches TSA1&#39;s directly measured thioredoxin-dependent peroxide reductase activity.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Correct core molecular function, independently grounded by PMID:7961686.
 - term:
     id: GO:0016209
     label: antioxidant activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: antioxidant activity may be context-dependent or peripheral for TSA1.&#39;
+    summary: InterPro/keyword mapping correctly captures TSA1&#39;s antioxidant role but is less specific than peroxiredoxin activity.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Broad umbrella activity retained as non-core because catalytic child terms are available.
 - term:
     id: GO:0016491
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: oxidoreductase activity may be context-dependent or peripheral for TSA1.&#39;
+    summary: Oxidoreductase activity is chemically correct but very broad for a characterized thioredoxin-dependent peroxiredoxin.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Retain as a non-core parent rather than obscuring the precise catalytic function.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
@@ -6227,18 +6742,18 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;Manual review: cell redox homeostasis is consistent with known biology of TSA1.&#39;
+    summary: ARBA inference is concordant with extensive direct evidence for TSA1-dependent peroxide/redox control.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Correct core process of the thioredoxin-peroxiredoxin system.
 - term:
     id: GO:0050821
     label: protein stabilization
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;Manual review: protein stabilization may be context-dependent or peripheral for TSA1.&#39;
+    summary: ARBA captures the aggregation-prevention consequence of TSA1&#39;s stress-activated chaperone state.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Correct but less mechanistically informative than protein folding chaperone activity.
 - term:
     id: GO:0051920
     label: peroxiredoxin activity
@@ -6286,48 +6801,53 @@ existing_annotations:
   original_reference_id: PMID:16272220
   review:
     summary: |-
-      Generic protein-binding annotation. Tsa1 does form extensive (often
-      transient, redox-based) interactions with client proteins - it forms
-      mixed-disulfide intermediates (peroxiredoxinylation) with hundreds of
-      targets - but the bare &#34;protein binding&#34; term is uninformative and these
-      interactions are better captured by the redox/chaperone functions.
+      The yeast two-hybrid study directly detected TSA1 as a thioredoxin target;
+      GOA identifies the partner as TRX2 (P22803). This validates the physical
+      interaction but not generic protein binding as a useful function.
     action: MARK_AS_OVER_ANNOTATED
     reason: |-
       Uninformative generic binding term; the underlying interactions reflect
       redox-relay/chaperone biology better described by specific MF terms.
-    additional_reference_ids:
-    - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
-    - reference_id: file:yeast/TSA1/TSA1-deep-research-falcon.md
+    - reference_id: PMID:16272220
       supporting_text: |-
-        A 2023 bioRxiv preprint reports that Tsa1 forms widespread covalent mixed disulfide intermediates with cellular proteins, termed **Tsa1-Induced Mixed Disulfide Intermediates (TIMDIs)**, and frames this as a bona fide redox-linked post-translational modification termed **peroxiredoxinylation**.
+        We demonstrate here that, in the CY306 strain, yeast TRX1 and TRX2, as well as Arabidopsis TRX introduced as bait, interact with known TRX targets or putative partners such as yeast peroxiredoxins AHP1 and TSA1, whereas the same interactions cannot be detected in classical Y2H strains.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for TSA1.&#39;
+    summary: |-
+      The high-throughput complex map reports association with TSA2 (Q04120),
+      consistent with peroxiredoxin oligomerization, but GO:0005515 does not
+      distinguish this structural association from TSA1&#39;s catalytic activity.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Retain the interaction evidence while flagging the generic binding term as mechanistically uninformative.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18719252
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for TSA1.&#39;
+    summary: |-
+      This binary-interactome row also records TSA2 (Q04120) as partner. The
+      interaction can be valid while the generic binding MF remains unsuitable
+      as a representation of TSA1&#39;s evolved function.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Preserve the experimental interaction but do not elevate generic protein binding to a core function.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for TSA1.&#39;
+    summary: |-
+      Two physical GOA rows collapse to this signature, with TRX2 (P22803) and
+      TSA2 (Q04120) as distinct partners. Both are biologically plausible, but
+      GO:0005515 obscures the redox-cycle and oligomerization mechanisms.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Retain both physical observations while treating the generic MF as over-annotated.
 - term:
     id: GO:0019207
     label: kinase regulator activity
@@ -6423,27 +6943,30 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:16251355
   review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of TSA1.&#39;
+    summary: |-
+      tsa1 deletion causes accumulation of aggregated, predominantly ribosomal
+      proteins, and the cached abstract attributes protection to Tsa1&#39;s
+      chaperone rather than peroxidase function (PMID:16251355).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct genetic evidence supports a core role in protein-folding proteostasis.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IDA
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.&#39;
+    summary: The paper directly shows oxidative stress drives Tsa1&#39;s structural and functional switch (PMID:15163410).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Oxidative stress is both substrate context for peroxidase activity and trigger for the chaperone switch.
 - term:
     id: GO:0034605
     label: cellular response to heat
   evidence_type: IDA
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: cellular response to heat may be context-dependent or peripheral for TSA1.&#39;
+    summary: Heat shock induces high-MW chaperone complexes and Tsa1 enhances heat resistance (PMID:15163410).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Correct stress context, but secondary to the molecular chaperone function it elicits.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -6451,241 +6974,250 @@ existing_annotations:
   original_reference_id: PMID:15163410
   review:
     summary: |-
-      Tsa1&#39;s holdase activity involves binding unfolded/misfolded proteins. The
-      activity-style term protein folding chaperone (GO:0044183) is more
-      informative than the simple binding term for this moonlighting function.
+      The paper directly demonstrates a stress-induced peroxiredoxin-to-chaperone
+      switch. GO:0051082 is now obsolete; GO:0044183 accurately captures binding
+      that assists protein folding, whereas GO:0140309 is inappropriate because
+      Tsa1 prevents aggregation in situ and does not escort clients to a destination.
     action: MODIFY
     reason: |-
-      Replace with the more specific chaperone activity term; both are MF so this
-      is a same-aspect refinement, not a cross-aspect change.
+      Replace the obsolete binding term with protein folding chaperone. The
+      experimental annotation is not rejected: its underlying chaperone/holdase
+      biology is sound and is represented by the current activity term.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
-    additional_reference_ids:
-    - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
-    - reference_id: file:yeast/TSA1/TSA1-deep-research-falcon.md
+    - reference_id: PMID:15163410
       supporting_text: |-
-        This supports a functional switch where hyperoxidized Tsa1 acts as a **stress-activated chaperone adaptor** to recruit the protein quality control machinery.
+        We show here that two cytosolic yeast Prxs, cPrxI and II, which display diversity in structure and apparent molecular weights (MW), can act alternatively as peroxidases and molecular chaperones.
 - term:
     id: GO:0072721
     label: cellular response to dithiothreitol
   evidence_type: IMP
   original_reference_id: PMID:16251355
   review:
-    summary: &#39;Manual review: cellular response to dithiothreitol may be context-dependent or peripheral for TSA1.&#39;
+    summary: tsa1 mutants are DTT-sensitive and accumulate ribosomal-protein aggregates under DTT stress (PMID:16251355).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Experimentally supported reductive-stress context, not a defining core function.
 - term:
     id: GO:0006457
     label: protein folding
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of TSA1.&#39;
+    summary: High-MW Tsa1 complexes display molecular-chaperone activity during oxidative or heat stress (PMID:15163410).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: This CAFA-assigned IMP signature is biologically consistent with the paper&#39;s direct chaperone evidence.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.&#39;
+    summary: The paper demonstrates the low-MW Tsa1 state is the peroxidase-dominant form (PMID:15163410).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Core catalytic activity independently established by direct biochemical studies.
 - term:
     id: GO:0034605
     label: cellular response to heat
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: cellular response to heat may be context-dependent or peripheral for TSA1.&#39;
+    summary: Heat shock triggers the peroxidase-to-chaperone switch and Tsa1-dependent resistance (PMID:15163410).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Valid contextual phenotype, subordinate to the core chaperone activity.
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: identical protein binding is too generic or over-extended for TSA1.&#39;
+    summary: Tsa1 forms high-MW homo-oligomeric assemblies, but an IMP code does not directly assay identical-protein binding.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Oligomerization is real, yet the generic binding term and evidence assignment do not capture the chaperone switch.
 - term:
     id: GO:0045454
     label: cell redox homeostasis
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: cell redox homeostasis is consistent with known biology of TSA1.&#39;
+    summary: Tsa1&#39;s peroxide-sensing catalytic cysteine couples redox state to a reversible functional switch (PMID:15163410).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Consistent with TSA1&#39;s core role in the thioredoxin-peroxiredoxin redox network.
 - term:
     id: GO:0050821
     label: protein stabilization
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: protein stabilization may be context-dependent or peripheral for TSA1.&#39;
+    summary: The stress-induced high-MW chaperone state stabilizes aggregation-prone proteins (PMID:15163410).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Valid downstream consequence of holdase activity, but less mechanistically specific.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for TSA1.&#39;
+    summary: |-
+      The genetic evidence supports Tsa1&#39;s aggregation-preventing chaperone role,
+      but GO:0051082 is obsolete. GO:0044183 is the current evidence-matched
+      activity term; GO:0140309 would incorrectly imply carrier-mediated escort.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: |-
+      Preserve the experimentally supported chaperone biology while replacing
+      the obsolete binding term with protein folding chaperone.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:15163410
+      supporting_text: |-
+        The chaperone function of these proteins enhances yeast resistance to heat shock.
 - term:
     id: GO:0051258
     label: protein polymerization
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: protein polymerization may be context-dependent or peripheral for TSA1.&#39;
+    summary: Oxidative stress and heat drive formation of high-MW Tsa1 complexes (PMID:15163410).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Describes the regulatory oligomerization state rather than TSA1&#39;s core catalytic or chaperone activity.
 - term:
     id: GO:0071447
     label: cellular response to hydroperoxide
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: &#39;Manual review: cellular response to hydroperoxide may be context-dependent or peripheral for TSA1.&#39;
+    summary: The peroxidatic cysteine acts as an H2O2 sensor that drives Tsa1&#39;s stress-dependent switch (PMID:15163410).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Correct peroxide-specific stress response, but subordinate to peroxidase and chaperone functions.
 - term:
     id: GO:0006457
     label: protein folding
   evidence_type: IMP
   original_reference_id: PMID:24022485
   review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of TSA1.&#39;
+    summary: A chaperone-only Tsa1 allele rescues zinc-deficient growth, and holdase overexpression phenocopies rescue (PMID:24022485 abstract).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct physiological genetic evidence supports the core chaperone/proteostasis role.
 - term:
     id: GO:0000077
     label: DNA damage checkpoint signaling
   evidence_type: IGI
   original_reference_id: PMID:19851444
   review:
-    summary: &#39;Manual review: DNA damage checkpoint signaling may be context-dependent or peripheral for TSA1.&#39;
+    summary: tsa1 loss activates the DNA-damage checkpoint and alters dNTP homeostasis (PMID:19851444).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Valid downstream consequence of genome instability, not a direct checkpoint activity of Tsa1.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:10681558
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of TSA1.&#39;
+    summary: The isoenzyme study explicitly identifies TSA1/cTPxI as a cytoplasmic thiol peroxidase (PMID:10681558).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct localization evidence supports the core cytoplasmic compartment.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:8344960
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of TSA1.&#39;
+    summary: Cytosolic and mitochondrial fractionation identifies TSA1 as cytosolic (PMID:8344960).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct experimental localization agrees with UniProt and the cytosol IBA.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IDA
   original_reference_id: PMID:18271751
   review:
-    summary: &#39;Manual review: cytosol is consistent with known biology of TSA1.&#39;
+    summary: Tsa1 is present in the cytosol and additionally associates with actively translating ribosomes (PMID:18271751).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Core localization supported by direct fractionation/localization work.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IDA
   original_reference_id: PMID:7961686
   review:
-    summary: &#39;Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.&#39;
+    summary: Purified TSA1 reduces H2O2 and alkyl hydroperoxides using thioredoxin, thioredoxin reductase and NADPH (PMID:7961686).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct biochemical demonstration of TSA1&#39;s defining molecular function.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IMP
   original_reference_id: PMID:7961686
   review:
-    summary: &#39;Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.&#39;
+    summary: Loss-of-function catalytic-cysteine analysis complements the purified-enzyme evidence for thioredoxin peroxidase activity (PMID:7961686).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Mutant phenotype/mechanism supports the same core catalytic function.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IDA
   original_reference_id: PMID:9799566
   review:
-    summary: &#39;Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.&#39;
+    summary: The study characterizes TSA1 as an NADPH/thioredoxin-dependent peroxidase in cellular heat-stress defense (PMID:9799566).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Experimental enzymology and phenotype support the core activity.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IMP
   original_reference_id: PMID:9799566
   review:
-    summary: &#39;Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.&#39;
+    summary: tsa1 disruption causes thermosensitivity and excess peroxide/protein oxidation, supporting its peroxidase role (PMID:9799566).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Genetic evidence independently supports the core enzymatic function.
 - term:
     id: GO:0033194
     label: response to hydroperoxide
   evidence_type: IMP
   original_reference_id: PMID:15210711
   review:
-    summary: &#39;Manual review: response to hydroperoxide may be context-dependent or peripheral for TSA1.&#39;
+    summary: tsa1 deletion is sensitive to both organic hydroperoxide and H2O2, and purified Tsa1 removes both substrates (PMID:15210711).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Correct general stress response, but less specific than peroxide catabolism and cellular response to oxidative stress.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IGI
   original_reference_id: PMID:15051715
   review:
-    summary: &#39;Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.&#39;
+    summary: Peroxiredoxin-null cells are oxidant-sensitive, and TSA1 rescues the mutator phenotype in a catalytic-site-dependent manner (PMID:15051715).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct genetic evidence supports TSA1 as a core oxidative-stress effector.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IMP
   original_reference_id: PMID:18271751
   review:
-    summary: &#39;Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.&#39;
+    summary: Tsa1 protects cytosol and active ribosomes from endogenous ROS and shifts toward chaperone function under peroxide stress (PMID:18271751).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Central experimentally supported oxidative-stress role.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IDA
   original_reference_id: PMID:8344960
   review:
-    summary: &#39;Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.&#39;
+    summary: tsa1 disruption impairs aerobic growth and peroxide resistance, demonstrating an antioxidant-stress role (PMID:8344960).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Foundational direct evidence for TSA1&#39;s core oxidative-stress function.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IMP
   original_reference_id: PMID:8344960
   review:
-    summary: &#39;Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.&#39;
+    summary: The tsa1 mutant&#39;s oxidant-sensitive phenotype supports a required cellular response to oxidative stress (PMID:8344960).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Core process directly linked to loss of TSA1.
 - term:
     id: GO:0042262
     label: DNA protection
@@ -6734,48 +7266,57 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:8344960
   review:
-    summary: &#39;Manual review: cell redox homeostasis is consistent with known biology of TSA1.&#39;
+    summary: TSA1 is a cytosolic thiol-specific antioxidant required for peroxide defense (PMID:8344960).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct evidence is consistent with its core role in cellular redox homeostasis.
 - term:
     id: GO:0045454
     label: cell redox homeostasis
   evidence_type: IMP
   original_reference_id: PMID:8344960
   review:
-    summary: &#39;Manual review: cell redox homeostasis is consistent with known biology of TSA1.&#39;
+    summary: Disruption of TSA1 perturbs oxidant resistance, genetically supporting redox homeostasis (PMID:8344960).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Core downstream process of the thioredoxin-dependent peroxidase reaction.
 - term:
     id: GO:0045454
     label: cell redox homeostasis
   evidence_type: IMP
   original_reference_id: PMID:9799566
   review:
-    summary: &#39;Manual review: cell redox homeostasis is consistent with known biology of TSA1.&#39;
+    summary: tsa1 mutants accumulate peroxide and oxidatively damaged proteins during heat stress (PMID:9799566).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Genetic evidence supports the core redox-homeostasis process.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IMP
   original_reference_id: PMID:16251355
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for TSA1.&#39;
+    summary: |-
+      The cached abstract directly attributes aggregate prevention to Tsa1&#39;s
+      chaperone function. Because GO:0051082 is obsolete, GO:0044183 is the best
+      current activity term; the carrier-specific GO:0140309 does not fit.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: |-
+      The experiment supports chaperone-assisted proteostasis, so retain the
+      biological assertion through an evidence-matched same-aspect replacement.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16251355
+      supporting_text: |-
+        We propose that Tsa1 normally functions to chaperone misassembled ribosomal proteins, preventing the toxicity that arises from their aggregation.
 - term:
     id: GO:0051920
     label: peroxiredoxin activity
   evidence_type: IDA
   original_reference_id: PMID:17210445
   review:
-    summary: &#39;Manual review: peroxiredoxin activity is consistent with known biology of TSA1.&#39;
+    summary: Competitive kinetics directly measure rapid Tsa1 reactions with H2O2 and peroxynitrite (PMID:17210445).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct kinetic evidence supports peroxiredoxin activity as a core function.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -6800,13 +7341,37 @@ references:
   findings: []
 - id: PMID:15163410
   title: Two enzymes in one; two yeast peroxiredoxins display oxidative stress-dependent switching from a peroxidase to a molecular chaperone function.
-  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. The cache is abstract-only,
+      but the abstract directly supports the peroxidase-to-chaperone switch,
+      higher-order complexes and heat-resistance claims used here.
+  findings:
+  - statement: Oxidative stress and heat shock switch yeast cytosolic peroxiredoxins from peroxidase to molecular-chaperone function.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      Oxidative stress and heat shock exposure of yeasts causes the protein structures of cPrxI and II to shift from low MW species to high MW complexes. This triggers a peroxidase-to-chaperone functional switch.
 - id: PMID:15210711
   title: &#39;Cytosolic thioredoxin peroxidase I and II are important defenses of yeast against organic hydroperoxide insult: catalases and peroxiredoxins cooperate in the decomposition of H2O2 by yeast.&#39;
   findings: []
 - id: PMID:16251355
   title: The thioredoxin system protects ribosomes against stress-induced aggregation.
-  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. Although the local cache is
+      abstract-only, it explicitly names TSA1 and distinguishes its chaperone
+      function from its peroxidase function in ribosomal-protein proteostasis.
+  findings:
+  - statement: Tsa1&#39;s chaperone function prevents aggregation of misassembled ribosomal proteins during reductive stress.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      We propose that Tsa1 normally functions to chaperone misassembled ribosomal proteins, preventing the toxicity that arises from their aggregation.
 - id: PMID:16272220
   title: A yeast two-hybrid knockout strain to explore thioredoxin-interacting proteins in vivo.
   findings: []
@@ -6833,7 +7398,20 @@ references:
   findings: []
 - id: PMID:24022485
   title: Peroxiredoxin chaperone activity is critical for protein homeostasis in zinc-deficient yeast.
-  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. The abstract directly tests
+      TSA1 alleles and holdase complementation, supporting a physiologically
+      important chaperone function under zinc limitation. Full text is not in
+      the local cache.
+  findings:
+  - statement: Tsa1 chaperone activity, rather than peroxidase activity, is critical for proteostasis in zinc-deficient yeast.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      In this report, we show that Tsa1 chaperone, and not peroxidase, activity is the more critical function in zinc-deficient cells.
 - id: PMID:27634403
   title: Redox-dependent Regulation of Gluconeogenesis by a Novel Mechanism Mediated by a Peroxidatic Cysteine of Peroxiredoxin.
   findings: []
@@ -6974,6 +7552,47 @@ core_functions:
   - reference_id: PMID:15163410
     supporting_text: |-
       The peroxidase function predominates in the lower MW forms, whereas the chaperone function predominates in the higher MW complexes. Oxidative stress and heat shock exposure of yeasts causes the protein structures of cPrxI and II to shift from low MW species to high MW complexes. This triggers a peroxidase-to-chaperone functional switch.
+
+proposed_new_terms:
+- proposed_name: in-situ holdase chaperone activity
+  proposed_definition: &gt;-
+    Binding to an unfolded or misfolded protein to prevent its aggregation at
+    the site where the client is encountered, without requiring escort to an
+    acceptor molecule or another cellular location.
+  justification: &gt;-
+    TSA1 is an ATP-independent, stress-activated holdase whose higher-order
+    oligomers prevent aggregation. GO:0051082 is obsolete; GO:0044183 captures
+    its participation in folding/proteostasis but not the holdase mechanism,
+    while GO:0140309 specifically requires carrier-mediated escort and therefore
+    does not fit TSA1. This is the general ontology gap documented by the
+    UNFOLDED_PROTEIN_BINDING project.
+  supported_by:
+  - reference_id: PMID:16251355
+    supporting_text: |-
+      We propose that Tsa1 normally functions to chaperone misassembled ribosomal proteins, preventing the toxicity that arises from their aggregation.
+
+suggested_questions:
+- question: &gt;-
+    Which endogenous client proteins are directly bound by the high-molecular-weight
+    Tsa1 holdase, and which contacts instead reflect redox-linked mixed disulfides?
+- question: &gt;-
+    Does Tsa1 merely hold aggregation-prone clients for Hsp70/Hsp104, or can it
+    directly promote productive folding of particular substrates?
+
+suggested_experiments:
+- description: &gt;-
+    Compare wild-type Tsa1 with peroxidase-only and chaperone-only separation-of-function
+    alleles using stress-resolved client crosslinking, aggregation assays and recovery
+    of native client activity.
+  hypothesis: &gt;-
+    High-molecular-weight Tsa1 directly stabilizes a defined client set without
+    catalyzing refolding, and productive recovery requires downstream Hsp70/Hsp104.
+- description: &gt;-
+    Reconstitute Tsa1-client complexes in vitro and separately measure aggregation
+    suppression, spontaneous refolding and transfer to Ssa1/Hsp104.
+  hypothesis: &gt;-
+    Tsa1 behaves as an in-situ holdase rather than the carrier/escort activity
+    defined by GO:0140309.
 </code></pre>
             </div>
         </details>

--- a/genes/yeast/TSA1/TSA1-ai-review.yaml
+++ b/genes/yeast/TSA1/TSA1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P34760
 gene_symbol: TSA1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -21,6 +21,8 @@ description: >-
   ribosomes as an antioxidant, protects against oxidative damage caused by
   nascent-protein misfolding, and is required for telomere length maintenance.
   Orthologous to human PRDX1/PRDX2.
+tags:
+- UPB
 existing_annotations:
 - term:
     id: GO:0005829
@@ -36,6 +38,16 @@ existing_annotations:
     reason: |-
       Core localization. Tsa1 is one of the most abundant cytosolic proteins and
       acts as the primary cytosolic peroxide sink.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000073874
+        source_label: PANTHER:PTN000073874
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          Current PTHR10681 PAINT places cytosol at this ancestral node. Its
+          experimental seeds span bacterial, fungal, fly, mouse and human
+          peroxiredoxins; SGD:S000004490 (TSA1) is itself a valid direct seed.
     additional_reference_ids:
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
@@ -56,6 +68,17 @@ existing_annotations:
     reason: |-
       Correct but general parent term; retained as non-core because more specific
       annotations represent the precise antioxidant function.
+    propagation_review:
+      root_cause: NO_FAILURE_NON_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000073874
+        source_label: PANTHER:PTN000073874
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          Current PTHR10681 PAINT places this broad stress-response term at the
+          same ancestral peroxiredoxin node. The diverse experimental seed set
+          includes TSA1 and its yeast paralog TSA2, so transfer is sound but
+          less informative than the peroxide-specific processes.
     additional_reference_ids:
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
@@ -77,6 +100,17 @@ existing_annotations:
     reason: |-
       Defining enzymatic activity of TSA1, well supported across phylogenetic
       inference, biochemistry and structural data.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000073874
+        source_label: PANTHER:PTN000073874
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          Current PTHR10681 PAINT retains thioredoxin peroxidase activity at
+          this node. The seed set includes TSA1, TSA2, fission-yeast Tpx1 and
+          experimentally characterized metazoan/protist peroxiredoxins; TSA1's
+          own biochemical evidence correctly grounds the ancestral assertion.
     additional_reference_ids:
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
@@ -96,6 +130,17 @@ existing_annotations:
     reason: |-
       Direct downstream process of the peroxidase activity; central to TSA1
       function.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000073874
+        source_label: PANTHER:PTN000073874
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          Current PTHR10681 PAINT retains hydrogen peroxide catabolism at this
+          node using broad experimental support across peroxiredoxins. TSA1 is
+          not listed as a seed for this particular call, but its conserved
+          catalytic mechanism and direct assays independently support transfer.
     additional_reference_ids:
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
@@ -116,6 +161,17 @@ existing_annotations:
     reason: |-
       Well supported as a core function; Tsa1 is a central node of the cytosolic
       thioredoxin-peroxiredoxin redox network.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000073874
+        source_label: PANTHER:PTN000073874
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          Current PTHR10681 PAINT retains cell redox homeostasis at this node.
+          The GOA seed identifiers for the two Arabidopsis loci use older TAIR
+          syntax than current PAINT, but the node and biological evidence are
+          unchanged; TSA1 is also an experimental seed.
     additional_reference_ids:
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
@@ -128,9 +184,9 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: cellular oxidant detoxification may be context-dependent or peripheral for TSA1.'
+    summary: This combined IEA parent term is correct because TSA1 enzymatically removes hydroperoxides.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Retained as a broad non-core parent of the more precise hydrogen peroxide catabolism annotation.
 - term:
     id: GO:0004601
     label: peroxidase activity
@@ -157,36 +213,36 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of TSA1.'
+    summary: UniProt subcellular-location mapping agrees with multiple direct cytosol/cytoplasm experiments.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Correct core localization; GO:0005829 cytosol supplies the more precise child term.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.'
+    summary: The ARBA prediction matches TSA1's directly measured thioredoxin-dependent peroxide reductase activity.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Correct core molecular function, independently grounded by PMID:7961686.
 - term:
     id: GO:0016209
     label: antioxidant activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: antioxidant activity may be context-dependent or peripheral for TSA1.'
+    summary: InterPro/keyword mapping correctly captures TSA1's antioxidant role but is less specific than peroxiredoxin activity.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Broad umbrella activity retained as non-core because catalytic child terms are available.
 - term:
     id: GO:0016491
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: oxidoreductase activity may be context-dependent or peripheral for TSA1.'
+    summary: Oxidoreductase activity is chemically correct but very broad for a characterized thioredoxin-dependent peroxiredoxin.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Retain as a non-core parent rather than obscuring the precise catalytic function.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
@@ -233,18 +289,18 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'Manual review: cell redox homeostasis is consistent with known biology of TSA1.'
+    summary: ARBA inference is concordant with extensive direct evidence for TSA1-dependent peroxide/redox control.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Correct core process of the thioredoxin-peroxiredoxin system.
 - term:
     id: GO:0050821
     label: protein stabilization
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'Manual review: protein stabilization may be context-dependent or peripheral for TSA1.'
+    summary: ARBA captures the aggregation-prevention consequence of TSA1's stress-activated chaperone state.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Correct but less mechanistically informative than protein folding chaperone activity.
 - term:
     id: GO:0051920
     label: peroxiredoxin activity
@@ -292,48 +348,53 @@ existing_annotations:
   original_reference_id: PMID:16272220
   review:
     summary: |-
-      Generic protein-binding annotation. Tsa1 does form extensive (often
-      transient, redox-based) interactions with client proteins - it forms
-      mixed-disulfide intermediates (peroxiredoxinylation) with hundreds of
-      targets - but the bare "protein binding" term is uninformative and these
-      interactions are better captured by the redox/chaperone functions.
+      The yeast two-hybrid study directly detected TSA1 as a thioredoxin target;
+      GOA identifies the partner as TRX2 (P22803). This validates the physical
+      interaction but not generic protein binding as a useful function.
     action: MARK_AS_OVER_ANNOTATED
     reason: |-
       Uninformative generic binding term; the underlying interactions reflect
       redox-relay/chaperone biology better described by specific MF terms.
-    additional_reference_ids:
-    - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
-    - reference_id: file:yeast/TSA1/TSA1-deep-research-falcon.md
+    - reference_id: PMID:16272220
       supporting_text: |-
-        A 2023 bioRxiv preprint reports that Tsa1 forms widespread covalent mixed disulfide intermediates with cellular proteins, termed **Tsa1-Induced Mixed Disulfide Intermediates (TIMDIs)**, and frames this as a bona fide redox-linked post-translational modification termed **peroxiredoxinylation**.
+        We demonstrate here that, in the CY306 strain, yeast TRX1 and TRX2, as well as Arabidopsis TRX introduced as bait, interact with known TRX targets or putative partners such as yeast peroxiredoxins AHP1 and TSA1, whereas the same interactions cannot be detected in classical Y2H strains.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16554755
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for TSA1.'
+    summary: |-
+      The high-throughput complex map reports association with TSA2 (Q04120),
+      consistent with peroxiredoxin oligomerization, but GO:0005515 does not
+      distinguish this structural association from TSA1's catalytic activity.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Retain the interaction evidence while flagging the generic binding term as mechanistically uninformative.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18719252
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for TSA1.'
+    summary: |-
+      This binary-interactome row also records TSA2 (Q04120) as partner. The
+      interaction can be valid while the generic binding MF remains unsuitable
+      as a representation of TSA1's evolved function.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Preserve the experimental interaction but do not elevate generic protein binding to a core function.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for TSA1.'
+    summary: |-
+      Two physical GOA rows collapse to this signature, with TRX2 (P22803) and
+      TSA2 (Q04120) as distinct partners. Both are biologically plausible, but
+      GO:0005515 obscures the redox-cycle and oligomerization mechanisms.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Retain both physical observations while treating the generic MF as over-annotated.
 - term:
     id: GO:0019207
     label: kinase regulator activity
@@ -429,27 +490,30 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:16251355
   review:
-    summary: 'Manual review: protein folding is consistent with known biology of TSA1.'
+    summary: |-
+      tsa1 deletion causes accumulation of aggregated, predominantly ribosomal
+      proteins, and the cached abstract attributes protection to Tsa1's
+      chaperone rather than peroxidase function (PMID:16251355).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct genetic evidence supports a core role in protein-folding proteostasis.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IDA
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.'
+    summary: The paper directly shows oxidative stress drives Tsa1's structural and functional switch (PMID:15163410).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Oxidative stress is both substrate context for peroxidase activity and trigger for the chaperone switch.
 - term:
     id: GO:0034605
     label: cellular response to heat
   evidence_type: IDA
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: cellular response to heat may be context-dependent or peripheral for TSA1.'
+    summary: Heat shock induces high-MW chaperone complexes and Tsa1 enhances heat resistance (PMID:15163410).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Correct stress context, but secondary to the molecular chaperone function it elicits.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -457,241 +521,250 @@ existing_annotations:
   original_reference_id: PMID:15163410
   review:
     summary: |-
-      Tsa1's holdase activity involves binding unfolded/misfolded proteins. The
-      activity-style term protein folding chaperone (GO:0044183) is more
-      informative than the simple binding term for this moonlighting function.
+      The paper directly demonstrates a stress-induced peroxiredoxin-to-chaperone
+      switch. GO:0051082 is now obsolete; GO:0044183 accurately captures binding
+      that assists protein folding, whereas GO:0140309 is inappropriate because
+      Tsa1 prevents aggregation in situ and does not escort clients to a destination.
     action: MODIFY
     reason: |-
-      Replace with the more specific chaperone activity term; both are MF so this
-      is a same-aspect refinement, not a cross-aspect change.
+      Replace the obsolete binding term with protein folding chaperone. The
+      experimental annotation is not rejected: its underlying chaperone/holdase
+      biology is sound and is represented by the current activity term.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
-    additional_reference_ids:
-    - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
-    - reference_id: file:yeast/TSA1/TSA1-deep-research-falcon.md
+    - reference_id: PMID:15163410
       supporting_text: |-
-        This supports a functional switch where hyperoxidized Tsa1 acts as a **stress-activated chaperone adaptor** to recruit the protein quality control machinery.
+        We show here that two cytosolic yeast Prxs, cPrxI and II, which display diversity in structure and apparent molecular weights (MW), can act alternatively as peroxidases and molecular chaperones.
 - term:
     id: GO:0072721
     label: cellular response to dithiothreitol
   evidence_type: IMP
   original_reference_id: PMID:16251355
   review:
-    summary: 'Manual review: cellular response to dithiothreitol may be context-dependent or peripheral for TSA1.'
+    summary: tsa1 mutants are DTT-sensitive and accumulate ribosomal-protein aggregates under DTT stress (PMID:16251355).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Experimentally supported reductive-stress context, not a defining core function.
 - term:
     id: GO:0006457
     label: protein folding
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: protein folding is consistent with known biology of TSA1.'
+    summary: High-MW Tsa1 complexes display molecular-chaperone activity during oxidative or heat stress (PMID:15163410).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: This CAFA-assigned IMP signature is biologically consistent with the paper's direct chaperone evidence.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.'
+    summary: The paper demonstrates the low-MW Tsa1 state is the peroxidase-dominant form (PMID:15163410).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Core catalytic activity independently established by direct biochemical studies.
 - term:
     id: GO:0034605
     label: cellular response to heat
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: cellular response to heat may be context-dependent or peripheral for TSA1.'
+    summary: Heat shock triggers the peroxidase-to-chaperone switch and Tsa1-dependent resistance (PMID:15163410).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Valid contextual phenotype, subordinate to the core chaperone activity.
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: identical protein binding is too generic or over-extended for TSA1.'
+    summary: Tsa1 forms high-MW homo-oligomeric assemblies, but an IMP code does not directly assay identical-protein binding.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Oligomerization is real, yet the generic binding term and evidence assignment do not capture the chaperone switch.
 - term:
     id: GO:0045454
     label: cell redox homeostasis
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: cell redox homeostasis is consistent with known biology of TSA1.'
+    summary: Tsa1's peroxide-sensing catalytic cysteine couples redox state to a reversible functional switch (PMID:15163410).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Consistent with TSA1's core role in the thioredoxin-peroxiredoxin redox network.
 - term:
     id: GO:0050821
     label: protein stabilization
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: protein stabilization may be context-dependent or peripheral for TSA1.'
+    summary: The stress-induced high-MW chaperone state stabilizes aggregation-prone proteins (PMID:15163410).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Valid downstream consequence of holdase activity, but less mechanistically specific.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for TSA1.'
+    summary: |-
+      The genetic evidence supports Tsa1's aggregation-preventing chaperone role,
+      but GO:0051082 is obsolete. GO:0044183 is the current evidence-matched
+      activity term; GO:0140309 would incorrectly imply carrier-mediated escort.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: |-
+      Preserve the experimentally supported chaperone biology while replacing
+      the obsolete binding term with protein folding chaperone.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:15163410
+      supporting_text: |-
+        The chaperone function of these proteins enhances yeast resistance to heat shock.
 - term:
     id: GO:0051258
     label: protein polymerization
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: protein polymerization may be context-dependent or peripheral for TSA1.'
+    summary: Oxidative stress and heat drive formation of high-MW Tsa1 complexes (PMID:15163410).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Describes the regulatory oligomerization state rather than TSA1's core catalytic or chaperone activity.
 - term:
     id: GO:0071447
     label: cellular response to hydroperoxide
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: 'Manual review: cellular response to hydroperoxide may be context-dependent or peripheral for TSA1.'
+    summary: The peroxidatic cysteine acts as an H2O2 sensor that drives Tsa1's stress-dependent switch (PMID:15163410).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Correct peroxide-specific stress response, but subordinate to peroxidase and chaperone functions.
 - term:
     id: GO:0006457
     label: protein folding
   evidence_type: IMP
   original_reference_id: PMID:24022485
   review:
-    summary: 'Manual review: protein folding is consistent with known biology of TSA1.'
+    summary: A chaperone-only Tsa1 allele rescues zinc-deficient growth, and holdase overexpression phenocopies rescue (PMID:24022485 abstract).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct physiological genetic evidence supports the core chaperone/proteostasis role.
 - term:
     id: GO:0000077
     label: DNA damage checkpoint signaling
   evidence_type: IGI
   original_reference_id: PMID:19851444
   review:
-    summary: 'Manual review: DNA damage checkpoint signaling may be context-dependent or peripheral for TSA1.'
+    summary: tsa1 loss activates the DNA-damage checkpoint and alters dNTP homeostasis (PMID:19851444).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Valid downstream consequence of genome instability, not a direct checkpoint activity of Tsa1.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:10681558
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of TSA1.'
+    summary: The isoenzyme study explicitly identifies TSA1/cTPxI as a cytoplasmic thiol peroxidase (PMID:10681558).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct localization evidence supports the core cytoplasmic compartment.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:8344960
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of TSA1.'
+    summary: Cytosolic and mitochondrial fractionation identifies TSA1 as cytosolic (PMID:8344960).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct experimental localization agrees with UniProt and the cytosol IBA.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IDA
   original_reference_id: PMID:18271751
   review:
-    summary: 'Manual review: cytosol is consistent with known biology of TSA1.'
+    summary: Tsa1 is present in the cytosol and additionally associates with actively translating ribosomes (PMID:18271751).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Core localization supported by direct fractionation/localization work.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IDA
   original_reference_id: PMID:7961686
   review:
-    summary: 'Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.'
+    summary: Purified TSA1 reduces H2O2 and alkyl hydroperoxides using thioredoxin, thioredoxin reductase and NADPH (PMID:7961686).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct biochemical demonstration of TSA1's defining molecular function.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IMP
   original_reference_id: PMID:7961686
   review:
-    summary: 'Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.'
+    summary: Loss-of-function catalytic-cysteine analysis complements the purified-enzyme evidence for thioredoxin peroxidase activity (PMID:7961686).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Mutant phenotype/mechanism supports the same core catalytic function.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IDA
   original_reference_id: PMID:9799566
   review:
-    summary: 'Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.'
+    summary: The study characterizes TSA1 as an NADPH/thioredoxin-dependent peroxidase in cellular heat-stress defense (PMID:9799566).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Experimental enzymology and phenotype support the core activity.
 - term:
     id: GO:0008379
     label: thioredoxin peroxidase activity
   evidence_type: IMP
   original_reference_id: PMID:9799566
   review:
-    summary: 'Manual review: thioredoxin peroxidase activity is consistent with known biology of TSA1.'
+    summary: tsa1 disruption causes thermosensitivity and excess peroxide/protein oxidation, supporting its peroxidase role (PMID:9799566).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Genetic evidence independently supports the core enzymatic function.
 - term:
     id: GO:0033194
     label: response to hydroperoxide
   evidence_type: IMP
   original_reference_id: PMID:15210711
   review:
-    summary: 'Manual review: response to hydroperoxide may be context-dependent or peripheral for TSA1.'
+    summary: tsa1 deletion is sensitive to both organic hydroperoxide and H2O2, and purified Tsa1 removes both substrates (PMID:15210711).
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Correct general stress response, but less specific than peroxide catabolism and cellular response to oxidative stress.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IGI
   original_reference_id: PMID:15051715
   review:
-    summary: 'Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.'
+    summary: Peroxiredoxin-null cells are oxidant-sensitive, and TSA1 rescues the mutator phenotype in a catalytic-site-dependent manner (PMID:15051715).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct genetic evidence supports TSA1 as a core oxidative-stress effector.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IMP
   original_reference_id: PMID:18271751
   review:
-    summary: 'Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.'
+    summary: Tsa1 protects cytosol and active ribosomes from endogenous ROS and shifts toward chaperone function under peroxide stress (PMID:18271751).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Central experimentally supported oxidative-stress role.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IDA
   original_reference_id: PMID:8344960
   review:
-    summary: 'Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.'
+    summary: tsa1 disruption impairs aerobic growth and peroxide resistance, demonstrating an antioxidant-stress role (PMID:8344960).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Foundational direct evidence for TSA1's core oxidative-stress function.
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IMP
   original_reference_id: PMID:8344960
   review:
-    summary: 'Manual review: cellular response to oxidative stress is consistent with known biology of TSA1.'
+    summary: The tsa1 mutant's oxidant-sensitive phenotype supports a required cellular response to oxidative stress (PMID:8344960).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Core process directly linked to loss of TSA1.
 - term:
     id: GO:0042262
     label: DNA protection
@@ -740,48 +813,57 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:8344960
   review:
-    summary: 'Manual review: cell redox homeostasis is consistent with known biology of TSA1.'
+    summary: TSA1 is a cytosolic thiol-specific antioxidant required for peroxide defense (PMID:8344960).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct evidence is consistent with its core role in cellular redox homeostasis.
 - term:
     id: GO:0045454
     label: cell redox homeostasis
   evidence_type: IMP
   original_reference_id: PMID:8344960
   review:
-    summary: 'Manual review: cell redox homeostasis is consistent with known biology of TSA1.'
+    summary: Disruption of TSA1 perturbs oxidant resistance, genetically supporting redox homeostasis (PMID:8344960).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Core downstream process of the thioredoxin-dependent peroxidase reaction.
 - term:
     id: GO:0045454
     label: cell redox homeostasis
   evidence_type: IMP
   original_reference_id: PMID:9799566
   review:
-    summary: 'Manual review: cell redox homeostasis is consistent with known biology of TSA1.'
+    summary: tsa1 mutants accumulate peroxide and oxidatively damaged proteins during heat stress (PMID:9799566).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Genetic evidence supports the core redox-homeostasis process.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IMP
   original_reference_id: PMID:16251355
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for TSA1.'
+    summary: |-
+      The cached abstract directly attributes aggregate prevention to Tsa1's
+      chaperone function. Because GO:0051082 is obsolete, GO:0044183 is the best
+      current activity term; the carrier-specific GO:0140309 does not fit.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: |-
+      The experiment supports chaperone-assisted proteostasis, so retain the
+      biological assertion through an evidence-matched same-aspect replacement.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16251355
+      supporting_text: |-
+        We propose that Tsa1 normally functions to chaperone misassembled ribosomal proteins, preventing the toxicity that arises from their aggregation.
 - term:
     id: GO:0051920
     label: peroxiredoxin activity
   evidence_type: IDA
   original_reference_id: PMID:17210445
   review:
-    summary: 'Manual review: peroxiredoxin activity is consistent with known biology of TSA1.'
+    summary: Competitive kinetics directly measure rapid Tsa1 reactions with H2O2 and peroxynitrite (PMID:17210445).
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct kinetic evidence supports peroxiredoxin activity as a core function.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -806,13 +888,37 @@ references:
   findings: []
 - id: PMID:15163410
   title: Two enzymes in one; two yeast peroxiredoxins display oxidative stress-dependent switching from a peroxidase to a molecular chaperone function.
-  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. The cache is abstract-only,
+      but the abstract directly supports the peroxidase-to-chaperone switch,
+      higher-order complexes and heat-resistance claims used here.
+  findings:
+  - statement: Oxidative stress and heat shock switch yeast cytosolic peroxiredoxins from peroxidase to molecular-chaperone function.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      Oxidative stress and heat shock exposure of yeasts causes the protein structures of cPrxI and II to shift from low MW species to high MW complexes. This triggers a peroxidase-to-chaperone functional switch.
 - id: PMID:15210711
   title: 'Cytosolic thioredoxin peroxidase I and II are important defenses of yeast against organic hydroperoxide insult: catalases and peroxiredoxins cooperate in the decomposition of H2O2 by yeast.'
   findings: []
 - id: PMID:16251355
   title: The thioredoxin system protects ribosomes against stress-induced aggregation.
-  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. Although the local cache is
+      abstract-only, it explicitly names TSA1 and distinguishes its chaperone
+      function from its peroxidase function in ribosomal-protein proteostasis.
+  findings:
+  - statement: Tsa1's chaperone function prevents aggregation of misassembled ribosomal proteins during reductive stress.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      We propose that Tsa1 normally functions to chaperone misassembled ribosomal proteins, preventing the toxicity that arises from their aggregation.
 - id: PMID:16272220
   title: A yeast two-hybrid knockout strain to explore thioredoxin-interacting proteins in vivo.
   findings: []
@@ -839,7 +945,20 @@ references:
   findings: []
 - id: PMID:24022485
   title: Peroxiredoxin chaperone activity is critical for protein homeostasis in zinc-deficient yeast.
-  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. The abstract directly tests
+      TSA1 alleles and holdase complementation, supporting a physiologically
+      important chaperone function under zinc limitation. Full text is not in
+      the local cache.
+  findings:
+  - statement: Tsa1 chaperone activity, rather than peroxidase activity, is critical for proteostasis in zinc-deficient yeast.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      In this report, we show that Tsa1 chaperone, and not peroxidase, activity is the more critical function in zinc-deficient cells.
 - id: PMID:27634403
   title: Redox-dependent Regulation of Gluconeogenesis by a Novel Mechanism Mediated by a Peroxidatic Cysteine of Peroxiredoxin.
   findings: []
@@ -980,3 +1099,44 @@ core_functions:
   - reference_id: PMID:15163410
     supporting_text: |-
       The peroxidase function predominates in the lower MW forms, whereas the chaperone function predominates in the higher MW complexes. Oxidative stress and heat shock exposure of yeasts causes the protein structures of cPrxI and II to shift from low MW species to high MW complexes. This triggers a peroxidase-to-chaperone functional switch.
+
+proposed_new_terms:
+- proposed_name: in-situ holdase chaperone activity
+  proposed_definition: >-
+    Binding to an unfolded or misfolded protein to prevent its aggregation at
+    the site where the client is encountered, without requiring escort to an
+    acceptor molecule or another cellular location.
+  justification: >-
+    TSA1 is an ATP-independent, stress-activated holdase whose higher-order
+    oligomers prevent aggregation. GO:0051082 is obsolete; GO:0044183 captures
+    its participation in folding/proteostasis but not the holdase mechanism,
+    while GO:0140309 specifically requires carrier-mediated escort and therefore
+    does not fit TSA1. This is the general ontology gap documented by the
+    UNFOLDED_PROTEIN_BINDING project.
+  supported_by:
+  - reference_id: PMID:16251355
+    supporting_text: |-
+      We propose that Tsa1 normally functions to chaperone misassembled ribosomal proteins, preventing the toxicity that arises from their aggregation.
+
+suggested_questions:
+- question: >-
+    Which endogenous client proteins are directly bound by the high-molecular-weight
+    Tsa1 holdase, and which contacts instead reflect redox-linked mixed disulfides?
+- question: >-
+    Does Tsa1 merely hold aggregation-prone clients for Hsp70/Hsp104, or can it
+    directly promote productive folding of particular substrates?
+
+suggested_experiments:
+- description: >-
+    Compare wild-type Tsa1 with peroxidase-only and chaperone-only separation-of-function
+    alleles using stress-resolved client crosslinking, aggregation assays and recovery
+    of native client activity.
+  hypothesis: >-
+    High-molecular-weight Tsa1 directly stabilizes a defined client set without
+    catalyzing refolding, and productive recovery requires downstream Hsp70/Hsp104.
+- description: >-
+    Reconstitute Tsa1-client complexes in vitro and separately measure aggregation
+    suppression, spontaneous refolding and transfer to Ssa1/Hsp104.
+  hypothesis: >-
+    Tsa1 behaves as an in-situ holdase rather than the carrier/escort activity
+    defined by GO:0140309.

--- a/genes/yeast/TSA1/TSA1-notes.md
+++ b/genes/yeast/TSA1/TSA1-notes.md
@@ -1,0 +1,78 @@
+# TSA1 annotation re-review notes
+
+## 2026-08-28 dedicated re-review
+
+TSA1 (P34760; SGD:S000004490) is the major cytosolic typical 2-Cys
+peroxiredoxin in budding yeast. Its primary catalytic function is reduction of
+hydrogen peroxide and organic hydroperoxides with reducing equivalents supplied
+by thioredoxin [PMID:7961686, "The 25-kDa enzyme is now shown to be a peroxidase
+that reduces H2O2 and alkyl hydroperoxides with the use of hydrogens provided by
+thioredoxin, thioredoxin reductase, and NADPH."].
+
+Tsa1 also has a stress-dependent chaperone function. Oxidative stress and heat
+shock shift the protein into high-molecular-weight assemblies and switch the
+dominant activity from peroxidase to chaperone [PMID:15163410, "Oxidative stress
+and heat shock exposure of yeasts causes the protein structures of cPrxI and II
+to shift from low MW species to high MW complexes. This triggers a
+peroxidase-to-chaperone functional switch."]. Genetic evidence connects that
+activity to prevention of ribosomal-protein aggregation [PMID:16251355, "We
+propose that Tsa1 normally functions to chaperone misassembled ribosomal
+proteins, preventing the toxicity that arises from their aggregation."], and a
+separate study establishes that chaperone activity is especially important in
+zinc-deficient cells [PMID:24022485, "In this report, we show that Tsa1
+chaperone, and not peroxidase, activity is the more critical function in
+zinc-deficient cells."]. All three cached records are abstract-only, so the
+review accepts their explicit abstract-level conclusions without inventing
+assay details from inaccessible full text.
+
+### GOA reconciliation
+
+The cached GOA contains 68 physical rows and 60 qualifier-aware signatures
+(qualifier + GO term + evidence code + reference). Four signatures collapse
+multiple physical rows: PMID:37968396 protein binding has two interaction
+partners, PMID:15163410 protein folding IDA occurs twice, and the IGI rows for
+PMID:19851444 and PMID:15051715 each have four distinct WITH/FROM partners. The
+review represents each exact signature once, as required by the current review
+schema; `just validate-goa yeast TSA1` checks this reconciliation. All physical
+rows use positive relation qualifiers (enables, involved_in, located_in,
+is_active_in); there are no NOT annotations or isoform-specific rows.
+
+The four IPI protein-binding signatures were retained only as
+MARK_AS_OVER_ANNOTATED because the generic term does not describe Tsa1's
+peroxidase, redox-transfer or chaperone mechanisms. The two PMID:37968396 rows
+correspond separately to TRX2 (P22803) and TSA2 (Q04120), rather than a duplicate
+curation accident.
+
+### PAINT audit
+
+All five IBA annotations descend from PTHR10681 node PTN000073874. Current
+`PTHR10681-paint.tsv` retains that same node for cytosol (GO:0005829),
+thioredoxin peroxidase activity (GO:0008379), response to oxidative stress
+(GO:0006979), hydrogen peroxide catabolic process (GO:0042744), and cell redox
+homeostasis (GO:0045454). TSA1 itself is an experimental seed for four of these
+five calls; this is valid target-grounded IBD evidence, not circularity. The
+hydrogen-peroxide-catabolism call is seeded by other experimentally
+characterized peroxiredoxins and is independently supported by TSA1
+biochemistry. The only source-format drift is that current PAINT writes the two
+Arabidopsis redox-homeostasis seeds as AGI_LocusCode identifiers whereas cached
+GOA writes TAIR:locus identifiers. No node-placement failure or target-specific
+loss/divergence was found.
+
+### Obsolete unfolded-protein term
+
+Live QuickGO was checked on 2026-08-28. GO:0051082 is obsolete. GO:0044183 is
+current and defined as binding a protein or complex to assist protein folding;
+it is therefore an evidence-matched replacement for the papers that explicitly
+call Tsa1 a molecular chaperone and annotate protein folding. GO:0140309 is
+currently labelled "unfolded protein holdase activity," but its unchanged
+definition requires escorting the client to an acceptor or specific location.
+Tsa1 prevents aggregation in situ and is not a carrier, so GO:0140309 was not
+used. A general in-situ holdase activity remains an ontology gap; the review
+records this as a proposed new term while retaining GO:0044183 as the available
+current chaperone activity.
+
+The final synthesis treats thioredoxin-dependent peroxiredoxin activity and the
+stress-activated chaperone/holdase switch as TSA1's two core functions. Broad
+parents, heat/zinc/DTT contexts, genome protection, gluconeogenic regulation,
+ribosome association and generic binding are retained as non-core or
+over-annotated rather than promoted into the core-function summary.


### PR DESCRIPTION
## Summary
- complete the TSA1 review, reconciling 68 physical GOA rows into 60 qualifier-aware signatures
- audit all five IBA annotations against current PTN000073874 PAINT evidence
- replace obsolete GO:0051082 assertions with GO:0044183 while rejecting carrier-specific GO:0140309 for an in-situ holdase
- synthesize TSA1 peroxiredoxin and stress-activated chaperone core functions, add an in-situ holdase NTR proposal, and document evidence provenance
- regenerate the TSA1 HTML review and browser payload

## Validation
- `just validate yeast TSA1`
- `just validate-goa yeast TSA1`
- `just render yeast TSA1`
- `just deploy-browser`
- `just refresh-bioreason-benchmark-sidecars`
- `just render-projects`
- targeted BioReason sidecar/publication parity tests (2 passed)
- `just test` (1793 unit tests, 154 doctests, mypy, Ruff)