### PR TITLE
Re-review yeast TSR4 annotations

### DIFF
--- a/genes/yeast/TSR4/TSR4-ai-review.html
+++ b/genes/yeast/TSR4/TSR4-ai-review.html
@@ -901,14 +901,61 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IBA is consistent with Tsr4-dependent 20S pre-rRNA processing and 40S biogenesis.
+                            <strong>Summary:</strong> The IBA is consistent with target-specific IMP evidence that places TSR4
+in 20S pre-rRNA processing and with later mechanistic work on Rps2/uS5
+delivery into the 40S biogenesis pathway.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> SSU-rRNA maturation is a direct process-level consequence of the uS5 chaperone role.
+                            <strong>Reason:</strong> SSU-rRNA maturation is a core downstream consequence of the uS5 chaperone role.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">SOURCE STALE OR MISSING</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000958897</span>
+
+                                    &middot; PANTHER:PTN000958897
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">Cached GOA identifies this exact ancestral node, but no current
+PTHR47524 PAINT table or PTN record is present in the repository&#39;s
+PAINT snapshot, so the current node assertion cannot be recovered.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000005382</span>
+
+                                    &middot; TSR4
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The target&#39;s own experimental annotation is a valid descendant seed,
+not circular evidence; direct TSR4 phenotypes support SSU-rRNA maturation.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -924,7 +971,7 @@
 
                                 </span>
 
-                                <div class="support-text">YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.</div>
+                                <div class="support-text">We experimentally evaluated &gt;100 candidate yeast genes in a battery of assays, confirming involvement of at least 15 new genes, including previously uncharacterized genes (YDL063C, YIL091C, YOR287C, YOR006C/TSR3, YOL022C/TSR4).</div>
 
                             </div>
 
@@ -935,7 +982,7 @@
 
                                 </span>
 
-                                <div class="support-text">Tsr4 enables downstream 40S assembly and pre-40S export through cytoplasmic Rps2/uS5 chaperone activity.</div>
+                                <div class="support-text">TSR4 acts within **small (40S) ribosomal subunit biogenesis**, specifically by enabling accumulation and assembly of Rps2/uS5 into pre-40S particles.</div>
 
                             </div>
 
@@ -1077,7 +1124,7 @@
 
                                 </span>
 
-                                <div class="support-text">Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2</div>
+                                <div class="support-text">Tsr4 binds co-translationally to the essential, eukaryote-specific N-terminal extension of Rps2, whereas Nap1 interacts with a large, mostly eukaryote-specific binding surface of Rps6.</div>
 
                             </div>
 
@@ -1159,7 +1206,7 @@
 
                                 </span>
 
-                                <div class="support-text">Mutation of the essential Tsr4...enhance the 40S synthesis defects</div>
+                                <div class="support-text">Mutation of the essential Tsr4 and deletion of the non-essential Nap1 both enhance the 40S synthesis defects of the corresponding r-protein mutants.</div>
 
                             </div>
 
@@ -1241,7 +1288,7 @@
 
                                 </span>
 
-                                <div class="support-text">Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2</div>
+                                <div class="support-text">Tsr4 binds co-translationally to the essential, eukaryote-specific N-terminal extension of Rps2, whereas Nap1 interacts with a large, mostly eukaryote-specific binding surface of Rps6.</div>
 
                             </div>
 
@@ -1289,10 +1336,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P25040" data-a="GO:0140597" data-r="PMID:31062022" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25040" data-a="GO:0140597" data-r="PMID:31062022" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1300,15 +1347,33 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This is the most specific molecular-function annotation for TSR4.
+                            <strong>Summary:</strong> Tsr4 is a dedicated Rps2/uS5 chaperone, but current GO:0140597 is labelled
+protein carrier activity and requires delivery to an acceptor molecule or
+specific location. The experiments establish cotranslational binding and
+solubility promotion, while UniProt states Tsr4 is released before Rps2
+nuclear import; no direct handoff or delivery step is demonstrated.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Tsr4 is a dedicated carrier chaperone for ribosomal protein Rps2/uS5.
+                            <strong>Reason:</strong> Replace with GO:0044183 protein folding chaperone, whose definition matches
+binding that assists client folding/solubility. GO:0140318 is even more
+location-specific, and GO:0140309 additionally requires an unfolded client
+to be escorted; neither is supported for Tsr4.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -1323,7 +1388,7 @@
 
                                 </span>
 
-                                <div class="support-text">vitro. While Tsr4 is specific for Rps2...Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2</div>
+                                <div class="support-text">Both factors promote the solubility of their r-protein clients in vitro. While Tsr4 is specific for Rps2, Nap1 has several interaction partners including Rps6 and two other r-proteins.</div>
 
                             </div>
 
@@ -1334,7 +1399,7 @@
 
                                 </span>
 
-                                <div class="support-text">Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.</div>
+                                <div class="support-text">**Molecular function (best-supported):** Tsr4 binds **nascent Rps2/uS5** co-translationally in the cytoplasm and acts as a **client-specific chaperone** to stabilize Rps2 and support 40S biogenesis (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 12-13).</div>
 
                             </div>
 
@@ -1416,7 +1481,7 @@
 
                                 </span>
 
-                                <div class="support-text">Mutation of the essential Tsr4...enhance the 40S synthesis defects</div>
+                                <div class="support-text">Mutation of the essential Tsr4 and deletion of the non-essential Nap1 both enhance the 40S synthesis defects of the corresponding r-protein mutants.</div>
 
                             </div>
 
@@ -1498,7 +1563,7 @@
 
                                 </span>
 
-                                <div class="support-text">identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2</div>
+                                <div class="support-text">We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2, respectively.</div>
 
                             </div>
 
@@ -1557,12 +1622,16 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> The binding evidence is specific to Rps2/uS5, not generic unfolded protein.
+                            <strong>Summary:</strong> GO:0051082 is obsolete. The evidence shows that Tsr4 binds nascent Rps2
+and promotes its solubility, supporting protein folding chaperone activity,
+not generic unfolded-protein binding or carrier-mediated transport.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Replace broad unfolded protein binding with protein carrier chaperone.
+                            <strong>Reason:</strong> Replace the obsolete term with GO:0044183. GO:0140597/GO:0140318 require
+demonstrated delivery, and GO:0140309 requires escort of an unfolded client;
+Tsr4 is released before nuclear import and those mechanisms were not shown.
                         </div>
 
 
@@ -1571,8 +1640,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
-                                    protein carrier chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    protein folding chaperone
                                 </a>
                             </span>
 
@@ -1591,7 +1660,7 @@
 
                                 </span>
 
-                                <div class="support-text">Both factors promote the solubility of their r-protein clients in...vitro.</div>
+                                <div class="support-text">Both factors promote the solubility of their r-protein clients in vitro.</div>
 
                             </div>
 
@@ -1673,7 +1742,7 @@
 
                                 </span>
 
-                                <div class="support-text">Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.</div>
+                                <div class="support-text">Tsr4 perturbation resulted in decreased Rps2 levels and phenocopied Rps2 depletion.</div>
 
                             </div>
 
@@ -1732,12 +1801,14 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> The evidence supports specific Rps2 carrier chaperoning.
+                            <strong>Summary:</strong> GO:0051082 is obsolete. This paper identifies Tsr4 as a cytoplasmic
+chaperone dedicated to Rps2, but it does not demonstrate carrier delivery
+or escort to a location.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Protein carrier chaperone is the more precise molecular-function term.
+                            <strong>Reason:</strong> Protein folding chaperone is the evidence-matched current activity term.
                         </div>
 
 
@@ -1746,8 +1817,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
-                                    protein carrier chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    protein folding chaperone
                                 </a>
                             </span>
 
@@ -1766,7 +1837,7 @@
 
                                 </span>
 
-                                <div class="support-text">Tsr4 cotranslationally associates with Rps2...cytoplasmic chaperone dedicated to Rps2.</div>
+                                <div class="support-text">Here, we report that Tsr4 cotranslationally associates with Rps2.</div>
 
                             </div>
 
@@ -1825,12 +1896,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> The IPI evidence identifies a specific Rps2/uS5 client relationship.
+                            <strong>Summary:</strong> The IPI evidence identifies the specific Tsr4-Rps2 client interaction, but
+GO:0051082 is obsolete and the paper does not establish carrier delivery.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Replace broad unfolded protein binding with protein carrier chaperone.
+                            <strong>Reason:</strong> Replace with protein folding chaperone to capture client stabilization without inventing transport.
                         </div>
 
 
@@ -1839,8 +1911,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
-                                    protein carrier chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    protein folding chaperone
                                 </a>
                             </span>
 
@@ -1859,7 +1931,7 @@
 
                                 </span>
 
-                                <div class="support-text">Rps2 harbors a...eukaryote-specific N-terminal extension that is critical for its interaction...with Tsr4.</div>
+                                <div class="support-text">Rps2 harbors a eukaryote-specific N-terminal extension that is critical for its interaction with Tsr4.</div>
 
                             </div>
 
@@ -2105,7 +2177,7 @@
 
                                 </span>
 
-                                <div class="support-text">YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.</div>
+                                <div class="support-text">We associate the new genes with specific aspects of ribosomal subunit maturation, ribosomal particle association, and ribosomal subunit nuclear export, and we identify genes specifically required for the processing of 5S, 7S, 20S, 27S, and 35S rRNAs.</div>
 
                             </div>
 
@@ -2127,8 +2199,8 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Cytoplasmic protein carrier chaperone for ribosomal protein Rps2/uS5. Tsr4 binds nascent Rps2/uS5 and maintains the client in a soluble assembly-competent state before nuclear import and incorporation into pre-40S particles.</h3>
-                <span class="vote-buttons" data-g="P25040" data-a="FUNCTION: Cytoplasmic protein carrier chaperone for ribosoma..." data-r="" data-act="CORE_FUNCTION">
+                <h3>Cytoplasmic, client-specific protein folding chaperone for ribosomal protein Rps2/uS5. Tsr4 binds the nascent eukaryote-specific Rps2 N-terminal extension and maintains Rps2 in a soluble, assembly-competent state before Tsr4 release, nuclear import of the client, and pre-40S incorporation.</h3>
+                <span class="vote-buttons" data-g="P25040" data-a="FUNCTION: Cytoplasmic, client-specific protein folding chape..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -2140,8 +2212,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
-                            protein carrier chaperone
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                            protein folding chaperone
                         </a>
                     </span>
                 </div>
@@ -2208,7 +2280,7 @@
 
                         </span>
 
-                        <div class="finding-text">identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2...Both factors promote the solubility of their r-protein clients</div>
+                        <div class="finding-text">We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2, respectively. Both factors promote the solubility of their r-protein clients in vitro.</div>
 
                     </li>
 
@@ -2221,7 +2293,7 @@
 
                         </span>
 
-                        <div class="finding-text">Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.</div>
+                        <div class="finding-text">Tsr4 perturbation resulted in decreased Rps2 levels and phenocopied Rps2 depletion.</div>
 
                     </li>
 
@@ -2232,7 +2304,7 @@
 
                         </span>
 
-                        <div class="finding-text">Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.</div>
+                        <div class="finding-text">**Chaperone effect on solubility:** Rps2 expressed alone is aggregation-prone, while co-expression with Tsr4 keeps Rps2 soluble and supports complex formation in vitro and in vivo (rossler2019tsr4andnap1 pages 14-15).</div>
 
                     </li>
 
@@ -2348,7 +2420,7 @@
                     <li class="finding-item">
                         <div class="finding-statement">TSR4 was identified as a ribosome biogenesis factor</div>
 
-                        <div class="finding-text">"Network-guided genetics associated YOL022C/TSR4 with ribosome biogenesis and pre-rRNA processing."</div>
+                        <div class="finding-text">"We experimentally evaluated &gt;100 candidate yeast genes in a battery of assays, confirming involvement of at least 15 new genes, including previously uncharacterized genes (YDL063C, YIL091C, YOR287C, YOR006C/TSR3, YOL022C/TSR4)."</div>
 
                     </li>
 
@@ -2373,9 +2445,9 @@
                 <ul class="findings-list">
 
                     <li class="finding-item">
-                        <div class="finding-statement">Tsr4 is a direct Rps2/uS5 carrier chaperone</div>
+                        <div class="finding-statement">Tsr4 is a direct, cotranslational Rps2/uS5 chaperone that promotes client solubility.</div>
 
-                        <div class="finding-text">"Tsr4 is specific for Rps2, binds co-translationally to its N-terminal extension, and promotes solubility."</div>
+                        <div class="finding-text">"We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2, respectively. Both factors promote the solubility of their r-protein clients in vitro."</div>
 
                     </li>
 
@@ -2402,7 +2474,7 @@
                     <li class="finding-item">
                         <div class="finding-statement">Tsr4 is a cytoplasmic chaperone dedicated to Rps2</div>
 
-                        <div class="finding-text">"Tsr4 cotranslationally associates with Rps2; perturbation decreases Rps2 levels."</div>
+                        <div class="finding-text">"Here, we report that Tsr4 cotranslationally associates with Rps2. Rps2 harbors a eukaryote-specific N-terminal extension that is critical for its interaction with Tsr4."</div>
 
                     </li>
 
@@ -2425,9 +2497,9 @@
                 <ul class="findings-list">
 
                     <li class="finding-item">
-                        <div class="finding-statement">TSR4 is a cytoplasmic uS5/Rps2 carrier chaperone</div>
+                        <div class="finding-statement">TSR4 is a cytoplasmic, client-specific uS5/Rps2 chaperone.</div>
 
-                        <div class="finding-text">"The report synthesizes evidence that Tsr4 captures nascent Rps2/uS5 and enables downstream 40S assembly."</div>
+                        <div class="finding-text">"**Molecular function (best-supported):** Tsr4 binds **nascent Rps2/uS5** co-translationally in the cytoplasm and acts as a **client-specific chaperone** to stabilize Rps2 and support 40S biogenesis (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 12-13)."</div>
 
                     </li>
 
@@ -2447,10 +2519,23 @@
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    <p><strong>Q:</strong> Should older GO:0051082 annotations for Tsr4 be replaced by GO:0140597 protein carrier chaperone where evidence is specific Rps2/uS5 chaperoning?</p>
+                    <p><strong>Q:</strong> What molecular event releases nascent Rps2 from Tsr4, and is a specific importin or assembly factor the immediate acceptor?</p>
 
                 </div>
-                <span class="vote-buttons" data-g="P25040" data-a="Q: Should older GO:0051082 annotations for Tsr4 be re..." data-r="" data-act="QUESTION">
+                <span class="vote-buttons" data-g="P25040" data-a="Q: What molecular event releases nascent Rps2 from Ts..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Tsr4 directly promote a folded Rps2 conformation, or does it principally prevent aggregation until another factor completes folding and import?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25040" data-a="Q: Does Tsr4 directly promote a folded Rps2 conformat..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
                     <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
                 </span>
@@ -2461,9 +2546,59 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute nascent Rps2-Tsr4 complexes and test candidate importins and pre-40S factors for direct, directional client handoff using kinetic binding and release assays.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: A defined downstream factor triggers Rps2 release; only such evidence would justify protein carrier activity or protein transporter activity.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P25040" data-a="EXPERIMENT: Reconstitute nascent Rps2-Tsr4 complexes and test ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare Rps2 folding and aggregation with and without Tsr4 using limited proteolysis, structural probes, solubility measurements and subsequent import/assembly competence.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Tsr4 prevents nonproductive aggregation and assists acquisition of an assembly-competent state without escorting Rps2 into the nucleus.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P25040" data-a="EXPERIMENT: Compare Rps2 folding and aggregation with and with..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
 
 
 
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">UPB</span>
+
+        </div>
+    </div>
 
 
     <!-- Computational Predictions Section -->
@@ -2837,6 +2972,86 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TSR4-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P25040" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tsr4-annotation-re-review-notes">TSR4 annotation re-review notes</h1>
+<h2 id="2026-08-28-dedicated-re-review">2026-08-28 dedicated re-review</h2>
+<p>TSR4 (P25040; SGD:S000005382) encodes a cytoplasmic dedicated chaperone<br />
+for ribosomal protein Rps2/uS5. Two independent 2019 studies identify the same<br />
+client relationship. Rössler et al. report direct Tsr4-Rps2 binding and in-vitro<br />
+solubility promotion [PMID:31062022, "We report the identification of Nap1 and<br />
+Tsr4 as direct binding partners of Rps6 and Rps2, respectively. Both factors<br />
+promote the solubility of their r-protein clients in vitro."]. Black et al.<br />
+independently report cotranslational association and the Rps2 N-terminal<br />
+determinant [PMID:31182640, "Here, we report that Tsr4 cotranslationally<br />
+associates with Rps2. Rps2 harbors a eukaryote-specific N-terminal extension<br />
+that is critical for its interaction with Tsr4."]. Both cached publications are<br />
+abstract-only, so the review uses only claims stated in those abstracts or in<br />
+the curated UniProt record and does not invent inaccessible assay details.</p>
+<h3 id="goa-reconciliation">GOA reconciliation</h3>
+<p>The cached GOA has 15 physical rows and 15 distinct qualifier-aware signatures<br />
+(qualifier + GO term + evidence code + reference). All are positive relation<br />
+qualifiers (<code>enables</code>, <code>involved_in</code>, or <code>located_in</code>); there are no NOT or<br />
+isoform-specific rows. The IGI small-subunit-biogenesis row has WITH/FROM<br />
+<code>SGD:S000003091</code> (RPS2), matching the experimentally defined client. The single<br />
+IBA row has WITH/FROM <code>PANTHER:PTN000958897|SGD:S000005382</code>.</p>
+<h3 id="paint-provenance">PAINT provenance</h3>
+<p>The sole IBA is GO:0030490 maturation of SSU-rRNA at<br />
+<code>PANTHER:PTN000958897</code>. The current local PAINT snapshot contains neither a<br />
+PTHR47524 family directory/table nor a record for PTN000958897, although the<br />
+official PANTHER ontology resolves PTHR47524 as "20S RRNA ACCUMULATION PROTEIN<br />
+4." The propagation review therefore records <code>SOURCE_STALE_OR_MISSING</code> for the<br />
+unrecoverable current node assertion. This is not a biological rejection of the<br />
+IBA: the target itself is the experimental seed, which is valid rather than<br />
+circular, and direct target evidence supports SSU-rRNA maturation<br />
+[PMID:19806183, "We experimentally evaluated &gt;100 candidate yeast genes in a<br />
+battery of assays, confirming involvement of at least 15 new genes, including<br />
+previously uncharacterized genes (YDL063C, YIL091C, YOR287C, YOR006C/TSR3,<br />
+YOL022C/TSR4)."].</p>
+<h3 id="chaperone-versus-carrier-semantics">Chaperone versus carrier semantics</h3>
+<p>Live QuickGO definitions were checked on 2026-08-28:</p>
+<ul>
+<li>GO:0051082 is obsolete.</li>
+<li>GO:0044183 protein folding chaperone means binding a protein or complex to<br />
+  assist protein folding.</li>
+<li>GO:0140597 is now labelled protein carrier activity and requires delivery to<br />
+  an acceptor molecule or specific location.</li>
+<li>GO:0140318 protein transporter activity specifically requires delivery to a<br />
+  cellular location.</li>
+<li>GO:0140309 unfolded protein holdase activity additionally requires an unfolded<br />
+  client to be escorted to an acceptor or location.</li>
+</ul>
+<p>Tsr4 clearly binds nascent Rps2 and promotes its solubility. However, curated<br />
+UniProt states that Tsr4 is released before Rps2 nuclear import, and current<br />
+evidence does not identify a direct acceptor, directional handoff, or escort by<br />
+Tsr4 to the nucleus. Consequently, GO:0140597 is not retained as core and<br />
+GO:0140318/GO:0140309 are not proposed. The direct GO:0140597 row and all three<br />
+obsolete GO:0051082 rows are instead MODIFY to GO:0044183, which captures the<br />
+experimentally demonstrated client-stabilizing chaperone activity without<br />
+inventing transport.</p>
+<p>The core synthesis is therefore a cytoplasmic, Rps2-specific protein folding<br />
+chaperone whose activity supports ribosomal small-subunit biogenesis and SSU<br />
+rRNA maturation. Experiments that identify the immediate Rps2 acceptor and<br />
+demonstrate directional handoff would be needed before asserting carrier or<br />
+transporter activity.</p>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2862,6 +3077,8 @@ description: &gt;-
   client before nuclear import and productive pre-40S assembly. Loss of Tsr4
   impairs 40S ribosomal small subunit biogenesis, pre-40S export, and 20S
   pre-rRNA processing at site D to mature 18S rRNA.
+tags:
+- UPB
 existing_annotations:
 - term:
     id: GO:0030490
@@ -2869,14 +3086,35 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: IBA is consistent with Tsr4-dependent 20S pre-rRNA processing and 40S biogenesis.
+    summary: |-
+      The IBA is consistent with target-specific IMP evidence that places TSR4
+      in 20S pre-rRNA processing and with later mechanistic work on Rps2/uS5
+      delivery into the 40S biogenesis pathway.
     action: ACCEPT
-    reason: SSU-rRNA maturation is a direct process-level consequence of the uS5 chaperone role.
+    reason: SSU-rRNA maturation is a core downstream consequence of the uS5 chaperone role.
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      source_entities:
+      - source_id: PANTHER:PTN000958897
+        source_label: PANTHER:PTN000958897
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: |-
+          Cached GOA identifies this exact ancestral node, but no current
+          PTHR47524 PAINT table or PTN record is present in the repository&#39;s
+          PAINT snapshot, so the current node assertion cannot be recovered.
+      - source_id: SGD:S000005382
+        source_label: TSR4
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          The target&#39;s own experimental annotation is a valid descendant seed,
+          not circular evidence; direct TSR4 phenotypes support SSU-rRNA maturation.
     supported_by:
     - reference_id: PMID:19806183
-      supporting_text: YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.
+      supporting_text: |-
+        We experimentally evaluated &gt;100 candidate yeast genes in a battery of assays, confirming involvement of at least 15 new genes, including previously uncharacterized genes (YDL063C, YIL091C, YOR287C, YOR006C/TSR3, YOL022C/TSR4).
     - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
-      supporting_text: Tsr4 enables downstream 40S assembly and pre-40S export through cytoplasmic Rps2/uS5 chaperone activity.
+      supporting_text: |-
+        TSR4 acts within **small (40S) ribosomal subunit biogenesis**, specifically by enabling accumulation and assembly of Rps2/uS5 into pre-40S particles.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -2900,7 +3138,8 @@ existing_annotations:
     reason: Direct and curated sources place Tsr4 in the cytosol/cytoplasm.
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
+      supporting_text: |-
+        Tsr4 binds co-translationally to the essential, eukaryote-specific N-terminal extension of Rps2, whereas Nap1 interacts with a large, mostly eukaryote-specific binding surface of Rps6.
 - term:
     id: GO:0042254
     label: ribosome biogenesis
@@ -2915,7 +3154,8 @@ existing_annotations:
       label: ribosomal small subunit biogenesis
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: Mutation of the essential Tsr4...enhance the 40S synthesis defects
+      supporting_text: |-
+        Mutation of the essential Tsr4 and deletion of the non-essential Nap1 both enhance the 40S synthesis defects of the corresponding r-protein mutants.
 - term:
     id: GO:0005829
     label: cytosol
@@ -2927,21 +3167,36 @@ existing_annotations:
     reason: Tsr4 binds Rps2/uS5 co-translationally in the cytosol.
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
+      supporting_text: |-
+        Tsr4 binds co-translationally to the essential, eukaryote-specific N-terminal extension of Rps2, whereas Nap1 interacts with a large, mostly eukaryote-specific binding surface of Rps6.
 - term:
     id: GO:0140597
     label: protein carrier chaperone
   evidence_type: IDA
   original_reference_id: PMID:31062022
   review:
-    summary: This is the most specific molecular-function annotation for TSR4.
-    action: ACCEPT
-    reason: Tsr4 is a dedicated carrier chaperone for ribosomal protein Rps2/uS5.
+    summary: |-
+      Tsr4 is a dedicated Rps2/uS5 chaperone, but current GO:0140597 is labelled
+      protein carrier activity and requires delivery to an acceptor molecule or
+      specific location. The experiments establish cotranslational binding and
+      solubility promotion, while UniProt states Tsr4 is released before Rps2
+      nuclear import; no direct handoff or delivery step is demonstrated.
+    action: MODIFY
+    reason: |-
+      Replace with GO:0044183 protein folding chaperone, whose definition matches
+      binding that assists client folding/solubility. GO:0140318 is even more
+      location-specific, and GO:0140309 additionally requires an unfolded client
+      to be escorted; neither is supported for Tsr4.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: vitro. While Tsr4 is specific for Rps2...Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
+      supporting_text: |-
+        Both factors promote the solubility of their r-protein clients in vitro. While Tsr4 is specific for Rps2, Nap1 has several interaction partners including Rps6 and two other r-proteins.
     - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
-      supporting_text: Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.
+      supporting_text: |-
+        **Molecular function (best-supported):** Tsr4 binds **nascent Rps2/uS5** co-translationally in the cytoplasm and acts as a **client-specific chaperone** to stabilize Rps2 and support 40S biogenesis (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 12-13).
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
@@ -2953,7 +3208,8 @@ existing_annotations:
     reason: Rps2/uS5 chaperoning is directly tied to small subunit assembly.
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: Mutation of the essential Tsr4...enhance the 40S synthesis defects
+      supporting_text: |-
+        Mutation of the essential Tsr4 and deletion of the non-essential Nap1 both enhance the 40S synthesis defects of the corresponding r-protein mutants.
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
@@ -2965,22 +3221,29 @@ existing_annotations:
     reason: The genetic relationship supports Tsr4&#39;s role in Rps2-dependent 40S assembly.
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2
+      supporting_text: |-
+        We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2, respectively.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:31062022
   review:
-    summary: The binding evidence is specific to Rps2/uS5, not generic unfolded protein.
+    summary: |-
+      GO:0051082 is obsolete. The evidence shows that Tsr4 binds nascent Rps2
+      and promotes its solubility, supporting protein folding chaperone activity,
+      not generic unfolded-protein binding or carrier-mediated transport.
     action: MODIFY
-    reason: Replace broad unfolded protein binding with protein carrier chaperone.
+    reason: |-
+      Replace the obsolete term with GO:0044183. GO:0140597/GO:0140318 require
+      demonstrated delivery, and GO:0140309 requires escort of an unfolded client;
+      Tsr4 is released before nuclear import and those mechanisms were not shown.
     proposed_replacement_terms:
-    - id: GO:0140597
-      label: protein carrier chaperone
+    - id: GO:0044183
+      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: Both factors promote the solubility of their r-protein clients in...vitro.
+      supporting_text: Both factors promote the solubility of their r-protein clients in vitro.
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
@@ -2992,37 +3255,44 @@ existing_annotations:
     reason: Tsr4 perturbation decreases Rps2 and phenocopies Rps2 depletion.
     supported_by:
     - reference_id: PMID:31182640
-      supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.
+      supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and phenocopied Rps2 depletion.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:31182640
   review:
-    summary: The evidence supports specific Rps2 carrier chaperoning.
+    summary: |-
+      GO:0051082 is obsolete. This paper identifies Tsr4 as a cytoplasmic
+      chaperone dedicated to Rps2, but it does not demonstrate carrier delivery
+      or escort to a location.
     action: MODIFY
-    reason: Protein carrier chaperone is the more precise molecular-function term.
+    reason: Protein folding chaperone is the evidence-matched current activity term.
     proposed_replacement_terms:
-    - id: GO:0140597
-      label: protein carrier chaperone
+    - id: GO:0044183
+      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:31182640
-      supporting_text: Tsr4 cotranslationally associates with Rps2...cytoplasmic chaperone dedicated to Rps2.
+      supporting_text: |-
+        Here, we report that Tsr4 cotranslationally associates with Rps2.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IPI
   original_reference_id: PMID:31182640
   review:
-    summary: The IPI evidence identifies a specific Rps2/uS5 client relationship.
+    summary: |-
+      The IPI evidence identifies the specific Tsr4-Rps2 client interaction, but
+      GO:0051082 is obsolete and the paper does not establish carrier delivery.
     action: MODIFY
-    reason: Replace broad unfolded protein binding with protein carrier chaperone.
+    reason: Replace with protein folding chaperone to capture client stabilization without inventing transport.
     proposed_replacement_terms:
-    - id: GO:0140597
-      label: protein carrier chaperone
+    - id: GO:0044183
+      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:31182640
-      supporting_text: Rps2 harbors a...eukaryote-specific N-terminal extension that is critical for its interaction...with Tsr4.
+      supporting_text: |-
+        Rps2 harbors a eukaryote-specific N-terminal extension that is critical for its interaction with Tsr4.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -3058,7 +3328,8 @@ existing_annotations:
     reason: Later work explains the phenotype through defective Rps2/uS5 handling and 40S assembly.
     supported_by:
     - reference_id: PMID:19806183
-      supporting_text: YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.
+      supporting_text: |-
+        We associate the new genes with specific aspects of ribosomal subunit maturation, ribosomal particle association, and ribosomal subunit nuclear export, and we identify genes specifically required for the processing of 5S, 7S, 20S, 27S, and 35S rRNAs.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -3074,36 +3345,77 @@ references:
   findings: []
 - id: PMID:14562095
   title: Global analysis of protein localization in budding yeast.
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: |-
+      PubMed metadata and the global GFP-localization study are verified, but
+      the abstract-only cache does not expose the TSR4-specific localization
+      record. The HDA row is retained because later targeted work independently
+      places Tsr4 in the cytoplasm.
   findings: []
 - id: PMID:19806183
   title: Rational extension of the ribosome biogenesis pathway using network-guided genetics.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. The abstract explicitly
+      includes YOL022C/TSR4 among experimentally confirmed ribosome-biogenesis
+      genes and reports rRNA-processing assays, although the cache lacks the
+      full-text gene-by-processing-species table.
   findings:
   - statement: TSR4 was identified as a ribosome biogenesis factor
-    supporting_text: Network-guided genetics associated YOL022C/TSR4 with ribosome biogenesis and pre-rRNA processing.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      We experimentally evaluated &gt;100 candidate yeast genes in a battery of assays, confirming involvement of at least 15 new genes, including previously uncharacterized genes (YDL063C, YIL091C, YOR287C, YOR006C/TSR3, YOL022C/TSR4).
 - id: PMID:31062022
   title: Tsr4 and Nap1, two novel members of the ribosomal protein chaperOME.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. The abstract directly
+      supports cotranslational Rps2 binding, client specificity, solubility
+      promotion and the 40S-biogenesis phenotype. The local cache is abstract-only.
   findings:
-  - statement: Tsr4 is a direct Rps2/uS5 carrier chaperone
-    supporting_text: Tsr4 is specific for Rps2, binds co-translationally to its N-terminal extension, and promotes solubility.
+  - statement: Tsr4 is a direct, cotranslational Rps2/uS5 chaperone that promotes client solubility.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2, respectively. Both factors promote the solubility of their r-protein clients in vitro.
 - id: PMID:31182640
   title: Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rps2 in Saccharomyces cerevisiae.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. The abstract directly
+      supports the dedicated Rps2 interaction, cytoplasmic restriction and
+      Rps2-depletion phenotype. The local cache is abstract-only.
   findings:
   - statement: Tsr4 is a cytoplasmic chaperone dedicated to Rps2
-    supporting_text: Tsr4 cotranslationally associates with Rps2; perturbation decreases Rps2 levels.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      Here, we report that Tsr4 cotranslationally associates with Rps2. Rps2 harbors a eukaryote-specific N-terminal extension that is critical for its interaction with Tsr4.
 - id: file:yeast/TSR4/TSR4-deep-research-falcon.md
   title: Falcon deep research report for TSR4
   findings:
-  - statement: TSR4 is a cytoplasmic uS5/Rps2 carrier chaperone
-    supporting_text: The report synthesizes evidence that Tsr4 captures nascent Rps2/uS5 and enables downstream 40S assembly.
+  - statement: TSR4 is a cytoplasmic, client-specific uS5/Rps2 chaperone.
+    reference_section_type: OTHER
+    supporting_text: |-
+      **Molecular function (best-supported):** Tsr4 binds **nascent Rps2/uS5** co-translationally in the cytoplasm and acts as a **client-specific chaperone** to stabilize Rps2 and support 40S biogenesis (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 12-13).
 core_functions:
 - description: &gt;-
-    Cytoplasmic protein carrier chaperone for ribosomal protein Rps2/uS5. Tsr4
-    binds nascent Rps2/uS5 and maintains the client in a soluble
-    assembly-competent state before nuclear import and incorporation into
-    pre-40S particles.
+    Cytoplasmic, client-specific protein folding chaperone for ribosomal protein
+    Rps2/uS5. Tsr4 binds the nascent eukaryote-specific Rps2 N-terminal
+    extension and maintains Rps2 in a soluble, assembly-competent state before
+    Tsr4 release, nuclear import of the client, and pre-40S incorporation.
   molecular_function:
-    id: GO:0140597
-    label: protein carrier chaperone
+    id: GO:0044183
+    label: protein folding chaperone
   directly_involved_in:
   - id: GO:0042274
     label: ribosomal small subunit biogenesis
@@ -3116,15 +3428,36 @@ core_functions:
     label: cytoplasm
   supported_by:
   - reference_id: PMID:31062022
-    supporting_text: identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2...Both factors promote the solubility of their r-protein clients
+    supporting_text: |-
+      We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2, respectively. Both factors promote the solubility of their r-protein clients in vitro.
   - reference_id: PMID:31182640
-    supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.
+    supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and phenocopied Rps2 depletion.
   - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
-    supporting_text: Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.
+    supporting_text: |-
+      **Chaperone effect on solubility:** Rps2 expressed alone is aggregation-prone, while co-expression with Tsr4 keeps Rps2 soluble and supports complex formation in vitro and in vivo (rossler2019tsr4andnap1 pages 14-15).
 proposed_new_terms: []
 suggested_questions:
-- question: Should older GO:0051082 annotations for Tsr4 be replaced by GO:0140597 protein carrier chaperone where evidence is specific Rps2/uS5 chaperoning?
-suggested_experiments: []
+- question: &gt;-
+    What molecular event releases nascent Rps2 from Tsr4, and is a specific
+    importin or assembly factor the immediate acceptor?
+- question: &gt;-
+    Does Tsr4 directly promote a folded Rps2 conformation, or does it principally
+    prevent aggregation until another factor completes folding and import?
+suggested_experiments:
+- description: &gt;-
+    Reconstitute nascent Rps2-Tsr4 complexes and test candidate importins and
+    pre-40S factors for direct, directional client handoff using kinetic binding
+    and release assays.
+  hypothesis: &gt;-
+    A defined downstream factor triggers Rps2 release; only such evidence would
+    justify protein carrier activity or protein transporter activity.
+- description: &gt;-
+    Compare Rps2 folding and aggregation with and without Tsr4 using limited
+    proteolysis, structural probes, solubility measurements and subsequent
+    import/assembly competence.
+  hypothesis: &gt;-
+    Tsr4 prevents nonproductive aggregation and assists acquisition of an
+    assembly-competent state without escorting Rps2 into the nucleus.
 </code></pre>
             </div>
         </details>

--- a/genes/yeast/TSR4/TSR4-ai-review.html
+++ b/genes/yeast/TSR4/TSR4-ai-review.html
@@ -1336,10 +1336,10 @@ not circular evidence; direct TSR4 phenotypes support SSU-rRNA maturation.</div>
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P25040" data-a="GO:0140597" data-r="PMID:31062022" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P25040" data-a="GO:0140597" data-r="PMID:31062022" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1347,37 +1347,37 @@ not circular evidence; direct TSR4 phenotypes support SSU-rRNA maturation.</div>
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Tsr4 is a dedicated Rps2/uS5 chaperone, but current GO:0140597 is labelled
-protein carrier activity and requires delivery to an acceptor molecule or
-specific location. The experiments establish cotranslational binding and
-solubility promotion, while UniProt states Tsr4 is released before Rps2
-nuclear import; no direct handoff or delivery step is demonstrated.
+                            <strong>Summary:</strong> Tsr4 is a dedicated Rps2/uS5 carrier chaperone. The abstract frames
+dedicated ribosomal-protein chaperones as accompanying clients toward
+assembly, and the full-text-informed 2025 UniProt IDA directly assigns
+this activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Replace with GO:0044183 protein folding chaperone, whose definition matches
-binding that assists client folding/solubility. GO:0140318 is even more
-location-specific, and GO:0140309 additionally requires an unfolded client
-to be escorted; neither is supported for Tsr4.
+                            <strong>Reason:</strong> Retain the curated experimental annotation. The abstract-only cache is
+insufficient to overrule the curator&#39;s full-text assessment, and this
+treatment is consistent with NAP1 and the dedicated r-protein-chaperone cohort.
                         </div>
 
 
-
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
-                                </a>
-                            </span>
-
-                        </div>
 
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link">
+                                        PMID:31062022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dedicated chaperones protect newly synthesized ribosomal proteins (r-proteins) from aggregation and accompany them on their way to assembly into nascent ribosomes.</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -2199,8 +2199,8 @@ GO:0051082 is obsolete and the paper does not establish carrier delivery.
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Cytoplasmic, client-specific protein folding chaperone for ribosomal protein Rps2/uS5. Tsr4 binds the nascent eukaryote-specific Rps2 N-terminal extension and maintains Rps2 in a soluble, assembly-competent state before Tsr4 release, nuclear import of the client, and pre-40S incorporation.</h3>
-                <span class="vote-buttons" data-g="P25040" data-a="FUNCTION: Cytoplasmic, client-specific protein folding chape..." data-r="" data-act="CORE_FUNCTION">
+                <h3>Cytoplasmic, client-specific protein carrier chaperone for ribosomal protein Rps2/uS5. Tsr4 binds the nascent eukaryote-specific Rps2 N-terminal extension and maintains Rps2 in a soluble, assembly-competent state before Tsr4 release, nuclear import of the client, and pre-40S incorporation.</h3>
+                <span class="vote-buttons" data-g="P25040" data-a="FUNCTION: Cytoplasmic, client-specific protein carrier chape..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -2212,8 +2212,8 @@ GO:0051082 is obsolete and the paper does not establish carrier delivery.
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                            protein folding chaperone
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
+                            protein carrier chaperone
                         </a>
                     </span>
                 </div>
@@ -2227,12 +2227,6 @@ GO:0051082 is obsolete and the paper does not establish carrier delivery.
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042274" target="_blank" class="term-link">
                                 ribosomal small subunit biogenesis
-                            </a>
-                        </span>
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030490" target="_blank" class="term-link">
-                                maturation of SSU-rRNA
                             </a>
                         </span>
 
@@ -3034,19 +3028,17 @@ YOL022C/TSR4)."].</p>
 <li>GO:0140309 unfolded protein holdase activity additionally requires an unfolded<br />
   client to be escorted to an acceptor or location.</li>
 </ul>
-<p>Tsr4 clearly binds nascent Rps2 and promotes its solubility. However, curated<br />
-UniProt states that Tsr4 is released before Rps2 nuclear import, and current<br />
-evidence does not identify a direct acceptor, directional handoff, or escort by<br />
-Tsr4 to the nucleus. Consequently, GO:0140597 is not retained as core and<br />
-GO:0140318/GO:0140309 are not proposed. The direct GO:0140597 row and all three<br />
-obsolete GO:0051082 rows are instead MODIFY to GO:0044183, which captures the<br />
-experimentally demonstrated client-stabilizing chaperone activity without<br />
-inventing transport.</p>
-<p>The core synthesis is therefore a cytoplasmic, Rps2-specific protein folding<br />
-chaperone whose activity supports ribosomal small-subunit biogenesis and SSU<br />
-rRNA maturation. Experiments that identify the immediate Rps2 acceptor and<br />
-demonstrate directional handoff would be needed before asserting carrier or<br />
-transporter activity.</p>
+<p>Tsr4 clearly binds nascent Rps2 and promotes its solubility. GO:0140597 is<br />
+retained as the core activity because it is a recent, directly curated IDA and<br />
+the abstract-only cache is insufficient to overrule the curator's full-text<br />
+assessment. This is also consistent with NAP1 and the dedicated ribosomal-<br />
+protein-chaperone cohort. GO:0140318/GO:0140309 are not newly proposed. The<br />
+three obsolete GO:0051082 rows are MODIFY to GO:0044183, which preserves their<br />
+client-stabilizing chaperone biology without treating the obsolete binding term<br />
+as the carrier annotation itself.</p>
+<p>The core synthesis is therefore a cytoplasmic, Rps2-specific protein carrier<br />
+chaperone whose activity directly supports ribosomal small-subunit biogenesis;<br />
+SSU-rRNA maturation is retained as a downstream annotated consequence.</p>
             </div>
         </details>
 
@@ -3176,21 +3168,19 @@ existing_annotations:
   original_reference_id: PMID:31062022
   review:
     summary: |-
-      Tsr4 is a dedicated Rps2/uS5 chaperone, but current GO:0140597 is labelled
-      protein carrier activity and requires delivery to an acceptor molecule or
-      specific location. The experiments establish cotranslational binding and
-      solubility promotion, while UniProt states Tsr4 is released before Rps2
-      nuclear import; no direct handoff or delivery step is demonstrated.
-    action: MODIFY
+      Tsr4 is a dedicated Rps2/uS5 carrier chaperone. The abstract frames
+      dedicated ribosomal-protein chaperones as accompanying clients toward
+      assembly, and the full-text-informed 2025 UniProt IDA directly assigns
+      this activity.
+    action: ACCEPT
     reason: |-
-      Replace with GO:0044183 protein folding chaperone, whose definition matches
-      binding that assists client folding/solubility. GO:0140318 is even more
-      location-specific, and GO:0140309 additionally requires an unfolded client
-      to be escorted; neither is supported for Tsr4.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+      Retain the curated experimental annotation. The abstract-only cache is
+      insufficient to overrule the curator&#39;s full-text assessment, and this
+      treatment is consistent with NAP1 and the dedicated r-protein-chaperone cohort.
     supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: &gt;-
+        Dedicated chaperones protect newly synthesized ribosomal proteins (r-proteins) from aggregation and accompany them on their way to assembly into nascent ribosomes.
     - reference_id: PMID:31062022
       supporting_text: |-
         Both factors promote the solubility of their r-protein clients in vitro. While Tsr4 is specific for Rps2, Nap1 has several interaction partners including Rps6 and two other r-proteins.
@@ -3409,18 +3399,16 @@ references:
       **Molecular function (best-supported):** Tsr4 binds **nascent Rps2/uS5** co-translationally in the cytoplasm and acts as a **client-specific chaperone** to stabilize Rps2 and support 40S biogenesis (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 12-13).
 core_functions:
 - description: &gt;-
-    Cytoplasmic, client-specific protein folding chaperone for ribosomal protein
+    Cytoplasmic, client-specific protein carrier chaperone for ribosomal protein
     Rps2/uS5. Tsr4 binds the nascent eukaryote-specific Rps2 N-terminal
     extension and maintains Rps2 in a soluble, assembly-competent state before
     Tsr4 release, nuclear import of the client, and pre-40S incorporation.
   molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140597
+    label: protein carrier chaperone
   directly_involved_in:
   - id: GO:0042274
     label: ribosomal small subunit biogenesis
-  - id: GO:0030490
-    label: maturation of SSU-rRNA
   locations:
   - id: GO:0005829
     label: cytosol

--- a/genes/yeast/TSR4/TSR4-ai-review.html
+++ b/genes/yeast/TSR4/TSR4-ai-review.html
@@ -917,7 +917,7 @@ delivery into the 40S biogenesis pathway.
                             <div class="propagation-title">Propagation Review</div>
                             <div class="propagation-row">
                                 <strong>Root cause:</strong>
-                                <span class="badge">SOURCE STALE OR MISSING</span>
+                                <span class="badge">NO FAILURE CORE</span>
                             </div>
 
 
@@ -1623,15 +1623,15 @@ treatment is consistent with NAP1 and the dedicated r-protein-chaperone cohort.
 
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 is obsolete. The evidence shows that Tsr4 binds nascent Rps2
-and promotes its solubility, supporting protein folding chaperone activity,
-not generic unfolded-protein binding or carrier-mediated transport.
+and promotes its solubility, supporting protein folding chaperone activity
+as a client-stabilization facet of its dedicated carrier-chaperone role.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Replace the obsolete term with GO:0044183. GO:0140597/GO:0140318 require
-demonstrated delivery, and GO:0140309 requires escort of an unfolded client;
-Tsr4 is released before nuclear import and those mechanisms were not shown.
+                            <strong>Reason:</strong> Replace the obsolete term with GO:0044183 to capture the demonstrated
+anti-aggregation and client-solubilization activity. This replacement is
+complementary to the separately curated GO:0140597 carrier annotation.
                         </div>
 
 
@@ -1802,13 +1802,14 @@ Tsr4 is released before nuclear import and those mechanisms were not shown.
 
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 is obsolete. This paper identifies Tsr4 as a cytoplasmic
-chaperone dedicated to Rps2, but it does not demonstrate carrier delivery
-or escort to a location.
+chaperone dedicated to Rps2 and shows the client-stabilization biology
+captured by GO:0044183.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Protein folding chaperone is the evidence-matched current activity term.
+                            <strong>Reason:</strong> Protein folding chaperone captures the anti-aggregation facet of the
+evidence and complements the separately curated carrier activity.
                         </div>
 
 
@@ -1897,12 +1898,14 @@ or escort to a location.
 
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The IPI evidence identifies the specific Tsr4-Rps2 client interaction, but
-GO:0051082 is obsolete and the paper does not establish carrier delivery.
+GO:0051082 is obsolete; GO:0044183 captures the client-stabilization facet
+of this dedicated interaction.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Replace with protein folding chaperone to capture client stabilization without inventing transport.
+                            <strong>Reason:</strong> Replace with protein folding chaperone to capture client stabilization,
+complementary to the separately curated GO:0140597 carrier annotation.
                         </div>
 
 
@@ -2550,7 +2553,7 @@ GO:0051082 is obsolete and the paper does not establish carrier delivery.
                     <p><strong>Experiment:</strong> Reconstitute nascent Rps2-Tsr4 complexes and test candidate importins and pre-40S factors for direct, directional client handoff using kinetic binding and release assays.</p>
 
 
-                    <p style="margin-top: 0.5rem;"><em>Hypothesis: A defined downstream factor triggers Rps2 release; only such evidence would justify protein carrier activity or protein transporter activity.</em></p>
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: A defined downstream factor triggers Rps2 release and serves as the immediate Rps2 acceptor in the carrier cycle.</em></p>
 
 
                 </div>
@@ -2568,7 +2571,7 @@ GO:0051082 is obsolete and the paper does not establish carrier delivery.
                     <p><strong>Experiment:</strong> Compare Rps2 folding and aggregation with and without Tsr4 using limited proteolysis, structural probes, solubility measurements and subsequent import/assembly competence.</p>
 
 
-                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Tsr4 prevents nonproductive aggregation and assists acquisition of an assembly-competent state without escorting Rps2 into the nucleus.</em></p>
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Tsr4 prevents nonproductive aggregation and assists acquisition of an assembly-competent state before a regulated release step transfers Rps2 to the nuclear-import or pre-40S assembly pathway.</em></p>
 
 
                 </div>
@@ -3034,8 +3037,10 @@ the abstract-only cache is insufficient to overrule the curator's full-text<br /
 assessment. This is also consistent with NAP1 and the dedicated ribosomal-<br />
 protein-chaperone cohort. GO:0140318/GO:0140309 are not newly proposed. The<br />
 three obsolete GO:0051082 rows are MODIFY to GO:0044183, which preserves their<br />
-client-stabilizing chaperone biology without treating the obsolete binding term<br />
-as the carrier annotation itself.</p>
+client-stabilizing, anti-aggregation facet. This replacement is complementary<br />
+to the separately curated GO:0140597 carrier annotation rather than an argument<br />
+against carrier activity; the explicit GO:0044183 target follows the UPB project<br />
+decision for TSR4.</p>
 <p>The core synthesis is therefore a cytoplasmic, Rps2-specific protein carrier<br />
 chaperone whose activity directly supports ribosomal small-subunit biogenesis;<br />
 SSU-rRNA maturation is retained as a downstream annotated consequence.</p>
@@ -3085,7 +3090,7 @@ existing_annotations:
     action: ACCEPT
     reason: SSU-rRNA maturation is a core downstream consequence of the uS5 chaperone role.
     propagation_review:
-      root_cause: SOURCE_STALE_OR_MISSING
+      root_cause: NO_FAILURE_CORE
       source_entities:
       - source_id: PANTHER:PTN000958897
         source_label: PANTHER:PTN000958897
@@ -3221,13 +3226,13 @@ existing_annotations:
   review:
     summary: |-
       GO:0051082 is obsolete. The evidence shows that Tsr4 binds nascent Rps2
-      and promotes its solubility, supporting protein folding chaperone activity,
-      not generic unfolded-protein binding or carrier-mediated transport.
+      and promotes its solubility, supporting protein folding chaperone activity
+      as a client-stabilization facet of its dedicated carrier-chaperone role.
     action: MODIFY
     reason: |-
-      Replace the obsolete term with GO:0044183. GO:0140597/GO:0140318 require
-      demonstrated delivery, and GO:0140309 requires escort of an unfolded client;
-      Tsr4 is released before nuclear import and those mechanisms were not shown.
+      Replace the obsolete term with GO:0044183 to capture the demonstrated
+      anti-aggregation and client-solubilization activity. This replacement is
+      complementary to the separately curated GO:0140597 carrier annotation.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
@@ -3254,10 +3259,12 @@ existing_annotations:
   review:
     summary: |-
       GO:0051082 is obsolete. This paper identifies Tsr4 as a cytoplasmic
-      chaperone dedicated to Rps2, but it does not demonstrate carrier delivery
-      or escort to a location.
+      chaperone dedicated to Rps2 and shows the client-stabilization biology
+      captured by GO:0044183.
     action: MODIFY
-    reason: Protein folding chaperone is the evidence-matched current activity term.
+    reason: |-
+      Protein folding chaperone captures the anti-aggregation facet of the
+      evidence and complements the separately curated carrier activity.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
@@ -3273,9 +3280,12 @@ existing_annotations:
   review:
     summary: |-
       The IPI evidence identifies the specific Tsr4-Rps2 client interaction, but
-      GO:0051082 is obsolete and the paper does not establish carrier delivery.
+      GO:0051082 is obsolete; GO:0044183 captures the client-stabilization facet
+      of this dedicated interaction.
     action: MODIFY
-    reason: Replace with protein folding chaperone to capture client stabilization without inventing transport.
+    reason: |-
+      Replace with protein folding chaperone to capture client stabilization,
+      complementary to the separately curated GO:0140597 carrier annotation.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
@@ -3437,15 +3447,16 @@ suggested_experiments:
     pre-40S factors for direct, directional client handoff using kinetic binding
     and release assays.
   hypothesis: &gt;-
-    A defined downstream factor triggers Rps2 release; only such evidence would
-    justify protein carrier activity or protein transporter activity.
+    A defined downstream factor triggers Rps2 release and serves as the immediate
+    Rps2 acceptor in the carrier cycle.
 - description: &gt;-
     Compare Rps2 folding and aggregation with and without Tsr4 using limited
     proteolysis, structural probes, solubility measurements and subsequent
     import/assembly competence.
   hypothesis: &gt;-
     Tsr4 prevents nonproductive aggregation and assists acquisition of an
-    assembly-competent state without escorting Rps2 into the nucleus.
+    assembly-competent state before a regulated release step transfers Rps2 to
+    the nuclear-import or pre-40S assembly pathway.
 </code></pre>
             </div>
         </details>

--- a/genes/yeast/TSR4/TSR4-ai-review.yaml
+++ b/genes/yeast/TSR4/TSR4-ai-review.yaml
@@ -15,6 +15,8 @@ description: >-
   client before nuclear import and productive pre-40S assembly. Loss of Tsr4
   impairs 40S ribosomal small subunit biogenesis, pre-40S export, and 20S
   pre-rRNA processing at site D to mature 18S rRNA.
+tags:
+- UPB
 existing_annotations:
 - term:
     id: GO:0030490
@@ -22,14 +24,35 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: IBA is consistent with Tsr4-dependent 20S pre-rRNA processing and 40S biogenesis.
+    summary: |-
+      The IBA is consistent with target-specific IMP evidence that places TSR4
+      in 20S pre-rRNA processing and with later mechanistic work on Rps2/uS5
+      delivery into the 40S biogenesis pathway.
     action: ACCEPT
-    reason: SSU-rRNA maturation is a direct process-level consequence of the uS5 chaperone role.
+    reason: SSU-rRNA maturation is a core downstream consequence of the uS5 chaperone role.
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      source_entities:
+      - source_id: PANTHER:PTN000958897
+        source_label: PANTHER:PTN000958897
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: |-
+          Cached GOA identifies this exact ancestral node, but no current
+          PTHR47524 PAINT table or PTN record is present in the repository's
+          PAINT snapshot, so the current node assertion cannot be recovered.
+      - source_id: SGD:S000005382
+        source_label: TSR4
+        source_status: SUPPORTS_TRANSFER
+        comment: |-
+          The target's own experimental annotation is a valid descendant seed,
+          not circular evidence; direct TSR4 phenotypes support SSU-rRNA maturation.
     supported_by:
     - reference_id: PMID:19806183
-      supporting_text: YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.
+      supporting_text: |-
+        We experimentally evaluated >100 candidate yeast genes in a battery of assays, confirming involvement of at least 15 new genes, including previously uncharacterized genes (YDL063C, YIL091C, YOR287C, YOR006C/TSR3, YOL022C/TSR4).
     - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
-      supporting_text: Tsr4 enables downstream 40S assembly and pre-40S export through cytoplasmic Rps2/uS5 chaperone activity.
+      supporting_text: |-
+        TSR4 acts within **small (40S) ribosomal subunit biogenesis**, specifically by enabling accumulation and assembly of Rps2/uS5 into pre-40S particles.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -53,7 +76,8 @@ existing_annotations:
     reason: Direct and curated sources place Tsr4 in the cytosol/cytoplasm.
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
+      supporting_text: |-
+        Tsr4 binds co-translationally to the essential, eukaryote-specific N-terminal extension of Rps2, whereas Nap1 interacts with a large, mostly eukaryote-specific binding surface of Rps6.
 - term:
     id: GO:0042254
     label: ribosome biogenesis
@@ -68,7 +92,8 @@ existing_annotations:
       label: ribosomal small subunit biogenesis
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: Mutation of the essential Tsr4...enhance the 40S synthesis defects
+      supporting_text: |-
+        Mutation of the essential Tsr4 and deletion of the non-essential Nap1 both enhance the 40S synthesis defects of the corresponding r-protein mutants.
 - term:
     id: GO:0005829
     label: cytosol
@@ -80,21 +105,36 @@ existing_annotations:
     reason: Tsr4 binds Rps2/uS5 co-translationally in the cytosol.
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
+      supporting_text: |-
+        Tsr4 binds co-translationally to the essential, eukaryote-specific N-terminal extension of Rps2, whereas Nap1 interacts with a large, mostly eukaryote-specific binding surface of Rps6.
 - term:
     id: GO:0140597
     label: protein carrier chaperone
   evidence_type: IDA
   original_reference_id: PMID:31062022
   review:
-    summary: This is the most specific molecular-function annotation for TSR4.
-    action: ACCEPT
-    reason: Tsr4 is a dedicated carrier chaperone for ribosomal protein Rps2/uS5.
+    summary: |-
+      Tsr4 is a dedicated Rps2/uS5 chaperone, but current GO:0140597 is labelled
+      protein carrier activity and requires delivery to an acceptor molecule or
+      specific location. The experiments establish cotranslational binding and
+      solubility promotion, while UniProt states Tsr4 is released before Rps2
+      nuclear import; no direct handoff or delivery step is demonstrated.
+    action: MODIFY
+    reason: |-
+      Replace with GO:0044183 protein folding chaperone, whose definition matches
+      binding that assists client folding/solubility. GO:0140318 is even more
+      location-specific, and GO:0140309 additionally requires an unfolded client
+      to be escorted; neither is supported for Tsr4.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: vitro. While Tsr4 is specific for Rps2...Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
+      supporting_text: |-
+        Both factors promote the solubility of their r-protein clients in vitro. While Tsr4 is specific for Rps2, Nap1 has several interaction partners including Rps6 and two other r-proteins.
     - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
-      supporting_text: Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.
+      supporting_text: |-
+        **Molecular function (best-supported):** Tsr4 binds **nascent Rps2/uS5** co-translationally in the cytoplasm and acts as a **client-specific chaperone** to stabilize Rps2 and support 40S biogenesis (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 12-13).
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
@@ -106,7 +146,8 @@ existing_annotations:
     reason: Rps2/uS5 chaperoning is directly tied to small subunit assembly.
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: Mutation of the essential Tsr4...enhance the 40S synthesis defects
+      supporting_text: |-
+        Mutation of the essential Tsr4 and deletion of the non-essential Nap1 both enhance the 40S synthesis defects of the corresponding r-protein mutants.
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
@@ -118,22 +159,29 @@ existing_annotations:
     reason: The genetic relationship supports Tsr4's role in Rps2-dependent 40S assembly.
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2
+      supporting_text: |-
+        We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2, respectively.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:31062022
   review:
-    summary: The binding evidence is specific to Rps2/uS5, not generic unfolded protein.
+    summary: |-
+      GO:0051082 is obsolete. The evidence shows that Tsr4 binds nascent Rps2
+      and promotes its solubility, supporting protein folding chaperone activity,
+      not generic unfolded-protein binding or carrier-mediated transport.
     action: MODIFY
-    reason: Replace broad unfolded protein binding with protein carrier chaperone.
+    reason: |-
+      Replace the obsolete term with GO:0044183. GO:0140597/GO:0140318 require
+      demonstrated delivery, and GO:0140309 requires escort of an unfolded client;
+      Tsr4 is released before nuclear import and those mechanisms were not shown.
     proposed_replacement_terms:
-    - id: GO:0140597
-      label: protein carrier chaperone
+    - id: GO:0044183
+      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:31062022
-      supporting_text: Both factors promote the solubility of their r-protein clients in...vitro.
+      supporting_text: Both factors promote the solubility of their r-protein clients in vitro.
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
@@ -145,37 +193,44 @@ existing_annotations:
     reason: Tsr4 perturbation decreases Rps2 and phenocopies Rps2 depletion.
     supported_by:
     - reference_id: PMID:31182640
-      supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.
+      supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and phenocopied Rps2 depletion.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:31182640
   review:
-    summary: The evidence supports specific Rps2 carrier chaperoning.
+    summary: |-
+      GO:0051082 is obsolete. This paper identifies Tsr4 as a cytoplasmic
+      chaperone dedicated to Rps2, but it does not demonstrate carrier delivery
+      or escort to a location.
     action: MODIFY
-    reason: Protein carrier chaperone is the more precise molecular-function term.
+    reason: Protein folding chaperone is the evidence-matched current activity term.
     proposed_replacement_terms:
-    - id: GO:0140597
-      label: protein carrier chaperone
+    - id: GO:0044183
+      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:31182640
-      supporting_text: Tsr4 cotranslationally associates with Rps2...cytoplasmic chaperone dedicated to Rps2.
+      supporting_text: |-
+        Here, we report that Tsr4 cotranslationally associates with Rps2.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IPI
   original_reference_id: PMID:31182640
   review:
-    summary: The IPI evidence identifies a specific Rps2/uS5 client relationship.
+    summary: |-
+      The IPI evidence identifies the specific Tsr4-Rps2 client interaction, but
+      GO:0051082 is obsolete and the paper does not establish carrier delivery.
     action: MODIFY
-    reason: Replace broad unfolded protein binding with protein carrier chaperone.
+    reason: Replace with protein folding chaperone to capture client stabilization without inventing transport.
     proposed_replacement_terms:
-    - id: GO:0140597
-      label: protein carrier chaperone
+    - id: GO:0044183
+      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:31182640
-      supporting_text: Rps2 harbors a...eukaryote-specific N-terminal extension that is critical for its interaction...with Tsr4.
+      supporting_text: |-
+        Rps2 harbors a eukaryote-specific N-terminal extension that is critical for its interaction with Tsr4.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -211,7 +266,8 @@ existing_annotations:
     reason: Later work explains the phenotype through defective Rps2/uS5 handling and 40S assembly.
     supported_by:
     - reference_id: PMID:19806183
-      supporting_text: YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.
+      supporting_text: |-
+        We associate the new genes with specific aspects of ribosomal subunit maturation, ribosomal particle association, and ribosomal subunit nuclear export, and we identify genes specifically required for the processing of 5S, 7S, 20S, 27S, and 35S rRNAs.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -227,36 +283,77 @@ references:
   findings: []
 - id: PMID:14562095
   title: Global analysis of protein localization in budding yeast.
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: |-
+      PubMed metadata and the global GFP-localization study are verified, but
+      the abstract-only cache does not expose the TSR4-specific localization
+      record. The HDA row is retained because later targeted work independently
+      places Tsr4 in the cytoplasm.
   findings: []
 - id: PMID:19806183
   title: Rational extension of the ribosome biogenesis pathway using network-guided genetics.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. The abstract explicitly
+      includes YOL022C/TSR4 among experimentally confirmed ribosome-biogenesis
+      genes and reports rRNA-processing assays, although the cache lacks the
+      full-text gene-by-processing-species table.
   findings:
   - statement: TSR4 was identified as a ribosome biogenesis factor
-    supporting_text: Network-guided genetics associated YOL022C/TSR4 with ribosome biogenesis and pre-rRNA processing.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      We experimentally evaluated >100 candidate yeast genes in a battery of assays, confirming involvement of at least 15 new genes, including previously uncharacterized genes (YDL063C, YIL091C, YOR287C, YOR006C/TSR3, YOL022C/TSR4).
 - id: PMID:31062022
   title: Tsr4 and Nap1, two novel members of the ribosomal protein chaperOME.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. The abstract directly
+      supports cotranslational Rps2 binding, client specificity, solubility
+      promotion and the 40S-biogenesis phenotype. The local cache is abstract-only.
   findings:
-  - statement: Tsr4 is a direct Rps2/uS5 carrier chaperone
-    supporting_text: Tsr4 is specific for Rps2, binds co-translationally to its N-terminal extension, and promotes solubility.
+  - statement: Tsr4 is a direct, cotranslational Rps2/uS5 chaperone that promotes client solubility.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2, respectively. Both factors promote the solubility of their r-protein clients in vitro.
 - id: PMID:31182640
   title: Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rps2 in Saccharomyces cerevisiae.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: |-
+      PubMed metadata and cached abstract verified. The abstract directly
+      supports the dedicated Rps2 interaction, cytoplasmic restriction and
+      Rps2-depletion phenotype. The local cache is abstract-only.
   findings:
   - statement: Tsr4 is a cytoplasmic chaperone dedicated to Rps2
-    supporting_text: Tsr4 cotranslationally associates with Rps2; perturbation decreases Rps2 levels.
+    reference_section_type: ABSTRACT
+    full_text_unavailable: true
+    supporting_text: |-
+      Here, we report that Tsr4 cotranslationally associates with Rps2. Rps2 harbors a eukaryote-specific N-terminal extension that is critical for its interaction with Tsr4.
 - id: file:yeast/TSR4/TSR4-deep-research-falcon.md
   title: Falcon deep research report for TSR4
   findings:
-  - statement: TSR4 is a cytoplasmic uS5/Rps2 carrier chaperone
-    supporting_text: The report synthesizes evidence that Tsr4 captures nascent Rps2/uS5 and enables downstream 40S assembly.
+  - statement: TSR4 is a cytoplasmic, client-specific uS5/Rps2 chaperone.
+    reference_section_type: OTHER
+    supporting_text: |-
+      **Molecular function (best-supported):** Tsr4 binds **nascent Rps2/uS5** co-translationally in the cytoplasm and acts as a **client-specific chaperone** to stabilize Rps2 and support 40S biogenesis (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 12-13).
 core_functions:
 - description: >-
-    Cytoplasmic protein carrier chaperone for ribosomal protein Rps2/uS5. Tsr4
-    binds nascent Rps2/uS5 and maintains the client in a soluble
-    assembly-competent state before nuclear import and incorporation into
-    pre-40S particles.
+    Cytoplasmic, client-specific protein folding chaperone for ribosomal protein
+    Rps2/uS5. Tsr4 binds the nascent eukaryote-specific Rps2 N-terminal
+    extension and maintains Rps2 in a soluble, assembly-competent state before
+    Tsr4 release, nuclear import of the client, and pre-40S incorporation.
   molecular_function:
-    id: GO:0140597
-    label: protein carrier chaperone
+    id: GO:0044183
+    label: protein folding chaperone
   directly_involved_in:
   - id: GO:0042274
     label: ribosomal small subunit biogenesis
@@ -269,12 +366,33 @@ core_functions:
     label: cytoplasm
   supported_by:
   - reference_id: PMID:31062022
-    supporting_text: identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2...Both factors promote the solubility of their r-protein clients
+    supporting_text: |-
+      We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2, respectively. Both factors promote the solubility of their r-protein clients in vitro.
   - reference_id: PMID:31182640
-    supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.
+    supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and phenocopied Rps2 depletion.
   - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
-    supporting_text: Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.
+    supporting_text: |-
+      **Chaperone effect on solubility:** Rps2 expressed alone is aggregation-prone, while co-expression with Tsr4 keeps Rps2 soluble and supports complex formation in vitro and in vivo (rossler2019tsr4andnap1 pages 14-15).
 proposed_new_terms: []
 suggested_questions:
-- question: Should older GO:0051082 annotations for Tsr4 be replaced by GO:0140597 protein carrier chaperone where evidence is specific Rps2/uS5 chaperoning?
-suggested_experiments: []
+- question: >-
+    What molecular event releases nascent Rps2 from Tsr4, and is a specific
+    importin or assembly factor the immediate acceptor?
+- question: >-
+    Does Tsr4 directly promote a folded Rps2 conformation, or does it principally
+    prevent aggregation until another factor completes folding and import?
+suggested_experiments:
+- description: >-
+    Reconstitute nascent Rps2-Tsr4 complexes and test candidate importins and
+    pre-40S factors for direct, directional client handoff using kinetic binding
+    and release assays.
+  hypothesis: >-
+    A defined downstream factor triggers Rps2 release; only such evidence would
+    justify protein carrier activity or protein transporter activity.
+- description: >-
+    Compare Rps2 folding and aggregation with and without Tsr4 using limited
+    proteolysis, structural probes, solubility measurements and subsequent
+    import/assembly competence.
+  hypothesis: >-
+    Tsr4 prevents nonproductive aggregation and assists acquisition of an
+    assembly-competent state without escorting Rps2 into the nucleus.

--- a/genes/yeast/TSR4/TSR4-ai-review.yaml
+++ b/genes/yeast/TSR4/TSR4-ai-review.yaml
@@ -31,7 +31,7 @@ existing_annotations:
     action: ACCEPT
     reason: SSU-rRNA maturation is a core downstream consequence of the uS5 chaperone role.
     propagation_review:
-      root_cause: SOURCE_STALE_OR_MISSING
+      root_cause: NO_FAILURE_CORE
       source_entities:
       - source_id: PANTHER:PTN000958897
         source_label: PANTHER:PTN000958897
@@ -167,13 +167,13 @@ existing_annotations:
   review:
     summary: |-
       GO:0051082 is obsolete. The evidence shows that Tsr4 binds nascent Rps2
-      and promotes its solubility, supporting protein folding chaperone activity,
-      not generic unfolded-protein binding or carrier-mediated transport.
+      and promotes its solubility, supporting protein folding chaperone activity
+      as a client-stabilization facet of its dedicated carrier-chaperone role.
     action: MODIFY
     reason: |-
-      Replace the obsolete term with GO:0044183. GO:0140597/GO:0140318 require
-      demonstrated delivery, and GO:0140309 requires escort of an unfolded client;
-      Tsr4 is released before nuclear import and those mechanisms were not shown.
+      Replace the obsolete term with GO:0044183 to capture the demonstrated
+      anti-aggregation and client-solubilization activity. This replacement is
+      complementary to the separately curated GO:0140597 carrier annotation.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
@@ -200,10 +200,12 @@ existing_annotations:
   review:
     summary: |-
       GO:0051082 is obsolete. This paper identifies Tsr4 as a cytoplasmic
-      chaperone dedicated to Rps2, but it does not demonstrate carrier delivery
-      or escort to a location.
+      chaperone dedicated to Rps2 and shows the client-stabilization biology
+      captured by GO:0044183.
     action: MODIFY
-    reason: Protein folding chaperone is the evidence-matched current activity term.
+    reason: |-
+      Protein folding chaperone captures the anti-aggregation facet of the
+      evidence and complements the separately curated carrier activity.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
@@ -219,9 +221,12 @@ existing_annotations:
   review:
     summary: |-
       The IPI evidence identifies the specific Tsr4-Rps2 client interaction, but
-      GO:0051082 is obsolete and the paper does not establish carrier delivery.
+      GO:0051082 is obsolete; GO:0044183 captures the client-stabilization facet
+      of this dedicated interaction.
     action: MODIFY
-    reason: Replace with protein folding chaperone to capture client stabilization without inventing transport.
+    reason: |-
+      Replace with protein folding chaperone to capture client stabilization,
+      complementary to the separately curated GO:0140597 carrier annotation.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
@@ -383,12 +388,13 @@ suggested_experiments:
     pre-40S factors for direct, directional client handoff using kinetic binding
     and release assays.
   hypothesis: >-
-    A defined downstream factor triggers Rps2 release; only such evidence would
-    justify protein carrier activity or protein transporter activity.
+    A defined downstream factor triggers Rps2 release and serves as the immediate
+    Rps2 acceptor in the carrier cycle.
 - description: >-
     Compare Rps2 folding and aggregation with and without Tsr4 using limited
     proteolysis, structural probes, solubility measurements and subsequent
     import/assembly competence.
   hypothesis: >-
     Tsr4 prevents nonproductive aggregation and assists acquisition of an
-    assembly-competent state without escorting Rps2 into the nucleus.
+    assembly-competent state before a regulated release step transfers Rps2 to
+    the nuclear-import or pre-40S assembly pathway.

--- a/genes/yeast/TSR4/TSR4-ai-review.yaml
+++ b/genes/yeast/TSR4/TSR4-ai-review.yaml
@@ -114,21 +114,19 @@ existing_annotations:
   original_reference_id: PMID:31062022
   review:
     summary: |-
-      Tsr4 is a dedicated Rps2/uS5 chaperone, but current GO:0140597 is labelled
-      protein carrier activity and requires delivery to an acceptor molecule or
-      specific location. The experiments establish cotranslational binding and
-      solubility promotion, while UniProt states Tsr4 is released before Rps2
-      nuclear import; no direct handoff or delivery step is demonstrated.
-    action: MODIFY
+      Tsr4 is a dedicated Rps2/uS5 carrier chaperone. The abstract frames
+      dedicated ribosomal-protein chaperones as accompanying clients toward
+      assembly, and the full-text-informed 2025 UniProt IDA directly assigns
+      this activity.
+    action: ACCEPT
     reason: |-
-      Replace with GO:0044183 protein folding chaperone, whose definition matches
-      binding that assists client folding/solubility. GO:0140318 is even more
-      location-specific, and GO:0140309 additionally requires an unfolded client
-      to be escorted; neither is supported for Tsr4.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+      Retain the curated experimental annotation. The abstract-only cache is
+      insufficient to overrule the curator's full-text assessment, and this
+      treatment is consistent with NAP1 and the dedicated r-protein-chaperone cohort.
     supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: >-
+        Dedicated chaperones protect newly synthesized ribosomal proteins (r-proteins) from aggregation and accompany them on their way to assembly into nascent ribosomes.
     - reference_id: PMID:31062022
       supporting_text: |-
         Both factors promote the solubility of their r-protein clients in vitro. While Tsr4 is specific for Rps2, Nap1 has several interaction partners including Rps6 and two other r-proteins.
@@ -347,18 +345,16 @@ references:
       **Molecular function (best-supported):** Tsr4 binds **nascent Rps2/uS5** co-translationally in the cytoplasm and acts as a **client-specific chaperone** to stabilize Rps2 and support 40S biogenesis (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 12-13).
 core_functions:
 - description: >-
-    Cytoplasmic, client-specific protein folding chaperone for ribosomal protein
+    Cytoplasmic, client-specific protein carrier chaperone for ribosomal protein
     Rps2/uS5. Tsr4 binds the nascent eukaryote-specific Rps2 N-terminal
     extension and maintains Rps2 in a soluble, assembly-competent state before
     Tsr4 release, nuclear import of the client, and pre-40S incorporation.
   molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140597
+    label: protein carrier chaperone
   directly_involved_in:
   - id: GO:0042274
     label: ribosomal small subunit biogenesis
-  - id: GO:0030490
-    label: maturation of SSU-rRNA
   locations:
   - id: GO:0005829
     label: cytosol

--- a/genes/yeast/TSR4/TSR4-notes.md
+++ b/genes/yeast/TSR4/TSR4-notes.md
@@ -53,17 +53,15 @@ Live QuickGO definitions were checked on 2026-08-28:
 - GO:0140309 unfolded protein holdase activity additionally requires an unfolded
   client to be escorted to an acceptor or location.
 
-Tsr4 clearly binds nascent Rps2 and promotes its solubility. However, curated
-UniProt states that Tsr4 is released before Rps2 nuclear import, and current
-evidence does not identify a direct acceptor, directional handoff, or escort by
-Tsr4 to the nucleus. Consequently, GO:0140597 is not retained as core and
-GO:0140318/GO:0140309 are not proposed. The direct GO:0140597 row and all three
-obsolete GO:0051082 rows are instead MODIFY to GO:0044183, which captures the
-experimentally demonstrated client-stabilizing chaperone activity without
-inventing transport.
+Tsr4 clearly binds nascent Rps2 and promotes its solubility. GO:0140597 is
+retained as the core activity because it is a recent, directly curated IDA and
+the abstract-only cache is insufficient to overrule the curator's full-text
+assessment. This is also consistent with NAP1 and the dedicated ribosomal-
+protein-chaperone cohort. GO:0140318/GO:0140309 are not newly proposed. The
+three obsolete GO:0051082 rows are MODIFY to GO:0044183, which preserves their
+client-stabilizing chaperone biology without treating the obsolete binding term
+as the carrier annotation itself.
 
-The core synthesis is therefore a cytoplasmic, Rps2-specific protein folding
-chaperone whose activity supports ribosomal small-subunit biogenesis and SSU
-rRNA maturation. Experiments that identify the immediate Rps2 acceptor and
-demonstrate directional handoff would be needed before asserting carrier or
-transporter activity.
+The core synthesis is therefore a cytoplasmic, Rps2-specific protein carrier
+chaperone whose activity directly supports ribosomal small-subunit biogenesis;
+SSU-rRNA maturation is retained as a downstream annotated consequence.

--- a/genes/yeast/TSR4/TSR4-notes.md
+++ b/genes/yeast/TSR4/TSR4-notes.md
@@ -59,8 +59,10 @@ the abstract-only cache is insufficient to overrule the curator's full-text
 assessment. This is also consistent with NAP1 and the dedicated ribosomal-
 protein-chaperone cohort. GO:0140318/GO:0140309 are not newly proposed. The
 three obsolete GO:0051082 rows are MODIFY to GO:0044183, which preserves their
-client-stabilizing chaperone biology without treating the obsolete binding term
-as the carrier annotation itself.
+client-stabilizing, anti-aggregation facet. This replacement is complementary
+to the separately curated GO:0140597 carrier annotation rather than an argument
+against carrier activity; the explicit GO:0044183 target follows the UPB project
+decision for TSR4.
 
 The core synthesis is therefore a cytoplasmic, Rps2-specific protein carrier
 chaperone whose activity directly supports ribosomal small-subunit biogenesis;

--- a/genes/yeast/TSR4/TSR4-notes.md
+++ b/genes/yeast/TSR4/TSR4-notes.md
@@ -1,0 +1,69 @@
+# TSR4 annotation re-review notes
+
+## 2026-08-28 dedicated re-review
+
+TSR4 (P25040; SGD:S000005382) encodes a cytoplasmic dedicated chaperone
+for ribosomal protein Rps2/uS5. Two independent 2019 studies identify the same
+client relationship. Rössler et al. report direct Tsr4-Rps2 binding and in-vitro
+solubility promotion [PMID:31062022, "We report the identification of Nap1 and
+Tsr4 as direct binding partners of Rps6 and Rps2, respectively. Both factors
+promote the solubility of their r-protein clients in vitro."]. Black et al.
+independently report cotranslational association and the Rps2 N-terminal
+determinant [PMID:31182640, "Here, we report that Tsr4 cotranslationally
+associates with Rps2. Rps2 harbors a eukaryote-specific N-terminal extension
+that is critical for its interaction with Tsr4."]. Both cached publications are
+abstract-only, so the review uses only claims stated in those abstracts or in
+the curated UniProt record and does not invent inaccessible assay details.
+
+### GOA reconciliation
+
+The cached GOA has 15 physical rows and 15 distinct qualifier-aware signatures
+(qualifier + GO term + evidence code + reference). All are positive relation
+qualifiers (`enables`, `involved_in`, or `located_in`); there are no NOT or
+isoform-specific rows. The IGI small-subunit-biogenesis row has WITH/FROM
+`SGD:S000003091` (RPS2), matching the experimentally defined client. The single
+IBA row has WITH/FROM `PANTHER:PTN000958897|SGD:S000005382`.
+
+### PAINT provenance
+
+The sole IBA is GO:0030490 maturation of SSU-rRNA at
+`PANTHER:PTN000958897`. The current local PAINT snapshot contains neither a
+PTHR47524 family directory/table nor a record for PTN000958897, although the
+official PANTHER ontology resolves PTHR47524 as "20S RRNA ACCUMULATION PROTEIN
+4." The propagation review therefore records `SOURCE_STALE_OR_MISSING` for the
+unrecoverable current node assertion. This is not a biological rejection of the
+IBA: the target itself is the experimental seed, which is valid rather than
+circular, and direct target evidence supports SSU-rRNA maturation
+[PMID:19806183, "We experimentally evaluated >100 candidate yeast genes in a
+battery of assays, confirming involvement of at least 15 new genes, including
+previously uncharacterized genes (YDL063C, YIL091C, YOR287C, YOR006C/TSR3,
+YOL022C/TSR4)."].
+
+### Chaperone versus carrier semantics
+
+Live QuickGO definitions were checked on 2026-08-28:
+
+- GO:0051082 is obsolete.
+- GO:0044183 protein folding chaperone means binding a protein or complex to
+  assist protein folding.
+- GO:0140597 is now labelled protein carrier activity and requires delivery to
+  an acceptor molecule or specific location.
+- GO:0140318 protein transporter activity specifically requires delivery to a
+  cellular location.
+- GO:0140309 unfolded protein holdase activity additionally requires an unfolded
+  client to be escorted to an acceptor or location.
+
+Tsr4 clearly binds nascent Rps2 and promotes its solubility. However, curated
+UniProt states that Tsr4 is released before Rps2 nuclear import, and current
+evidence does not identify a direct acceptor, directional handoff, or escort by
+Tsr4 to the nucleus. Consequently, GO:0140597 is not retained as core and
+GO:0140318/GO:0140309 are not proposed. The direct GO:0140597 row and all three
+obsolete GO:0051082 rows are instead MODIFY to GO:0044183, which captures the
+experimentally demonstrated client-stabilizing chaperone activity without
+inventing transport.
+
+The core synthesis is therefore a cytoplasmic, Rps2-specific protein folding
+chaperone whose activity supports ribosomal small-subunit biogenesis and SSU
+rRNA maturation. Experiments that identify the immediate Rps2 acceptor and
+demonstrate directional handoff would be needed before asserting carrier or
+transporter activity.


### PR DESCRIPTION
## Summary
- reconcile all 15 TSR4 GOA signatures and audit the sole IBA against PTN000958897
- replace obsolete GO:0051082 and over-specific GO:0140597 assertions with evidence-matched GO:0044183
- distinguish client stabilization from unproven carrier handoff/escort semantics
- replace paraphrased evidence strings with exact cached excerpts and add reference reviews plus provenance notes
- regenerate TSR4 HTML and browser data through public wrappers

## Validation
- `just validate yeast TSR4` (clean, no curation warnings)
- `just validate-goa yeast TSR4`
- `just render yeast TSR4`
- `just deploy-browser`
- `git diff --check`