### PR TITLE
Re-review yeast VMA22 annotations

### DIFF
--- a/genes/yeast/VMA22/VMA22-ai-review.html
+++ b/genes/yeast/VMA22/VMA22-ai-review.html
@@ -924,7 +924,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Vma22 acts in a dedicated Vma12-Vma22 ER assembly complex for the V-ATPase V0 sector. The experimentally described client, Vph1, is already fully translocated and folded before association, so neither this IBA nor its target-derived seed supports broad unfolded protein binding. GO:0051082 is obsolete, and no current holdase/chaperone term accurately describes this dedicated assembly-factor role.
+                            <strong>Reason:</strong> Vma22 acts in a dedicated Vma12-Vma22 ER assembly complex for the V-ATPase V0 sector, and the authors explicitly distinguish these assembly factors from general molecular chaperones. Their proposed model places a fully translocated and folded Vph1 client at the interaction step, while the experiments establish stabilization and assembly rather than client folding. GO:0051082 is obsolete. GO:0044183 protein folding chaperone is not proposed because no assistance of protein folding was demonstrated.
                         </div>
 
 
@@ -966,10 +966,10 @@
                                     &middot; VMA22
 
 
-                                    <span class="badge">SOURCE BAD</span>
+                                    <span class="badge">SOURCE WEAK OR INFERRED</span>
 
 
-                                    <div class="propagation-comment">VMA22 is a legitimate target-descendant source rather than a circular donor, but its experimental assembly phenotypes do not establish unfolded-protein binding and should not seed this term.</div>
+                                    <div class="propagation-comment">VMA22 is a legitimate target-descendant source rather than a circular donor, but its experimental assembly phenotypes support only a dedicated stabilization/assembly role and are over-scoped when used to seed unfolded-protein binding.</div>
 
                                 </div>
 
@@ -991,7 +991,33 @@
 
                                 </span>
 
+                                <div class="support-text">Unlike general molecular chaperones such as Kar2p/BiP (Gething and Sambrook, 1992), Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins dedicated to the assembly of a specific enzyme complex, the V-ATPase.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9660861" target="_blank" class="term-link">
+                                        PMID:9660861
+                                    </a>
+
+                                </span>
+
                                 <div class="support-text">The first step in the assembly pathway would involve the association of the fully translocated and folded Vph1p with the Vma12p/Vma22p assembly complex in the ER membrane.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9660861" target="_blank" class="term-link">
+                                        PMID:9660861
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We conclude that the interaction of Vph1p with the assembly complex stabilizes this Vo subunit in the ER allowing it to assemble into the Vo subcomplex.</div>
 
                             </div>
 
@@ -1250,7 +1276,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> ER localization is strongly supported and is the known site of function, but it does not logically exclude a minor or tag-dependent nuclear signal. The study assigned localization by eye without co-localization markers, and its cached main text does not expose the VMA22-specific observation. Following the abstract/full-text limitation rule, this experimental row is therefore retained as UNDECIDED rather than removed.
+                            <strong>Reason:</strong> ER localization is strongly supported and is the known site of function, but it does not logically exclude a minor or tag-dependent nuclear signal. The study used amino-terminal GFP tagging and manual localization without co-localization markers; an amino-terminal fusion is a concrete caveat for VMA22 because UniProt records alternative initiation products. The cached main text does not expose the VMA22-specific observation, so this experimental row is retained as UNDECIDED rather than removed.
                         </div>
 
 
@@ -1258,6 +1284,19 @@
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                                        PMID:26928762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">To establish this strategy we constructed a library containing ~1,800 strains where all proteins with known or predicted localization to the yeast endomembrane system are tagged with an amino terminal (N′) SWAT acceptor module. The used module also contains a constitutive promoter and a GFP tag.</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -1411,10 +1450,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P38784" data-a="GO:0007035" data-r="PMID:1628805" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P38784" data-a="GO:0007035" data-r="PMID:1628805" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1509,7 +1548,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Vma22 is ER-associated and required for V-ATPase assembly, but the evidence does not show broad binding to unfolded proteins. Later full-text work explicitly models the Vma12-Vma22 client as fully translocated and folded; the assembly process and named complex capture the biology more accurately.
+                            <strong>Reason:</strong> GO:0051082 is obsolete. Vma22 is ER-associated and required for V-ATPase assembly, but the evidence does not show broad binding to unfolded proteins. Later full-text work distinguishes Vma22 from general chaperones and proposes that its Vph1 client is folded at association. Although the complex stabilizes Vph1, GO:0044183 protein folding chaperone is not proposed because the experiments establish assembly and stability rather than client folding.
                         </div>
 
 
@@ -1604,7 +1643,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> This annotation generalizes a specific assembly-factor defect into a broad chaperone-like molecular function. V-ATPase complex assembly is the defensible process annotation.
+                            <strong>Reason:</strong> GO:0051082 is obsolete, and this annotation generalizes a specific assembly-factor defect into a broad chaperone-like molecular function. GO:0044183 protein folding chaperone is not proposed because this mutant study establishes failed V-ATPase assembly, not assistance of client protein folding.
                         </div>
 
 
@@ -1803,7 +1842,7 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Vma22 is a dedicated ER-associated V-ATPase assembly factor. In complex with Vma12, it transiently binds the Vph1/V0-sector assembly intermediate in the ER, stabilizing V0 assembly before the V-ATPase reaches the vacuole. Vma22 is therefore required for V-ATPase complex assembly and downstream vacuolar acidification, but it is not a mature V-ATPase subunit or a general unfolded-protein binding factor.</h3>
+                <h3>Vma22 is a dedicated ER-associated V-ATPase assembly factor. In complex with Vma12, it transiently binds the Vph1/V0-sector assembly intermediate in the ER, stabilizing V0 assembly before the V-ATPase reaches the vacuole. Vma22 is therefore required for V-ATPase complex assembly and downstream vacuolar acidification, but it is not a mature V-ATPase subunit.</h3>
                 <span class="vote-buttons" data-g="P38784" data-a="FUNCTION: Vma22 is a dedicated ER-associated V-ATPase assemb..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -2122,7 +2161,7 @@
                     <li class="finding-item">
                         <div class="finding-statement">Vma22 is a dedicated assembly factor, not a general molecular chaperone.</div>
 
-                        <div class="finding-text">"Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins dedicated to the assembly of a specific enzyme complex, the V-ATPase."</div>
+                        <div class="finding-text">"Unlike general molecular chaperones such as Kar2p/BiP (Gething and Sambrook, 1992), Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins dedicated to the assembly of a specific enzyme complex, the V-ATPase."</div>
 
                     </li>
 
@@ -2197,6 +2236,19 @@
 
                 </div>
                 <span class="vote-buttons" data-g="P38784" data-a="Q: Which VMA22 isoform(s), if any, are functional in ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does amino-terminal tagging alter Vma22 isoform usage, ER association, or localization and account for the high-throughput nuclear signal?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38784" data-a="Q: Does amino-terminal tagging alter Vma22 isoform us..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
                     <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
                 </span>
@@ -2603,25 +2655,36 @@ the ER so it can assemble into V0.</p>
 <h2 id="go0051082-and-molecular-function-scope">GO:0051082 and molecular-function scope</h2>
 <p>All three <code>unfolded protein binding</code> rows are marked over-annotated. GO:0051082<br />
 is obsolete, but no current generic holdase or protein-folding-chaperone term is<br />
-an evidence-matched replacement. Crucially, the full text describes association<br />
-with a folded assembly intermediate: [PMID:9660861, "The first step in the<br />
-assembly pathway would involve the association of the fully translocated and<br />
-folded Vph1p with the Vma12p/Vma22p assembly complex in the ER membrane."] It<br />
-also distinguishes these proteins from general chaperones: [PMID:9660861,<br />
+an evidence-matched replacement. The authors' proposed model, rather than a<br />
+direct folding-state assay, places a folded assembly intermediate at the<br />
+interaction step: [PMID:9660861, "The first step in the assembly pathway would<br />
+involve the association of the fully translocated and folded Vph1p with the<br />
+Vma12p/Vma22p assembly complex in the ER membrane."] The experiments establish<br />
+stabilization in the assembly pathway [PMID:9660861, "We conclude that the<br />
+interaction of Vph1p with the assembly complex stabilizes this Vo subunit in the<br />
+ER allowing it to assemble into the Vo subcomplex."], while the authors<br />
+explicitly distinguish these proteins from general chaperones: [PMID:9660861,<br />
 "Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins dedicated<br />
 to the assembly of a specific enzyme complex, the V-ATPase."] Accordingly, the<br />
-review does not replace GO:0051082 with a holdase/chaperone term and instead<br />
-proposes a dedicated V-ATPase V0-sector assembly-factor activity term.</p>
+review does not replace GO:0051082 with GO:0044183 protein folding chaperone:<br />
+stabilization is demonstrated, but assistance of client protein folding is not.<br />
+It instead proposes a dedicated V-ATPase V0-sector assembly-factor activity term.</p>
 <p>For the IBA GO:0051082 row, the PTN source cannot be recovered. The VMA22 source<br />
-seed is classified <code>SOURCE_BAD</code> for this term because the experimental mutant<br />
-and assembly evidence does not establish unfolded-protein binding. This is a<br />
+seed is classified <code>SOURCE_WEAK_OR_INFERRED</code> because the experimental mutant and<br />
+assembly evidence does not establish unfolded-protein binding; this reflects<br />
+over-scoping rather than a wrong experiment. This is a<br />
 term-scoping/role-conflation problem, not a claim that target self-evidence is<br />
 circular.</p>
 <h2 id="localization-and-evidence-limitations">Localization and evidence limitations</h2>
 <p>The PMID:26928762 nucleus HDA row is UNDECIDED. The full cached article describes<br />
 the library and its manual localization calls without co-localization markers,<br />
 but the VMA22-specific supplementary row is absent from the cache. The method<br />
-states: [PMID:26928762, "Since no co-localization markers were used we only<br />
+used amino-terminal GFP tagging, a concrete caveat for a protein with alternative<br />
+initiation products [PMID:26928762, "To establish this strategy we constructed a<br />
+library containing ~1,800 strains where all proteins with known or predicted<br />
+localization to the yeast endomembrane system are tagged with an amino terminal<br />
+(N′) SWAT acceptor module. The used module also contains a constitutive promoter<br />
+and a GFP tag."]. It also states: [PMID:26928762, "Since no co-localization markers were used we only<br />
 assigned localizations that could be easily discriminated by eye: ER, nuclear<br />
 periphery, cytosol, cell periphery, vacuole lumen, vacuole membrane, mitochondria,<br />
 nucleus, bud/bud neck and punctate"]. Focused evidence strongly establishes the<br />
@@ -2638,9 +2701,9 @@ data limitation above.</p>
 <p>The core function is V-ATPase V0-sector assembly in the ER as part of the<br />
 Vma12-Vma22 assembly complex, with vacuolar acidification as a valid downstream<br />
 process consequence. The NEW ER membrane annotation is supported by focused<br />
-biochemical evidence. The nine physical GOA rows have five ACCEPT decisions,<br />
-three MARK_AS_OVER_ANNOTATED decisions, and one UNDECIDED decision; the review<br />
-also contains one NEW annotation.</p>
+biochemical evidence. The nine physical GOA rows have four ACCEPT decisions,<br />
+three MARK_AS_OVER_ANNOTATED decisions, one KEEP_AS_NON_CORE decision, and one<br />
+UNDECIDED decision; the review also contains one NEW annotation.</p>
             </div>
         </details>
 
@@ -2689,11 +2752,12 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Vma22 acts in a dedicated Vma12-Vma22 ER assembly complex for the V-ATPase
-      V0 sector. The experimentally described client, Vph1, is already fully
-      translocated and folded before association, so neither this IBA nor its
-      target-derived seed supports broad unfolded protein binding. GO:0051082 is
-      obsolete, and no current holdase/chaperone term accurately describes this
-      dedicated assembly-factor role.
+      V0 sector, and the authors explicitly distinguish these assembly factors
+      from general molecular chaperones. Their proposed model places a fully
+      translocated and folded Vph1 client at the interaction step, while the
+      experiments establish stabilization and assembly rather than client
+      folding. GO:0051082 is obsolete. GO:0044183 protein folding chaperone is
+      not proposed because no assistance of protein folding was demonstrated.
     propagation_review:
       root_cause: TERM_SCOPING_PROBLEM
       failure_modes:
@@ -2708,17 +2772,29 @@ existing_annotations:
           cannot be recovered for direct inspection.
       - source_id: SGD:S000001102
         source_label: VMA22
-        source_status: SOURCE_BAD
+        source_status: SOURCE_WEAK_OR_INFERRED
         comment: &gt;-
           VMA22 is a legitimate target-descendant source rather than a circular
-          donor, but its experimental assembly phenotypes do not establish
-          unfolded-protein binding and should not seed this term.
+          donor, but its experimental assembly phenotypes support only a
+          dedicated stabilization/assembly role and are over-scoped when used to
+          seed unfolded-protein binding.
     supported_by:
+    - reference_id: PMID:9660861
+      supporting_text: &gt;-
+        Unlike general molecular chaperones such as Kar2p/BiP (Gething and
+        Sambrook, 1992), Vma12p, Vma21p, and Vma22p represent a class of ER
+        resident proteins dedicated to the assembly of a specific enzyme complex,
+        the V-ATPase.
     - reference_id: PMID:9660861
       supporting_text: &gt;-
         The first step in the assembly pathway would involve the association of
         the fully translocated and folded Vph1p with the Vma12p/Vma22p assembly
         complex in the ER membrane.
+    - reference_id: PMID:9660861
+      supporting_text: &gt;-
+        We conclude that the interaction of Vph1p with the assembly complex
+        stabilizes this Vo subunit in the ER allowing it to assemble into the Vo
+        subcomplex.
     - reference_id: file:yeast/VMA22/VMA22-deep-research-falcon.md
       supporting_text: &gt;-
         **VMA22 (P38784/YHR060W)** encodes **Vma22p**, an **ER-associated
@@ -2791,11 +2867,19 @@ existing_annotations:
     reason: &gt;-
       ER localization is strongly supported and is the known site of function,
       but it does not logically exclude a minor or tag-dependent nuclear signal.
-      The study assigned localization by eye without co-localization markers, and
-      its cached main text does not expose the VMA22-specific observation.
-      Following the abstract/full-text limitation rule, this experimental row is
-      therefore retained as UNDECIDED rather than removed.
+      The study used amino-terminal GFP tagging and manual localization without
+      co-localization markers; an amino-terminal fusion is a concrete caveat for
+      VMA22 because UniProt records alternative initiation products. The cached
+      main text does not expose the VMA22-specific observation, so this
+      experimental row is retained as UNDECIDED rather than removed.
     supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: &gt;-
+        To establish this strategy we constructed a library containing ~1,800
+        strains where all proteins with known or predicted localization to the
+        yeast endomembrane system are tagged with an amino terminal (N′) SWAT
+        acceptor module. The used module also contains a constitutive promoter and
+        a GFP tag.
     - reference_id: PMID:26928762
       supporting_text: &gt;-
         Since no co-localization markers were used we only assigned localizations
@@ -2834,7 +2918,7 @@ existing_annotations:
     summary: &gt;-
       VMA22 was identified among VPH/VMA genes required for vacuolar acidity.
       The phenotype is a downstream consequence of failed V-ATPase assembly.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       Vacuolar acidification is a valid biological-process outcome of Vma22
       function, but the mechanistic core should be understood as V-ATPase
@@ -2854,10 +2938,12 @@ existing_annotations:
       unfolded protein binding.
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Vma22 is ER-associated and required for V-ATPase assembly, but the evidence
-      does not show broad binding to unfolded proteins. Later full-text work
-      explicitly models the Vma12-Vma22 client as fully translocated and folded;
-      the assembly process and named complex capture the biology more accurately.
+      GO:0051082 is obsolete. Vma22 is ER-associated and required for V-ATPase
+      assembly, but the evidence does not show broad binding to unfolded proteins.
+      Later full-text work distinguishes Vma22 from general chaperones and proposes
+      that its Vph1 client is folded at association. Although the complex
+      stabilizes Vph1, GO:0044183 protein folding chaperone is not proposed because
+      the experiments establish assembly and stability rather than client folding.
     supported_by:
     - reference_id: PMID:7673216
       supporting_text: &gt;-
@@ -2879,9 +2965,11 @@ existing_annotations:
       than a standalone unfolded-protein binding activity.
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      This annotation generalizes a specific assembly-factor defect into a broad
-      chaperone-like molecular function. V-ATPase complex assembly is the
-      defensible process annotation.
+      GO:0051082 is obsolete, and this annotation generalizes a specific
+      assembly-factor defect into a broad chaperone-like molecular function.
+      GO:0044183 protein folding chaperone is not proposed because this mutant
+      study establishes failed V-ATPase assembly, not assistance of client
+      protein folding.
     supported_by:
     - reference_id: PMID:8582630
       supporting_text: &gt;-
@@ -3050,8 +3138,10 @@ references:
   - statement: &gt;-
       Vma22 is a dedicated assembly factor, not a general molecular chaperone.
     supporting_text: &gt;-
-      Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins
-      dedicated to the assembly of a specific enzyme complex, the V-ATPase.
+      Unlike general molecular chaperones such as Kar2p/BiP (Gething and
+      Sambrook, 1992), Vma12p, Vma21p, and Vma22p represent a class of ER
+      resident proteins dedicated to the assembly of a specific enzyme complex,
+      the V-ATPase.
 - id: file:yeast/VMA22/VMA22-deep-research-falcon.md
   title: Falcon deep research report for VMA22
   findings:
@@ -3068,8 +3158,7 @@ core_functions:
     Vma12, it transiently binds the Vph1/V0-sector assembly intermediate in the
     ER, stabilizing V0 assembly before the V-ATPase reaches the vacuole. Vma22 is
     therefore required for V-ATPase complex assembly and downstream vacuolar
-    acidification, but it is not a mature V-ATPase subunit or a general
-    unfolded-protein binding factor.
+    acidification, but it is not a mature V-ATPase subunit.
   directly_involved_in:
   - id: GO:0070072
     label: vacuolar proton-transporting V-type ATPase complex assembly
@@ -3116,6 +3205,9 @@ suggested_questions:
     Which VMA22 isoform(s), if any, are functional in V-ATPase assembly, and do
     the alternative initiation products differ in stability or assembly-complex
     incorporation?
+- question: &gt;-
+    Does amino-terminal tagging alter Vma22 isoform usage, ER association, or
+    localization and account for the high-throughput nuclear signal?
 suggested_experiments:
 - description: &gt;-
     Use structure-guided Vma22 mutants to disrupt Vma12 binding or Vph1

--- a/genes/yeast/VMA22/VMA22-ai-review.html
+++ b/genes/yeast/VMA22/VMA22-ai-review.html
@@ -830,7 +830,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>VMA22 encodes a dedicated endoplasmic-reticulum-associated assembly factor for the vacuolar proton-translocating V-type ATPase. Vma22 is not a mature V-ATPase subunit. Instead, it associates with Vma12 in a stable ER membrane assembly complex that transiently contacts the newly synthesized Vph1/V0 sector subunit, stabilizing V0 assembly intermediates before export to the vacuole. Loss of VMA22 blocks V-ATPase assembly and activity and causes vacuolar acidification defects. The &#34;unfolded protein binding&#34; annotations overgeneralize this specific assembly-factor role.</p>
+        <p>VMA22 encodes a dedicated endoplasmic-reticulum-associated assembly factor for the vacuolar proton-translocating V-type ATPase. Vma22 is not a mature V-ATPase subunit. Instead, it associates with Vma12 in a stable ER membrane assembly complex that transiently contacts the newly synthesized Vph1/V0 sector subunit, stabilizing V0 assembly intermediates before export to the vacuole. Loss of VMA22 blocks V-ATPase assembly and activity and causes vacuolar acidification defects.</p>
     </div>
 
 
@@ -854,7 +854,7 @@
 
 
 
-            <p><strong>Justification:</strong> Vma22 has a clear molecular role as part of the ER-localized Vma12-Vma22 assembly complex that transiently binds Vph1/V0-sector intermediates, but current GO terms capture only the biological process or the Vma12-Vma22 complex. QuickGO has no GO:0140557 term available, and generic protein folding chaperone terms would overstate Vma22 as a general foldase rather than a V-ATPase assembly factor.</p>
+            <p><strong>Justification:</strong> Vma22 has a clear molecular role as part of the ER-localized Vma12-Vma22 assembly complex that transiently binds Vph1/V0-sector intermediates, but current GO terms capture only the biological process or the Vma12-Vma22 complex. Generic protein folding chaperone terms would overstate Vma22 as a general foldase rather than a V-ATPase assembly factor.</p>
 
 
 
@@ -924,9 +924,58 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Vma22 acts in a dedicated Vma12-Vma22 ER assembly complex for the V-ATPase V0 sector. The evidence supports specific assembly-intermediate binding, not broad unfolded protein binding.
+                            <strong>Reason:</strong> Vma22 acts in a dedicated Vma12-Vma22 ER assembly complex for the V-ATPase V0 sector. The experimentally described client, Vph1, is already fully translocated and folded before association, so neither this IBA nor its target-derived seed supports broad unfolded protein binding. GO:0051082 is obsolete, and no current holdase/chaperone term accurately describes this dedicated assembly-factor role.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">ROLE CONFLATION</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001592797</span>
+
+                                    &middot; PANTHER:PTN001592797
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">The exact PTN is present in the pinned GOA WITH/FROM, but it is absent from the current local PAINT snapshot, so its ancestral assertion cannot be recovered for direct inspection.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000001102</span>
+
+                                    &middot; VMA22
+
+
+                                    <span class="badge">SOURCE BAD</span>
+
+
+                                    <div class="propagation-comment">VMA22 is a legitimate target-descendant source rather than a circular donor, but its experimental assembly phenotypes do not establish unfolded-protein binding and should not seed this term.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -942,7 +991,7 @@
 
                                 </span>
 
-                                <div class="support-text">Unlike general molecular chaperones such as Kar2p/BiP (Gething and Sambrook, 1992), Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins dedicated to the assembly of a specific enzyme complex, the V-ATPase.</div>
+                                <div class="support-text">The first step in the assembly pathway would involve the association of the fully translocated and folded Vph1p with the Vma12p/Vma22p assembly complex in the ER membrane.</div>
 
                             </div>
 
@@ -1009,6 +1058,48 @@
                             <strong>Reason:</strong> Vma12-Vma22 complex membership is a core feature of Vma22 function and is supported by both family-transfer and direct experimental evidence.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001278552</span>
+
+                                    &middot; PANTHER:PTN001278552
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">The exact PTN is recorded in the pinned GOA WITH/FROM but is absent from the current local PAINT snapshot; independent Vma22-specific biochemical evidence nevertheless establishes the complex membership.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000001102</span>
+
+                                    &middot; VMA22
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The target&#39;s own direct evidence validly grounds the ancestral inference: Vma12 and Vma22 interact and form the named stable complex.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1143,10 +1234,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P38784" data-a="GO:0005634" data-r="PMID:26928762" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P38784" data-a="GO:0005634" data-r="PMID:26928762" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1154,12 +1245,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> The nucleus annotation is from a high-throughput localization resource and conflicts with focused biochemical evidence that Vma22 is ER-associated.
+                            <strong>Summary:</strong> The nucleus annotation comes from a high-throughput tagged-protein library, whereas focused biochemical studies establish ER membrane association. The cached article lacks the VMA22-specific supplementary localization record, so the experimental HDA call cannot be adjudicated directly.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Vma22&#39;s established function is in the ER-localized Vma12-Vma22 assembly complex. No gene-specific evidence supports nuclear localization as a site of Vma22 function.
+                            <strong>Reason:</strong> ER localization is strongly supported and is the known site of function, but it does not logically exclude a minor or tag-dependent nuclear signal. The study assigned localization by eye without co-localization markers, and its cached main text does not expose the VMA22-specific observation. Following the abstract/full-text limitation rule, this experimental row is therefore retained as UNDECIDED rather than removed.
                         </div>
 
 
@@ -1167,6 +1258,19 @@
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                                        PMID:26928762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Since no co-localization markers were used we only assigned localizations that could be easily discriminated by eye: ER, nuclear periphery, cytosol, cell periphery, vacuole lumen, vacuole membrane, mitochondria, nucleus, bud/bud neck and punctate</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -1405,7 +1509,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Vma22 is ER-associated and required for V-ATPase assembly, but the evidence does not show broad binding to unfolded proteins. The assembly process and Vma12-Vma22 complex annotations capture the biology more accurately.
+                            <strong>Reason:</strong> Vma22 is ER-associated and required for V-ATPase assembly, but the evidence does not show broad binding to unfolded proteins. Later full-text work explicitly models the Vma12-Vma22 client as fully translocated and folded; the assembly process and named complex capture the biology more accurately.
                         </div>
 
 
@@ -1424,6 +1528,19 @@
                                 </span>
 
                                 <div class="support-text">Vma22p is a 21-kDa hydrophilic protein that is not a subunit of the V-ATPase but rather is associated with ER membranes.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9660861" target="_blank" class="term-link">
+                                        PMID:9660861
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The first step in the assembly pathway would involve the association of the fully translocated and folded Vph1p with the Vma12p/Vma22p assembly complex in the ER membrane.</div>
 
                             </div>
 
@@ -1633,7 +1750,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Existing GOA contains a misleading nucleus annotation but lacks the experimentally supported ER membrane localization. Vma22 is hydrophilic but membrane-associated in the ER via the Vma12-Vma22 assembly complex.
+                            <strong>Reason:</strong> Existing GOA contains an unresolved high-throughput nucleus annotation but lacks the experimentally supported ER membrane localization. Vma22 is hydrophilic but membrane-associated in the ER via the Vma12-Vma22 assembly complex.
                         </div>
 
 
@@ -1686,7 +1803,7 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Vma22 is a dedicated ER-associated V-ATPase assembly factor. In complex with Vma12, it transiently binds the Vph1/V0-sector assembly intermediate in the ER, stabilizing V0 assembly before the V-ATPase reaches the vacuole. Vma22 is therefore required for V-ATPase complex assembly and downstream vacuolar acidification, but it is not a mature V-ATPase subunit and should not be curated as a general unfolded-protein binding factor.</h3>
+                <h3>Vma22 is a dedicated ER-associated V-ATPase assembly factor. In complex with Vma12, it transiently binds the Vph1/V0-sector assembly intermediate in the ER, stabilizing V0 assembly before the V-ATPase reaches the vacuole. Vma22 is therefore required for V-ATPase complex assembly and downstream vacuolar acidification, but it is not a mature V-ATPase subunit or a general unfolded-protein binding factor.</h3>
                 <span class="vote-buttons" data-g="P38784" data-a="FUNCTION: Vma22 is a dedicated ER-associated V-ATPase assemb..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -1779,7 +1896,7 @@
 
                         </span>
 
-                        <div class="finding-text">VMA22 encodes Vma22p, an ER-associated peripheral assembly factor required for V-ATPase V0-region biogenesis. Vma22p forms a stable complex with Vma12p that transiently binds and stabilizes Vph1p during ER-stage assembly.</div>
+                        <div class="finding-text">**VMA22 (P38784/YHR060W)** encodes **Vma22p**, an **ER-associated peripheral assembly factor** required for **V-ATPase V0-region biogenesis**.</div>
 
                     </li>
 
@@ -1905,6 +2022,17 @@
                 <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy</div>
 
 
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The localization library used visual assignments without co-localization markers; the cached main text does not identify VMA22&#39;s individual score.</div>
+
+                        <div class="finding-text">"Since no co-localization markers were used we only assigned localizations that could be easily discriminated by eye: ER, nuclear periphery, cytosol, cell periphery, vacuole lumen, vacuole membrane, mitochondria, nucleus, bud/bud neck and punctate"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
 
             <div class="reference-item">
@@ -1994,7 +2122,7 @@
                     <li class="finding-item">
                         <div class="finding-statement">Vma22 is a dedicated assembly factor, not a general molecular chaperone.</div>
 
-                        <div class="finding-text">"Unlike general molecular chaperones such as Kar2p/BiP, Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins dedicated to the assembly of a specific enzyme complex, the V-ATPase."</div>
+                        <div class="finding-text">"Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins dedicated to the assembly of a specific enzyme complex, the V-ATPase."</div>
 
                     </li>
 
@@ -2019,7 +2147,7 @@
                     <li class="finding-item">
                         <div class="finding-statement">Falcon supports Vma22 as an ER-associated V-ATPase V0-region assembly factor and not a general unfolded-protein binding protein.</div>
 
-                        <div class="finding-text">"VMA22 encodes Vma22p, an ER-associated peripheral assembly factor required for V-ATPase V0-region biogenesis. Vma22p forms a stable complex with Vma12p that transiently binds and stabilizes Vph1p during ER-stage assembly."</div>
+                        <div class="finding-text">"**VMA22 (P38784/YHR060W)** encodes **Vma22p**, an **ER-associated peripheral assembly factor** required for **V-ATPase V0-region biogenesis**."</div>
 
                     </li>
 
@@ -2426,6 +2554,98 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(VMA22-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38784" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="vma22-annotation-re-review-notes">VMA22 annotation re-review notes</h1>
+<h2 id="scope-and-reconciliation">Scope and reconciliation</h2>
+<p>Dedicated re-review performed on 2026-08-28 against <code>VMA22-goa.tsv</code>, UniProt<br />
+P38784, the Falcon deep-research report, all locally cached cited publications,<br />
+and the available local PAINT snapshot. The GOA contains nine physical rows and<br />
+nine unique qualifier-aware signatures; all nine are represented one-for-one in<br />
+the review. All are positive annotations, with no NOT annotations or isoform-<br />
+specific rows. The review additionally proposes one NEW ER-membrane annotation.</p>
+<p>The exact IBA WITH/FROM traces are:</p>
+<ul>
+<li>GO:0051082 <code>enables</code>: <code>PANTHER:PTN001592797|SGD:S000001102</code></li>
+<li>GO:1990871 <code>part_of</code>: <code>PANTHER:PTN001278552|SGD:S000001102</code></li>
+</ul>
+<p>Neither PTN is recoverable in the current local PAINT snapshot, and the UniProt<br />
+PANTHER family PTHR31996 has no local PAINT table. Both PTNs are therefore<br />
+recorded with bare PTN labels and <code>SOURCE_STALE_OR_MISSING</code>. The target's own SGD<br />
+identifier in WITH/FROM is expected experimental grounding, not circularity.</p>
+<h2 id="biological-synthesis">Biological synthesis</h2>
+<p>Vma22 is a dedicated ER-associated V-ATPase assembly factor, not a mature<br />
+V-ATPase subunit. Deletion prevents enzyme assembly: [PMID:7673216, "vma22 delta<br />
+cells contain no V-ATPase activity due to a failure to assemble the enzyme<br />
+complex; V1 subunits accumulate in the cytosol, and the V0 100-kDa subunit is<br />
+rapidly degraded."] Vma22 is ER-membrane-associated despite being hydrophilic:<br />
+[PMID:7673216, "Vma22p is a 21-kDa hydrophilic protein that is not a subunit of<br />
+the V-ATPase but rather is associated with ER membranes."]</p>
+<p>Full-text biochemical evidence establishes the stable named complex and its<br />
+direct assembly-substrate interaction: [PMID:9660861, "Vma12p and Vma22p were<br />
+found to interact directly as determined by chemical cross-linking analysis and<br />
+cofractionation under conditions of gentle detergent solubilization."] The<br />
+authors further conclude that interaction with the complex stabilizes Vph1 in<br />
+the ER so it can assemble into V0.</p>
+<h2 id="go0051082-and-molecular-function-scope">GO:0051082 and molecular-function scope</h2>
+<p>All three <code>unfolded protein binding</code> rows are marked over-annotated. GO:0051082<br />
+is obsolete, but no current generic holdase or protein-folding-chaperone term is<br />
+an evidence-matched replacement. Crucially, the full text describes association<br />
+with a folded assembly intermediate: [PMID:9660861, "The first step in the<br />
+assembly pathway would involve the association of the fully translocated and<br />
+folded Vph1p with the Vma12p/Vma22p assembly complex in the ER membrane."] It<br />
+also distinguishes these proteins from general chaperones: [PMID:9660861,<br />
+"Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins dedicated<br />
+to the assembly of a specific enzyme complex, the V-ATPase."] Accordingly, the<br />
+review does not replace GO:0051082 with a holdase/chaperone term and instead<br />
+proposes a dedicated V-ATPase V0-sector assembly-factor activity term.</p>
+<p>For the IBA GO:0051082 row, the PTN source cannot be recovered. The VMA22 source<br />
+seed is classified <code>SOURCE_BAD</code> for this term because the experimental mutant<br />
+and assembly evidence does not establish unfolded-protein binding. This is a<br />
+term-scoping/role-conflation problem, not a claim that target self-evidence is<br />
+circular.</p>
+<h2 id="localization-and-evidence-limitations">Localization and evidence limitations</h2>
+<p>The PMID:26928762 nucleus HDA row is UNDECIDED. The full cached article describes<br />
+the library and its manual localization calls without co-localization markers,<br />
+but the VMA22-specific supplementary row is absent from the cache. The method<br />
+states: [PMID:26928762, "Since no co-localization markers were used we only<br />
+assigned localizations that could be easily discriminated by eye: ER, nuclear<br />
+periphery, cytosol, cell periphery, vacuole lumen, vacuole membrane, mitochondria,<br />
+nucleus, bud/bud neck and punctate"]. Focused evidence strongly establishes the<br />
+ER as Vma22's functional location, but it cannot exclude a minor, conditional,<br />
+or tag-dependent nuclear signal. The experimental row is therefore not removed<br />
+without its gene-specific evidence.</p>
+<p>PMID:7673216, PMID:8582630, and PMID:1628805 are abstract-only in the local cache.<br />
+Their directly visible claims are used conservatively. The vacuolar-acidification<br />
+IMP from PMID:1628805 is retained with curator deference because the abstract<br />
+establishes the Vph- mutant screen but does not expose the VMA22-specific assay.<br />
+PMID:9660861 and PMID:26928762 have cached full text, subject to the supplementary-<br />
+data limitation above.</p>
+<h2 id="final-curation-shape">Final curation shape</h2>
+<p>The core function is V-ATPase V0-sector assembly in the ER as part of the<br />
+Vma12-Vma22 assembly complex, with vacuolar acidification as a valid downstream<br />
+process consequence. The NEW ER membrane annotation is supported by focused<br />
+biochemical evidence. The nine physical GOA rows have five ACCEPT decisions,<br />
+three MARK_AS_OVER_ANNOTATED decisions, and one UNDECIDED decision; the review<br />
+also contains one NEW annotation.</p>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2448,8 +2668,7 @@ description: &gt;-
   complex that transiently contacts the newly synthesized Vph1/V0 sector subunit,
   stabilizing V0 assembly intermediates before export to the vacuole. Loss of
   VMA22 blocks V-ATPase assembly and activity and causes vacuolar acidification
-  defects. The &#34;unfolded protein binding&#34; annotations overgeneralize this
-  specific assembly-factor role.
+  defects.
 alternative_products:
 - name: &#34;1&#34;
   id: P38784-1
@@ -2470,15 +2689,36 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Vma22 acts in a dedicated Vma12-Vma22 ER assembly complex for the V-ATPase
-      V0 sector. The evidence supports specific assembly-intermediate binding,
-      not broad unfolded protein binding.
+      V0 sector. The experimentally described client, Vph1, is already fully
+      translocated and folded before association, so neither this IBA nor its
+      target-derived seed supports broad unfolded protein binding. GO:0051082 is
+      obsolete, and no current holdase/chaperone term accurately describes this
+      dedicated assembly-factor role.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - ROLE_CONFLATION
+      source_entities:
+      - source_id: PANTHER:PTN001592797
+        source_label: PANTHER:PTN001592797
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          The exact PTN is present in the pinned GOA WITH/FROM, but it is absent
+          from the current local PAINT snapshot, so its ancestral assertion
+          cannot be recovered for direct inspection.
+      - source_id: SGD:S000001102
+        source_label: VMA22
+        source_status: SOURCE_BAD
+        comment: &gt;-
+          VMA22 is a legitimate target-descendant source rather than a circular
+          donor, but its experimental assembly phenotypes do not establish
+          unfolded-protein binding and should not seed this term.
     supported_by:
     - reference_id: PMID:9660861
       supporting_text: &gt;-
-        Unlike general molecular chaperones such as Kar2p/BiP (Gething and
-        Sambrook, 1992), Vma12p, Vma21p, and Vma22p represent a class of ER
-        resident proteins dedicated to the assembly of a specific enzyme complex,
-        the V-ATPase.
+        The first step in the assembly pathway would involve the association of
+        the fully translocated and folded Vph1p with the Vma12p/Vma22p assembly
+        complex in the ER membrane.
     - reference_id: file:yeast/VMA22/VMA22-deep-research-falcon.md
       supporting_text: &gt;-
         **VMA22 (P38784/YHR060W)** encodes **Vma22p**, an **ER-associated
@@ -2498,6 +2738,22 @@ existing_annotations:
     reason: &gt;-
       Vma12-Vma22 complex membership is a core feature of Vma22 function and is
       supported by both family-transfer and direct experimental evidence.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN001278552
+        source_label: PANTHER:PTN001278552
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          The exact PTN is recorded in the pinned GOA WITH/FROM but is absent
+          from the current local PAINT snapshot; independent Vma22-specific
+          biochemical evidence nevertheless establishes the complex membership.
+      - source_id: SGD:S000001102
+        source_label: VMA22
+        source_status: SUPPORTS_TRANSFER
+        comment: &gt;-
+          The target&#39;s own direct evidence validly grounds the ancestral
+          inference: Vma12 and Vma22 interact and form the named stable complex.
     supported_by:
     - reference_id: PMID:9660861
       supporting_text: &gt;-
@@ -2527,14 +2783,25 @@ existing_annotations:
   original_reference_id: PMID:26928762
   review:
     summary: &gt;-
-      The nucleus annotation is from a high-throughput localization resource and
-      conflicts with focused biochemical evidence that Vma22 is ER-associated.
-    action: REMOVE
+      The nucleus annotation comes from a high-throughput tagged-protein library,
+      whereas focused biochemical studies establish ER membrane association. The
+      cached article lacks the VMA22-specific supplementary localization record,
+      so the experimental HDA call cannot be adjudicated directly.
+    action: UNDECIDED
     reason: &gt;-
-      Vma22&#39;s established function is in the ER-localized Vma12-Vma22 assembly
-      complex. No gene-specific evidence supports nuclear localization as a site
-      of Vma22 function.
+      ER localization is strongly supported and is the known site of function,
+      but it does not logically exclude a minor or tag-dependent nuclear signal.
+      The study assigned localization by eye without co-localization markers, and
+      its cached main text does not expose the VMA22-specific observation.
+      Following the abstract/full-text limitation rule, this experimental row is
+      therefore retained as UNDECIDED rather than removed.
     supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: &gt;-
+        Since no co-localization markers were used we only assigned localizations
+        that could be easily discriminated by eye: ER, nuclear periphery,
+        cytosol, cell periphery, vacuole lumen, vacuole membrane, mitochondria,
+        nucleus, bud/bud neck and punctate
     - reference_id: PMID:7673216
       supporting_text: &gt;-
         Vma22p is a 21-kDa hydrophilic protein that is not a subunit of the
@@ -2588,13 +2855,19 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Vma22 is ER-associated and required for V-ATPase assembly, but the evidence
-      does not show broad binding to unfolded proteins. The assembly process and
-      Vma12-Vma22 complex annotations capture the biology more accurately.
+      does not show broad binding to unfolded proteins. Later full-text work
+      explicitly models the Vma12-Vma22 client as fully translocated and folded;
+      the assembly process and named complex capture the biology more accurately.
     supported_by:
     - reference_id: PMID:7673216
       supporting_text: &gt;-
         Vma22p is a 21-kDa hydrophilic protein that is not a subunit of the
         V-ATPase but rather is associated with ER membranes.
+    - reference_id: PMID:9660861
+      supporting_text: &gt;-
+        The first step in the assembly pathway would involve the association of
+        the fully translocated and folded Vph1p with the Vma12p/Vma22p assembly
+        complex in the ER membrane.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -2642,9 +2915,10 @@ existing_annotations:
       assembly complex formation.
     action: NEW
     reason: &gt;-
-      Existing GOA contains a misleading nucleus annotation but lacks the
-      experimentally supported ER membrane localization. Vma22 is hydrophilic but
-      membrane-associated in the ER via the Vma12-Vma22 assembly complex.
+      Existing GOA contains an unresolved high-throughput nucleus annotation but
+      lacks the experimentally supported ER membrane localization. Vma22 is
+      hydrophilic but membrane-associated in the ER via the Vma12-Vma22 assembly
+      complex.
     supported_by:
     - reference_id: PMID:7673216
       supporting_text: &gt;-
@@ -2679,6 +2953,14 @@ references:
       Alternative initiation; Named isoforms = 2.
 - id: PMID:1628805
   title: Genes required for vacuolar acidity in Saccharomyces cerevisiae
+  full_text_unavailable: true
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed and cached abstract verified. The abstract establishes the Vph-
+      mutant screen but does not expose the VMA22-specific mapping or experiment;
+      the IMP annotation therefore retains curator deference.
   findings:
   - statement: &gt;-
       VPH/VMA mutants identify genes required for vacuolar acidity.
@@ -2688,11 +2970,35 @@ references:
   title: &gt;-
     One library to make them all: streamlining the creation of yeast libraries
     via a SWAp-Tag strategy
-  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      The cached full article verifies the SWAT-GFP localization methodology,
+      including manual scoring without co-localization markers, but the
+      VMA22-specific supplementary record underlying the nucleus HDA annotation
+      is not present in the cache and could not be checked directly.
+  findings:
+  - statement: &gt;-
+      The localization library used visual assignments without co-localization
+      markers; the cached main text does not identify VMA22&#39;s individual score.
+    supporting_text: &gt;-
+      Since no co-localization markers were used we only assigned localizations
+      that could be easily discriminated by eye: ER, nuclear periphery, cytosol,
+      cell periphery, vacuole lumen, vacuole membrane, mitochondria, nucleus,
+      bud/bud neck and punctate
 - id: PMID:7673216
   title: &gt;-
     Vma22p is a novel endoplasmic reticulum-associated protein required for
     assembly of the yeast vacuolar H(+)-ATPase complex
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed and cached abstract verified. It directly establishes Vma22 as an
+      ER-associated non-subunit required for V-ATPase assembly, but does not
+      assay unfolded-protein binding.
   findings:
   - statement: &gt;-
       Vma22 is ER-associated and required for V-ATPase assembly but is not a
@@ -2709,6 +3015,14 @@ references:
   title: &gt;-
     vph6 mutants of Saccharomyces cerevisiae require calcineurin for growth and
     are defective in vacuolar H(+)-ATPase assembly
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed and cached abstract verified. VPH6 is identified and its mutants
+      fail V-ATPase assembly; the abstract contains no unfolded-client binding
+      assay.
   findings:
   - statement: &gt;-
       VPH6/VMA22 mutants fail to assemble the V-ATPase.
@@ -2718,6 +3032,13 @@ references:
   title: &gt;-
     Assembly of the yeast vacuolar H+-ATPase occurs in the endoplasmic reticulum
     and requires a Vma12p/Vma22p assembly complex
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text verified. Direct cross-linking, cofractionation, and kinetic
+      evidence establishes the stable Vma12-Vma22 complex and its transient
+      interaction with Vph1; the proposed client is explicitly fully folded.
   findings:
   - statement: &gt;-
       Vma12 and Vma22 form a stable ER-associated complex that transiently
@@ -2729,9 +3050,8 @@ references:
   - statement: &gt;-
       Vma22 is a dedicated assembly factor, not a general molecular chaperone.
     supporting_text: &gt;-
-      Unlike general molecular chaperones such as Kar2p/BiP, Vma12p, Vma21p,
-      and Vma22p represent a class of ER resident proteins dedicated to the
-      assembly of a specific enzyme complex, the V-ATPase.
+      Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins
+      dedicated to the assembly of a specific enzyme complex, the V-ATPase.
 - id: file:yeast/VMA22/VMA22-deep-research-falcon.md
   title: Falcon deep research report for VMA22
   findings:
@@ -2739,18 +3059,17 @@ references:
       Falcon supports Vma22 as an ER-associated V-ATPase V0-region assembly
       factor and not a general unfolded-protein binding protein.
     supporting_text: &gt;-
-      VMA22 encodes Vma22p, an ER-associated peripheral assembly factor required
-      for V-ATPase V0-region biogenesis. Vma22p forms a stable complex with
-      Vma12p that transiently binds and stabilizes Vph1p during ER-stage
-      assembly.
+      **VMA22 (P38784/YHR060W)** encodes **Vma22p**, an **ER-associated
+      peripheral assembly factor** required for **V-ATPase V0-region
+      biogenesis**.
 core_functions:
 - description: &gt;-
     Vma22 is a dedicated ER-associated V-ATPase assembly factor. In complex with
     Vma12, it transiently binds the Vph1/V0-sector assembly intermediate in the
     ER, stabilizing V0 assembly before the V-ATPase reaches the vacuole. Vma22 is
     therefore required for V-ATPase complex assembly and downstream vacuolar
-    acidification, but it is not a mature V-ATPase subunit and should not be
-    curated as a general unfolded-protein binding factor.
+    acidification, but it is not a mature V-ATPase subunit or a general
+    unfolded-protein binding factor.
   directly_involved_in:
   - id: GO:0070072
     label: vacuolar proton-transporting V-type ATPase complex assembly
@@ -2772,10 +3091,9 @@ core_functions:
       V-ATPase complex to the vacuole.
   - reference_id: file:yeast/VMA22/VMA22-deep-research-falcon.md
     supporting_text: &gt;-
-      VMA22 encodes Vma22p, an ER-associated peripheral assembly factor required
-      for V-ATPase V0-region biogenesis. Vma22p forms a stable complex with
-      Vma12p that transiently binds and stabilizes Vph1p during ER-stage
-      assembly.
+      **VMA22 (P38784/YHR060W)** encodes **Vma22p**, an **ER-associated
+      peripheral assembly factor** required for **V-ATPase V0-region
+      biogenesis**.
 proposed_new_terms:
 - proposed_name: V-ATPase V0 sector assembly factor activity
   proposed_definition: &gt;-
@@ -2785,9 +3103,8 @@ proposed_new_terms:
     Vma22 has a clear molecular role as part of the ER-localized Vma12-Vma22
     assembly complex that transiently binds Vph1/V0-sector intermediates, but
     current GO terms capture only the biological process or the Vma12-Vma22
-    complex. QuickGO has no GO:0140557 term available, and generic protein
-    folding chaperone terms would overstate Vma22 as a general foldase rather
-    than a V-ATPase assembly factor.
+    complex. Generic protein folding chaperone terms would overstate Vma22 as a
+    general foldase rather than a V-ATPase assembly factor.
 suggested_questions:
 - question: &gt;-
     What is the precise structural interface by which the Vma12-Vma22 complex

--- a/genes/yeast/VMA22/VMA22-ai-review.yaml
+++ b/genes/yeast/VMA22/VMA22-ai-review.yaml
@@ -33,11 +33,12 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Vma22 acts in a dedicated Vma12-Vma22 ER assembly complex for the V-ATPase
-      V0 sector. The experimentally described client, Vph1, is already fully
-      translocated and folded before association, so neither this IBA nor its
-      target-derived seed supports broad unfolded protein binding. GO:0051082 is
-      obsolete, and no current holdase/chaperone term accurately describes this
-      dedicated assembly-factor role.
+      V0 sector, and the authors explicitly distinguish these assembly factors
+      from general molecular chaperones. Their proposed model places a fully
+      translocated and folded Vph1 client at the interaction step, while the
+      experiments establish stabilization and assembly rather than client
+      folding. GO:0051082 is obsolete. GO:0044183 protein folding chaperone is
+      not proposed because no assistance of protein folding was demonstrated.
     propagation_review:
       root_cause: TERM_SCOPING_PROBLEM
       failure_modes:
@@ -52,17 +53,29 @@ existing_annotations:
           cannot be recovered for direct inspection.
       - source_id: SGD:S000001102
         source_label: VMA22
-        source_status: SOURCE_BAD
+        source_status: SOURCE_WEAK_OR_INFERRED
         comment: >-
           VMA22 is a legitimate target-descendant source rather than a circular
-          donor, but its experimental assembly phenotypes do not establish
-          unfolded-protein binding and should not seed this term.
+          donor, but its experimental assembly phenotypes support only a
+          dedicated stabilization/assembly role and are over-scoped when used to
+          seed unfolded-protein binding.
     supported_by:
+    - reference_id: PMID:9660861
+      supporting_text: >-
+        Unlike general molecular chaperones such as Kar2p/BiP (Gething and
+        Sambrook, 1992), Vma12p, Vma21p, and Vma22p represent a class of ER
+        resident proteins dedicated to the assembly of a specific enzyme complex,
+        the V-ATPase.
     - reference_id: PMID:9660861
       supporting_text: >-
         The first step in the assembly pathway would involve the association of
         the fully translocated and folded Vph1p with the Vma12p/Vma22p assembly
         complex in the ER membrane.
+    - reference_id: PMID:9660861
+      supporting_text: >-
+        We conclude that the interaction of Vph1p with the assembly complex
+        stabilizes this Vo subunit in the ER allowing it to assemble into the Vo
+        subcomplex.
     - reference_id: file:yeast/VMA22/VMA22-deep-research-falcon.md
       supporting_text: >-
         **VMA22 (P38784/YHR060W)** encodes **Vma22p**, an **ER-associated
@@ -135,11 +148,19 @@ existing_annotations:
     reason: >-
       ER localization is strongly supported and is the known site of function,
       but it does not logically exclude a minor or tag-dependent nuclear signal.
-      The study assigned localization by eye without co-localization markers, and
-      its cached main text does not expose the VMA22-specific observation.
-      Following the abstract/full-text limitation rule, this experimental row is
-      therefore retained as UNDECIDED rather than removed.
+      The study used amino-terminal GFP tagging and manual localization without
+      co-localization markers; an amino-terminal fusion is a concrete caveat for
+      VMA22 because UniProt records alternative initiation products. The cached
+      main text does not expose the VMA22-specific observation, so this
+      experimental row is retained as UNDECIDED rather than removed.
     supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: >-
+        To establish this strategy we constructed a library containing ~1,800
+        strains where all proteins with known or predicted localization to the
+        yeast endomembrane system are tagged with an amino terminal (N′) SWAT
+        acceptor module. The used module also contains a constitutive promoter and
+        a GFP tag.
     - reference_id: PMID:26928762
       supporting_text: >-
         Since no co-localization markers were used we only assigned localizations
@@ -178,7 +199,7 @@ existing_annotations:
     summary: >-
       VMA22 was identified among VPH/VMA genes required for vacuolar acidity.
       The phenotype is a downstream consequence of failed V-ATPase assembly.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       Vacuolar acidification is a valid biological-process outcome of Vma22
       function, but the mechanistic core should be understood as V-ATPase
@@ -198,10 +219,12 @@ existing_annotations:
       unfolded protein binding.
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Vma22 is ER-associated and required for V-ATPase assembly, but the evidence
-      does not show broad binding to unfolded proteins. Later full-text work
-      explicitly models the Vma12-Vma22 client as fully translocated and folded;
-      the assembly process and named complex capture the biology more accurately.
+      GO:0051082 is obsolete. Vma22 is ER-associated and required for V-ATPase
+      assembly, but the evidence does not show broad binding to unfolded proteins.
+      Later full-text work distinguishes Vma22 from general chaperones and proposes
+      that its Vph1 client is folded at association. Although the complex
+      stabilizes Vph1, GO:0044183 protein folding chaperone is not proposed because
+      the experiments establish assembly and stability rather than client folding.
     supported_by:
     - reference_id: PMID:7673216
       supporting_text: >-
@@ -223,9 +246,11 @@ existing_annotations:
       than a standalone unfolded-protein binding activity.
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      This annotation generalizes a specific assembly-factor defect into a broad
-      chaperone-like molecular function. V-ATPase complex assembly is the
-      defensible process annotation.
+      GO:0051082 is obsolete, and this annotation generalizes a specific
+      assembly-factor defect into a broad chaperone-like molecular function.
+      GO:0044183 protein folding chaperone is not proposed because this mutant
+      study establishes failed V-ATPase assembly, not assistance of client
+      protein folding.
     supported_by:
     - reference_id: PMID:8582630
       supporting_text: >-
@@ -394,8 +419,10 @@ references:
   - statement: >-
       Vma22 is a dedicated assembly factor, not a general molecular chaperone.
     supporting_text: >-
-      Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins
-      dedicated to the assembly of a specific enzyme complex, the V-ATPase.
+      Unlike general molecular chaperones such as Kar2p/BiP (Gething and
+      Sambrook, 1992), Vma12p, Vma21p, and Vma22p represent a class of ER
+      resident proteins dedicated to the assembly of a specific enzyme complex,
+      the V-ATPase.
 - id: file:yeast/VMA22/VMA22-deep-research-falcon.md
   title: Falcon deep research report for VMA22
   findings:
@@ -412,8 +439,7 @@ core_functions:
     Vma12, it transiently binds the Vph1/V0-sector assembly intermediate in the
     ER, stabilizing V0 assembly before the V-ATPase reaches the vacuole. Vma22 is
     therefore required for V-ATPase complex assembly and downstream vacuolar
-    acidification, but it is not a mature V-ATPase subunit or a general
-    unfolded-protein binding factor.
+    acidification, but it is not a mature V-ATPase subunit.
   directly_involved_in:
   - id: GO:0070072
     label: vacuolar proton-transporting V-type ATPase complex assembly
@@ -460,6 +486,9 @@ suggested_questions:
     Which VMA22 isoform(s), if any, are functional in V-ATPase assembly, and do
     the alternative initiation products differ in stability or assembly-complex
     incorporation?
+- question: >-
+    Does amino-terminal tagging alter Vma22 isoform usage, ER association, or
+    localization and account for the high-throughput nuclear signal?
 suggested_experiments:
 - description: >-
     Use structure-guided Vma22 mutants to disrupt Vma12 binding or Vph1

--- a/genes/yeast/VMA22/VMA22-ai-review.yaml
+++ b/genes/yeast/VMA22/VMA22-ai-review.yaml
@@ -12,8 +12,7 @@ description: >-
   complex that transiently contacts the newly synthesized Vph1/V0 sector subunit,
   stabilizing V0 assembly intermediates before export to the vacuole. Loss of
   VMA22 blocks V-ATPase assembly and activity and causes vacuolar acidification
-  defects. The "unfolded protein binding" annotations overgeneralize this
-  specific assembly-factor role.
+  defects.
 alternative_products:
 - name: "1"
   id: P38784-1
@@ -34,15 +33,36 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Vma22 acts in a dedicated Vma12-Vma22 ER assembly complex for the V-ATPase
-      V0 sector. The evidence supports specific assembly-intermediate binding,
-      not broad unfolded protein binding.
+      V0 sector. The experimentally described client, Vph1, is already fully
+      translocated and folded before association, so neither this IBA nor its
+      target-derived seed supports broad unfolded protein binding. GO:0051082 is
+      obsolete, and no current holdase/chaperone term accurately describes this
+      dedicated assembly-factor role.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - ROLE_CONFLATION
+      source_entities:
+      - source_id: PANTHER:PTN001592797
+        source_label: PANTHER:PTN001592797
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          The exact PTN is present in the pinned GOA WITH/FROM, but it is absent
+          from the current local PAINT snapshot, so its ancestral assertion
+          cannot be recovered for direct inspection.
+      - source_id: SGD:S000001102
+        source_label: VMA22
+        source_status: SOURCE_BAD
+        comment: >-
+          VMA22 is a legitimate target-descendant source rather than a circular
+          donor, but its experimental assembly phenotypes do not establish
+          unfolded-protein binding and should not seed this term.
     supported_by:
     - reference_id: PMID:9660861
       supporting_text: >-
-        Unlike general molecular chaperones such as Kar2p/BiP (Gething and
-        Sambrook, 1992), Vma12p, Vma21p, and Vma22p represent a class of ER
-        resident proteins dedicated to the assembly of a specific enzyme complex,
-        the V-ATPase.
+        The first step in the assembly pathway would involve the association of
+        the fully translocated and folded Vph1p with the Vma12p/Vma22p assembly
+        complex in the ER membrane.
     - reference_id: file:yeast/VMA22/VMA22-deep-research-falcon.md
       supporting_text: >-
         **VMA22 (P38784/YHR060W)** encodes **Vma22p**, an **ER-associated
@@ -62,6 +82,22 @@ existing_annotations:
     reason: >-
       Vma12-Vma22 complex membership is a core feature of Vma22 function and is
       supported by both family-transfer and direct experimental evidence.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN001278552
+        source_label: PANTHER:PTN001278552
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          The exact PTN is recorded in the pinned GOA WITH/FROM but is absent
+          from the current local PAINT snapshot; independent Vma22-specific
+          biochemical evidence nevertheless establishes the complex membership.
+      - source_id: SGD:S000001102
+        source_label: VMA22
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          The target's own direct evidence validly grounds the ancestral
+          inference: Vma12 and Vma22 interact and form the named stable complex.
     supported_by:
     - reference_id: PMID:9660861
       supporting_text: >-
@@ -91,14 +127,25 @@ existing_annotations:
   original_reference_id: PMID:26928762
   review:
     summary: >-
-      The nucleus annotation is from a high-throughput localization resource and
-      conflicts with focused biochemical evidence that Vma22 is ER-associated.
-    action: REMOVE
+      The nucleus annotation comes from a high-throughput tagged-protein library,
+      whereas focused biochemical studies establish ER membrane association. The
+      cached article lacks the VMA22-specific supplementary localization record,
+      so the experimental HDA call cannot be adjudicated directly.
+    action: UNDECIDED
     reason: >-
-      Vma22's established function is in the ER-localized Vma12-Vma22 assembly
-      complex. No gene-specific evidence supports nuclear localization as a site
-      of Vma22 function.
+      ER localization is strongly supported and is the known site of function,
+      but it does not logically exclude a minor or tag-dependent nuclear signal.
+      The study assigned localization by eye without co-localization markers, and
+      its cached main text does not expose the VMA22-specific observation.
+      Following the abstract/full-text limitation rule, this experimental row is
+      therefore retained as UNDECIDED rather than removed.
     supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: >-
+        Since no co-localization markers were used we only assigned localizations
+        that could be easily discriminated by eye: ER, nuclear periphery,
+        cytosol, cell periphery, vacuole lumen, vacuole membrane, mitochondria,
+        nucleus, bud/bud neck and punctate
     - reference_id: PMID:7673216
       supporting_text: >-
         Vma22p is a 21-kDa hydrophilic protein that is not a subunit of the
@@ -152,13 +199,19 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Vma22 is ER-associated and required for V-ATPase assembly, but the evidence
-      does not show broad binding to unfolded proteins. The assembly process and
-      Vma12-Vma22 complex annotations capture the biology more accurately.
+      does not show broad binding to unfolded proteins. Later full-text work
+      explicitly models the Vma12-Vma22 client as fully translocated and folded;
+      the assembly process and named complex capture the biology more accurately.
     supported_by:
     - reference_id: PMID:7673216
       supporting_text: >-
         Vma22p is a 21-kDa hydrophilic protein that is not a subunit of the
         V-ATPase but rather is associated with ER membranes.
+    - reference_id: PMID:9660861
+      supporting_text: >-
+        The first step in the assembly pathway would involve the association of
+        the fully translocated and folded Vph1p with the Vma12p/Vma22p assembly
+        complex in the ER membrane.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -206,9 +259,10 @@ existing_annotations:
       assembly complex formation.
     action: NEW
     reason: >-
-      Existing GOA contains a misleading nucleus annotation but lacks the
-      experimentally supported ER membrane localization. Vma22 is hydrophilic but
-      membrane-associated in the ER via the Vma12-Vma22 assembly complex.
+      Existing GOA contains an unresolved high-throughput nucleus annotation but
+      lacks the experimentally supported ER membrane localization. Vma22 is
+      hydrophilic but membrane-associated in the ER via the Vma12-Vma22 assembly
+      complex.
     supported_by:
     - reference_id: PMID:7673216
       supporting_text: >-
@@ -243,6 +297,14 @@ references:
       Alternative initiation; Named isoforms = 2.
 - id: PMID:1628805
   title: Genes required for vacuolar acidity in Saccharomyces cerevisiae
+  full_text_unavailable: true
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed and cached abstract verified. The abstract establishes the Vph-
+      mutant screen but does not expose the VMA22-specific mapping or experiment;
+      the IMP annotation therefore retains curator deference.
   findings:
   - statement: >-
       VPH/VMA mutants identify genes required for vacuolar acidity.
@@ -252,11 +314,35 @@ references:
   title: >-
     One library to make them all: streamlining the creation of yeast libraries
     via a SWAp-Tag strategy
-  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: >-
+      The cached full article verifies the SWAT-GFP localization methodology,
+      including manual scoring without co-localization markers, but the
+      VMA22-specific supplementary record underlying the nucleus HDA annotation
+      is not present in the cache and could not be checked directly.
+  findings:
+  - statement: >-
+      The localization library used visual assignments without co-localization
+      markers; the cached main text does not identify VMA22's individual score.
+    supporting_text: >-
+      Since no co-localization markers were used we only assigned localizations
+      that could be easily discriminated by eye: ER, nuclear periphery, cytosol,
+      cell periphery, vacuole lumen, vacuole membrane, mitochondria, nucleus,
+      bud/bud neck and punctate
 - id: PMID:7673216
   title: >-
     Vma22p is a novel endoplasmic reticulum-associated protein required for
     assembly of the yeast vacuolar H(+)-ATPase complex
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed and cached abstract verified. It directly establishes Vma22 as an
+      ER-associated non-subunit required for V-ATPase assembly, but does not
+      assay unfolded-protein binding.
   findings:
   - statement: >-
       Vma22 is ER-associated and required for V-ATPase assembly but is not a
@@ -273,6 +359,14 @@ references:
   title: >-
     vph6 mutants of Saccharomyces cerevisiae require calcineurin for growth and
     are defective in vacuolar H(+)-ATPase assembly
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed and cached abstract verified. VPH6 is identified and its mutants
+      fail V-ATPase assembly; the abstract contains no unfolded-client binding
+      assay.
   findings:
   - statement: >-
       VPH6/VMA22 mutants fail to assemble the V-ATPase.
@@ -282,6 +376,13 @@ references:
   title: >-
     Assembly of the yeast vacuolar H+-ATPase occurs in the endoplasmic reticulum
     and requires a Vma12p/Vma22p assembly complex
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Full text verified. Direct cross-linking, cofractionation, and kinetic
+      evidence establishes the stable Vma12-Vma22 complex and its transient
+      interaction with Vph1; the proposed client is explicitly fully folded.
   findings:
   - statement: >-
       Vma12 and Vma22 form a stable ER-associated complex that transiently
@@ -293,9 +394,8 @@ references:
   - statement: >-
       Vma22 is a dedicated assembly factor, not a general molecular chaperone.
     supporting_text: >-
-      Unlike general molecular chaperones such as Kar2p/BiP, Vma12p, Vma21p,
-      and Vma22p represent a class of ER resident proteins dedicated to the
-      assembly of a specific enzyme complex, the V-ATPase.
+      Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins
+      dedicated to the assembly of a specific enzyme complex, the V-ATPase.
 - id: file:yeast/VMA22/VMA22-deep-research-falcon.md
   title: Falcon deep research report for VMA22
   findings:
@@ -303,18 +403,17 @@ references:
       Falcon supports Vma22 as an ER-associated V-ATPase V0-region assembly
       factor and not a general unfolded-protein binding protein.
     supporting_text: >-
-      VMA22 encodes Vma22p, an ER-associated peripheral assembly factor required
-      for V-ATPase V0-region biogenesis. Vma22p forms a stable complex with
-      Vma12p that transiently binds and stabilizes Vph1p during ER-stage
-      assembly.
+      **VMA22 (P38784/YHR060W)** encodes **Vma22p**, an **ER-associated
+      peripheral assembly factor** required for **V-ATPase V0-region
+      biogenesis**.
 core_functions:
 - description: >-
     Vma22 is a dedicated ER-associated V-ATPase assembly factor. In complex with
     Vma12, it transiently binds the Vph1/V0-sector assembly intermediate in the
     ER, stabilizing V0 assembly before the V-ATPase reaches the vacuole. Vma22 is
     therefore required for V-ATPase complex assembly and downstream vacuolar
-    acidification, but it is not a mature V-ATPase subunit and should not be
-    curated as a general unfolded-protein binding factor.
+    acidification, but it is not a mature V-ATPase subunit or a general
+    unfolded-protein binding factor.
   directly_involved_in:
   - id: GO:0070072
     label: vacuolar proton-transporting V-type ATPase complex assembly
@@ -336,10 +435,9 @@ core_functions:
       V-ATPase complex to the vacuole.
   - reference_id: file:yeast/VMA22/VMA22-deep-research-falcon.md
     supporting_text: >-
-      VMA22 encodes Vma22p, an ER-associated peripheral assembly factor required
-      for V-ATPase V0-region biogenesis. Vma22p forms a stable complex with
-      Vma12p that transiently binds and stabilizes Vph1p during ER-stage
-      assembly.
+      **VMA22 (P38784/YHR060W)** encodes **Vma22p**, an **ER-associated
+      peripheral assembly factor** required for **V-ATPase V0-region
+      biogenesis**.
 proposed_new_terms:
 - proposed_name: V-ATPase V0 sector assembly factor activity
   proposed_definition: >-
@@ -349,9 +447,8 @@ proposed_new_terms:
     Vma22 has a clear molecular role as part of the ER-localized Vma12-Vma22
     assembly complex that transiently binds Vph1/V0-sector intermediates, but
     current GO terms capture only the biological process or the Vma12-Vma22
-    complex. QuickGO has no GO:0140557 term available, and generic protein
-    folding chaperone terms would overstate Vma22 as a general foldase rather
-    than a V-ATPase assembly factor.
+    complex. Generic protein folding chaperone terms would overstate Vma22 as a
+    general foldase rather than a V-ATPase assembly factor.
 suggested_questions:
 - question: >-
     What is the precise structural interface by which the Vma12-Vma22 complex

--- a/genes/yeast/VMA22/VMA22-notes.md
+++ b/genes/yeast/VMA22/VMA22-notes.md
@@ -1,0 +1,86 @@
+# VMA22 annotation re-review notes
+
+## Scope and reconciliation
+
+Dedicated re-review performed on 2026-08-28 against `VMA22-goa.tsv`, UniProt
+P38784, the Falcon deep-research report, all locally cached cited publications,
+and the available local PAINT snapshot. The GOA contains nine physical rows and
+nine unique qualifier-aware signatures; all nine are represented one-for-one in
+the review. All are positive annotations, with no NOT annotations or isoform-
+specific rows. The review additionally proposes one NEW ER-membrane annotation.
+
+The exact IBA WITH/FROM traces are:
+
+- GO:0051082 `enables`: `PANTHER:PTN001592797|SGD:S000001102`
+- GO:1990871 `part_of`: `PANTHER:PTN001278552|SGD:S000001102`
+
+Neither PTN is recoverable in the current local PAINT snapshot, and the UniProt
+PANTHER family PTHR31996 has no local PAINT table. Both PTNs are therefore
+recorded with bare PTN labels and `SOURCE_STALE_OR_MISSING`. The target's own SGD
+identifier in WITH/FROM is expected experimental grounding, not circularity.
+
+## Biological synthesis
+
+Vma22 is a dedicated ER-associated V-ATPase assembly factor, not a mature
+V-ATPase subunit. Deletion prevents enzyme assembly: [PMID:7673216, "vma22 delta
+cells contain no V-ATPase activity due to a failure to assemble the enzyme
+complex; V1 subunits accumulate in the cytosol, and the V0 100-kDa subunit is
+rapidly degraded."] Vma22 is ER-membrane-associated despite being hydrophilic:
+[PMID:7673216, "Vma22p is a 21-kDa hydrophilic protein that is not a subunit of
+the V-ATPase but rather is associated with ER membranes."]
+
+Full-text biochemical evidence establishes the stable named complex and its
+direct assembly-substrate interaction: [PMID:9660861, "Vma12p and Vma22p were
+found to interact directly as determined by chemical cross-linking analysis and
+cofractionation under conditions of gentle detergent solubilization."] The
+authors further conclude that interaction with the complex stabilizes Vph1 in
+the ER so it can assemble into V0.
+
+## GO:0051082 and molecular-function scope
+
+All three `unfolded protein binding` rows are marked over-annotated. GO:0051082
+is obsolete, but no current generic holdase or protein-folding-chaperone term is
+an evidence-matched replacement. Crucially, the full text describes association
+with a folded assembly intermediate: [PMID:9660861, "The first step in the
+assembly pathway would involve the association of the fully translocated and
+folded Vph1p with the Vma12p/Vma22p assembly complex in the ER membrane."] It
+also distinguishes these proteins from general chaperones: [PMID:9660861,
+"Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins dedicated
+to the assembly of a specific enzyme complex, the V-ATPase."] Accordingly, the
+review does not replace GO:0051082 with a holdase/chaperone term and instead
+proposes a dedicated V-ATPase V0-sector assembly-factor activity term.
+
+For the IBA GO:0051082 row, the PTN source cannot be recovered. The VMA22 source
+seed is classified `SOURCE_BAD` for this term because the experimental mutant
+and assembly evidence does not establish unfolded-protein binding. This is a
+term-scoping/role-conflation problem, not a claim that target self-evidence is
+circular.
+
+## Localization and evidence limitations
+
+The PMID:26928762 nucleus HDA row is UNDECIDED. The full cached article describes
+the library and its manual localization calls without co-localization markers,
+but the VMA22-specific supplementary row is absent from the cache. The method
+states: [PMID:26928762, "Since no co-localization markers were used we only
+assigned localizations that could be easily discriminated by eye: ER, nuclear
+periphery, cytosol, cell periphery, vacuole lumen, vacuole membrane, mitochondria,
+nucleus, bud/bud neck and punctate"]. Focused evidence strongly establishes the
+ER as Vma22's functional location, but it cannot exclude a minor, conditional,
+or tag-dependent nuclear signal. The experimental row is therefore not removed
+without its gene-specific evidence.
+
+PMID:7673216, PMID:8582630, and PMID:1628805 are abstract-only in the local cache.
+Their directly visible claims are used conservatively. The vacuolar-acidification
+IMP from PMID:1628805 is retained with curator deference because the abstract
+establishes the Vph- mutant screen but does not expose the VMA22-specific assay.
+PMID:9660861 and PMID:26928762 have cached full text, subject to the supplementary-
+data limitation above.
+
+## Final curation shape
+
+The core function is V-ATPase V0-sector assembly in the ER as part of the
+Vma12-Vma22 assembly complex, with vacuolar acidification as a valid downstream
+process consequence. The NEW ER membrane annotation is supported by focused
+biochemical evidence. The nine physical GOA rows have five ACCEPT decisions,
+three MARK_AS_OVER_ANNOTATED decisions, and one UNDECIDED decision; the review
+also contains one NEW annotation.

--- a/genes/yeast/VMA22/VMA22-notes.md
+++ b/genes/yeast/VMA22/VMA22-notes.md
@@ -40,19 +40,25 @@ the ER so it can assemble into V0.
 
 All three `unfolded protein binding` rows are marked over-annotated. GO:0051082
 is obsolete, but no current generic holdase or protein-folding-chaperone term is
-an evidence-matched replacement. Crucially, the full text describes association
-with a folded assembly intermediate: [PMID:9660861, "The first step in the
-assembly pathway would involve the association of the fully translocated and
-folded Vph1p with the Vma12p/Vma22p assembly complex in the ER membrane."] It
-also distinguishes these proteins from general chaperones: [PMID:9660861,
+an evidence-matched replacement. The authors' proposed model, rather than a
+direct folding-state assay, places a folded assembly intermediate at the
+interaction step: [PMID:9660861, "The first step in the assembly pathway would
+involve the association of the fully translocated and folded Vph1p with the
+Vma12p/Vma22p assembly complex in the ER membrane."] The experiments establish
+stabilization in the assembly pathway [PMID:9660861, "We conclude that the
+interaction of Vph1p with the assembly complex stabilizes this Vo subunit in the
+ER allowing it to assemble into the Vo subcomplex."], while the authors
+explicitly distinguish these proteins from general chaperones: [PMID:9660861,
 "Vma12p, Vma21p, and Vma22p represent a class of ER resident proteins dedicated
 to the assembly of a specific enzyme complex, the V-ATPase."] Accordingly, the
-review does not replace GO:0051082 with a holdase/chaperone term and instead
-proposes a dedicated V-ATPase V0-sector assembly-factor activity term.
+review does not replace GO:0051082 with GO:0044183 protein folding chaperone:
+stabilization is demonstrated, but assistance of client protein folding is not.
+It instead proposes a dedicated V-ATPase V0-sector assembly-factor activity term.
 
 For the IBA GO:0051082 row, the PTN source cannot be recovered. The VMA22 source
-seed is classified `SOURCE_BAD` for this term because the experimental mutant
-and assembly evidence does not establish unfolded-protein binding. This is a
+seed is classified `SOURCE_WEAK_OR_INFERRED` because the experimental mutant and
+assembly evidence does not establish unfolded-protein binding; this reflects
+over-scoping rather than a wrong experiment. This is a
 term-scoping/role-conflation problem, not a claim that target self-evidence is
 circular.
 
@@ -61,7 +67,12 @@ circular.
 The PMID:26928762 nucleus HDA row is UNDECIDED. The full cached article describes
 the library and its manual localization calls without co-localization markers,
 but the VMA22-specific supplementary row is absent from the cache. The method
-states: [PMID:26928762, "Since no co-localization markers were used we only
+used amino-terminal GFP tagging, a concrete caveat for a protein with alternative
+initiation products [PMID:26928762, "To establish this strategy we constructed a
+library containing ~1,800 strains where all proteins with known or predicted
+localization to the yeast endomembrane system are tagged with an amino terminal
+(N′) SWAT acceptor module. The used module also contains a constitutive promoter
+and a GFP tag."]. It also states: [PMID:26928762, "Since no co-localization markers were used we only
 assigned localizations that could be easily discriminated by eye: ER, nuclear
 periphery, cytosol, cell periphery, vacuole lumen, vacuole membrane, mitochondria,
 nucleus, bud/bud neck and punctate"]. Focused evidence strongly establishes the
@@ -81,6 +92,6 @@ data limitation above.
 The core function is V-ATPase V0-sector assembly in the ER as part of the
 Vma12-Vma22 assembly complex, with vacuolar acidification as a valid downstream
 process consequence. The NEW ER membrane annotation is supported by focused
-biochemical evidence. The nine physical GOA rows have five ACCEPT decisions,
-three MARK_AS_OVER_ANNOTATED decisions, and one UNDECIDED decision; the review
-also contains one NEW annotation.
+biochemical evidence. The nine physical GOA rows have four ACCEPT decisions,
+three MARK_AS_OVER_ANNOTATED decisions, one KEEP_AS_NON_CORE decision, and one
+UNDECIDED decision; the review also contains one NEW annotation.


### PR DESCRIPTION
## Summary

- reconcile all 9 qualifier-aware GOA rows for VMA22
- retain the three obsolete GO:0051082 annotations as over-annotated because full text describes folded Vph1 assembly intermediates, not unfolded clients
- document both IBA PTN traces and distinguish valid target self-sources from the unavailable local PAINT nodes
- soften the high-throughput nucleus HDA from REMOVE to UNDECIDED because the cached article lacks the VMA22-specific supplementary observation
- add the experimentally supported ER membrane localization and provenance-rich notes
- regenerate the gene HTML and browser data

## Validation

- just validate yeast VMA22
- just validate-goa yeast VMA22
- just render yeast VMA22
- just deploy-browser
- git diff --check