### PR TITLE
Canonicalize TSA1 holdase proposal

### DIFF
--- a/genes/yeast/TSA1/TSA1-ai-review.html
+++ b/genes/yeast/TSA1/TSA1-ai-review.html
@@ -850,7 +850,7 @@
             </div>
 
 
-            <p><strong>Definition:</strong> Binding to an unfolded or misfolded protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains the client in a soluble, folding-competent state and does not require escort to an acceptor molecule or another cellular location.</p>
+            <p><strong>Definition:</strong> Binding to an unfolded or misfolded protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains the client protein in a soluble, folding-competent state.</p>
 
 
 
@@ -2133,6 +2133,19 @@ the experimentally characterized thioredoxin-coupled peroxidase activity
                             <div class="support-item">
                                 <span class="support-ref">
 
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9888818" target="_blank" class="term-link">
+                                        PMID:9888818
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Kinetic characterization of the reactions catalyzed by type I and II TPxs revealed that type I preferentially reduces H2O2 rather than alkyl hydroperoxides, whereas type II shows the reverse specificity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     file:yeast/TSA1/TSA1-deep-research-falcon.md
 
                                 </span>
@@ -3396,7 +3409,7 @@ biology is sound and is represented by the current activity term.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Tsa1 forms high-MW homo-oligomeric assemblies, but an IMP code does not directly assay identical-protein binding.
+                            <strong>Summary:</strong> Tsa1 forms high-MW homo-oligomeric assemblies during the stress-induced chaperone switch, but the generic binding term does not express that mechanism.
                         </div>
 
 
@@ -6819,6 +6832,9 @@ existing_annotations:
     - PMID:9888818
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
+    - reference_id: PMID:9888818
+      supporting_text: &gt;-
+        Kinetic characterization of the reactions catalyzed by type I and II TPxs revealed that type I preferentially reduces H2O2 rather than alkyl hydroperoxides, whereas type II shows the reverse specificity.
     - reference_id: file:yeast/TSA1/TSA1-deep-research-falcon.md
       supporting_text: |-
         Reduction of oxidized Tsa1 is primarily driven by the **cytosolic thioredoxin system**: **Trx1/Trx2** reduce the Tsa1 disulfide, and oxidized thioredoxin is recycled by **thioredoxin reductase** using **NADPH**.
@@ -7060,7 +7076,9 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: Tsa1 forms high-MW homo-oligomeric assemblies, but an IMP code does not directly assay identical-protein binding.
+    summary: &gt;-
+      Tsa1 forms high-MW homo-oligomeric assemblies during the stress-induced
+      chaperone switch, but the generic binding term does not express that mechanism.
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Oligomerization is real, yet this generic MF binding term and its IMP
@@ -7605,9 +7623,8 @@ proposed_new_terms:
 - proposed_name: holdase chaperone activity
   proposed_definition: &gt;-
     Binding to an unfolded or misfolded protein to prevent its aggregation
-    without actively catalyzing refolding. The holdase maintains the client in
-    a soluble, folding-competent state and does not require escort to an
-    acceptor molecule or another cellular location.
+    without actively catalyzing refolding. The holdase maintains the client protein
+    in a soluble, folding-competent state.
   justification: &gt;-
     TSA1 is an ATP-independent, stress-activated holdase whose higher-order
     oligomers prevent aggregation. GO:0051082 is obsolete; GO:0044183 captures

--- a/genes/yeast/TSA1/TSA1-ai-review.yaml
+++ b/genes/yeast/TSA1/TSA1-ai-review.yaml
@@ -339,6 +339,9 @@ existing_annotations:
     - PMID:9888818
     - file:yeast/TSA1/TSA1-deep-research-falcon.md
     supported_by:
+    - reference_id: PMID:9888818
+      supporting_text: >-
+        Kinetic characterization of the reactions catalyzed by type I and II TPxs revealed that type I preferentially reduces H2O2 rather than alkyl hydroperoxides, whereas type II shows the reverse specificity.
     - reference_id: file:yeast/TSA1/TSA1-deep-research-falcon.md
       supporting_text: |-
         Reduction of oxidized Tsa1 is primarily driven by the **cytosolic thioredoxin system**: **Trx1/Trx2** reduce the Tsa1 disulfide, and oxidized thioredoxin is recycled by **thioredoxin reductase** using **NADPH**.
@@ -580,7 +583,9 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:15163410
   review:
-    summary: Tsa1 forms high-MW homo-oligomeric assemblies, but an IMP code does not directly assay identical-protein binding.
+    summary: >-
+      Tsa1 forms high-MW homo-oligomeric assemblies during the stress-induced
+      chaperone switch, but the generic binding term does not express that mechanism.
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Oligomerization is real, yet this generic MF binding term and its IMP
@@ -1125,9 +1130,8 @@ proposed_new_terms:
 - proposed_name: holdase chaperone activity
   proposed_definition: >-
     Binding to an unfolded or misfolded protein to prevent its aggregation
-    without actively catalyzing refolding. The holdase maintains the client in
-    a soluble, folding-competent state and does not require escort to an
-    acceptor molecule or another cellular location.
+    without actively catalyzing refolding. The holdase maintains the client protein
+    in a soluble, folding-competent state.
   justification: >-
     TSA1 is an ATP-independent, stress-activated holdase whose higher-order
     oligomers prevent aggregation. GO:0051082 is obsolete; GO:0044183 captures


### PR DESCRIPTION
## Summary
- make the TSA1 holdase NTR definition byte-identical to the project canonical definition
- keep the carrier/escort exclusion in the NTR justification
- attach PMID:9888818 supporting text directly to GO:0140824
- revise the GO:0042802 summary to focus on biological term informativeness rather than the evidence code
- regenerate TSA1 HTML and browser data through public wrappers

## Validation
- `just validate yeast TSA1`
- `just validate-goa yeast TSA1`
- `just render yeast TSA1`
- `just deploy-browser`