### PR TITLE
Correct YAR1 obsolete-term rationale

### DIFF
--- a/genes/yeast/YAR1/YAR1-ai-review.html
+++ b/genes/yeast/YAR1/YAR1-ai-review.html
@@ -1433,7 +1433,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Current GO marks GO:0051082 obsolete and recommends replacement by an activity term. Yar1 protects Rps3 from aggregation and keeps it soluble before pre-ribosome incorporation; GO:0140597 captures this specific carrier-chaperone role.
+                            <strong>Reason:</strong> Current GO marks GO:0051082 obsolete and recommends replacement by an activity term, with GO:0044183 and GO:0140309 as generic consider targets. Yar1 protects Rps3 from aggregation and keeps it soluble before pre-ribosome incorporation; the more specific GO:0140597 captures this carrier-chaperone role.
                         </div>
 
 
@@ -1463,17 +1463,6 @@
                                 </span>
 
                                 <div class="support-text">Yar1 protects Rps3 from aggregation in vitro and increases its solubility in vivo.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:yeast/YAR1/YAR1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">Falcon synthesis supports Yar1 as a dedicated Rps3 carrier chaperone rather than a general unfolded-protein binding factor.</div>
 
                             </div>
 
@@ -2313,7 +2302,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Current GO marks GO:0051082 obsolete and recommends replacement by an activity term. GO:0140597 reflects Yar1&#39;s dedicated role in binding and carrying nascent Rps3 to prevent aggregation.
+                            <strong>Reason:</strong> Current GO marks GO:0051082 obsolete and recommends replacement by an activity term, with GO:0044183 and GO:0140309 as generic consider targets. The more specific GO:0140597 reflects Yar1&#39;s dedicated role in binding and carrying nascent Rps3 to prevent aggregation.
                         </div>
 
 
@@ -3806,10 +3795,11 @@ complex roles. This conclusion is independently consistent with the focused<br /
 OpenScientist report, but the report's incorrect PTHR43828/SF10 family identifier<br />
 is not used; the repository's PTHR24198:SF165 membership and current PAINT table<br />
 are authoritative for provenance.</p>
-<p>GO:0051082 <code>unfolded protein binding</code> is obsolete in current GO, whose obsoletion<br />
-comment recommends replacement by an activity term. Both rows are modified to<br />
-the more specific GO:0140597 <code>protein carrier chaperone</code>. This is not a generic<br />
-holdase inference:<br />
+<p>GO:0051082 <code>unfolded protein binding</code> is obsolete in the live GO record checked<br />
+2026-08-28. Its obsoletion comment lists GO:0044183 <code>protein folding chaperone</code><br />
+and GO:0140309 <code>unfolded protein holdase activity</code> as generic consider targets.<br />
+Both Yar1 rows are instead modified to the evidence-matched, more specific<br />
+GO:0140597 <code>protein carrier chaperone</code>. This is not a generic holdase inference:<br />
 Yar1 binds nascent Rps3, prevents aggregation, maintains solubility, and<br />
 accompanies the client toward its assembly site. The protein-binding rows remain<br />
 marked over-annotated because the specific Rps3 carrier-chaperone term is more<br />
@@ -4005,8 +3995,9 @@ existing_annotations:
     action: MODIFY
     reason: &gt;-
       Current GO marks GO:0051082 obsolete and recommends replacement by an
-      activity term. Yar1 protects Rps3 from aggregation and keeps it soluble
-      before pre-ribosome incorporation; GO:0140597 captures this specific
+      activity term, with GO:0044183 and GO:0140309 as generic consider targets.
+      Yar1 protects Rps3 from aggregation and keeps it soluble before
+      pre-ribosome incorporation; the more specific GO:0140597 captures this
       carrier-chaperone role.
     proposed_replacement_terms:
     - id: GO:0140597
@@ -4014,8 +4005,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:22570489
       supporting_text: Yar1 protects Rps3 from aggregation in vitro and increases its solubility in vivo.
-    - reference_id: file:yeast/YAR1/YAR1-deep-research-falcon.md
-      supporting_text: Falcon synthesis supports Yar1 as a dedicated Rps3 carrier chaperone rather than a general unfolded-protein binding factor.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -4140,7 +4129,8 @@ existing_annotations:
     action: MODIFY
     reason: &gt;-
       Current GO marks GO:0051082 obsolete and recommends replacement by an
-      activity term. GO:0140597 reflects Yar1&#39;s dedicated role in binding and
+      activity term, with GO:0044183 and GO:0140309 as generic consider targets.
+      The more specific GO:0140597 reflects Yar1&#39;s dedicated role in binding and
       carrying nascent Rps3 to prevent aggregation.
     proposed_replacement_terms:
     - id: GO:0140597

--- a/genes/yeast/YAR1/YAR1-ai-review.html
+++ b/genes/yeast/YAR1/YAR1-ai-review.html
@@ -1428,12 +1428,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Yar1 acts as a dedicated protein-carrier chaperone for Rps3, so the broader term should be replaced.
+                            <strong>Summary:</strong> GO:0051082 is obsolete; Yar1 acts as a dedicated protein-carrier chaperone for Rps3.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Yar1 protects Rps3 from aggregation and keeps it soluble before pre-ribosome incorporation; GO:0140597 captures this carrier-chaperone role better than generic unfolded-protein binding.
+                            <strong>Reason:</strong> Current GO marks GO:0051082 obsolete and recommends replacement by an activity term. Yar1 protects Rps3 from aggregation and keeps it soluble before pre-ribosome incorporation; GO:0140597 captures this specific carrier-chaperone role.
                         </div>
 
 
@@ -2308,12 +2308,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Yar1&#39;s substrate binding is a specific carrier-chaperone function for Rps3.
+                            <strong>Summary:</strong> GO:0051082 is obsolete; Yar1&#39;s substrate binding is a specific carrier-chaperone function for Rps3.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The replacement term GO:0140597 reflects Yar1&#39;s dedicated role in binding and carrying nascent Rps3 to prevent aggregation.
+                            <strong>Reason:</strong> Current GO marks GO:0051082 obsolete and recommends replacement by an activity term. GO:0140597 reflects Yar1&#39;s dedicated role in binding and carrying nascent Rps3 to prevent aggregation.
                         </div>
 
 
@@ -3806,8 +3806,10 @@ complex roles. This conclusion is independently consistent with the focused<br /
 OpenScientist report, but the report's incorrect PTHR43828/SF10 family identifier<br />
 is not used; the repository's PTHR24198:SF165 membership and current PAINT table<br />
 are authoritative for provenance.</p>
-<p>Both GO:0051082 <code>unfolded protein binding</code> rows are modified to the more specific<br />
-GO:0140597 <code>protein carrier chaperone</code>. This is not a generic holdase inference:<br />
+<p>GO:0051082 <code>unfolded protein binding</code> is obsolete in current GO, whose obsoletion<br />
+comment recommends replacement by an activity term. Both rows are modified to<br />
+the more specific GO:0140597 <code>protein carrier chaperone</code>. This is not a generic<br />
+holdase inference:<br />
 Yar1 binds nascent Rps3, prevents aggregation, maintains solubility, and<br />
 accompanies the client toward its assembly site. The protein-binding rows remain<br />
 marked over-annotated because the specific Rps3 carrier-chaperone term is more<br />
@@ -3999,9 +4001,13 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:26112308
   review:
-    summary: Yar1 acts as a dedicated protein-carrier chaperone for Rps3, so the broader term should be replaced.
+    summary: GO:0051082 is obsolete; Yar1 acts as a dedicated protein-carrier chaperone for Rps3.
     action: MODIFY
-    reason: Yar1 protects Rps3 from aggregation and keeps it soluble before pre-ribosome incorporation; GO:0140597 captures this carrier-chaperone role better than generic unfolded-protein binding.
+    reason: &gt;-
+      Current GO marks GO:0051082 obsolete and recommends replacement by an
+      activity term. Yar1 protects Rps3 from aggregation and keeps it soluble
+      before pre-ribosome incorporation; GO:0140597 captures this specific
+      carrier-chaperone role.
     proposed_replacement_terms:
     - id: GO:0140597
       label: protein carrier chaperone
@@ -4130,9 +4136,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:22570489
   review:
-    summary: Yar1&#39;s substrate binding is a specific carrier-chaperone function for Rps3.
+    summary: GO:0051082 is obsolete; Yar1&#39;s substrate binding is a specific carrier-chaperone function for Rps3.
     action: MODIFY
-    reason: The replacement term GO:0140597 reflects Yar1&#39;s dedicated role in binding and carrying nascent Rps3 to prevent aggregation.
+    reason: &gt;-
+      Current GO marks GO:0051082 obsolete and recommends replacement by an
+      activity term. GO:0140597 reflects Yar1&#39;s dedicated role in binding and
+      carrying nascent Rps3 to prevent aggregation.
     proposed_replacement_terms:
     - id: GO:0140597
       label: protein carrier chaperone

--- a/genes/yeast/YAR1/YAR1-ai-review.yaml
+++ b/genes/yeast/YAR1/YAR1-ai-review.yaml
@@ -155,9 +155,13 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:26112308
   review:
-    summary: Yar1 acts as a dedicated protein-carrier chaperone for Rps3, so the broader term should be replaced.
+    summary: GO:0051082 is obsolete; Yar1 acts as a dedicated protein-carrier chaperone for Rps3.
     action: MODIFY
-    reason: Yar1 protects Rps3 from aggregation and keeps it soluble before pre-ribosome incorporation; GO:0140597 captures this carrier-chaperone role better than generic unfolded-protein binding.
+    reason: >-
+      Current GO marks GO:0051082 obsolete and recommends replacement by an
+      activity term. Yar1 protects Rps3 from aggregation and keeps it soluble
+      before pre-ribosome incorporation; GO:0140597 captures this specific
+      carrier-chaperone role.
     proposed_replacement_terms:
     - id: GO:0140597
       label: protein carrier chaperone
@@ -286,9 +290,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:22570489
   review:
-    summary: Yar1's substrate binding is a specific carrier-chaperone function for Rps3.
+    summary: GO:0051082 is obsolete; Yar1's substrate binding is a specific carrier-chaperone function for Rps3.
     action: MODIFY
-    reason: The replacement term GO:0140597 reflects Yar1's dedicated role in binding and carrying nascent Rps3 to prevent aggregation.
+    reason: >-
+      Current GO marks GO:0051082 obsolete and recommends replacement by an
+      activity term. GO:0140597 reflects Yar1's dedicated role in binding and
+      carrying nascent Rps3 to prevent aggregation.
     proposed_replacement_terms:
     - id: GO:0140597
       label: protein carrier chaperone

--- a/genes/yeast/YAR1/YAR1-ai-review.yaml
+++ b/genes/yeast/YAR1/YAR1-ai-review.yaml
@@ -159,8 +159,9 @@ existing_annotations:
     action: MODIFY
     reason: >-
       Current GO marks GO:0051082 obsolete and recommends replacement by an
-      activity term. Yar1 protects Rps3 from aggregation and keeps it soluble
-      before pre-ribosome incorporation; GO:0140597 captures this specific
+      activity term, with GO:0044183 and GO:0140309 as generic consider targets.
+      Yar1 protects Rps3 from aggregation and keeps it soluble before
+      pre-ribosome incorporation; the more specific GO:0140597 captures this
       carrier-chaperone role.
     proposed_replacement_terms:
     - id: GO:0140597
@@ -168,8 +169,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:22570489
       supporting_text: Yar1 protects Rps3 from aggregation in vitro and increases its solubility in vivo.
-    - reference_id: file:yeast/YAR1/YAR1-deep-research-falcon.md
-      supporting_text: Falcon synthesis supports Yar1 as a dedicated Rps3 carrier chaperone rather than a general unfolded-protein binding factor.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -294,7 +293,8 @@ existing_annotations:
     action: MODIFY
     reason: >-
       Current GO marks GO:0051082 obsolete and recommends replacement by an
-      activity term. GO:0140597 reflects Yar1's dedicated role in binding and
+      activity term, with GO:0044183 and GO:0140309 as generic consider targets.
+      The more specific GO:0140597 reflects Yar1's dedicated role in binding and
       carrying nascent Rps3 to prevent aggregation.
     proposed_replacement_terms:
     - id: GO:0140597

--- a/genes/yeast/YAR1/YAR1-notes.md
+++ b/genes/yeast/YAR1/YAR1-notes.md
@@ -76,10 +76,11 @@ OpenScientist report, but the report's incorrect PTHR43828/SF10 family identifie
 is not used; the repository's PTHR24198:SF165 membership and current PAINT table
 are authoritative for provenance.
 
-GO:0051082 `unfolded protein binding` is obsolete in current GO, whose obsoletion
-comment recommends replacement by an activity term. Both rows are modified to
-the more specific GO:0140597 `protein carrier chaperone`. This is not a generic
-holdase inference:
+GO:0051082 `unfolded protein binding` is obsolete in the live GO record checked
+2026-08-28. Its obsoletion comment lists GO:0044183 `protein folding chaperone`
+and GO:0140309 `unfolded protein holdase activity` as generic consider targets.
+Both Yar1 rows are instead modified to the evidence-matched, more specific
+GO:0140597 `protein carrier chaperone`. This is not a generic holdase inference:
 Yar1 binds nascent Rps3, prevents aggregation, maintains solubility, and
 accompanies the client toward its assembly site. The protein-binding rows remain
 marked over-annotated because the specific Rps3 carrier-chaperone term is more

--- a/genes/yeast/YAR1/YAR1-notes.md
+++ b/genes/yeast/YAR1/YAR1-notes.md
@@ -76,8 +76,10 @@ OpenScientist report, but the report's incorrect PTHR43828/SF10 family identifie
 is not used; the repository's PTHR24198:SF165 membership and current PAINT table
 are authoritative for provenance.
 
-Both GO:0051082 `unfolded protein binding` rows are modified to the more specific
-GO:0140597 `protein carrier chaperone`. This is not a generic holdase inference:
+GO:0051082 `unfolded protein binding` is obsolete in current GO, whose obsoletion
+comment recommends replacement by an activity term. Both rows are modified to
+the more specific GO:0140597 `protein carrier chaperone`. This is not a generic
+holdase inference:
 Yar1 binds nascent Rps3, prevents aggregation, maintains solubility, and
 accompanies the client toward its assembly site. The protein-binding rows remain
 marked over-annotated because the specific Rps3 carrier-chaperone term is more


### PR DESCRIPTION
## Summary
- correct the YAR1 review to state that GO:0051082 `unfolded protein binding` is obsolete in current GO
- retain GO:0140597 `protein carrier chaperone` as the evidence-specific replacement for Yar1
- regenerate the YAR1 HTML page and browser data

The correction follows the current GO obsoletion record, which recommends replacement by an activity term: https://amigo.geneontology.org/amigo/term/GO:0051082

## Validation
- `just validate yeast YAR1`
- `just validate-goa yeast YAR1`
- `just render yeast YAR1`
- `just deploy-browser`
- strict duplicate-key YAML parse
- `git diff --check`