### PR TITLE
Align TSA1 holdase review provenance

### DIFF
--- a/genes/yeast/TSA1/TSA1-ai-review.html
+++ b/genes/yeast/TSA1/TSA1-ai-review.html
@@ -842,19 +842,19 @@
 
         <div class="proposed-term">
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>in-situ holdase chaperone activity</h3>
-                <span class="vote-buttons" data-g="P34760" data-a="in-situ holdase chaperone activity" data-r="" data-act="NEW">
+                <h3>holdase chaperone activity</h3>
+                <span class="vote-buttons" data-g="P34760" data-a="holdase chaperone activity" data-r="" data-act="NEW">
                     <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
                 </span>
             </div>
 
 
-            <p><strong>Definition:</strong> Binding to an unfolded or misfolded protein to prevent its aggregation at the site where the client is encountered, without requiring escort to an acceptor molecule or another cellular location.</p>
+            <p><strong>Definition:</strong> Binding to an unfolded or misfolded protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains the client in a soluble, folding-competent state and does not require escort to an acceptor molecule or another cellular location.</p>
 
 
 
-            <p><strong>Justification:</strong> TSA1 is an ATP-independent, stress-activated holdase whose higher-order oligomers prevent aggregation. GO:0051082 is obsolete; GO:0044183 captures its participation in folding/proteostasis but not the holdase mechanism, while GO:0140309 specifically requires carrier-mediated escort and therefore does not fit TSA1. This is the general ontology gap documented by the UNFOLDED_PROTEIN_BINDING project.</p>
+            <p><strong>Justification:</strong> TSA1 is an ATP-independent, stress-activated holdase whose higher-order oligomers prevent aggregation. GO:0051082 is obsolete; GO:0044183 captures its participation in folding/proteostasis but not the holdase mechanism, while GO:0140309 specifically requires carrier-mediated escort and therefore does not fit TSA1. This is the same general ontology request documented by the UNFOLDED_PROTEIN_BINDING project and go-ontology#30962/#30552, not a separate TSA1-specific NTR.</p>
 
 
 
@@ -3401,7 +3401,7 @@ biology is sound and is represented by the current activity term.
 
 
                         <div>
-                            <strong>Reason:</strong> Oligomerization is real, yet the generic binding term and evidence assignment do not capture the chaperone switch.
+                            <strong>Reason:</strong> Oligomerization is real, yet this generic MF binding term and its IMP assignment do not capture the chaperone switch. The corresponding GO:0051258 protein polymerization BP is retained as non-core because it directly describes formation of the high-MW assembly, whereas GO:0042802 only restates that identical subunits contact one another.
                         </div>
 
 
@@ -5817,6 +5817,33 @@ damaged aggregates; reactivation requires reduction by sulfiredoxin Srx1.</h3>
                 <div class="reference-header">
                     <span class="reference-id">
 
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9888818" target="_blank" class="term-link">
+                            PMID:9888818
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Purification and characterization of a second type thioredoxin peroxidase (type II TPx) from Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The study&#39;s kinetic comparison confirms that type I TPx preferentially reduces hydrogen peroxide.</div>
+
+                        <div class="finding-text">"Kinetic characterization of the reactions catalyzed by type I and II TPxs revealed that type I preferentially reduces H2O2 rather than alkyl hydroperoxides, whereas type II shows the reverse specificity."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         file:yeast/TSA1/TSA1-deep-research-falcon.md
 
                     </span>
@@ -6430,8 +6457,8 @@ call Tsa1 a molecular chaperone and annotate protein folding. GO:0140309 is<br /
 currently labelled "unfolded protein holdase activity," but its unchanged<br />
 definition requires escorting the client to an acceptor or specific location.<br />
 Tsa1 prevents aggregation in situ and is not a carrier, so GO:0140309 was not<br />
-used. A general in-situ holdase activity remains an ontology gap; the review<br />
-records this as a proposed new term while retaining GO:0044183 as the available<br />
+used. A general <code>holdase chaperone activity</code> remains an ontology gap; the review<br />
+uses the canonical project NTR name while retaining GO:0044183 as the available<br />
 current chaperone activity.</p>
 <p>The final synthesis treats thioredoxin-dependent peroxiredoxin activity and the<br />
 stress-activated chaperone/holdase switch as TSA1's two core functions. Broad<br />
@@ -6789,6 +6816,7 @@ existing_annotations:
     reason: |-
       Most specific and accurate MF term; designated the core molecular function.
     additional_reference_ids:
+    - PMID:9888818
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
     - reference_id: file:yeast/TSA1/TSA1-deep-research-falcon.md
@@ -7034,7 +7062,12 @@ existing_annotations:
   review:
     summary: Tsa1 forms high-MW homo-oligomeric assemblies, but an IMP code does not directly assay identical-protein binding.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Oligomerization is real, yet the generic binding term and evidence assignment do not capture the chaperone switch.
+    reason: &gt;-
+      Oligomerization is real, yet this generic MF binding term and its IMP
+      assignment do not capture the chaperone switch. The corresponding
+      GO:0051258 protein polymerization BP is retained as non-core because it
+      directly describes formation of the high-MW assembly, whereas
+      GO:0042802 only restates that identical subunits contact one another.
 - term:
     id: GO:0045454
     label: cell redox homeostasis
@@ -7427,6 +7460,21 @@ references:
 - id: PMID:9799566
   title: Thermosensitive phenotype of yeast mutant lacking thioredoxin peroxidase.
   findings: []
+- id: PMID:9888818
+  title: Purification and characterization of a second type thioredoxin peroxidase (type II TPx) from Saccharomyces cerevisiae.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed metadata and cached abstract verified. Although the paper focuses
+      on type II TPx, its direct kinetic comparison reports the substrate
+      preference of the previously characterized type I TPx/Tsa1.
+  findings:
+  - statement: The study&#39;s kinetic comparison confirms that type I TPx preferentially reduces hydrogen peroxide.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: &gt;-
+      Kinetic characterization of the reactions catalyzed by type I and II TPxs revealed that type I preferentially reduces H2O2 rather than alkyl hydroperoxides, whereas type II shows the reverse specificity.
 - id: file:yeast/TSA1/TSA1-deep-research-falcon.md
   title: Falcon deep research on TSA1 (Edison Scientific Literature)
   findings:
@@ -7554,18 +7602,20 @@ core_functions:
       The peroxidase function predominates in the lower MW forms, whereas the chaperone function predominates in the higher MW complexes. Oxidative stress and heat shock exposure of yeasts causes the protein structures of cPrxI and II to shift from low MW species to high MW complexes. This triggers a peroxidase-to-chaperone functional switch.
 
 proposed_new_terms:
-- proposed_name: in-situ holdase chaperone activity
+- proposed_name: holdase chaperone activity
   proposed_definition: &gt;-
-    Binding to an unfolded or misfolded protein to prevent its aggregation at
-    the site where the client is encountered, without requiring escort to an
+    Binding to an unfolded or misfolded protein to prevent its aggregation
+    without actively catalyzing refolding. The holdase maintains the client in
+    a soluble, folding-competent state and does not require escort to an
     acceptor molecule or another cellular location.
   justification: &gt;-
     TSA1 is an ATP-independent, stress-activated holdase whose higher-order
     oligomers prevent aggregation. GO:0051082 is obsolete; GO:0044183 captures
     its participation in folding/proteostasis but not the holdase mechanism,
     while GO:0140309 specifically requires carrier-mediated escort and therefore
-    does not fit TSA1. This is the general ontology gap documented by the
-    UNFOLDED_PROTEIN_BINDING project.
+    does not fit TSA1. This is the same general ontology request documented by
+    the UNFOLDED_PROTEIN_BINDING project and go-ontology#30962/#30552, not a
+    separate TSA1-specific NTR.
   supported_by:
   - reference_id: PMID:16251355
     supporting_text: |-

--- a/genes/yeast/TSA1/TSA1-ai-review.yaml
+++ b/genes/yeast/TSA1/TSA1-ai-review.yaml
@@ -336,6 +336,7 @@ existing_annotations:
     reason: |-
       Most specific and accurate MF term; designated the core molecular function.
     additional_reference_ids:
+    - PMID:9888818
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
     - reference_id: file:yeast/TSA1/TSA1-deep-research-falcon.md
@@ -581,7 +582,12 @@ existing_annotations:
   review:
     summary: Tsa1 forms high-MW homo-oligomeric assemblies, but an IMP code does not directly assay identical-protein binding.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Oligomerization is real, yet the generic binding term and evidence assignment do not capture the chaperone switch.
+    reason: >-
+      Oligomerization is real, yet this generic MF binding term and its IMP
+      assignment do not capture the chaperone switch. The corresponding
+      GO:0051258 protein polymerization BP is retained as non-core because it
+      directly describes formation of the high-MW assembly, whereas
+      GO:0042802 only restates that identical subunits contact one another.
 - term:
     id: GO:0045454
     label: cell redox homeostasis
@@ -974,6 +980,21 @@ references:
 - id: PMID:9799566
   title: Thermosensitive phenotype of yeast mutant lacking thioredoxin peroxidase.
   findings: []
+- id: PMID:9888818
+  title: Purification and characterization of a second type thioredoxin peroxidase (type II TPx) from Saccharomyces cerevisiae.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed metadata and cached abstract verified. Although the paper focuses
+      on type II TPx, its direct kinetic comparison reports the substrate
+      preference of the previously characterized type I TPx/Tsa1.
+  findings:
+  - statement: The study's kinetic comparison confirms that type I TPx preferentially reduces hydrogen peroxide.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: >-
+      Kinetic characterization of the reactions catalyzed by type I and II TPxs revealed that type I preferentially reduces H2O2 rather than alkyl hydroperoxides, whereas type II shows the reverse specificity.
 - id: file:yeast/TSA1/TSA1-deep-research-falcon.md
   title: Falcon deep research on TSA1 (Edison Scientific Literature)
   findings:
@@ -1101,18 +1122,20 @@ core_functions:
       The peroxidase function predominates in the lower MW forms, whereas the chaperone function predominates in the higher MW complexes. Oxidative stress and heat shock exposure of yeasts causes the protein structures of cPrxI and II to shift from low MW species to high MW complexes. This triggers a peroxidase-to-chaperone functional switch.
 
 proposed_new_terms:
-- proposed_name: in-situ holdase chaperone activity
+- proposed_name: holdase chaperone activity
   proposed_definition: >-
-    Binding to an unfolded or misfolded protein to prevent its aggregation at
-    the site where the client is encountered, without requiring escort to an
+    Binding to an unfolded or misfolded protein to prevent its aggregation
+    without actively catalyzing refolding. The holdase maintains the client in
+    a soluble, folding-competent state and does not require escort to an
     acceptor molecule or another cellular location.
   justification: >-
     TSA1 is an ATP-independent, stress-activated holdase whose higher-order
     oligomers prevent aggregation. GO:0051082 is obsolete; GO:0044183 captures
     its participation in folding/proteostasis but not the holdase mechanism,
     while GO:0140309 specifically requires carrier-mediated escort and therefore
-    does not fit TSA1. This is the general ontology gap documented by the
-    UNFOLDED_PROTEIN_BINDING project.
+    does not fit TSA1. This is the same general ontology request documented by
+    the UNFOLDED_PROTEIN_BINDING project and go-ontology#30962/#30552, not a
+    separate TSA1-specific NTR.
   supported_by:
   - reference_id: PMID:16251355
     supporting_text: |-

--- a/genes/yeast/TSA1/TSA1-notes.md
+++ b/genes/yeast/TSA1/TSA1-notes.md
@@ -67,8 +67,8 @@ call Tsa1 a molecular chaperone and annotate protein folding. GO:0140309 is
 currently labelled "unfolded protein holdase activity," but its unchanged
 definition requires escorting the client to an acceptor or specific location.
 Tsa1 prevents aggregation in situ and is not a carrier, so GO:0140309 was not
-used. A general in-situ holdase activity remains an ontology gap; the review
-records this as a proposed new term while retaining GO:0044183 as the available
+used. A general `holdase chaperone activity` remains an ontology gap; the review
+uses the canonical project NTR name while retaining GO:0044183 as the available
 current chaperone activity.
 
 The final synthesis treats thioredoxin-dependent peroxiredoxin activity and the

--- a/publications/PMID_9888818.md
+++ b/publications/PMID_9888818.md
@@ -1,0 +1,67 @@
+---
+pmid: '9888818'
+title: Purification and characterization of a second type thioredoxin peroxidase (type
+  II TPx) from Saccharomyces cerevisiae.
+authors:
+- Jeong JS
+- Kwon SJ
+- Kang SW
+- Rhee SG
+- Kim K
+journal: Biochemistry
+year: '1999'
+full_text_available: false
+doi: 10.1021/bi9817818
+pubmed_publication_types:
+- Comparative Study
+- Journal Article
+- Research Support, Non-U.S. Gov't
+publication_type: PRIMARY_RESEARCH
+---
+
+# Purification and characterization of a second type thioredoxin peroxidase (type II TPx) from Saccharomyces cerevisiae.
+**Authors:** Jeong JS, Kwon SJ, Kang SW, Rhee SG, Kim K
+**Journal:** Biochemistry (1999)
+**DOI:** [10.1021/bi9817818](https://doi.org/10.1021/bi9817818)
+
+## Abstract
+
+1. Biochemistry. 1999 Jan 12;38(2):776-83. doi: 10.1021/bi9817818.
+
+Purification and characterization of a second type thioredoxin peroxidase (type
+II TPx) from Saccharomyces cerevisiae.
+
+Jeong JS(1), Kwon SJ, Kang SW, Rhee SG, Kim K.
+
+Author information:
+(1)Department of Food and Nutrition, College of Home Economics, Chonnam National
+University, Kwang-Ju, Korea.
+
+A yeast peroxidase that reduces H2O2 and alkyl hydroperoxides with the use of
+reducing equivalents provided by thioredoxin was identified previously and named
+thioredoxin peroxidase (TPx) [Chae, H. Z., Chung, S. J., and Rhee, S. G. (1994)
+J. Biol. Chem. 269, 27670-27678]. A second type thioredoxin-dependent
+peroxidase, named type II TPx, has now been purified from yeast, and several
+peptide sequences have been obtained. Using those sequences, the corresponding
+cDNA has been identified from the GenBank database. Comparison of the predicted
+sequence of 176 amino acids of type II TPx with that of the 195 residues of TPx,
+now renamed type I TPx, revealed no substantial homology except for a short
+segment preceding Cys62 of type II TPx. Kinetic characterization of the
+reactions catalyzed by type I and II TPxs revealed that type I preferentially
+reduces H2O2 rather than alkyl hydroperoxides, whereas type II shows the reverse
+specificity. Type II TPx contains three cysteine residues at positions 31, 62,
+and 120. Experiments with mutant proteins in which these three cysteine residues
+were replaced individually with serine suggest that Cys62-SH constitutes the
+site of oxidation by peroxides and that the oxidized Cys62 reacts with the
+Cys120-SH group of another type II TPx molecule to form an intermolecular
+disulfide linkage. The formed disulfide can then be reduced by thioredoxin, but
+not by glutathione. Thus, type II TPx mutants lacking Cys62 or Cys120 showed no
+detectable TPx activity, whereas mutation of Cys31 had no effect on TPx
+activity. An antioxidant function of type II TPx in intact cells was
+demonstrated by the observation that Escherichia coli cells overexpressing
+wild-type protein were less sensitive to inhibition of growth by alkyl
+hydroperoxides than were control cells or cells overexpressing the mutant
+protein lacking Cys62.
+
+DOI: 10.1021/bi9817818
+PMID: 9888818 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- align TSA1 with the project-wide `holdase chaperone activity` NTR instead of introducing a parallel name
- fetch PMID:9888818 through `just fetch-pmid`, add it to the validated reference list, and anchor its type-I TPx comparison with an exact abstract quote
- explain why generic identical-protein binding is over-annotated while protein polymerization is retained as a non-core description of high-MW assembly
- regenerate TSA1 HTML and browser data through public wrappers

## Validation
- `just fetch-pmid 9888818`
- `just validate yeast TSA1`
- `just validate-goa yeast TSA1`
- `just render yeast TSA1`
- `just deploy-browser`