### PR TITLE
Re-review yeast YAR1 annotations

### DIFF
--- a/genes/yeast/YAR1/YAR1-ai-review.html
+++ b/genes/yeast/YAR1/YAR1-ai-review.html
@@ -1051,7 +1051,7 @@
                                     <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
 
 
-                                    <div class="propagation-comment">The source node includes SWI4/MBP1-like transcription regulators, but YAR1 lacks the APSES DNA-binding domain and functions as an Rps3 carrier chaperone.</div>
+                                    <div class="propagation-comment">The source set includes genuine Swi6/Cdc10-like transcription-complex regulators, but Yar1 is a 200-residue protein with only two ankyrin repeats, not the larger Swi6/Cdc10 co-ortholog that carries this role. No Yar1-specific cell-cycle or promoter-association evidence supports transcriptional regulation.</div>
 
                                 </div>
 
@@ -1144,7 +1144,7 @@
                                     <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
 
 
-                                    <div class="propagation-comment">SWI4/MBP1-family source proteins support MBF-related transcription-complex biology, but YAR1 is not an MBF component and instead binds Rps3 during ribosome biogenesis.</div>
+                                    <div class="propagation-comment">The source set includes bona fide MBF subunits such as Swi6/Cdc10-like proteins, but 200-residue, two-ankyrin-repeat Yar1 is not that co-ortholog and has no cell-cycle or promoter-association evidence. Yar1 instead binds Rps3 during ribosome biogenesis.</div>
 
                                 </div>
 
@@ -1153,22 +1153,6 @@
                         </div>
 
 
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:interpro/panther/PTHR24198/PTHR24198-metadata.yaml
-
-                                </span>
-
-                                <div class="support-text">PTHR24198 is a broad ankyrin repeat domain-containing protein family rather than a Yar1-specific transcription complex family.</div>
-
-                            </div>
-
-                        </div>
 
 
                     </td>
@@ -1253,7 +1237,7 @@
                                     <span class="badge">SOURCE STALE OR MISSING</span>
 
 
-                                    <div class="propagation-comment">The pinned 2018 GOA row traces to this node, but GO:0033309 is absent from the current PTHR24198 PAINT table. Independently, Yar1 lacks the transcription-factor architecture and is an Rps3 chaperone.</div>
+                                    <div class="propagation-comment">The pinned 2018 GOA row traces to this node, but GO:0033309 is absent from the current PTHR24198 PAINT table. Independently, 200-residue, two-ankyrin-repeat Yar1 is not the Swi6/Cdc10-like co-ortholog that carries SBF membership, has no cell-cycle or promoter-association evidence, and instead functions as an Rps3 chaperone.</div>
 
                                 </div>
 
@@ -1973,7 +1957,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> The term captures Yar1&#39;s direct effect on Rps3 localization before pre-40S assembly.
+                            <strong>Reason:</strong> The term is retained as the curator&#39;s experimentally supported framing of Yar1&#39;s direct effect on Rps3 localization before pre-40S assembly; it is not being interpreted as a separate indirect signaling role.
                         </div>
 
 
@@ -2664,7 +2648,7 @@
                 <ul class="findings-list">
 
                     <li class="finding-item">
-                        <div class="finding-statement">PTN000917496 currently carries GO:0001228, GO:0045944, and GO:0030907, while the pinned GO:0033309 SBF-complex assertion is no longer present.</div>
+                        <div class="finding-statement">PTN000917496 currently carries positive IBD assertions for GO:0005737, GO:0030907, GO:0000978, GO:0001228, GO:0000082, and GO:0045944. The sequence-specific DNA-binding and G1/S-transition assertions were added on 2026-02-24 and can newly propagate to Yar1, while the pinned GO:0033309 SBF-complex assertion is no longer present.</div>
 
                     </li>
 
@@ -2720,6 +2704,19 @@
 
                 </div>
                 <span class="vote-buttons" data-g="P46683" data-a="Q: Should yeast Yar1 annotations explicitly distingui..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should PAINT curators revise PTN000917496 so that MBF membership, sequence-specific DNA binding, transcription activation, positive regulation of transcription, and G1/S-transition annotations do not propagate from Swi6/Cdc10- and APSES-like proteins to divergent ankyrin proteins such as Yar1?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P46683" data-a="Q: Should PAINT curators revise PTN000917496 so that ..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
                     <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
                 </span>
@@ -3766,11 +3763,20 @@ table shows this subfamily also contains highly diverse ankyrin proteins.</p>
 <p>The current PAINT table still places GO:0001228, GO:0045944, and GO:0030907 at<br />
 PTN000917496 with the same experimentally grounded transcription-factor source<br />
 sets. Those sources support their own transcription biology but not transfer to<br />
-Yar1, which shares ankyrin repeats without the transcription-factor domain<br />
-architecture. These are <code>PROPAGATION_BAD</code> calls, not weak-source or donor-count<br />
-arguments. The SBF-complex term GO:0033309 is absent from current PAINT, so its<br />
-pinned 2018 row is additionally <code>SOURCE_STALE_OR_MISSING</code>. PTN labels are kept<br />
-as bare <code>PANTHER:PTN000917496</code>.</p>
+Yar1. The APSES-domain argument applies specifically to GO:0001228. For MBF,<br />
+SBF, and broader transcription regulation, the donor sets also contain<br />
+Swi6/Cdc10-like ankyrin proteins that genuinely lack APSES domains; Yar1 is not<br />
+their co-ortholog but a much smaller 200-residue protein with only two ankyrin<br />
+repeats, and no Yar1 study reports cell-cycle or promoter-association evidence.<br />
+These are <code>PROPAGATION_BAD</code> calls, not weak-source or donor-count arguments. The<br />
+SBF-complex term GO:0033309 is absent from current PAINT, so its pinned 2018 row<br />
+is additionally <code>SOURCE_STALE_OR_MISSING</code>. PTN labels are kept as bare<br />
+<code>PANTHER:PTN000917496</code>.</p>
+<p>The current node also has positive IBD assertions for GO:0000978<br />
+<code>RNA polymerase II cis-regulatory region sequence-specific DNA binding</code> and<br />
+GO:0000082 <code>G1/S transition of mitotic cell cycle</code>, both dated 2026-02-24. These<br />
+are absent from the pinned YAR1 GOA snapshot but can propagate on refresh, so the<br />
+review raises the broad node placement itself for PAINT-curator reconsideration.</p>
 <h2 id="experimental-biology">Experimental biology</h2>
 <p>Yar1 is a dedicated chaperone for Rps3. The initial study established the<br />
 specific physical and genetic context: [PMID:15611164, "We provide genetic and<br />
@@ -3800,7 +3806,7 @@ complex roles. This conclusion is independently consistent with the focused<br /
 OpenScientist report, but the report's incorrect PTHR43828/SF10 family identifier<br />
 is not used; the repository's PTHR24198:SF165 membership and current PAINT table<br />
 are authoritative for provenance.</p>
-<p>Both obsolete GO:0051082 <code>unfolded protein binding</code> rows are modified to current<br />
+<p>Both GO:0051082 <code>unfolded protein binding</code> rows are modified to the more specific<br />
 GO:0140597 <code>protein carrier chaperone</code>. This is not a generic holdase inference:<br />
 Yar1 binds nascent Rps3, prevents aggregation, maintains solubility, and<br />
 accompanies the client toward its assembly site. The protein-binding rows remain<br />
@@ -3908,9 +3914,12 @@ existing_annotations:
       - source_id: PANTHER:PTN000917496
         source_label: PANTHER:PTN000917496
         source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
-        comment: The source node includes SWI4/MBP1-like transcription
-          regulators, but YAR1 lacks the APSES DNA-binding domain and functions
-          as an Rps3 carrier chaperone.
+        comment: &gt;-
+          The source set includes genuine Swi6/Cdc10-like transcription-complex
+          regulators, but Yar1 is a 200-residue protein with only two ankyrin
+          repeats, not the larger Swi6/Cdc10 co-ortholog that carries this role.
+          No Yar1-specific cell-cycle or promoter-association evidence supports
+          transcriptional regulation.
     additional_reference_ids:
     - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
 - term:
@@ -3932,14 +3941,13 @@ existing_annotations:
       - source_id: PANTHER:PTN000917496
         source_label: PANTHER:PTN000917496
         source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
-        comment: SWI4/MBP1-family source proteins support MBF-related
-          transcription-complex biology, but YAR1 is not an MBF component and
-          instead binds Rps3 during ribosome biogenesis.
+        comment: &gt;-
+          The source set includes bona fide MBF subunits such as Swi6/Cdc10-like
+          proteins, but 200-residue, two-ankyrin-repeat Yar1 is not that
+          co-ortholog and has no cell-cycle or promoter-association evidence.
+          Yar1 instead binds Rps3 during ribosome biogenesis.
     additional_reference_ids:
     - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
-    supported_by:
-    - reference_id: file:interpro/panther/PTHR24198/PTHR24198-metadata.yaml
-      supporting_text: PTHR24198 is a broad ankyrin repeat domain-containing protein family rather than a Yar1-specific transcription complex family.
 - term:
     id: GO:0033309
     label: SBF transcription complex
@@ -3961,8 +3969,10 @@ existing_annotations:
         source_status: SOURCE_STALE_OR_MISSING
         comment: &gt;-
           The pinned 2018 GOA row traces to this node, but GO:0033309 is absent
-          from the current PTHR24198 PAINT table. Independently, Yar1 lacks the
-          transcription-factor architecture and is an Rps3 chaperone.
+          from the current PTHR24198 PAINT table. Independently, 200-residue,
+          two-ankyrin-repeat Yar1 is not the Swi6/Cdc10-like co-ortholog that
+          carries SBF membership, has no cell-cycle or promoter-association
+          evidence, and instead functions as an Rps3 chaperone.
     additional_reference_ids:
     - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
 - term:
@@ -4068,7 +4078,10 @@ existing_annotations:
   review:
     summary: Yar1 regulates Rps3 localization by keeping Rps3 soluble and escorting it to the nucleus.
     action: ACCEPT
-    reason: The term captures Yar1&#39;s direct effect on Rps3 localization before pre-40S assembly.
+    reason: &gt;-
+      The term is retained as the curator&#39;s experimentally supported framing of
+      Yar1&#39;s direct effect on Rps3 localization before pre-40S assembly; it is
+      not being interpreted as a separate indirect signaling role.
     supported_by:
     - reference_id: PMID:22570489
       supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.
@@ -4156,6 +4169,12 @@ suggested_questions:
 - question: &gt;-
     Should yeast Yar1 annotations explicitly distinguish Rps3 carrier-chaperone
     activity from downstream 40S export phenotypes?
+- question: &gt;-
+    Should PAINT curators revise PTN000917496 so that MBF membership,
+    sequence-specific DNA binding, transcription activation, positive regulation
+    of transcription, and G1/S-transition annotations do not propagate from
+    Swi6/Cdc10- and APSES-like proteins to divergent ankyrin proteins such as
+    Yar1?
 suggested_experiments:
 - description: &gt;-
     Test whether point mutations that disrupt the Yar1-Rps3 interface abolish
@@ -4240,8 +4259,11 @@ references:
   publication_type: DATABASE
   findings:
   - statement: &gt;-
-      PTN000917496 currently carries GO:0001228, GO:0045944, and GO:0030907,
-      while the pinned GO:0033309 SBF-complex assertion is no longer present.
+      PTN000917496 currently carries positive IBD assertions for GO:0005737,
+      GO:0030907, GO:0000978, GO:0001228, GO:0000082, and GO:0045944. The
+      sequence-specific DNA-binding and G1/S-transition assertions were added
+      on 2026-02-24 and can newly propagate to Yar1, while the pinned GO:0033309
+      SBF-complex assertion is no longer present.
 - id: file:yeast/YAR1/YAR1-hypotheses/function-hypothesis-go-0001228/openscientist.md
   title: OpenScientist hypothesis review of YAR1 GO:0001228
   publication_type: DEEP_RESEARCH

--- a/genes/yeast/YAR1/YAR1-ai-review.html
+++ b/genes/yeast/YAR1/YAR1-ai-review.html
@@ -910,9 +910,9 @@
                             <div class="propagation-row">
                                 <strong>Failure modes:</strong>
 
-                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
 
-                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
 
                             </div>
 
@@ -923,7 +923,7 @@
                                 <div class="propagation-row">
                                     <span class="propagation-source-id">PANTHER:PTN000917496</span>
 
-                                    &middot; PANTHER ankyrin-repeat transcription-factor source node
+                                    &middot; PANTHER:PTN000917496
 
 
                                     <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
@@ -1030,6 +1030,8 @@
                             <div class="propagation-row">
                                 <strong>Failure modes:</strong>
 
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
                                 <span class="badge">FUNCTIONAL DIVERGENCE</span>
 
                                 <span class="badge">ROLE CONFLATION</span>
@@ -1043,7 +1045,7 @@
                                 <div class="propagation-row">
                                     <span class="propagation-source-id">PANTHER:PTN000917496</span>
 
-                                    &middot; PANTHER ankyrin-repeat transcription-factor source node
+                                    &middot; PANTHER:PTN000917496
 
 
                                     <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
@@ -1121,6 +1123,8 @@
                             <div class="propagation-row">
                                 <strong>Failure modes:</strong>
 
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
                                 <span class="badge">FUNCTIONAL DIVERGENCE</span>
 
                                 <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
@@ -1134,7 +1138,7 @@
                                 <div class="propagation-row">
                                     <span class="propagation-source-id">PANTHER:PTN000917496</span>
 
-                                    &middot; PANTHER ankyrin-repeat transcription-factor source node
+                                    &middot; PANTHER:PTN000917496
 
 
                                     <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
@@ -1228,6 +1232,8 @@
                             <div class="propagation-row">
                                 <strong>Failure modes:</strong>
 
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
                                 <span class="badge">FUNCTIONAL DIVERGENCE</span>
 
                                 <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
@@ -1241,13 +1247,13 @@
                                 <div class="propagation-row">
                                     <span class="propagation-source-id">PANTHER:PTN000917496</span>
 
-                                    &middot; PANTHER ankyrin-repeat transcription-factor source node
+                                    &middot; PANTHER:PTN000917496
 
 
-                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
 
 
-                                    <div class="propagation-comment">SWI4/SWI6-family source proteins support SBF-related transcription-complex biology, but YAR1 lacks the transcription-factor domain architecture and is an Rps3 chaperone.</div>
+                                    <div class="propagation-comment">The pinned 2018 GOA row traces to this node, but GO:0033309 is absent from the current PTHR24198 PAINT table. Independently, Yar1 lacks the transcription-factor architecture and is an Rps3 chaperone.</div>
 
                                 </div>
 
@@ -2647,6 +2653,29 @@
                 <div class="reference-header">
                     <span class="reference-id">
 
+                        file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Current PAINT annotations for PTHR24198</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PTN000917496 currently carries GO:0001228, GO:0045944, and GO:0030907, while the pinned GO:0033309 SBF-complex assertion is no longer present.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         file:yeast/YAR1/YAR1-hypotheses/function-hypothesis-go-0001228/openscientist.md
 
                     </span>
@@ -3700,6 +3729,105 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(YAR1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P46683" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="yar1-annotation-re-review-notes">YAR1 annotation re-review notes</h1>
+<h2 id="scope-and-reconciliation">Scope and reconciliation</h2>
+<p>Dedicated re-review completed 2026-08-28 against <code>YAR1-goa.tsv</code>, UniProt<br />
+P46683, the Falcon synthesis, all five cached PMID records, the focused<br />
+OpenScientist hypothesis report, and the current PTHR24198 PAINT table. The GOA<br />
+has 19 physical rows and 19 qualifier-aware signatures; all are represented<br />
+one-for-one. All rows are positive, with no NOT or isoform-specific annotations.</p>
+<h2 id="paint-provenance">PAINT provenance</h2>
+<p>All four IBA rows trace to <code>PANTHER:PTN000917496</code> in the very broad ankyrin-<br />
+repeat family PTHR24198. UniProt and PANTHER place Yar1 in PTHR24198:SF165,<br />
+officially <code>ANKYRIN REPEAT-CONTAINING PROTEIN-RELATED</code>; the local membership<br />
+table shows this subfamily also contains highly diverse ankyrin proteins.</p>
+<p>The exact pinned GOA traces are:</p>
+<ul>
+<li>GO:0001228: <code>PANTHER:PTN000917496|PomBase:SPAC22F3.09c|SGD:S000000913|SGD:S000002214</code></li>
+<li>GO:0045944: <code>CGD:CAL0000174900|CGD:CAL0000183437|CGD:CAL0000186541|PANTHER:PTN000917496|PomBase:SPAC22F3.09c|PomBase:SPBC336.12c|PomBase:SPBC725.16|SGD:S000000913|SGD:S000002214|SGD:S000004172|UniProtKB:Q5B8H6</code></li>
+<li>GO:0030907: <code>PANTHER:PTN000917496|PomBase:SPAC22F3.09c|PomBase:SPBC336.12c|PomBase:SPBC725.16|SGD:S000002214|SGD:S000004172</code></li>
+<li>GO:0033309: <code>PANTHER:PTN000917496|SGD:S000000913|SGD:S000004172</code></li>
+</ul>
+<p>The current PAINT table still places GO:0001228, GO:0045944, and GO:0030907 at<br />
+PTN000917496 with the same experimentally grounded transcription-factor source<br />
+sets. Those sources support their own transcription biology but not transfer to<br />
+Yar1, which shares ankyrin repeats without the transcription-factor domain<br />
+architecture. These are <code>PROPAGATION_BAD</code> calls, not weak-source or donor-count<br />
+arguments. The SBF-complex term GO:0033309 is absent from current PAINT, so its<br />
+pinned 2018 row is additionally <code>SOURCE_STALE_OR_MISSING</code>. PTN labels are kept<br />
+as bare <code>PANTHER:PTN000917496</code>.</p>
+<h2 id="experimental-biology">Experimental biology</h2>
+<p>Yar1 is a dedicated chaperone for Rps3. The initial study established the<br />
+specific physical and genetic context: [PMID:15611164, "We provide genetic and<br />
+biochemical evidence that Yar1, a small ankyrin-repeat protein, physically<br />
+interacts with RpS3, a component of the 40S subunit, and with Ltv1, a protein<br />
+recently identified as a substoichiometric component of a 43S preribosomal<br />
+particle."] RPS3 dosage suppresses both major yar1 phenotypes: [PMID:15611164,<br />
+"Overexpression of RPS3 suppresses both the stress sensitivity and the ribosome<br />
+biogenesis defect of Deltayar1 mutants"].</p>
+<p>Focused work directly establishes the carrier/holdase-like mechanism:<br />
+[PMID:22570489, "We further show that Yar1 protects Rps3 from aggregation in<br />
+vitro and increases its solubility in vivo."] The same abstract supports the<br />
+delivery route: [PMID:22570489, "Here, we report that the ankyrin repeat protein<br />
+Yar1 directly interacts with the small ribosomal subunit protein Rps3 and<br />
+accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where<br />
+Rps3 is assembled into pre-ribosomal subunits."]</p>
+<p>Full-text PMID:26112308 independently demonstrates co-translational specificity:<br />
+[PMID:26112308, "Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and<br />
+Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein<br />
+clients (Rpl3, Rpl5, Rpl10 and Rps3)."] The paper describes Yar1 as a holding<br />
+chaperone protecting Rps3 from illicit interactions and aggregation rather than<br />
+a general folding enzyme.</p>
+<h2 id="curation-decisions-and-limitations">Curation decisions and limitations</h2>
+<p>The four transcription-related IBAs are removed because target-specific<br />
+biochemistry and domain architecture contradict transcription-factor or MBF/SBF<br />
+complex roles. This conclusion is independently consistent with the focused<br />
+OpenScientist report, but the report's incorrect PTHR43828/SF10 family identifier<br />
+is not used; the repository's PTHR24198:SF165 membership and current PAINT table<br />
+are authoritative for provenance.</p>
+<p>Both obsolete GO:0051082 <code>unfolded protein binding</code> rows are modified to current<br />
+GO:0140597 <code>protein carrier chaperone</code>. This is not a generic holdase inference:<br />
+Yar1 binds nascent Rps3, prevents aggregation, maintains solubility, and<br />
+accompanies the client toward its assembly site. The protein-binding rows remain<br />
+marked over-annotated because the specific Rps3 carrier-chaperone term is more<br />
+informative.</p>
+<p>The PMID:14562095 cytoplasm HDA is accepted with explicit evidence restraint.<br />
+The cache is abstract-only and lacks the gene-specific localization table, but<br />
+cytoplasmic Yar1 is independently established by direct Rps3-accompaniment work;<br />
+the HDA is therefore biologically concordant rather than removed or treated as<br />
+the sole evidence. PMID:15611164 and PMID:22570489 are also abstract-only in the<br />
+cache, whereas PMID:26112308 and PMID:37968396 have full text. The individual<br />
+Yar1-Rps3 row from the 2023 interactome is in the dataset rather than the cached<br />
+prose, so that reference is recorded as UNVERIFIED for the exact row.</p>
+<p>Osmotic- and oxidative-stress response annotations are kept as non-core mutant<br />
+phenotypes. Ribosomal small-subunit biogenesis, Rps3 localization regulation,<br />
+cytoplasm-to-nucleus distribution, and the downstream 40S export phenotype are<br />
+retained. The core synthesis is the Rps3-specific carrier-chaperone role in 40S<br />
+biogenesis.</p>
+<h2 id="final-action-profile">Final action profile</h2>
+<p>The 19 physical rows have 9 ACCEPT, 4 REMOVE, 2 MODIFY, 2<br />
+MARK_AS_OVER_ANNOTATED, and 2 KEEP_AS_NON_CORE decisions. There are no PENDING,<br />
+UNDECIDED, or NEW rows, and COMPLETE status remains justified.</p>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3743,15 +3871,17 @@ existing_annotations:
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
       - FUNCTIONAL_DIVERGENCE
-      - PSEUDO_OR_SUBACTIVITY_LOSS
       source_entities:
       - source_id: PANTHER:PTN000917496
-        source_label: PANTHER ankyrin-repeat transcription-factor source node
+        source_label: PANTHER:PTN000917496
         source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
         comment: The source node includes APSES-domain transcription factors such
           as SWI4/MBP1; YAR1 shares ankyrin repeats but lacks the DNA-binding
           domain that confers GO:0001228 activity.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
     supported_by:
     - reference_id: PMID:22570489
       supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.
@@ -3771,15 +3901,18 @@ existing_annotations:
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
       - FUNCTIONAL_DIVERGENCE
       - ROLE_CONFLATION
       source_entities:
       - source_id: PANTHER:PTN000917496
-        source_label: PANTHER ankyrin-repeat transcription-factor source node
+        source_label: PANTHER:PTN000917496
         source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
         comment: The source node includes SWI4/MBP1-like transcription
           regulators, but YAR1 lacks the APSES DNA-binding domain and functions
           as an Rps3 carrier chaperone.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
 - term:
     id: GO:0030907
     label: MBF transcription complex
@@ -3792,15 +3925,18 @@ existing_annotations:
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
       - FUNCTIONAL_DIVERGENCE
       - COMPARTMENT_OR_COMPLEX_MISMATCH
       source_entities:
       - source_id: PANTHER:PTN000917496
-        source_label: PANTHER ankyrin-repeat transcription-factor source node
+        source_label: PANTHER:PTN000917496
         source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
         comment: SWI4/MBP1-family source proteins support MBF-related
           transcription-complex biology, but YAR1 is not an MBF component and
           instead binds Rps3 during ribosome biogenesis.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
     supported_by:
     - reference_id: file:interpro/panther/PTHR24198/PTHR24198-metadata.yaml
       supporting_text: PTHR24198 is a broad ankyrin repeat domain-containing protein family rather than a Yar1-specific transcription complex family.
@@ -3816,15 +3952,19 @@ existing_annotations:
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
       - FUNCTIONAL_DIVERGENCE
       - COMPARTMENT_OR_COMPLEX_MISMATCH
       source_entities:
       - source_id: PANTHER:PTN000917496
-        source_label: PANTHER ankyrin-repeat transcription-factor source node
-        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
-        comment: SWI4/SWI6-family source proteins support SBF-related
-          transcription-complex biology, but YAR1 lacks the transcription-factor
-          domain architecture and is an Rps3 chaperone.
+        source_label: PANTHER:PTN000917496
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: &gt;-
+          The pinned 2018 GOA row traces to this node, but GO:0033309 is absent
+          from the current PTHR24198 PAINT table. Independently, Yar1 lacks the
+          transcription-factor architecture and is an Rps3 chaperone.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
 - term:
     id: GO:0005515
     label: protein binding
@@ -4027,18 +4167,57 @@ references:
   findings: []
 - id: PMID:14562095
   title: Global analysis of protein localization in budding yeast.
+  full_text_unavailable: true
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      The cached record is abstract-only and verifies the genome-wide GFP
+      localization study, but it does not expose the Yar1-specific cytoplasm
+      observation. Cytoplasmic Yar1 is independently supported by its direct
+      interaction with newly synthesized Rps3.
   findings: []
 - id: PMID:15611164
   title: Genetic and biochemical interactions among Yar1, Ltv1 and Rps3 define novel links between environmental stress and ribosome biogenesis in Saccharomyces cerevisiae.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed and cached abstract verified. It directly establishes Yar1-Rps3
+      interaction, 40S-biogenesis defects, stress sensitivity, and suppression
+      by RPS3 overexpression.
   findings: []
 - id: PMID:22570489
   title: Yar1 protects the ribosomal protein Rps3 from aggregation.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed and cached abstract verified. It directly supports Rps3-specific
+      aggregation prevention, solubility, cytoplasm-to-nucleus accompaniment,
+      and the downstream 40S export phenotype.
   findings: []
 - id: PMID:26112308
   title: Co-translational capturing of nascent ribosomal proteins by their dedicated chaperones.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text verified. Yar1 selectively enriches RPS3 mRNA and is explicitly
+      described as a dedicated chaperone that protects Rps3 from aggregation.
   findings: []
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
+  reference_review:
+    relevance: LOW
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      Full article verifies the quantitative affinity-enrichment interactome,
+      but the individual Yar1-Rps3 row is present in the dataset rather than in
+      the cached prose. The interaction is independently established by focused
+      studies.
   findings: []
 - id: file:yeast/YAR1/YAR1-goa.tsv
   title: YAR1 GOA annotation snapshot
@@ -4056,6 +4235,13 @@ references:
 - id: file:interpro/panther/PTHR24198/PTHR24198-metadata.yaml
   title: PANTHER family PTHR24198 ankyrin repeat metadata
   findings: []
+- id: file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
+  title: Current PAINT annotations for PTHR24198
+  publication_type: DATABASE
+  findings:
+  - statement: &gt;-
+      PTN000917496 currently carries GO:0001228, GO:0045944, and GO:0030907,
+      while the pinned GO:0033309 SBF-complex assertion is no longer present.
 - id: file:yeast/YAR1/YAR1-hypotheses/function-hypothesis-go-0001228/openscientist.md
   title: OpenScientist hypothesis review of YAR1 GO:0001228
   publication_type: DEEP_RESEARCH

--- a/genes/yeast/YAR1/YAR1-ai-review.yaml
+++ b/genes/yeast/YAR1/YAR1-ai-review.yaml
@@ -33,15 +33,17 @@ existing_annotations:
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
       - FUNCTIONAL_DIVERGENCE
-      - PSEUDO_OR_SUBACTIVITY_LOSS
       source_entities:
       - source_id: PANTHER:PTN000917496
-        source_label: PANTHER ankyrin-repeat transcription-factor source node
+        source_label: PANTHER:PTN000917496
         source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
         comment: The source node includes APSES-domain transcription factors such
           as SWI4/MBP1; YAR1 shares ankyrin repeats but lacks the DNA-binding
           domain that confers GO:0001228 activity.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
     supported_by:
     - reference_id: PMID:22570489
       supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.
@@ -61,15 +63,18 @@ existing_annotations:
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
       - FUNCTIONAL_DIVERGENCE
       - ROLE_CONFLATION
       source_entities:
       - source_id: PANTHER:PTN000917496
-        source_label: PANTHER ankyrin-repeat transcription-factor source node
+        source_label: PANTHER:PTN000917496
         source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
         comment: The source node includes SWI4/MBP1-like transcription
           regulators, but YAR1 lacks the APSES DNA-binding domain and functions
           as an Rps3 carrier chaperone.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
 - term:
     id: GO:0030907
     label: MBF transcription complex
@@ -82,15 +87,18 @@ existing_annotations:
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
       - FUNCTIONAL_DIVERGENCE
       - COMPARTMENT_OR_COMPLEX_MISMATCH
       source_entities:
       - source_id: PANTHER:PTN000917496
-        source_label: PANTHER ankyrin-repeat transcription-factor source node
+        source_label: PANTHER:PTN000917496
         source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
         comment: SWI4/MBP1-family source proteins support MBF-related
           transcription-complex biology, but YAR1 is not an MBF component and
           instead binds Rps3 during ribosome biogenesis.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
     supported_by:
     - reference_id: file:interpro/panther/PTHR24198/PTHR24198-metadata.yaml
       supporting_text: PTHR24198 is a broad ankyrin repeat domain-containing protein family rather than a Yar1-specific transcription complex family.
@@ -106,15 +114,19 @@ existing_annotations:
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
       - FUNCTIONAL_DIVERGENCE
       - COMPARTMENT_OR_COMPLEX_MISMATCH
       source_entities:
       - source_id: PANTHER:PTN000917496
-        source_label: PANTHER ankyrin-repeat transcription-factor source node
-        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
-        comment: SWI4/SWI6-family source proteins support SBF-related
-          transcription-complex biology, but YAR1 lacks the transcription-factor
-          domain architecture and is an Rps3 chaperone.
+        source_label: PANTHER:PTN000917496
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: >-
+          The pinned 2018 GOA row traces to this node, but GO:0033309 is absent
+          from the current PTHR24198 PAINT table. Independently, Yar1 lacks the
+          transcription-factor architecture and is an Rps3 chaperone.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
 - term:
     id: GO:0005515
     label: protein binding
@@ -317,18 +329,57 @@ references:
   findings: []
 - id: PMID:14562095
   title: Global analysis of protein localization in budding yeast.
+  full_text_unavailable: true
+  reference_review:
+    relevance: MEDIUM
+    correctness: UNVERIFIED
+    review_notes: >-
+      The cached record is abstract-only and verifies the genome-wide GFP
+      localization study, but it does not expose the Yar1-specific cytoplasm
+      observation. Cytoplasmic Yar1 is independently supported by its direct
+      interaction with newly synthesized Rps3.
   findings: []
 - id: PMID:15611164
   title: Genetic and biochemical interactions among Yar1, Ltv1 and Rps3 define novel links between environmental stress and ribosome biogenesis in Saccharomyces cerevisiae.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed and cached abstract verified. It directly establishes Yar1-Rps3
+      interaction, 40S-biogenesis defects, stress sensitivity, and suppression
+      by RPS3 overexpression.
   findings: []
 - id: PMID:22570489
   title: Yar1 protects the ribosomal protein Rps3 from aggregation.
+  full_text_unavailable: true
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed and cached abstract verified. It directly supports Rps3-specific
+      aggregation prevention, solubility, cytoplasm-to-nucleus accompaniment,
+      and the downstream 40S export phenotype.
   findings: []
 - id: PMID:26112308
   title: Co-translational capturing of nascent ribosomal proteins by their dedicated chaperones.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Full text verified. Yar1 selectively enriches RPS3 mRNA and is explicitly
+      described as a dedicated chaperone that protects Rps3 from aggregation.
   findings: []
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
+  reference_review:
+    relevance: LOW
+    correctness: UNVERIFIED
+    review_notes: >-
+      Full article verifies the quantitative affinity-enrichment interactome,
+      but the individual Yar1-Rps3 row is present in the dataset rather than in
+      the cached prose. The interaction is independently established by focused
+      studies.
   findings: []
 - id: file:yeast/YAR1/YAR1-goa.tsv
   title: YAR1 GOA annotation snapshot
@@ -346,6 +397,13 @@ references:
 - id: file:interpro/panther/PTHR24198/PTHR24198-metadata.yaml
   title: PANTHER family PTHR24198 ankyrin repeat metadata
   findings: []
+- id: file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
+  title: Current PAINT annotations for PTHR24198
+  publication_type: DATABASE
+  findings:
+  - statement: >-
+      PTN000917496 currently carries GO:0001228, GO:0045944, and GO:0030907,
+      while the pinned GO:0033309 SBF-complex assertion is no longer present.
 - id: file:yeast/YAR1/YAR1-hypotheses/function-hypothesis-go-0001228/openscientist.md
   title: OpenScientist hypothesis review of YAR1 GO:0001228
   publication_type: DEEP_RESEARCH

--- a/genes/yeast/YAR1/YAR1-ai-review.yaml
+++ b/genes/yeast/YAR1/YAR1-ai-review.yaml
@@ -70,9 +70,12 @@ existing_annotations:
       - source_id: PANTHER:PTN000917496
         source_label: PANTHER:PTN000917496
         source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
-        comment: The source node includes SWI4/MBP1-like transcription
-          regulators, but YAR1 lacks the APSES DNA-binding domain and functions
-          as an Rps3 carrier chaperone.
+        comment: >-
+          The source set includes genuine Swi6/Cdc10-like transcription-complex
+          regulators, but Yar1 is a 200-residue protein with only two ankyrin
+          repeats, not the larger Swi6/Cdc10 co-ortholog that carries this role.
+          No Yar1-specific cell-cycle or promoter-association evidence supports
+          transcriptional regulation.
     additional_reference_ids:
     - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
 - term:
@@ -94,14 +97,13 @@ existing_annotations:
       - source_id: PANTHER:PTN000917496
         source_label: PANTHER:PTN000917496
         source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
-        comment: SWI4/MBP1-family source proteins support MBF-related
-          transcription-complex biology, but YAR1 is not an MBF component and
-          instead binds Rps3 during ribosome biogenesis.
+        comment: >-
+          The source set includes bona fide MBF subunits such as Swi6/Cdc10-like
+          proteins, but 200-residue, two-ankyrin-repeat Yar1 is not that
+          co-ortholog and has no cell-cycle or promoter-association evidence.
+          Yar1 instead binds Rps3 during ribosome biogenesis.
     additional_reference_ids:
     - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
-    supported_by:
-    - reference_id: file:interpro/panther/PTHR24198/PTHR24198-metadata.yaml
-      supporting_text: PTHR24198 is a broad ankyrin repeat domain-containing protein family rather than a Yar1-specific transcription complex family.
 - term:
     id: GO:0033309
     label: SBF transcription complex
@@ -123,8 +125,10 @@ existing_annotations:
         source_status: SOURCE_STALE_OR_MISSING
         comment: >-
           The pinned 2018 GOA row traces to this node, but GO:0033309 is absent
-          from the current PTHR24198 PAINT table. Independently, Yar1 lacks the
-          transcription-factor architecture and is an Rps3 chaperone.
+          from the current PTHR24198 PAINT table. Independently, 200-residue,
+          two-ankyrin-repeat Yar1 is not the Swi6/Cdc10-like co-ortholog that
+          carries SBF membership, has no cell-cycle or promoter-association
+          evidence, and instead functions as an Rps3 chaperone.
     additional_reference_ids:
     - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
 - term:
@@ -230,7 +234,10 @@ existing_annotations:
   review:
     summary: Yar1 regulates Rps3 localization by keeping Rps3 soluble and escorting it to the nucleus.
     action: ACCEPT
-    reason: The term captures Yar1's direct effect on Rps3 localization before pre-40S assembly.
+    reason: >-
+      The term is retained as the curator's experimentally supported framing of
+      Yar1's direct effect on Rps3 localization before pre-40S assembly; it is
+      not being interpreted as a separate indirect signaling role.
     supported_by:
     - reference_id: PMID:22570489
       supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.
@@ -318,6 +325,12 @@ suggested_questions:
 - question: >-
     Should yeast Yar1 annotations explicitly distinguish Rps3 carrier-chaperone
     activity from downstream 40S export phenotypes?
+- question: >-
+    Should PAINT curators revise PTN000917496 so that MBF membership,
+    sequence-specific DNA binding, transcription activation, positive regulation
+    of transcription, and G1/S-transition annotations do not propagate from
+    Swi6/Cdc10- and APSES-like proteins to divergent ankyrin proteins such as
+    Yar1?
 suggested_experiments:
 - description: >-
     Test whether point mutations that disrupt the Yar1-Rps3 interface abolish
@@ -402,8 +415,11 @@ references:
   publication_type: DATABASE
   findings:
   - statement: >-
-      PTN000917496 currently carries GO:0001228, GO:0045944, and GO:0030907,
-      while the pinned GO:0033309 SBF-complex assertion is no longer present.
+      PTN000917496 currently carries positive IBD assertions for GO:0005737,
+      GO:0030907, GO:0000978, GO:0001228, GO:0000082, and GO:0045944. The
+      sequence-specific DNA-binding and G1/S-transition assertions were added
+      on 2026-02-24 and can newly propagate to Yar1, while the pinned GO:0033309
+      SBF-complex assertion is no longer present.
 - id: file:yeast/YAR1/YAR1-hypotheses/function-hypothesis-go-0001228/openscientist.md
   title: OpenScientist hypothesis review of YAR1 GO:0001228
   publication_type: DEEP_RESEARCH

--- a/genes/yeast/YAR1/YAR1-notes.md
+++ b/genes/yeast/YAR1/YAR1-notes.md
@@ -1,0 +1,95 @@
+# YAR1 annotation re-review notes
+
+## Scope and reconciliation
+
+Dedicated re-review completed 2026-08-28 against `YAR1-goa.tsv`, UniProt
+P46683, the Falcon synthesis, all five cached PMID records, the focused
+OpenScientist hypothesis report, and the current PTHR24198 PAINT table. The GOA
+has 19 physical rows and 19 qualifier-aware signatures; all are represented
+one-for-one. All rows are positive, with no NOT or isoform-specific annotations.
+
+## PAINT provenance
+
+All four IBA rows trace to `PANTHER:PTN000917496` in the very broad ankyrin-
+repeat family PTHR24198. UniProt and PANTHER place Yar1 in PTHR24198:SF165,
+officially `ANKYRIN REPEAT-CONTAINING PROTEIN-RELATED`; the local membership
+table shows this subfamily also contains highly diverse ankyrin proteins.
+
+The exact pinned GOA traces are:
+
+- GO:0001228: `PANTHER:PTN000917496|PomBase:SPAC22F3.09c|SGD:S000000913|SGD:S000002214`
+- GO:0045944: `CGD:CAL0000174900|CGD:CAL0000183437|CGD:CAL0000186541|PANTHER:PTN000917496|PomBase:SPAC22F3.09c|PomBase:SPBC336.12c|PomBase:SPBC725.16|SGD:S000000913|SGD:S000002214|SGD:S000004172|UniProtKB:Q5B8H6`
+- GO:0030907: `PANTHER:PTN000917496|PomBase:SPAC22F3.09c|PomBase:SPBC336.12c|PomBase:SPBC725.16|SGD:S000002214|SGD:S000004172`
+- GO:0033309: `PANTHER:PTN000917496|SGD:S000000913|SGD:S000004172`
+
+The current PAINT table still places GO:0001228, GO:0045944, and GO:0030907 at
+PTN000917496 with the same experimentally grounded transcription-factor source
+sets. Those sources support their own transcription biology but not transfer to
+Yar1, which shares ankyrin repeats without the transcription-factor domain
+architecture. These are `PROPAGATION_BAD` calls, not weak-source or donor-count
+arguments. The SBF-complex term GO:0033309 is absent from current PAINT, so its
+pinned 2018 row is additionally `SOURCE_STALE_OR_MISSING`. PTN labels are kept
+as bare `PANTHER:PTN000917496`.
+
+## Experimental biology
+
+Yar1 is a dedicated chaperone for Rps3. The initial study established the
+specific physical and genetic context: [PMID:15611164, "We provide genetic and
+biochemical evidence that Yar1, a small ankyrin-repeat protein, physically
+interacts with RpS3, a component of the 40S subunit, and with Ltv1, a protein
+recently identified as a substoichiometric component of a 43S preribosomal
+particle."] RPS3 dosage suppresses both major yar1 phenotypes: [PMID:15611164,
+"Overexpression of RPS3 suppresses both the stress sensitivity and the ribosome
+biogenesis defect of Deltayar1 mutants"].
+
+Focused work directly establishes the carrier/holdase-like mechanism:
+[PMID:22570489, "We further show that Yar1 protects Rps3 from aggregation in
+vitro and increases its solubility in vivo."] The same abstract supports the
+delivery route: [PMID:22570489, "Here, we report that the ankyrin repeat protein
+Yar1 directly interacts with the small ribosomal subunit protein Rps3 and
+accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where
+Rps3 is assembled into pre-ribosomal subunits."]
+
+Full-text PMID:26112308 independently demonstrates co-translational specificity:
+[PMID:26112308, "Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and
+Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein
+clients (Rpl3, Rpl5, Rpl10 and Rps3)."] The paper describes Yar1 as a holding
+chaperone protecting Rps3 from illicit interactions and aggregation rather than
+a general folding enzyme.
+
+## Curation decisions and limitations
+
+The four transcription-related IBAs are removed because target-specific
+biochemistry and domain architecture contradict transcription-factor or MBF/SBF
+complex roles. This conclusion is independently consistent with the focused
+OpenScientist report, but the report's incorrect PTHR43828/SF10 family identifier
+is not used; the repository's PTHR24198:SF165 membership and current PAINT table
+are authoritative for provenance.
+
+Both obsolete GO:0051082 `unfolded protein binding` rows are modified to current
+GO:0140597 `protein carrier chaperone`. This is not a generic holdase inference:
+Yar1 binds nascent Rps3, prevents aggregation, maintains solubility, and
+accompanies the client toward its assembly site. The protein-binding rows remain
+marked over-annotated because the specific Rps3 carrier-chaperone term is more
+informative.
+
+The PMID:14562095 cytoplasm HDA is accepted with explicit evidence restraint.
+The cache is abstract-only and lacks the gene-specific localization table, but
+cytoplasmic Yar1 is independently established by direct Rps3-accompaniment work;
+the HDA is therefore biologically concordant rather than removed or treated as
+the sole evidence. PMID:15611164 and PMID:22570489 are also abstract-only in the
+cache, whereas PMID:26112308 and PMID:37968396 have full text. The individual
+Yar1-Rps3 row from the 2023 interactome is in the dataset rather than the cached
+prose, so that reference is recorded as UNVERIFIED for the exact row.
+
+Osmotic- and oxidative-stress response annotations are kept as non-core mutant
+phenotypes. Ribosomal small-subunit biogenesis, Rps3 localization regulation,
+cytoplasm-to-nucleus distribution, and the downstream 40S export phenotype are
+retained. The core synthesis is the Rps3-specific carrier-chaperone role in 40S
+biogenesis.
+
+## Final action profile
+
+The 19 physical rows have 9 ACCEPT, 4 REMOVE, 2 MODIFY, 2
+MARK_AS_OVER_ANNOTATED, and 2 KEEP_AS_NON_CORE decisions. There are no PENDING,
+UNDECIDED, or NEW rows, and COMPLETE status remains justified.

--- a/genes/yeast/YAR1/YAR1-notes.md
+++ b/genes/yeast/YAR1/YAR1-notes.md
@@ -25,11 +25,21 @@ The exact pinned GOA traces are:
 The current PAINT table still places GO:0001228, GO:0045944, and GO:0030907 at
 PTN000917496 with the same experimentally grounded transcription-factor source
 sets. Those sources support their own transcription biology but not transfer to
-Yar1, which shares ankyrin repeats without the transcription-factor domain
-architecture. These are `PROPAGATION_BAD` calls, not weak-source or donor-count
-arguments. The SBF-complex term GO:0033309 is absent from current PAINT, so its
-pinned 2018 row is additionally `SOURCE_STALE_OR_MISSING`. PTN labels are kept
-as bare `PANTHER:PTN000917496`.
+Yar1. The APSES-domain argument applies specifically to GO:0001228. For MBF,
+SBF, and broader transcription regulation, the donor sets also contain
+Swi6/Cdc10-like ankyrin proteins that genuinely lack APSES domains; Yar1 is not
+their co-ortholog but a much smaller 200-residue protein with only two ankyrin
+repeats, and no Yar1 study reports cell-cycle or promoter-association evidence.
+These are `PROPAGATION_BAD` calls, not weak-source or donor-count arguments. The
+SBF-complex term GO:0033309 is absent from current PAINT, so its pinned 2018 row
+is additionally `SOURCE_STALE_OR_MISSING`. PTN labels are kept as bare
+`PANTHER:PTN000917496`.
+
+The current node also has positive IBD assertions for GO:0000978
+`RNA polymerase II cis-regulatory region sequence-specific DNA binding` and
+GO:0000082 `G1/S transition of mitotic cell cycle`, both dated 2026-02-24. These
+are absent from the pinned YAR1 GOA snapshot but can propagate on refresh, so the
+review raises the broad node placement itself for PAINT-curator reconsideration.
 
 ## Experimental biology
 
@@ -66,7 +76,7 @@ OpenScientist report, but the report's incorrect PTHR43828/SF10 family identifie
 is not used; the repository's PTHR24198:SF165 membership and current PAINT table
 are authoritative for provenance.
 
-Both obsolete GO:0051082 `unfolded protein binding` rows are modified to current
+Both GO:0051082 `unfolded protein binding` rows are modified to the more specific
 GO:0140597 `protein carrier chaperone`. This is not a generic holdase inference:
 Yar1 binds nascent Rps3, prevents aggregation, maintains solubility, and
 accompanies the client toward its assembly site. The protein-binding rows remain


### PR DESCRIPTION
## Summary
- reconcile all 19 qualifier-aware GOA rows for yeast YAR1
- remove four transcription-related IBAs propagated through a broad ankyrin-repeat PAINT node, distinguishing three current assertions from one stale SBF-complex assertion
- replace broad `unfolded protein binding` annotations with the more specific `protein carrier chaperone` term and retain stress phenotypes as non-core
- flag newer DNA-binding and G1/S PAINT assertions that can propagate to YAR1 on refresh
- add literature-backed notes, reference assessments, and regenerated HTML/browser artifacts

## Validation
- `just validate yeast YAR1`
- `just validate-goa yeast YAR1`
- `just render yeast YAR1`
- `just deploy-browser`
- strict duplicate-key YAML parse
- `git diff --check`