### PR TITLE
Use verbatim YAR1 supporting quotes

### DIFF
--- a/genes/yeast/YAR1/YAR1-ai-review.html
+++ b/genes/yeast/YAR1/YAR1-ai-review.html
@@ -951,7 +951,7 @@
 
                                 </span>
 
-                                <div class="support-text">Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.</div>
+                                <div class="support-text">Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where Rps3 is assembled into pre-ribosomal subunits.</div>
 
                             </div>
 
@@ -1765,7 +1765,7 @@
 
                                 </span>
 
-                                <div class="support-text">Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.</div>
+                                <div class="support-text">Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where Rps3 is assembled into pre-ribosomal subunits.</div>
 
                             </div>
 
@@ -1975,7 +1975,7 @@
 
                                 </span>
 
-                                <div class="support-text">Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.</div>
+                                <div class="support-text">Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where Rps3 is assembled into pre-ribosomal subunits.</div>
 
                             </div>
 
@@ -2185,7 +2185,7 @@
 
                                 </span>
 
-                                <div class="support-text">Overexpression of RPS3 suppresses both the stress sensitivity and the ribosome biogenesis defect of Deltayar1.</div>
+                                <div class="support-text">Overexpression of RPS3 suppresses both the stress sensitivity and the ribosome biogenesis defect of Deltayar1 mutants, but does not suppress either defect in Deltaltv1 mutants.</div>
 
                             </div>
 
@@ -2342,7 +2342,7 @@
 
                                 </span>
 
-                                <div class="support-text">Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients.</div>
+                                <div class="support-text">Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients (Rpl3, Rpl5, Rpl10 and Rps3).</div>
 
                             </div>
 
@@ -2458,7 +2458,7 @@
 
                         </span>
 
-                        <div class="finding-text">Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients.</div>
+                        <div class="finding-text">Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients (Rpl3, Rpl5, Rpl10 and Rps3).</div>
 
                     </li>
 
@@ -3890,7 +3890,7 @@ existing_annotations:
     - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
     supported_by:
     - reference_id: PMID:22570489
-      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.
+      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where Rps3 is assembled into pre-ribosomal subunits.
     - reference_id: file:yeast/YAR1/YAR1-hypotheses/function-hypothesis-go-0001228/openscientist.md
       supporting_text: &gt;-
         The GO:0001228 annotation and all associated transcription-related IBA annotations should be
@@ -4051,7 +4051,7 @@ existing_annotations:
     reason: Direct microscopy/biochemical evidence shows Yar1 travels with newly synthesized Rps3 from cytoplasm into the nucleus.
     supported_by:
     - reference_id: PMID:22570489
-      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.
+      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where Rps3 is assembled into pre-ribosomal subunits.
 - term:
     id: GO:0005634
     label: nucleus
@@ -4084,7 +4084,7 @@ existing_annotations:
       not being interpreted as a separate indirect signaling role.
     supported_by:
     - reference_id: PMID:22570489
-      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.
+      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where Rps3 is assembled into pre-ribosomal subunits.
 - term:
     id: GO:0032880
     label: regulation of protein localization
@@ -4114,7 +4114,7 @@ existing_annotations:
     reason: Yar1 acts through Rps3, a 40S subunit protein; yar1 deletion causes ribosome-biogenesis defects that are suppressed by RPS3 overexpression.
     supported_by:
     - reference_id: PMID:15611164
-      supporting_text: Overexpression of RPS3 suppresses both the stress sensitivity and the ribosome biogenesis defect of Deltayar1.
+      supporting_text: Overexpression of RPS3 suppresses both the stress sensitivity and the ribosome biogenesis defect of Deltayar1 mutants, but does not suppress either defect in Deltaltv1 mutants.
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
@@ -4138,7 +4138,7 @@ existing_annotations:
       label: protein carrier chaperone
     supported_by:
     - reference_id: PMID:26112308
-      supporting_text: Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients.
+      supporting_text: Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients (Rpl3, Rpl5, Rpl10 and Rps3).
 core_functions:
 - molecular_function:
     id: GO:0140597
@@ -4161,7 +4161,7 @@ core_functions:
   - reference_id: PMID:22570489
     supporting_text: Yar1 protects Rps3 from aggregation in vitro and increases its solubility in vivo.
   - reference_id: PMID:26112308
-    supporting_text: Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients.
+    supporting_text: Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients (Rpl3, Rpl5, Rpl10 and Rps3).
   - reference_id: file:yeast/YAR1/YAR1-deep-research-falcon.md
     supporting_text: Falcon literature synthesis supports Yar1 as an Rps3-specific ribosomal protein carrier chaperone.
 proposed_new_terms: []

--- a/genes/yeast/YAR1/YAR1-ai-review.yaml
+++ b/genes/yeast/YAR1/YAR1-ai-review.yaml
@@ -46,7 +46,7 @@ existing_annotations:
     - file:interpro/panther/PTHR24198/PTHR24198-paint.tsv
     supported_by:
     - reference_id: PMID:22570489
-      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.
+      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where Rps3 is assembled into pre-ribosomal subunits.
     - reference_id: file:yeast/YAR1/YAR1-hypotheses/function-hypothesis-go-0001228/openscientist.md
       supporting_text: >-
         The GO:0001228 annotation and all associated transcription-related IBA annotations should be
@@ -207,7 +207,7 @@ existing_annotations:
     reason: Direct microscopy/biochemical evidence shows Yar1 travels with newly synthesized Rps3 from cytoplasm into the nucleus.
     supported_by:
     - reference_id: PMID:22570489
-      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.
+      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where Rps3 is assembled into pre-ribosomal subunits.
 - term:
     id: GO:0005634
     label: nucleus
@@ -240,7 +240,7 @@ existing_annotations:
       not being interpreted as a separate indirect signaling role.
     supported_by:
     - reference_id: PMID:22570489
-      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus.
+      supporting_text: Yar1 directly interacts with the small ribosomal subunit protein Rps3 and accompanies newly synthesized Rps3 from the cytoplasm into the nucleus where Rps3 is assembled into pre-ribosomal subunits.
 - term:
     id: GO:0032880
     label: regulation of protein localization
@@ -270,7 +270,7 @@ existing_annotations:
     reason: Yar1 acts through Rps3, a 40S subunit protein; yar1 deletion causes ribosome-biogenesis defects that are suppressed by RPS3 overexpression.
     supported_by:
     - reference_id: PMID:15611164
-      supporting_text: Overexpression of RPS3 suppresses both the stress sensitivity and the ribosome biogenesis defect of Deltayar1.
+      supporting_text: Overexpression of RPS3 suppresses both the stress sensitivity and the ribosome biogenesis defect of Deltayar1 mutants, but does not suppress either defect in Deltaltv1 mutants.
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
@@ -294,7 +294,7 @@ existing_annotations:
       label: protein carrier chaperone
     supported_by:
     - reference_id: PMID:26112308
-      supporting_text: Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients.
+      supporting_text: Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients (Rpl3, Rpl5, Rpl10 and Rps3).
 core_functions:
 - molecular_function:
     id: GO:0140597
@@ -317,7 +317,7 @@ core_functions:
   - reference_id: PMID:22570489
     supporting_text: Yar1 protects Rps3 from aggregation in vitro and increases its solubility in vivo.
   - reference_id: PMID:26112308
-    supporting_text: Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients.
+    supporting_text: Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients (Rpl3, Rpl5, Rpl10 and Rps3).
   - reference_id: file:yeast/YAR1/YAR1-deep-research-falcon.md
     supporting_text: Falcon literature synthesis supports Yar1 as an Rps3-specific ribosomal protein carrier chaperone.
 proposed_new_terms: []


### PR DESCRIPTION
## Summary
- extend six YAR1 `supported_by` excerpts to the complete cached publication sentences
- preserve the scientific claims while making every nested literature quote a strict raw substring
- regenerate the YAR1 HTML page and browser data

## Validation
- `just validate yeast YAR1`
- `just validate-goa yeast YAR1`
- `just render yeast YAR1`
- `just deploy-browser`
- strict raw-substring audit: 0 failures
- strict duplicate-key YAML parse
- `git diff --check`