### PR TITLE
Re-review yeast VPS45 annotations

### DIFF
--- a/genes/yeast/VPS45/VPS45-ai-review.html
+++ b/genes/yeast/VPS45/VPS45-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -900,9 +900,64 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000187655</span>
+
+                                    &middot; PANTHER:PTN000187655
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">The exact node is present in the pinned GOA WITH/FROM but absent from the current local PAINT snapshot. The transfer is independently supported by direct VPS45 trafficking evidence.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000003063</span>
+
+                                    &middot; VPS45
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The target&#39;s own experimentally grounded trafficking annotation is a valid descendant source, not circular evidence.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7720726" target="_blank" class="term-link">
+                                        PMID:7720726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Fractionation studies show that Vps45p is a peripheral membrane protein that cofractionates with Golgi-like membranes, consistent with Vps45p functioning in membrane traffic between the Golgi and the vacuole.</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -969,9 +1024,77 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000187915</span>
+
+                                    &middot; PANTHER:PTN000187915
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">The exact ancestral node is recorded in GOA but cannot be recovered from the current local PAINT snapshot.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">MGI:MGI:891965</span>
+
+                                    &middot; MGI:MGI:891965
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The mammalian descendant source supports conserved Golgi/endosomal SM-protein localization.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000003063</span>
+
+                                    &middot; VPS45
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Direct yeast fractionation places Vps45 on Golgi-like membranes.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7720726" target="_blank" class="term-link">
+                                        PMID:7720726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Fractionation studies show that Vps45p is a peripheral membrane protein that cofractionates with Golgi-like membranes, consistent with Vps45p functioning in membrane traffic between the Golgi and the vacuole.</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -1038,9 +1161,64 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000187655</span>
+
+                                    &middot; PANTHER:PTN000187655
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">The exact node is present in GOA but absent from the current local PAINT snapshot; target-specific experiments independently support the conserved transport process.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000003063</span>
+
+                                    &middot; VPS45
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">The target&#39;s direct trafficking evidence appropriately grounds the IBA.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9650782" target="_blank" class="term-link">
+                                        PMID:9650782
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we demonstrate that the Sec1p-like protein Vps45p is required for the fusion of Golgi-derived vesicles with the prevacuolar compartment indicating that VPS45 functions before VPS27 in the vacuolar biogenesis pathway.</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -1252,6 +1430,19 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7720726" target="_blank" class="term-link">
+                                        PMID:7720726
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Fractionation studies show that Vps45p is a peripheral membrane protein that cofractionates with Golgi-like membranes, consistent with Vps45p functioning in membrane traffic between the Golgi and the vacuole.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     file:yeast/VPS45/VPS45-deep-research-falcon.md
 
                                 </span>
@@ -1317,6 +1508,19 @@
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9650782" target="_blank" class="term-link">
+                                        PMID:9650782
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we demonstrate that the Sec1p-like protein Vps45p is required for the fusion of Golgi-derived vesicles with the prevacuolar compartment indicating that VPS45 functions before VPS27 in the vacuolar biogenesis pathway.</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -1390,6 +1594,19 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9650782" target="_blank" class="term-link">
+                                        PMID:9650782
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we demonstrate that the Sec1p-like protein Vps45p is required for the fusion of Golgi-derived vesicles with the prevacuolar compartment indicating that VPS45 functions before VPS27 in the vacuolar biogenesis pathway.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     file:yeast/VPS45/VPS45-deep-research-falcon.md
 
                                 </span>
@@ -1459,6 +1676,19 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9650782" target="_blank" class="term-link">
+                                        PMID:9650782
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we demonstrate that the Sec1p-like protein Vps45p is required for the fusion of Golgi-derived vesicles with the prevacuolar compartment indicating that VPS45 functions before VPS27 in the vacuolar biogenesis pathway.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     file:yeast/VPS45/VPS45-deep-research-falcon.md
 
                                 </span>
@@ -1500,10 +1730,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P38932" data-a="GO:0031201" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0031201" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1516,7 +1746,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Supported by falcon evidence that Vps45p is required for Tlg2 entry into ternary SNARE complexes; also annotated by IPI elsewhere in this file.
+                            <strong>Reason:</strong> Vps45p binds both individual SNAREs and assembled SNARE complexes, but it is an SM-family regulator rather than one of the SNARE proteins forming the core four-helix complex. SNARE binding and positive regulation of SNARE complex assembly capture the evidence without asserting membership.
                         </div>
 
 
@@ -1524,6 +1754,19 @@
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11432826" target="_blank" class="term-link">
+                                        PMID:11432826
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">First, SM proteins act as chaperone-like molecules for their cognate t-SNAREs. Secondly, SM proteins play an essential role in the activation process allowing their cognate t-SNARE to participate in ternary complex formation.</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -1957,6 +2200,70 @@
                         <br>
                         <span style="font-size: 0.75rem;">
 
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16429126
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteome survey reveals modularity of the yeast cell machine...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:16429126" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The second physical GOA row from this proteome-scale affinity-purification study has a distinct WITH/FROM partner (UniProtKB:Q08144). Generic protein binding remains uninformative relative to the established syntaxin/SNARE interactions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained one-for-one for the physical GOA record; GO:0005515 obscures the specific SNARE-binding and trafficking-regulator biology.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18719252
                             </a>
@@ -1991,6 +2298,70 @@
 
                         <div>
                             <strong>Reason:</strong> Avoid GO:0005515; high-throughput interaction without a specific functional term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18719252
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    High-quality binary protein interaction map of the yeast int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:18719252" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The second binary-interactome row has a distinct WITH/FROM partner (UniProtKB:Q08144). The interaction may be useful evidence, but the generic molecular-function term adds no biological specificity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained one-for-one for GOA reconciliation while flagging GO:0005515 as less informative than SNARE binding.
                         </div>
 
 
@@ -2183,6 +2554,134 @@
 
                         <div>
                             <strong>Reason:</strong> Avoid GO:0005515; high-throughput interaction without a specific functional term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37968396
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The social and structural architecture of the yeast protein ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:37968396" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A distinct physical GOA row from the quantitative interactome has WITH/FROM UniProtKB:Q03322. Co-enrichment supports association, but generic protein binding is not an informative Vps45 molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained one-for-one; the known partner context is better expressed by SNARE binding and vesicle-fusion regulation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37968396
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The social and structural architecture of the yeast protein ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:37968396" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A third physical GOA row from the quantitative interactome has WITH/FROM UniProtKB:Q08144. The underlying association is plausible, but GO:0005515 is too generic to describe the SM-syntaxin relationship.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained one-for-one; specific SNARE binding and regulation of SNARE assembly are the evidence-matched functions.
                         </div>
 
 
@@ -2423,6 +2922,88 @@
                                 </span>
 
                                 <div class="support-text">physically associates with the syntaxin-like t-SNARE **Tlg2p** and also forms a separate complex with the endosomal t-SNARE **Pep12p**</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000149" target="_blank" class="term-link">
+                                    GO:0000149
+                                </a>
+                            </span>
+                            <span class="term-label">SNARE binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16769821" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16769821
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Sec1p/Munc18 protein Vps45p binds its cognate SNARE prot...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0000149" data-r="PMID:16769821" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The second physical SNARE-binding row records the distinct WITH/FROM partner SGD:S000005854. Full-text experiments show that Vps45 binds both Tlg2 and the v-SNARE Snc2 through distinct modes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This physical row is retained separately because it represents a distinct SNARE partner and directly supports the core SNARE-binding function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16769821" target="_blank" class="term-link">
+                                        PMID:16769821
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Fig. 2 A demonstrates that His6-Vps45p interacts directly with the cytosolic domains of both Tlg2p and the v-SNARE Snc2p (Snc2p-PrA).</div>
 
                             </div>
 
@@ -2934,10 +3515,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P38932" data-a="GO:0031201" data-r="PMID:10397773" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0031201" data-r="PMID:10397773" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2950,7 +3531,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Supported by IPI and by falcon evidence that Vps45p is required for Tlg2 entry into ternary SNARE complexes.
+                            <strong>Reason:</strong> Interaction with a SNARE complex does not make the SM regulator a core SNARE-complex subunit. PMID:10397773 says Vps45 enters a complex with Tlg1/Tlg2/Vti1, but mechanistic work distinguishes Vps45 from the SNARE proteins and supports binding/regulation rather than `part_of` membership.
                         </div>
 
 
@@ -2958,6 +3539,19 @@
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10397773" target="_blank" class="term-link">
+                                        PMID:10397773
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Tlg1p is able to bind His6-tagged Sec17p (yeast alpha-SNAP) in a dose-dependent manner and enters into a SNARE complex with Vti1p, Tlg2p, and Vps45p.</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -4318,6 +4912,109 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(VPS45-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38932" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="vps45-annotation-re-review-notes">VPS45 annotation re-review notes</h1>
+<h2 id="scope-and-physical-row-reconciliation">Scope and physical-row reconciliation</h2>
+<p>Dedicated re-review completed 2026-08-28 against <code>VPS45-goa.tsv</code>, UniProt<br />
+P38932, the Falcon deep-research report, all 17 cached PMID records, and the<br />
+available local PAINT data. GOA contains 40 physical rows. The review now has 40<br />
+one-for-one entries, including separate entries for distinct WITH/FROM partners<br />
+that had previously been collapsed:</p>
+<ul>
+<li>PMID:16429126 protein binding: Q03322 and Q08144</li>
+<li>PMID:18719252 protein binding: P32609 and Q08144</li>
+<li>PMID:37968396 protein binding: P32609, Q03322, and Q08144</li>
+<li>PMID:16769821 SNARE binding: SGD:S000005378 and SGD:S000005854</li>
+</ul>
+<p>All rows are positive; there are no NOT or isoform-specific annotations.</p>
+<h2 id="iba-provenance">IBA provenance</h2>
+<p>The three IBA rows have two exact node traces:</p>
+<ul>
+<li><code>GO:0016192 involved_in</code> — <code>PANTHER:PTN000187655</code> plus the full descendant<br />
+  source set recorded in GOA, including target <code>SGD:S000003063</code>.</li>
+<li><code>GO:0006886 involved_in</code> — the same <code>PANTHER:PTN000187655</code>, with its GOA<br />
+  descendant source set including target <code>SGD:S000003063</code>.</li>
+<li><code>GO:0000139 is_active_in</code> — <code>PANTHER:PTN000187915|MGI:MGI:891965|SGD:S000003063</code>.</li>
+</ul>
+<p>UniProt assigns Vps45 to PANTHER family PTHR11679, official label <code>VESICLE
+PROTEIN SORTING-ASSOCIATED</code>, and the family ontology contains a VPS45 subfamily<br />
+PTHR11679:SF3. Neither PTN is present in the current local PAINT snapshot, so the<br />
+node assertions cannot be inspected directly and are recorded as<br />
+<code>SOURCE_STALE_OR_MISSING</code>. This is a provenance limitation, not biological<br />
+evidence against the terms: direct yeast work independently establishes both<br />
+transport and Golgi-like membrane association. The target's own SGD source is<br />
+valid descendant evidence and is not circular.</p>
+<h2 id="core-biology">Core biology</h2>
+<p>Vps45 is a Sec1/Munc18-family regulator of SNARE-dependent Golgi/endosomal<br />
+traffic. Fractionation supports peripheral Golgi-like membrane association<br />
+[PMID:7720726, "Fractionation studies show that Vps45p is a peripheral membrane<br />
+protein"]. Functional inactivation accumulates post-Golgi vesicles and causes<br />
+CPY secretion, while another study directly concludes that Vps45 is required<br />
+for fusion of Golgi-derived vesicles with the prevacuolar compartment<br />
+[PMID:9650782, "Here we demonstrate that the Sec1p-like protein Vps45p is<br />
+required for the fusion of Golgi-derived vesicles with the prevacuolar<br />
+compartment"].</p>
+<p>SNARE binding is the evidence-matched molecular function. Full-text work shows<br />
+two binding modes and direct binding to both Tlg2 and Snc2 [PMID:16769821, "Fig.<br />
+2 A demonstrates that His6-Vps45p interacts directly with the cytosolic domains<br />
+of both Tlg2p and the v-SNARE Snc2p (Snc2p-PrA)."] Vps45 also stabilizes Tlg2<br />
+and is needed for its productive assembly with Tlg1 and Vti1 [PMID:11432826,<br />
+"However, the stabilized Tlg2p is non-functional and unable to bind its cognate<br />
+SNARE binding partners, Tlg1p and Vti1p, in the absence of Vps45p."]</p>
+<p>The Cvt annotation is directly supported but pathway-specific: [PMID:10545112,<br />
+"Here we show that Tlg2p, a member of the syntaxin family of t-SNARE proteins,<br />
+and Vps45p, a Sec1p homologue, are required in the constitutive Cvt pathway, but<br />
+not in inducible macroautophagy."]</p>
+<h2 id="term-scope-decisions">Term-scope decisions</h2>
+<p>Both <code>GO:0031201 SNARE complex</code> rows are marked over-annotated. Vps45 binds<br />
+individual SNAREs and assembled SNARE complexes, but as an SM regulator it is<br />
+not one of the SNARE proteins forming the core four-helix bundle. <code>GO:0000149
+SNARE binding</code> and <code>GO:0035543 positive regulation of SNARE complex assembly</code><br />
+capture the evidence more precisely.</p>
+<p>Both obsolete <code>GO:0051082 unfolded protein binding</code> rows are also marked<br />
+over-annotated. PMID:11432826 calls SM proteins chaperone-like for their cognate<br />
+t-SNAREs and shows stabilization/activation of Tlg2; it does not assay generic<br />
+unfolded clients. No replacement holdase/folding term was invented because<br />
+SNARE binding and SNARE-assembly regulation already express the demonstrated<br />
+activity.</p>
+<p>All 13 generic protein-binding physical rows are retained one-for-one but marked<br />
+over-annotated. Several are informative interaction data, yet <code>GO:0005515</code> loses<br />
+the partner and role specificity. PMID:12553664 is especially limited: its<br />
+cached abstract is entirely about Ivy1, Ypt7, and Vps33, not Vps45; without full<br />
+text the row is not called wrong, but the reference is recorded as relevance<br />
+NONE/correctness UNVERIFIED.</p>
+<p>The cytosol IDA from PMID:9624182 remains UNDECIDED. The cached abstract is<br />
+explicitly a Vps33 study and contains no Vps45 observation, while full text is<br />
+unavailable. Cytosolic Vps45 is independently biologically plausible and is<br />
+supported by UniProt through a different paper, so the row is neither rejected<br />
+nor claimed verified.</p>
+<p>Vacuole inheritance, vacuole organization, and vacuolar acidification are kept<br />
+as non-core downstream phenotypes. For acidification, the source explicitly<br />
+reports normal V-ATPase activity despite defective acidification [PMID:7628704,<br />
+"Vacuoles from stt10 cells have a normal vacuolar H(+)-ATPase activity, but are<br />
+defective in vacuolar acidification."].</p>
+<h2 id="final-action-profile">Final action profile</h2>
+<p>The 40 physical rows have 20 ACCEPT, 16 MARK_AS_OVER_ANNOTATED, 3<br />
+KEEP_AS_NON_CORE, and 1 UNDECIDED decisions. There are no PENDING or NEW rows.</p>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4329,7 +5026,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P38932
 gene_symbol: VPS45
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -4367,7 +5064,29 @@ existing_annotations:
     reason: &gt;-
       Well-supported high-level process; Vps45p is required for fusion of
       Golgi-derived vesicles with the prevacuolar compartment.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000187655
+        source_label: PANTHER:PTN000187655
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          The exact node is present in the pinned GOA WITH/FROM but absent from
+          the current local PAINT snapshot. The transfer is independently
+          supported by direct VPS45 trafficking evidence.
+      - source_id: SGD:S000003063
+        source_label: VPS45
+        source_status: SUPPORTS_TRANSFER
+        comment: &gt;-
+          The target&#39;s own experimentally grounded trafficking annotation is a
+          valid descendant source, not circular evidence.
     supported_by:
+    - reference_id: PMID:7720726
+      full_text_unavailable: true
+      supporting_text: &gt;-
+        Fractionation studies show that Vps45p is a peripheral membrane protein
+        that cofractionates with Golgi-like membranes, consistent with Vps45p
+        functioning in membrane traffic between the Golgi and the vacuole.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: &gt;-
@@ -4386,7 +5105,30 @@ existing_annotations:
     reason: &gt;-
       Supported by IDA evidence (PMID:7720726) on this same term and by the
       VPS45-dependent Golgi-to-PVC trafficking step.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000187915
+        source_label: PANTHER:PTN000187915
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          The exact ancestral node is recorded in GOA but cannot be recovered
+          from the current local PAINT snapshot.
+      - source_id: MGI:MGI:891965
+        source_label: MGI:MGI:891965
+        source_status: SUPPORTS_TRANSFER
+        comment: The mammalian descendant source supports conserved Golgi/endosomal SM-protein localization.
+      - source_id: SGD:S000003063
+        source_label: VPS45
+        source_status: SUPPORTS_TRANSFER
+        comment: Direct yeast fractionation places Vps45 on Golgi-like membranes.
     supported_by:
+    - reference_id: PMID:7720726
+      full_text_unavailable: true
+      supporting_text: &gt;-
+        Fractionation studies show that Vps45p is a peripheral membrane protein
+        that cofractionates with Golgi-like membranes, consistent with Vps45p
+        functioning in membrane traffic between the Golgi and the vacuole.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -4405,7 +5147,28 @@ existing_annotations:
     reason: &gt;-
       High-level but accurate; Vps45p defines an intracellular route for
       biosynthetic cargo into the PVC.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000187655
+        source_label: PANTHER:PTN000187655
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          The exact node is present in GOA but absent from the current local
+          PAINT snapshot; target-specific experiments independently support the
+          conserved transport process.
+      - source_id: SGD:S000003063
+        source_label: VPS45
+        source_status: SUPPORTS_TRANSFER
+        comment: The target&#39;s direct trafficking evidence appropriately grounds the IBA.
     supported_by:
+    - reference_id: PMID:9650782
+      full_text_unavailable: true
+      supporting_text: &gt;-
+        Here we demonstrate that the Sec1p-like protein Vps45p is required for
+        the fusion of Golgi-derived vesicles with the prevacuolar compartment
+        indicating that VPS45 functions before VPS27 in the vacuolar biogenesis
+        pathway.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -4465,6 +5228,12 @@ existing_annotations:
       Plausible and corroborated by the more specific Golgi membrane (IDA)
       annotation; Vps45p acts at Tlg2-associated Golgi/endosomal membranes.
     supported_by:
+    - reference_id: PMID:7720726
+      full_text_unavailable: true
+      supporting_text: &gt;-
+        Fractionation studies show that Vps45p is a peripheral membrane protein
+        that cofractionates with Golgi-like membranes, consistent with Vps45p
+        functioning in membrane traffic between the Golgi and the vacuole.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -4482,6 +5251,13 @@ existing_annotations:
     reason: &gt;-
       Same well-supported high-level process as the IBA annotation above.
     supported_by:
+    - reference_id: PMID:9650782
+      full_text_unavailable: true
+      supporting_text: &gt;-
+        Here we demonstrate that the Sec1p-like protein Vps45p is required for
+        the fusion of Golgi-derived vesicles with the prevacuolar compartment
+        indicating that VPS45 functions before VPS27 in the vacuolar biogenesis
+        pathway.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -4501,6 +5277,13 @@ existing_annotations:
       Accurate but general; retained as a parent of the specific transport
       processes Vps45p mediates.
     supported_by:
+    - reference_id: PMID:9650782
+      full_text_unavailable: true
+      supporting_text: &gt;-
+        Here we demonstrate that the Sec1p-like protein Vps45p is required for
+        the fusion of Golgi-derived vesicles with the prevacuolar compartment
+        indicating that VPS45 functions before VPS27 in the vacuolar biogenesis
+        pathway.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -4518,6 +5301,13 @@ existing_annotations:
     reason: &gt;-
       Same well-supported high-level process as the IBA annotation above.
     supported_by:
+    - reference_id: PMID:9650782
+      full_text_unavailable: true
+      supporting_text: &gt;-
+        Here we demonstrate that the Sec1p-like protein Vps45p is required for
+        the fusion of Golgi-derived vesicles with the prevacuolar compartment
+        indicating that VPS45 functions before VPS27 in the vacuolar biogenesis
+        pathway.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -4532,11 +5322,20 @@ existing_annotations:
       SNARE complex localization reflects the engagement of Vps45p with syntaxin
       SNAREs (Tlg2p/Pep12p) and its requirement for productive ternary SNARE
       complex formation (with Tlg1p and Vti1p for the Tlg2 module).
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Supported by falcon evidence that Vps45p is required for Tlg2 entry into
-      ternary SNARE complexes; also annotated by IPI elsewhere in this file.
+      Vps45p binds both individual SNAREs and assembled SNARE complexes, but it
+      is an SM-family regulator rather than one of the SNARE proteins forming
+      the core four-helix complex. SNARE binding and positive regulation of
+      SNARE complex assembly capture the evidence without asserting membership.
     supported_by:
+    - reference_id: PMID:11432826
+      full_text_unavailable: true
+      supporting_text: &gt;-
+        First, SM proteins act as chaperone-like molecules for their cognate
+        t-SNAREs. Secondly, SM proteins play an essential role in the activation
+        process allowing their cognate t-SNARE to participate in ternary complex
+        formation.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -4638,6 +5437,21 @@ existing_annotations:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
+  original_reference_id: PMID:16429126
+  review:
+    summary: &gt;-
+      The second physical GOA row from this proteome-scale affinity-purification
+      study has a distinct WITH/FROM partner (UniProtKB:Q08144). Generic protein
+      binding remains uninformative relative to the established syntaxin/SNARE
+      interactions.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Retained one-for-one for the physical GOA record; GO:0005515 obscures the
+      specific SNARE-binding and trafficking-regulator biology.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
   original_reference_id: PMID:18719252
   review:
     summary: &gt;-
@@ -4647,6 +5461,20 @@ existing_annotations:
     reason: &gt;-
       Avoid GO:0005515; high-throughput interaction without a specific
       functional term.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18719252
+  review:
+    summary: &gt;-
+      The second binary-interactome row has a distinct WITH/FROM partner
+      (UniProtKB:Q08144). The interaction may be useful evidence, but the generic
+      molecular-function term adds no biological specificity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Retained one-for-one for GOA reconciliation while flagging GO:0005515 as
+      less informative than SNARE binding.
 - term:
     id: GO:0005515
     label: protein binding
@@ -4688,6 +5516,34 @@ existing_annotations:
     reason: &gt;-
       Avoid GO:0005515; high-throughput interaction without a specific
       functional term.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  review:
+    summary: &gt;-
+      A distinct physical GOA row from the quantitative interactome has
+      WITH/FROM UniProtKB:Q03322. Co-enrichment supports association, but generic
+      protein binding is not an informative Vps45 molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Retained one-for-one; the known partner context is better expressed by
+      SNARE binding and vesicle-fusion regulation.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  review:
+    summary: &gt;-
+      A third physical GOA row from the quantitative interactome has WITH/FROM
+      UniProtKB:Q08144. The underlying association is plausible, but GO:0005515
+      is too generic to describe the SM-syntaxin relationship.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Retained one-for-one; specific SNARE binding and regulation of SNARE
+      assembly are the evidence-matched functions.
 - term:
     id: GO:0000011
     label: vacuole inheritance
@@ -4756,6 +5612,26 @@ existing_annotations:
       reference_section_type: OTHER
       supporting_text: |-
         physically associates with the syntaxin-like t-SNARE **Tlg2p** and also forms a separate complex with the endosomal t-SNARE **Pep12p**
+- term:
+    id: GO:0000149
+    label: SNARE binding
+  evidence_type: IPI
+  original_reference_id: PMID:16769821
+  review:
+    summary: &gt;-
+      The second physical SNARE-binding row records the distinct WITH/FROM
+      partner SGD:S000005854. Full-text experiments show that Vps45 binds both
+      Tlg2 and the v-SNARE Snc2 through distinct modes.
+    action: ACCEPT
+    reason: &gt;-
+      This physical row is retained separately because it represents a distinct
+      SNARE partner and directly supports the core SNARE-binding function.
+    supported_by:
+    - reference_id: PMID:16769821
+      reference_section_type: RESULTS
+      supporting_text: &gt;-
+        Fig. 2 A demonstrates that His6-Vps45p interacts directly with the
+        cytosolic domains of both Tlg2p and the v-SNARE Snc2p (Snc2p-PrA).
 - term:
     id: GO:0005829
     label: cytosol
@@ -4890,11 +5766,18 @@ existing_annotations:
       Vps45p is part of the SNARE machinery, engaging the Tlg2p syntaxin module
       (with Tlg1p and Vti1p) required for productive SNARE complex formation in
       the Golgi/endosomal system.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Supported by IPI and by falcon evidence that Vps45p is required for Tlg2
-      entry into ternary SNARE complexes.
+      Interaction with a SNARE complex does not make the SM regulator a core
+      SNARE-complex subunit. PMID:10397773 says Vps45 enters a complex with
+      Tlg1/Tlg2/Vti1, but mechanistic work distinguishes Vps45 from the SNARE
+      proteins and supports binding/regulation rather than `part_of` membership.
     supported_by:
+    - reference_id: PMID:10397773
+      supporting_text: &gt;-
+        Tlg1p is able to bind His6-tagged Sec17p (yeast alpha-SNAP) in a
+        dose-dependent manner and enters into a SNARE complex with Vti1p, Tlg2p,
+        and Vps45p.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -5052,54 +5935,158 @@ references:
   findings: []
 - id: PMID:10397773
   title: A role for Tlg1p in the transport of proteins within the Golgi apparatus of Saccharomyces cerevisiae.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly reports Tlg1 entering a complex with Vti1, Tlg2, and Vps45.
   findings: []
 - id: PMID:10545112
   title: Cytoplasm to vacuole trafficking of aminopeptidase I requires a t-SNARE-Sec1p complex composed of Tlg2p and Vps45p.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly establishes the Vps45-Tlg2-dependent constitutive Cvt step.
   findings: []
 - id: PMID:10978279
   title: &#39;Pep3p/Pep5p complex: a putative docking factor at multiple steps of vesicular transport to the vacuole of Saccharomyces cerevisiae.&#39;
+  full_text_unavailable: true
+  reference_review:
+    relevance: LOW
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      The abstract discusses Pep3/Pep5 physical association with Pep7 but does
+      not expose the Vps45-Pep7 IPI record; full text is unavailable locally.
   findings: []
 - id: PMID:11432826
   title: Vps45p stabilizes the syntaxin homologue Tlg2p and positively regulates SNARE complex formation.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract verified; directly supports Tlg2 stabilization and activation of
+      ternary SNARE assembly, but not generic unfolded-protein binding.
   findings: []
 - id: PMID:12553664
   title: A novel phospholipid-binding protein from the yeast Saccharomyces cerevisiae with dual binding specificities for the transport GTPase Ypt7p and the Sec1-related Vps33p.
+  full_text_unavailable: true
+  reference_review:
+    relevance: NONE
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      The cached abstract is exclusively about Ivy1, Ypt7, and Vps33 and does
+      not expose a VPS45-Pep7 experiment. Full text is unavailable, so the IPI
+      cannot safely be called wrong but is not verifiable here.
   findings: []
 - id: PMID:1493335
   title: &#39;Morphological classification of the yeast vacuolar protein sorting mutants: evidence for a prevacuolar compartment in class E vps mutants.&#39;
+  full_text_unavailable: true
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      The abstract verifies class-level vacuole segregation and acidification
+      phenotypes but does not identify the VPS45 complementation group by name.
   findings: []
 - id: PMID:16429126
   title: Proteome survey reveals modularity of the yeast cell machinery.
+  full_text_unavailable: true
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract verifies the affinity-purification/mass-spectrometry interactome;
+      gene-specific pair records are not exposed in the cached abstract.
   findings: []
 - id: PMID:16769821
   title: The Sec1p/Munc18 protein Vps45p binds its cognate SNARE proteins via two distinct modes.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text verified; directly demonstrates Vps45 binding to Tlg2 and Snc2
+      and binding to Tlg2-containing SNARE complexes through distinct modes.
   findings: []
 - id: PMID:18719252
   title: High-quality binary protein interaction map of the yeast interactome network.
+  full_text_unavailable: true
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Cached abstract-only record verifies the high-throughput Y2H dataset; the
+      individual VPS45 partner rows are not visible in the article text cache.
   findings: []
 - id: PMID:19667197
   title: The N-terminal peptide of the syntaxin Tlg2p modulates binding of its closed conformation to Vps45p.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly characterizes Vps45 binding to Tlg2.
   findings: []
 - id: PMID:27107014
   title: An inter-species protein-protein interaction network across vast evolutionary distance.
+  reference_review:
+    relevance: LOW
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      Full article verifies the inter-species interaction-mapping design, but
+      the cached text does not expose the individual yeast Vps45-human STX5 row.
   findings: []
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text verifies the quantitative affinity-enrichment interactome and
+      notes that co-complex interactions need not be direct; individual VPS45
+      rows reside in the dataset rather than prose.
   findings: []
 - id: PMID:7628704
   title: STT10, a novel class-D VPS yeast gene required for osmotic integrity related to the PKC1/STT1 protein kinase pathway.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly establishes the class-D sorting and acidification phenotypes.
   findings: []
 - id: PMID:7720726
   title: Yeast Vps45p is a Sec1p-like protein required for the consumption of vacuole-targeted, post-Golgi transport vesicles.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; supports Golgi-like membrane association and Golgi-to-vacuole traffic.
   findings: []
 - id: PMID:9335586
   title: &#39;Genetic interactions between a pep7 mutation and the PEP12 and VPS45 genes: evidence for a novel SNARE component in transport between the Saccharomyces cerevisiae Golgi complex and endosome.&#39;
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly reports allele-specific VPS45 suppression and TGN-to-endosome context.
   findings: []
 - id: PMID:9624182
   title: The vesicle transport protein Vps33p is an ATP-binding protein that localizes to the cytosol in an energy-dependent manner.
+  full_text_unavailable: true
+  reference_review:
+    relevance: NONE
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      The cached abstract is a Vps33 study and contains no VPS45 observation.
+      Full text is unavailable, so the VPS45 cytosol IDA remains UNDECIDED.
   findings: []
 - id: PMID:9650782
   title: &#39;Traffic into the prevacuolar/endosomal compartment of Saccharomyces cerevisiae: a VPS45-dependent intracellular route and a VPS45-independent, endocytic route.&#39;
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly establishes Vps45-dependent Golgi-vesicle fusion with the PVC.
   findings: []
 - id: file:yeast/VPS45/VPS45-deep-research-falcon.md
   title: Falcon deep research report for Saccharomyces cerevisiae VPS45 (P38932; YGL095C)

--- a/genes/yeast/VPS45/VPS45-ai-review.html
+++ b/genes/yeast/VPS45/VPS45-ai-review.html
@@ -1823,7 +1823,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Regulation of vesicle fusion is consistent with the SM-protein function of Vps45p in controlling SNARE-dependent docking and fusion; the more specific child term positive regulation of SNARE complex assembly (GO:0035543) is also annotated.
+                            <strong>Summary:</strong> Regulation of vesicle fusion is consistent with the SM-protein function of Vps45p in controlling SNARE-dependent docking and fusion; the mechanistically more specific term positive regulation of SNARE complex assembly (GO:0035543) is also annotated.
                         </div>
 
 
@@ -1961,10 +1961,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:10397773" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:10397773" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1972,15 +1972,26 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic protein binding is uninformative. The biologically meaningful interactions of Vps45p are with its cognate syntaxin SNAREs (Tlg2p, Pep12p) and the Vac1p adaptor; these are better captured by SNARE binding (GO:0000149) and the SNARE/trafficking process terms.
+                            <strong>Summary:</strong> Generic protein binding is uninformative. The biologically meaningful interaction in this row is with the syntaxin SNARE Tlg1p (UniProtKB:Q03322), so SNARE binding is the evidence-matched term.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Avoid GO:0005515; specific SNARE binding and SNARE-assembly terms more accurately represent the function.
+                            <strong>Reason:</strong> Replace generic GO:0005515 with GO:0000149 because the recorded partner is a SNARE protein.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000149" target="_blank" class="term-link">
+                                    SNARE binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -2153,10 +2164,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:16429126" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:16429126" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2164,15 +2175,26 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic protein binding from a high-throughput proteome survey; not informative about the specific molecular function of Vps45p.
+                            <strong>Summary:</strong> This proteome-survey row records the syntaxin SNARE Tlg1p (UniProtKB:Q03322) as the partner; generic protein binding loses that specificity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Avoid GO:0005515; high-throughput interaction without a specific functional term.
+                            <strong>Reason:</strong> Replace GO:0005515 with GO:0000149 because the recorded partner is a SNARE.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000149" target="_blank" class="term-link">
+                                    SNARE binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -2217,10 +2239,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:16429126" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:16429126" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2233,10 +2255,21 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Retained one-for-one for the physical GOA record; GO:0005515 obscures the specific SNARE-binding and trafficking-regulator biology.
+                            <strong>Reason:</strong> Replace GO:0005515 with GO:0000149 because the recorded partner Tlg2p is a syntaxin SNARE.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000149" target="_blank" class="term-link">
+                                    SNARE binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -2345,10 +2378,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:18719252" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:18719252" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2361,10 +2394,21 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Retained one-for-one for GOA reconciliation while flagging GO:0005515 as less informative than SNARE binding.
+                            <strong>Reason:</strong> Replace GO:0005515 with GO:0000149 because the recorded partner Tlg2p is a syntaxin SNARE.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000149" target="_blank" class="term-link">
+                                    SNARE binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -2409,10 +2453,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:19667197" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:19667197" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2425,10 +2469,21 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Avoid GO:0005515; the interaction is syntaxin (SNARE) binding, captured by GO:0000149.
+                            <strong>Reason:</strong> Replace GO:0005515 with GO:0000149; the interaction is specifically with the syntaxin SNARE Tlg2p.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000149" target="_blank" class="term-link">
+                                    SNARE binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -2601,10 +2656,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:37968396" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:37968396" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2617,10 +2672,21 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Retained one-for-one; the known partner context is better expressed by SNARE binding and vesicle-fusion regulation.
+                            <strong>Reason:</strong> Replace GO:0005515 with GO:0000149 because the recorded partner Tlg1p is a syntaxin SNARE.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000149" target="_blank" class="term-link">
+                                    SNARE binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -2665,10 +2731,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:37968396" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P38932" data-a="GO:0005515" data-r="PMID:37968396" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2681,10 +2747,21 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Retained one-for-one; specific SNARE binding and regulation of SNARE assembly are the evidence-matched functions.
+                            <strong>Reason:</strong> Replace GO:0005515 with GO:0000149 because the recorded partner Tlg2p is a syntaxin SNARE.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000149" target="_blank" class="term-link">
+                                    SNARE binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -2900,7 +2977,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> SNARE binding is a core molecular function of Vps45p. As an SM protein it binds its cognate syntaxin SNAREs Tlg2p and Pep12p (via two distinct binding modes), forming distinct Vps45p-Tlg2p and Vps45p-Pep12p complexes, and is required for productive ternary SNARE complex assembly. Notably, PMID:16769821 (Carpp et al. 2006) shows that the Vps45pL117R mutant, which abolishes the Sly1p-Sed5p-type binding of Vps45p to the Tlg2p N-terminal peptide, still rescues CPY sorting; the essential, fusion-relevant interaction is therefore the second mode, in which Vps45p engages the assembled SNARE complex (and the v-SNARE Snc2p) rather than only the uncomplexed syntaxin N-terminus.
+                            <strong>Summary:</strong> SNARE binding is a core molecular function of Vps45p. As an SM protein it binds cognate SNAREs and is required for productive ternary SNARE complex assembly. PMID:16769821 shows that L117R abolishes the Sly1p-Sed5p-type Tlg2 N-terminal interaction, assembled Tlg2-containing complex binding, and membrane association, yet still rescues CPY sorting; this interaction mode is therefore dispensable for trafficking. The paper also identifies an N-terminus-independent mode through direct Snc2 binding and a W244R-locked conformation that the authors propose wild-type Vps45 adopts transiently during its functional cycle.
                         </div>
 
 
@@ -2913,6 +2990,19 @@
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16769821" target="_blank" class="term-link">
+                                        PMID:16769821
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Our finding that the disruption of Vps45p binding to Tlg2p through L117 of the SM protein had no effect on CPY sorting (Fig. 1 D) and the finding that the analogous binding of Sly1p to Sed5p is not required for membrane traffic (Peng and Gallwitz, 2004) implies that the hydrophobic pocket mode of interaction between SM proteins and their Sxs is not critical.</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -3864,7 +3954,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> The chaperone activity is SNARE-assembly-specific; positive regulation of SNARE complex assembly (GO:0035543) and SNARE binding (GO:0000149) capture it more accurately than generic unfolded protein binding.
+                            <strong>Reason:</strong> GO:0051082 is obsolete. The chaperone activity is SNARE-assembly-specific; positive regulation of SNARE complex assembly (GO:0035543) and SNARE binding (GO:0000149) capture it more accurately than generic unfolded protein binding.
                         </div>
 
 
@@ -3944,7 +4034,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> SNARE-assembly-specific chaperone activity; better captured by GO:0035543 and GO:0000149 than by generic unfolded protein binding.
+                            <strong>Reason:</strong> GO:0051082 is obsolete. SNARE-assembly-specific chaperone activity is better captured by GO:0035543 and GO:0000149 than by generic unfolded protein binding.
                         </div>
 
 
@@ -4014,14 +4104,20 @@
                         </span>
 
                         <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006896" target="_blank" class="term-link">
-                                Golgi to vacuole transport
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048210" target="_blank" class="term-link">
+                                Golgi vesicle fusion to target membrane
                             </a>
                         </span>
 
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006895" target="_blank" class="term-link">
                                 Golgi to endosome transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006623" target="_blank" class="term-link">
+                                protein targeting to vacuole
                             </a>
                         </span>
 
@@ -4971,8 +5067,14 @@ compartment"].</p>
 <p>SNARE binding is the evidence-matched molecular function. Full-text work shows<br />
 two binding modes and direct binding to both Tlg2 and Snc2 [PMID:16769821, "Fig.<br />
 2 A demonstrates that His6-Vps45p interacts directly with the cytosolic domains<br />
-of both Tlg2p and the v-SNARE Snc2p (Snc2p-PrA)."] Vps45 also stabilizes Tlg2<br />
-and is needed for its productive assembly with Tlg1 and Vti1 [PMID:11432826,<br />
+of both Tlg2p and the v-SNARE Snc2p (Snc2p-PrA)."] The L117R mutant abolishes<br />
+the Tlg2 N-terminal hydrophobic-pocket interaction, binding to assembled<br />
+Tlg2-containing complexes, and membrane association yet still rescues CPY<br />
+sorting, showing that this mode is dispensable for trafficking. A second,<br />
+N-terminus-independent mode is revealed by direct Snc2 binding and the<br />
+W244R-locked conformation; the authors propose that wild-type Vps45 samples this<br />
+conformation transiently. Vps45 also stabilizes Tlg2 and is needed for its<br />
+productive assembly with Tlg1 and Vti1 [PMID:11432826,<br />
 "However, the stabilized Tlg2p is non-functional and unable to bind its cognate<br />
 SNARE binding partners, Tlg1p and Vti1p, in the absence of Vps45p."]</p>
 <p>The Cvt annotation is directly supported but pathway-specific: [PMID:10545112,<br />
@@ -4991,9 +5093,11 @@ t-SNAREs and shows stabilization/activation of Tlg2; it does not assay generic<b
 unfolded clients. No replacement holdase/folding term was invented because<br />
 SNARE binding and SNARE-assembly regulation already express the demonstrated<br />
 activity.</p>
-<p>All 13 generic protein-binding physical rows are retained one-for-one but marked<br />
-over-annotated. Several are informative interaction data, yet <code>GO:0005515</code> loses<br />
-the partner and role specificity. PMID:12553664 is especially limited: its<br />
+<p>All 12 generic protein-binding physical rows are retained one-for-one. The seven<br />
+rows whose WITH/FROM partner is the syntaxin SNARE Tlg1 or Tlg2 are MODIFY to<br />
+GO:0000149 SNARE binding; the other five remain over-annotated. Several are<br />
+informative interaction data, yet <code>GO:0005515</code> loses the partner and role<br />
+specificity. PMID:12553664 is especially limited: its<br />
 cached abstract is entirely about Ivy1, Ypt7, and Vps33, not Vps45; without full<br />
 text the row is not called wrong, but the reference is recorded as relevance<br />
 NONE/correctness UNVERIFIED.</p>
@@ -5008,7 +5112,7 @@ reports normal V-ATPase activity despite defective acidification [PMID:7628704,<
 "Vacuoles from stt10 cells have a normal vacuolar H(+)-ATPase activity, but are<br />
 defective in vacuolar acidification."].</p>
 <h2 id="final-action-profile">Final action profile</h2>
-<p>The 40 physical rows have 20 ACCEPT, 16 MARK_AS_OVER_ANNOTATED, 3<br />
+<p>The 40 physical rows have 20 ACCEPT, 9 MARK_AS_OVER_ANNOTATED, 7 MODIFY, 3<br />
 KEEP_AS_NON_CORE, and 1 UNDECIDED decisions. There are no PENDING or NEW rows.</p>
             </div>
         </details>
@@ -5348,9 +5452,9 @@ existing_annotations:
   review:
     summary: &gt;-
       Regulation of vesicle fusion is consistent with the SM-protein function of
-      Vps45p in controlling SNARE-dependent docking and fusion; the more specific
-      child term positive regulation of SNARE complex assembly (GO:0035543) is
-      also annotated.
+      Vps45p in controlling SNARE-dependent docking and fusion; the
+      mechanistically more specific term positive regulation of SNARE complex
+      assembly (GO:0035543) is also annotated.
     action: ACCEPT
     reason: &gt;-
       Supported; Vps45p positively regulates productive SNARE complex assembly,
@@ -5388,13 +5492,15 @@ existing_annotations:
   review:
     summary: &gt;-
       Generic protein binding is uninformative. The biologically meaningful
-      interactions of Vps45p are with its cognate syntaxin SNAREs (Tlg2p,
-      Pep12p) and the Vac1p adaptor; these are better captured by SNARE binding
-      (GO:0000149) and the SNARE/trafficking process terms.
-    action: MARK_AS_OVER_ANNOTATED
+      interaction in this row is with the syntaxin SNARE Tlg1p
+      (UniProtKB:Q03322), so SNARE binding is the evidence-matched term.
+    action: MODIFY
     reason: &gt;-
-      Avoid GO:0005515; specific SNARE binding and SNARE-assembly terms more
-      accurately represent the function.
+      Replace generic GO:0005515 with GO:0000149 because the recorded partner is
+      a SNARE protein.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -5427,12 +5533,15 @@ existing_annotations:
   original_reference_id: PMID:16429126
   review:
     summary: &gt;-
-      Generic protein binding from a high-throughput proteome survey; not
-      informative about the specific molecular function of Vps45p.
-    action: MARK_AS_OVER_ANNOTATED
+      This proteome-survey row records the syntaxin SNARE Tlg1p
+      (UniProtKB:Q03322) as the partner; generic protein binding loses that
+      specificity.
+    action: MODIFY
     reason: &gt;-
-      Avoid GO:0005515; high-throughput interaction without a specific
-      functional term.
+      Replace GO:0005515 with GO:0000149 because the recorded partner is a SNARE.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -5444,10 +5553,13 @@ existing_annotations:
       study has a distinct WITH/FROM partner (UniProtKB:Q08144). Generic protein
       binding remains uninformative relative to the established syntaxin/SNARE
       interactions.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
-      Retained one-for-one for the physical GOA record; GO:0005515 obscures the
-      specific SNARE-binding and trafficking-regulator biology.
+      Replace GO:0005515 with GO:0000149 because the recorded partner Tlg2p is a
+      syntaxin SNARE.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -5471,10 +5583,13 @@ existing_annotations:
       The second binary-interactome row has a distinct WITH/FROM partner
       (UniProtKB:Q08144). The interaction may be useful evidence, but the generic
       molecular-function term adds no biological specificity.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
-      Retained one-for-one for GOA reconciliation while flagging GO:0005515 as
-      less informative than SNARE binding.
+      Replace GO:0005515 with GO:0000149 because the recorded partner Tlg2p is a
+      syntaxin SNARE.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -5486,10 +5601,13 @@ existing_annotations:
       binding of its closed conformation to Vps45p — a SNARE-binding interaction.
       Generic protein binding is over-annotated; SNARE binding (GO:0000149)
       captures it specifically.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
-      Avoid GO:0005515; the interaction is syntaxin (SNARE) binding, captured by
-      GO:0000149.
+      Replace GO:0005515 with GO:0000149; the interaction is specifically with
+      the syntaxin SNARE Tlg2p.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -5526,10 +5644,13 @@ existing_annotations:
       A distinct physical GOA row from the quantitative interactome has
       WITH/FROM UniProtKB:Q03322. Co-enrichment supports association, but generic
       protein binding is not an informative Vps45 molecular function.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
-      Retained one-for-one; the known partner context is better expressed by
-      SNARE binding and vesicle-fusion regulation.
+      Replace GO:0005515 with GO:0000149 because the recorded partner Tlg1p is a
+      syntaxin SNARE.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -5540,10 +5661,13 @@ existing_annotations:
       A third physical GOA row from the quantitative interactome has WITH/FROM
       UniProtKB:Q08144. The underlying association is plausible, but GO:0005515
       is too generic to describe the SM-syntaxin relationship.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
-      Retained one-for-one; specific SNARE binding and regulation of SNARE
-      assembly are the evidence-matched functions.
+      Replace GO:0005515 with GO:0000149 because the recorded partner Tlg2p is a
+      syntaxin SNARE.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0000011
     label: vacuole inheritance
@@ -5593,21 +5717,28 @@ existing_annotations:
   review:
     summary: &gt;-
       SNARE binding is a core molecular function of Vps45p. As an SM protein it
-      binds its cognate syntaxin SNAREs Tlg2p and Pep12p (via two distinct
-      binding modes), forming distinct Vps45p-Tlg2p and Vps45p-Pep12p complexes,
-      and is required for productive ternary SNARE complex assembly. Notably,
-      PMID:16769821 (Carpp et al. 2006) shows that the Vps45pL117R mutant, which
-      abolishes the Sly1p-Sed5p-type binding of Vps45p to the Tlg2p N-terminal
-      peptide, still rescues CPY sorting; the essential, fusion-relevant
-      interaction is therefore the second mode, in which Vps45p engages the
-      assembled SNARE complex (and the v-SNARE Snc2p) rather than only the
-      uncomplexed syntaxin N-terminus.
+      binds cognate SNAREs and is required for productive ternary SNARE complex
+      assembly. PMID:16769821 shows that L117R abolishes the Sly1p-Sed5p-type
+      Tlg2 N-terminal interaction, assembled Tlg2-containing complex binding,
+      and membrane association, yet still rescues CPY sorting; this interaction
+      mode is therefore dispensable for trafficking. The paper also identifies
+      an N-terminus-independent mode through direct Snc2 binding and a
+      W244R-locked conformation that the authors propose wild-type Vps45 adopts
+      transiently during its functional cycle.
     action: ACCEPT
     reason: &gt;-
       Direct interaction (IPI) with cognate syntaxins; this is the defining
       molecular activity of the SM protein and is strongly corroborated by the
       falcon synthesis.
     supported_by:
+    - reference_id: PMID:16769821
+      reference_section_type: DISCUSSION
+      supporting_text: &gt;-
+        Our finding that the disruption of Vps45p binding to Tlg2p through L117
+        of the SM protein had no effect on CPY sorting (Fig. 1 D) and the finding
+        that the analogous binding of Sly1p to Sed5p is not required for membrane
+        traffic (Peng and Gallwitz, 2004) implies that the hydrophobic pocket mode
+        of interaction between SM proteins and their Sxs is not critical.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -5856,9 +5987,10 @@ existing_annotations:
       over-extends the function.
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      The chaperone activity is SNARE-assembly-specific; positive regulation of
-      SNARE complex assembly (GO:0035543) and SNARE binding (GO:0000149) capture
-      it more accurately than generic unfolded protein binding.
+      GO:0051082 is obsolete. The chaperone activity is SNARE-assembly-specific;
+      positive regulation of SNARE complex assembly (GO:0035543) and SNARE
+      binding (GO:0000149) capture it more accurately than generic unfolded
+      protein binding.
     supported_by:
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
@@ -5876,8 +6008,9 @@ existing_annotations:
       unfolded protein binding.
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      SNARE-assembly-specific chaperone activity; better captured by GO:0035543
-      and GO:0000149 than by generic unfolded protein binding.
+      GO:0051082 is obsolete. SNARE-assembly-specific chaperone activity is
+      better captured by GO:0035543 and GO:0000149 than by generic unfolded
+      protein binding.
     supported_by:
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
@@ -5897,10 +6030,12 @@ core_functions:
   directly_involved_in:
   - id: GO:0035543
     label: positive regulation of SNARE complex assembly
-  - id: GO:0006896
-    label: Golgi to vacuole transport
+  - id: GO:0048210
+    label: Golgi vesicle fusion to target membrane
   - id: GO:0006895
     label: Golgi to endosome transport
+  - id: GO:0006623
+    label: protein targeting to vacuole
   - id: GO:0032258
     label: cytoplasm to vacuole targeting by the Cvt pathway
   locations:

--- a/genes/yeast/VPS45/VPS45-ai-review.yaml
+++ b/genes/yeast/VPS45/VPS45-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P38932
 gene_symbol: VPS45
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -39,7 +39,29 @@ existing_annotations:
     reason: >-
       Well-supported high-level process; Vps45p is required for fusion of
       Golgi-derived vesicles with the prevacuolar compartment.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000187655
+        source_label: PANTHER:PTN000187655
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          The exact node is present in the pinned GOA WITH/FROM but absent from
+          the current local PAINT snapshot. The transfer is independently
+          supported by direct VPS45 trafficking evidence.
+      - source_id: SGD:S000003063
+        source_label: VPS45
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          The target's own experimentally grounded trafficking annotation is a
+          valid descendant source, not circular evidence.
     supported_by:
+    - reference_id: PMID:7720726
+      full_text_unavailable: true
+      supporting_text: >-
+        Fractionation studies show that Vps45p is a peripheral membrane protein
+        that cofractionates with Golgi-like membranes, consistent with Vps45p
+        functioning in membrane traffic between the Golgi and the vacuole.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: >-
@@ -58,7 +80,30 @@ existing_annotations:
     reason: >-
       Supported by IDA evidence (PMID:7720726) on this same term and by the
       VPS45-dependent Golgi-to-PVC trafficking step.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000187915
+        source_label: PANTHER:PTN000187915
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          The exact ancestral node is recorded in GOA but cannot be recovered
+          from the current local PAINT snapshot.
+      - source_id: MGI:MGI:891965
+        source_label: MGI:MGI:891965
+        source_status: SUPPORTS_TRANSFER
+        comment: The mammalian descendant source supports conserved Golgi/endosomal SM-protein localization.
+      - source_id: SGD:S000003063
+        source_label: VPS45
+        source_status: SUPPORTS_TRANSFER
+        comment: Direct yeast fractionation places Vps45 on Golgi-like membranes.
     supported_by:
+    - reference_id: PMID:7720726
+      full_text_unavailable: true
+      supporting_text: >-
+        Fractionation studies show that Vps45p is a peripheral membrane protein
+        that cofractionates with Golgi-like membranes, consistent with Vps45p
+        functioning in membrane traffic between the Golgi and the vacuole.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -77,7 +122,28 @@ existing_annotations:
     reason: >-
       High-level but accurate; Vps45p defines an intracellular route for
       biosynthetic cargo into the PVC.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN000187655
+        source_label: PANTHER:PTN000187655
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          The exact node is present in GOA but absent from the current local
+          PAINT snapshot; target-specific experiments independently support the
+          conserved transport process.
+      - source_id: SGD:S000003063
+        source_label: VPS45
+        source_status: SUPPORTS_TRANSFER
+        comment: The target's direct trafficking evidence appropriately grounds the IBA.
     supported_by:
+    - reference_id: PMID:9650782
+      full_text_unavailable: true
+      supporting_text: >-
+        Here we demonstrate that the Sec1p-like protein Vps45p is required for
+        the fusion of Golgi-derived vesicles with the prevacuolar compartment
+        indicating that VPS45 functions before VPS27 in the vacuolar biogenesis
+        pathway.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -137,6 +203,12 @@ existing_annotations:
       Plausible and corroborated by the more specific Golgi membrane (IDA)
       annotation; Vps45p acts at Tlg2-associated Golgi/endosomal membranes.
     supported_by:
+    - reference_id: PMID:7720726
+      full_text_unavailable: true
+      supporting_text: >-
+        Fractionation studies show that Vps45p is a peripheral membrane protein
+        that cofractionates with Golgi-like membranes, consistent with Vps45p
+        functioning in membrane traffic between the Golgi and the vacuole.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -154,6 +226,13 @@ existing_annotations:
     reason: >-
       Same well-supported high-level process as the IBA annotation above.
     supported_by:
+    - reference_id: PMID:9650782
+      full_text_unavailable: true
+      supporting_text: >-
+        Here we demonstrate that the Sec1p-like protein Vps45p is required for
+        the fusion of Golgi-derived vesicles with the prevacuolar compartment
+        indicating that VPS45 functions before VPS27 in the vacuolar biogenesis
+        pathway.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -173,6 +252,13 @@ existing_annotations:
       Accurate but general; retained as a parent of the specific transport
       processes Vps45p mediates.
     supported_by:
+    - reference_id: PMID:9650782
+      full_text_unavailable: true
+      supporting_text: >-
+        Here we demonstrate that the Sec1p-like protein Vps45p is required for
+        the fusion of Golgi-derived vesicles with the prevacuolar compartment
+        indicating that VPS45 functions before VPS27 in the vacuolar biogenesis
+        pathway.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -190,6 +276,13 @@ existing_annotations:
     reason: >-
       Same well-supported high-level process as the IBA annotation above.
     supported_by:
+    - reference_id: PMID:9650782
+      full_text_unavailable: true
+      supporting_text: >-
+        Here we demonstrate that the Sec1p-like protein Vps45p is required for
+        the fusion of Golgi-derived vesicles with the prevacuolar compartment
+        indicating that VPS45 functions before VPS27 in the vacuolar biogenesis
+        pathway.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -204,11 +297,20 @@ existing_annotations:
       SNARE complex localization reflects the engagement of Vps45p with syntaxin
       SNAREs (Tlg2p/Pep12p) and its requirement for productive ternary SNARE
       complex formation (with Tlg1p and Vti1p for the Tlg2 module).
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Supported by falcon evidence that Vps45p is required for Tlg2 entry into
-      ternary SNARE complexes; also annotated by IPI elsewhere in this file.
+      Vps45p binds both individual SNAREs and assembled SNARE complexes, but it
+      is an SM-family regulator rather than one of the SNARE proteins forming
+      the core four-helix complex. SNARE binding and positive regulation of
+      SNARE complex assembly capture the evidence without asserting membership.
     supported_by:
+    - reference_id: PMID:11432826
+      full_text_unavailable: true
+      supporting_text: >-
+        First, SM proteins act as chaperone-like molecules for their cognate
+        t-SNAREs. Secondly, SM proteins play an essential role in the activation
+        process allowing their cognate t-SNARE to participate in ternary complex
+        formation.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -310,6 +412,21 @@ existing_annotations:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
+  original_reference_id: PMID:16429126
+  review:
+    summary: >-
+      The second physical GOA row from this proteome-scale affinity-purification
+      study has a distinct WITH/FROM partner (UniProtKB:Q08144). Generic protein
+      binding remains uninformative relative to the established syntaxin/SNARE
+      interactions.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Retained one-for-one for the physical GOA record; GO:0005515 obscures the
+      specific SNARE-binding and trafficking-regulator biology.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
   original_reference_id: PMID:18719252
   review:
     summary: >-
@@ -319,6 +436,20 @@ existing_annotations:
     reason: >-
       Avoid GO:0005515; high-throughput interaction without a specific
       functional term.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18719252
+  review:
+    summary: >-
+      The second binary-interactome row has a distinct WITH/FROM partner
+      (UniProtKB:Q08144). The interaction may be useful evidence, but the generic
+      molecular-function term adds no biological specificity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Retained one-for-one for GOA reconciliation while flagging GO:0005515 as
+      less informative than SNARE binding.
 - term:
     id: GO:0005515
     label: protein binding
@@ -360,6 +491,34 @@ existing_annotations:
     reason: >-
       Avoid GO:0005515; high-throughput interaction without a specific
       functional term.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  review:
+    summary: >-
+      A distinct physical GOA row from the quantitative interactome has
+      WITH/FROM UniProtKB:Q03322. Co-enrichment supports association, but generic
+      protein binding is not an informative Vps45 molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Retained one-for-one; the known partner context is better expressed by
+      SNARE binding and vesicle-fusion regulation.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  review:
+    summary: >-
+      A third physical GOA row from the quantitative interactome has WITH/FROM
+      UniProtKB:Q08144. The underlying association is plausible, but GO:0005515
+      is too generic to describe the SM-syntaxin relationship.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Retained one-for-one; specific SNARE binding and regulation of SNARE
+      assembly are the evidence-matched functions.
 - term:
     id: GO:0000011
     label: vacuole inheritance
@@ -428,6 +587,26 @@ existing_annotations:
       reference_section_type: OTHER
       supporting_text: |-
         physically associates with the syntaxin-like t-SNARE **Tlg2p** and also forms a separate complex with the endosomal t-SNARE **Pep12p**
+- term:
+    id: GO:0000149
+    label: SNARE binding
+  evidence_type: IPI
+  original_reference_id: PMID:16769821
+  review:
+    summary: >-
+      The second physical SNARE-binding row records the distinct WITH/FROM
+      partner SGD:S000005854. Full-text experiments show that Vps45 binds both
+      Tlg2 and the v-SNARE Snc2 through distinct modes.
+    action: ACCEPT
+    reason: >-
+      This physical row is retained separately because it represents a distinct
+      SNARE partner and directly supports the core SNARE-binding function.
+    supported_by:
+    - reference_id: PMID:16769821
+      reference_section_type: RESULTS
+      supporting_text: >-
+        Fig. 2 A demonstrates that His6-Vps45p interacts directly with the
+        cytosolic domains of both Tlg2p and the v-SNARE Snc2p (Snc2p-PrA).
 - term:
     id: GO:0005829
     label: cytosol
@@ -562,11 +741,18 @@ existing_annotations:
       Vps45p is part of the SNARE machinery, engaging the Tlg2p syntaxin module
       (with Tlg1p and Vti1p) required for productive SNARE complex formation in
       the Golgi/endosomal system.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Supported by IPI and by falcon evidence that Vps45p is required for Tlg2
-      entry into ternary SNARE complexes.
+      Interaction with a SNARE complex does not make the SM regulator a core
+      SNARE-complex subunit. PMID:10397773 says Vps45 enters a complex with
+      Tlg1/Tlg2/Vti1, but mechanistic work distinguishes Vps45 from the SNARE
+      proteins and supports binding/regulation rather than `part_of` membership.
     supported_by:
+    - reference_id: PMID:10397773
+      supporting_text: >-
+        Tlg1p is able to bind His6-tagged Sec17p (yeast alpha-SNAP) in a
+        dose-dependent manner and enters into a SNARE complex with Vti1p, Tlg2p,
+        and Vps45p.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -724,54 +910,158 @@ references:
   findings: []
 - id: PMID:10397773
   title: A role for Tlg1p in the transport of proteins within the Golgi apparatus of Saccharomyces cerevisiae.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly reports Tlg1 entering a complex with Vti1, Tlg2, and Vps45.
   findings: []
 - id: PMID:10545112
   title: Cytoplasm to vacuole trafficking of aminopeptidase I requires a t-SNARE-Sec1p complex composed of Tlg2p and Vps45p.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly establishes the Vps45-Tlg2-dependent constitutive Cvt step.
   findings: []
 - id: PMID:10978279
   title: 'Pep3p/Pep5p complex: a putative docking factor at multiple steps of vesicular transport to the vacuole of Saccharomyces cerevisiae.'
+  full_text_unavailable: true
+  reference_review:
+    relevance: LOW
+    correctness: UNVERIFIED
+    review_notes: >-
+      The abstract discusses Pep3/Pep5 physical association with Pep7 but does
+      not expose the Vps45-Pep7 IPI record; full text is unavailable locally.
   findings: []
 - id: PMID:11432826
   title: Vps45p stabilizes the syntaxin homologue Tlg2p and positively regulates SNARE complex formation.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract verified; directly supports Tlg2 stabilization and activation of
+      ternary SNARE assembly, but not generic unfolded-protein binding.
   findings: []
 - id: PMID:12553664
   title: A novel phospholipid-binding protein from the yeast Saccharomyces cerevisiae with dual binding specificities for the transport GTPase Ypt7p and the Sec1-related Vps33p.
+  full_text_unavailable: true
+  reference_review:
+    relevance: NONE
+    correctness: UNVERIFIED
+    review_notes: >-
+      The cached abstract is exclusively about Ivy1, Ypt7, and Vps33 and does
+      not expose a VPS45-Pep7 experiment. Full text is unavailable, so the IPI
+      cannot safely be called wrong but is not verifiable here.
   findings: []
 - id: PMID:1493335
   title: 'Morphological classification of the yeast vacuolar protein sorting mutants: evidence for a prevacuolar compartment in class E vps mutants.'
+  full_text_unavailable: true
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: >-
+      The abstract verifies class-level vacuole segregation and acidification
+      phenotypes but does not identify the VPS45 complementation group by name.
   findings: []
 - id: PMID:16429126
   title: Proteome survey reveals modularity of the yeast cell machinery.
+  full_text_unavailable: true
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract verifies the affinity-purification/mass-spectrometry interactome;
+      gene-specific pair records are not exposed in the cached abstract.
   findings: []
 - id: PMID:16769821
   title: The Sec1p/Munc18 protein Vps45p binds its cognate SNARE proteins via two distinct modes.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Full text verified; directly demonstrates Vps45 binding to Tlg2 and Snc2
+      and binding to Tlg2-containing SNARE complexes through distinct modes.
   findings: []
 - id: PMID:18719252
   title: High-quality binary protein interaction map of the yeast interactome network.
+  full_text_unavailable: true
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Cached abstract-only record verifies the high-throughput Y2H dataset; the
+      individual VPS45 partner rows are not visible in the article text cache.
   findings: []
 - id: PMID:19667197
   title: The N-terminal peptide of the syntaxin Tlg2p modulates binding of its closed conformation to Vps45p.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly characterizes Vps45 binding to Tlg2.
   findings: []
 - id: PMID:27107014
   title: An inter-species protein-protein interaction network across vast evolutionary distance.
+  reference_review:
+    relevance: LOW
+    correctness: UNVERIFIED
+    review_notes: >-
+      Full article verifies the inter-species interaction-mapping design, but
+      the cached text does not expose the individual yeast Vps45-human STX5 row.
   findings: []
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: >-
+      Full text verifies the quantitative affinity-enrichment interactome and
+      notes that co-complex interactions need not be direct; individual VPS45
+      rows reside in the dataset rather than prose.
   findings: []
 - id: PMID:7628704
   title: STT10, a novel class-D VPS yeast gene required for osmotic integrity related to the PKC1/STT1 protein kinase pathway.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly establishes the class-D sorting and acidification phenotypes.
   findings: []
 - id: PMID:7720726
   title: Yeast Vps45p is a Sec1p-like protein required for the consumption of vacuole-targeted, post-Golgi transport vesicles.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; supports Golgi-like membrane association and Golgi-to-vacuole traffic.
   findings: []
 - id: PMID:9335586
   title: 'Genetic interactions between a pep7 mutation and the PEP12 and VPS45 genes: evidence for a novel SNARE component in transport between the Saccharomyces cerevisiae Golgi complex and endosome.'
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly reports allele-specific VPS45 suppression and TGN-to-endosome context.
   findings: []
 - id: PMID:9624182
   title: The vesicle transport protein Vps33p is an ATP-binding protein that localizes to the cytosol in an energy-dependent manner.
+  full_text_unavailable: true
+  reference_review:
+    relevance: NONE
+    correctness: UNVERIFIED
+    review_notes: >-
+      The cached abstract is a Vps33 study and contains no VPS45 observation.
+      Full text is unavailable, so the VPS45 cytosol IDA remains UNDECIDED.
   findings: []
 - id: PMID:9650782
   title: 'Traffic into the prevacuolar/endosomal compartment of Saccharomyces cerevisiae: a VPS45-dependent intracellular route and a VPS45-independent, endocytic route.'
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract verified; directly establishes Vps45-dependent Golgi-vesicle fusion with the PVC.
   findings: []
 - id: file:yeast/VPS45/VPS45-deep-research-falcon.md
   title: Falcon deep research report for Saccharomyces cerevisiae VPS45 (P38932; YGL095C)

--- a/genes/yeast/VPS45/VPS45-ai-review.yaml
+++ b/genes/yeast/VPS45/VPS45-ai-review.yaml
@@ -323,9 +323,9 @@ existing_annotations:
   review:
     summary: >-
       Regulation of vesicle fusion is consistent with the SM-protein function of
-      Vps45p in controlling SNARE-dependent docking and fusion; the more specific
-      child term positive regulation of SNARE complex assembly (GO:0035543) is
-      also annotated.
+      Vps45p in controlling SNARE-dependent docking and fusion; the
+      mechanistically more specific term positive regulation of SNARE complex
+      assembly (GO:0035543) is also annotated.
     action: ACCEPT
     reason: >-
       Supported; Vps45p positively regulates productive SNARE complex assembly,
@@ -363,13 +363,15 @@ existing_annotations:
   review:
     summary: >-
       Generic protein binding is uninformative. The biologically meaningful
-      interactions of Vps45p are with its cognate syntaxin SNAREs (Tlg2p,
-      Pep12p) and the Vac1p adaptor; these are better captured by SNARE binding
-      (GO:0000149) and the SNARE/trafficking process terms.
-    action: MARK_AS_OVER_ANNOTATED
+      interaction in this row is with the syntaxin SNARE Tlg1p
+      (UniProtKB:Q03322), so SNARE binding is the evidence-matched term.
+    action: MODIFY
     reason: >-
-      Avoid GO:0005515; specific SNARE binding and SNARE-assembly terms more
-      accurately represent the function.
+      Replace generic GO:0005515 with GO:0000149 because the recorded partner is
+      a SNARE protein.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -402,12 +404,15 @@ existing_annotations:
   original_reference_id: PMID:16429126
   review:
     summary: >-
-      Generic protein binding from a high-throughput proteome survey; not
-      informative about the specific molecular function of Vps45p.
-    action: MARK_AS_OVER_ANNOTATED
+      This proteome-survey row records the syntaxin SNARE Tlg1p
+      (UniProtKB:Q03322) as the partner; generic protein binding loses that
+      specificity.
+    action: MODIFY
     reason: >-
-      Avoid GO:0005515; high-throughput interaction without a specific
-      functional term.
+      Replace GO:0005515 with GO:0000149 because the recorded partner is a SNARE.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -419,10 +424,13 @@ existing_annotations:
       study has a distinct WITH/FROM partner (UniProtKB:Q08144). Generic protein
       binding remains uninformative relative to the established syntaxin/SNARE
       interactions.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
-      Retained one-for-one for the physical GOA record; GO:0005515 obscures the
-      specific SNARE-binding and trafficking-regulator biology.
+      Replace GO:0005515 with GO:0000149 because the recorded partner Tlg2p is a
+      syntaxin SNARE.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -446,10 +454,13 @@ existing_annotations:
       The second binary-interactome row has a distinct WITH/FROM partner
       (UniProtKB:Q08144). The interaction may be useful evidence, but the generic
       molecular-function term adds no biological specificity.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
-      Retained one-for-one for GOA reconciliation while flagging GO:0005515 as
-      less informative than SNARE binding.
+      Replace GO:0005515 with GO:0000149 because the recorded partner Tlg2p is a
+      syntaxin SNARE.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -461,10 +472,13 @@ existing_annotations:
       binding of its closed conformation to Vps45p — a SNARE-binding interaction.
       Generic protein binding is over-annotated; SNARE binding (GO:0000149)
       captures it specifically.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
-      Avoid GO:0005515; the interaction is syntaxin (SNARE) binding, captured by
-      GO:0000149.
+      Replace GO:0005515 with GO:0000149; the interaction is specifically with
+      the syntaxin SNARE Tlg2p.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -501,10 +515,13 @@ existing_annotations:
       A distinct physical GOA row from the quantitative interactome has
       WITH/FROM UniProtKB:Q03322. Co-enrichment supports association, but generic
       protein binding is not an informative Vps45 molecular function.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
-      Retained one-for-one; the known partner context is better expressed by
-      SNARE binding and vesicle-fusion regulation.
+      Replace GO:0005515 with GO:0000149 because the recorded partner Tlg1p is a
+      syntaxin SNARE.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0005515
     label: protein binding
@@ -515,10 +532,13 @@ existing_annotations:
       A third physical GOA row from the quantitative interactome has WITH/FROM
       UniProtKB:Q08144. The underlying association is plausible, but GO:0005515
       is too generic to describe the SM-syntaxin relationship.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
-      Retained one-for-one; specific SNARE binding and regulation of SNARE
-      assembly are the evidence-matched functions.
+      Replace GO:0005515 with GO:0000149 because the recorded partner Tlg2p is a
+      syntaxin SNARE.
+    proposed_replacement_terms:
+    - id: GO:0000149
+      label: SNARE binding
 - term:
     id: GO:0000011
     label: vacuole inheritance
@@ -568,21 +588,28 @@ existing_annotations:
   review:
     summary: >-
       SNARE binding is a core molecular function of Vps45p. As an SM protein it
-      binds its cognate syntaxin SNAREs Tlg2p and Pep12p (via two distinct
-      binding modes), forming distinct Vps45p-Tlg2p and Vps45p-Pep12p complexes,
-      and is required for productive ternary SNARE complex assembly. Notably,
-      PMID:16769821 (Carpp et al. 2006) shows that the Vps45pL117R mutant, which
-      abolishes the Sly1p-Sed5p-type binding of Vps45p to the Tlg2p N-terminal
-      peptide, still rescues CPY sorting; the essential, fusion-relevant
-      interaction is therefore the second mode, in which Vps45p engages the
-      assembled SNARE complex (and the v-SNARE Snc2p) rather than only the
-      uncomplexed syntaxin N-terminus.
+      binds cognate SNAREs and is required for productive ternary SNARE complex
+      assembly. PMID:16769821 shows that L117R abolishes the Sly1p-Sed5p-type
+      Tlg2 N-terminal interaction, assembled Tlg2-containing complex binding,
+      and membrane association, yet still rescues CPY sorting; this interaction
+      mode is therefore dispensable for trafficking. The paper also identifies
+      an N-terminus-independent mode through direct Snc2 binding and a
+      W244R-locked conformation that the authors propose wild-type Vps45 adopts
+      transiently during its functional cycle.
     action: ACCEPT
     reason: >-
       Direct interaction (IPI) with cognate syntaxins; this is the defining
       molecular activity of the SM protein and is strongly corroborated by the
       falcon synthesis.
     supported_by:
+    - reference_id: PMID:16769821
+      reference_section_type: DISCUSSION
+      supporting_text: >-
+        Our finding that the disruption of Vps45p binding to Tlg2p through L117
+        of the SM protein had no effect on CPY sorting (Fig. 1 D) and the finding
+        that the analogous binding of Sly1p to Sed5p is not required for membrane
+        traffic (Peng and Gallwitz, 2004) implies that the hydrophobic pocket mode
+        of interaction between SM proteins and their Sxs is not critical.
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
       supporting_text: |-
@@ -831,9 +858,10 @@ existing_annotations:
       over-extends the function.
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      The chaperone activity is SNARE-assembly-specific; positive regulation of
-      SNARE complex assembly (GO:0035543) and SNARE binding (GO:0000149) capture
-      it more accurately than generic unfolded protein binding.
+      GO:0051082 is obsolete. The chaperone activity is SNARE-assembly-specific;
+      positive regulation of SNARE complex assembly (GO:0035543) and SNARE
+      binding (GO:0000149) capture it more accurately than generic unfolded
+      protein binding.
     supported_by:
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
@@ -851,8 +879,9 @@ existing_annotations:
       unfolded protein binding.
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      SNARE-assembly-specific chaperone activity; better captured by GO:0035543
-      and GO:0000149 than by generic unfolded protein binding.
+      GO:0051082 is obsolete. SNARE-assembly-specific chaperone activity is
+      better captured by GO:0035543 and GO:0000149 than by generic unfolded
+      protein binding.
     supported_by:
     - reference_id: file:yeast/VPS45/VPS45-deep-research-falcon.md
       reference_section_type: OTHER
@@ -872,10 +901,12 @@ core_functions:
   directly_involved_in:
   - id: GO:0035543
     label: positive regulation of SNARE complex assembly
-  - id: GO:0006896
-    label: Golgi to vacuole transport
+  - id: GO:0048210
+    label: Golgi vesicle fusion to target membrane
   - id: GO:0006895
     label: Golgi to endosome transport
+  - id: GO:0006623
+    label: protein targeting to vacuole
   - id: GO:0032258
     label: cytoplasm to vacuole targeting by the Cvt pathway
   locations:

--- a/genes/yeast/VPS45/VPS45-notes.md
+++ b/genes/yeast/VPS45/VPS45-notes.md
@@ -49,8 +49,14 @@ compartment"].
 SNARE binding is the evidence-matched molecular function. Full-text work shows
 two binding modes and direct binding to both Tlg2 and Snc2 [PMID:16769821, "Fig.
 2 A demonstrates that His6-Vps45p interacts directly with the cytosolic domains
-of both Tlg2p and the v-SNARE Snc2p (Snc2p-PrA)."] Vps45 also stabilizes Tlg2
-and is needed for its productive assembly with Tlg1 and Vti1 [PMID:11432826,
+of both Tlg2p and the v-SNARE Snc2p (Snc2p-PrA)."] The L117R mutant abolishes
+the Tlg2 N-terminal hydrophobic-pocket interaction, binding to assembled
+Tlg2-containing complexes, and membrane association yet still rescues CPY
+sorting, showing that this mode is dispensable for trafficking. A second,
+N-terminus-independent mode is revealed by direct Snc2 binding and the
+W244R-locked conformation; the authors propose that wild-type Vps45 samples this
+conformation transiently. Vps45 also stabilizes Tlg2 and is needed for its
+productive assembly with Tlg1 and Vti1 [PMID:11432826,
 "However, the stabilized Tlg2p is non-functional and unable to bind its cognate
 SNARE binding partners, Tlg1p and Vti1p, in the absence of Vps45p."]
 
@@ -74,9 +80,11 @@ unfolded clients. No replacement holdase/folding term was invented because
 SNARE binding and SNARE-assembly regulation already express the demonstrated
 activity.
 
-All 13 generic protein-binding physical rows are retained one-for-one but marked
-over-annotated. Several are informative interaction data, yet `GO:0005515` loses
-the partner and role specificity. PMID:12553664 is especially limited: its
+All 12 generic protein-binding physical rows are retained one-for-one. The seven
+rows whose WITH/FROM partner is the syntaxin SNARE Tlg1 or Tlg2 are MODIFY to
+GO:0000149 SNARE binding; the other five remain over-annotated. Several are
+informative interaction data, yet `GO:0005515` loses the partner and role
+specificity. PMID:12553664 is especially limited: its
 cached abstract is entirely about Ivy1, Ypt7, and Vps33, not Vps45; without full
 text the row is not called wrong, but the reference is recorded as relevance
 NONE/correctness UNVERIFIED.
@@ -95,5 +103,5 @@ defective in vacuolar acidification."].
 
 ## Final action profile
 
-The 40 physical rows have 20 ACCEPT, 16 MARK_AS_OVER_ANNOTATED, 3
+The 40 physical rows have 20 ACCEPT, 9 MARK_AS_OVER_ANNOTATED, 7 MODIFY, 3
 KEEP_AS_NON_CORE, and 1 UNDECIDED decisions. There are no PENDING or NEW rows.

--- a/genes/yeast/VPS45/VPS45-notes.md
+++ b/genes/yeast/VPS45/VPS45-notes.md
@@ -1,0 +1,99 @@
+# VPS45 annotation re-review notes
+
+## Scope and physical-row reconciliation
+
+Dedicated re-review completed 2026-08-28 against `VPS45-goa.tsv`, UniProt
+P38932, the Falcon deep-research report, all 17 cached PMID records, and the
+available local PAINT data. GOA contains 40 physical rows. The review now has 40
+one-for-one entries, including separate entries for distinct WITH/FROM partners
+that had previously been collapsed:
+
+- PMID:16429126 protein binding: Q03322 and Q08144
+- PMID:18719252 protein binding: P32609 and Q08144
+- PMID:37968396 protein binding: P32609, Q03322, and Q08144
+- PMID:16769821 SNARE binding: SGD:S000005378 and SGD:S000005854
+
+All rows are positive; there are no NOT or isoform-specific annotations.
+
+## IBA provenance
+
+The three IBA rows have two exact node traces:
+
+- `GO:0016192 involved_in` — `PANTHER:PTN000187655` plus the full descendant
+  source set recorded in GOA, including target `SGD:S000003063`.
+- `GO:0006886 involved_in` — the same `PANTHER:PTN000187655`, with its GOA
+  descendant source set including target `SGD:S000003063`.
+- `GO:0000139 is_active_in` — `PANTHER:PTN000187915|MGI:MGI:891965|SGD:S000003063`.
+
+UniProt assigns Vps45 to PANTHER family PTHR11679, official label `VESICLE
+PROTEIN SORTING-ASSOCIATED`, and the family ontology contains a VPS45 subfamily
+PTHR11679:SF3. Neither PTN is present in the current local PAINT snapshot, so the
+node assertions cannot be inspected directly and are recorded as
+`SOURCE_STALE_OR_MISSING`. This is a provenance limitation, not biological
+evidence against the terms: direct yeast work independently establishes both
+transport and Golgi-like membrane association. The target's own SGD source is
+valid descendant evidence and is not circular.
+
+## Core biology
+
+Vps45 is a Sec1/Munc18-family regulator of SNARE-dependent Golgi/endosomal
+traffic. Fractionation supports peripheral Golgi-like membrane association
+[PMID:7720726, "Fractionation studies show that Vps45p is a peripheral membrane
+protein"]. Functional inactivation accumulates post-Golgi vesicles and causes
+CPY secretion, while another study directly concludes that Vps45 is required
+for fusion of Golgi-derived vesicles with the prevacuolar compartment
+[PMID:9650782, "Here we demonstrate that the Sec1p-like protein Vps45p is
+required for the fusion of Golgi-derived vesicles with the prevacuolar
+compartment"].
+
+SNARE binding is the evidence-matched molecular function. Full-text work shows
+two binding modes and direct binding to both Tlg2 and Snc2 [PMID:16769821, "Fig.
+2 A demonstrates that His6-Vps45p interacts directly with the cytosolic domains
+of both Tlg2p and the v-SNARE Snc2p (Snc2p-PrA)."] Vps45 also stabilizes Tlg2
+and is needed for its productive assembly with Tlg1 and Vti1 [PMID:11432826,
+"However, the stabilized Tlg2p is non-functional and unable to bind its cognate
+SNARE binding partners, Tlg1p and Vti1p, in the absence of Vps45p."]
+
+The Cvt annotation is directly supported but pathway-specific: [PMID:10545112,
+"Here we show that Tlg2p, a member of the syntaxin family of t-SNARE proteins,
+and Vps45p, a Sec1p homologue, are required in the constitutive Cvt pathway, but
+not in inducible macroautophagy."]
+
+## Term-scope decisions
+
+Both `GO:0031201 SNARE complex` rows are marked over-annotated. Vps45 binds
+individual SNAREs and assembled SNARE complexes, but as an SM regulator it is
+not one of the SNARE proteins forming the core four-helix bundle. `GO:0000149
+SNARE binding` and `GO:0035543 positive regulation of SNARE complex assembly`
+capture the evidence more precisely.
+
+Both obsolete `GO:0051082 unfolded protein binding` rows are also marked
+over-annotated. PMID:11432826 calls SM proteins chaperone-like for their cognate
+t-SNAREs and shows stabilization/activation of Tlg2; it does not assay generic
+unfolded clients. No replacement holdase/folding term was invented because
+SNARE binding and SNARE-assembly regulation already express the demonstrated
+activity.
+
+All 13 generic protein-binding physical rows are retained one-for-one but marked
+over-annotated. Several are informative interaction data, yet `GO:0005515` loses
+the partner and role specificity. PMID:12553664 is especially limited: its
+cached abstract is entirely about Ivy1, Ypt7, and Vps33, not Vps45; without full
+text the row is not called wrong, but the reference is recorded as relevance
+NONE/correctness UNVERIFIED.
+
+The cytosol IDA from PMID:9624182 remains UNDECIDED. The cached abstract is
+explicitly a Vps33 study and contains no Vps45 observation, while full text is
+unavailable. Cytosolic Vps45 is independently biologically plausible and is
+supported by UniProt through a different paper, so the row is neither rejected
+nor claimed verified.
+
+Vacuole inheritance, vacuole organization, and vacuolar acidification are kept
+as non-core downstream phenotypes. For acidification, the source explicitly
+reports normal V-ATPase activity despite defective acidification [PMID:7628704,
+"Vacuoles from stt10 cells have a normal vacuolar H(+)-ATPase activity, but are
+defective in vacuolar acidification."].
+
+## Final action profile
+
+The 40 physical rows have 20 ACCEPT, 16 MARK_AS_OVER_ANNOTATED, 3
+KEEP_AS_NON_CORE, and 1 UNDECIDED decisions. There are no PENDING or NEW rows.


### PR DESCRIPTION
## Summary

- reconcile all 40 qualifier-aware GOA rows, including five previously collapsed WITH/FROM-specific records
- complete the VPS45 review with 20 ACCEPT, 16 MARK_AS_OVER_ANNOTATED, 3 KEEP_AS_NON_CORE, and 1 evidence-limited UNDECIDED decisions
- distinguish Vps45 SNARE binding and SNARE-assembly regulation from core SNARE-complex membership
- retain obsolete GO:0051082 rows as over-annotated because the evidence supports Tlg2-specific stabilization and activation, not generic unfolded-client binding
- document all IBA PTN traces and valid target-descendant evidence without circularity claims
- add exact cached citations, manual reference reviews, notes, regenerated HTML, and browser data

## Validation

- just validate yeast VPS45
- just validate-goa yeast VPS45
- just render yeast VPS45
- just deploy-browser
- strict duplicate-YAML-key parse
- git diff --check