### PR TITLE
Use verbatim YAR1 Falcon support

### DIFF
--- a/genes/yeast/YAR1/YAR1-ai-review.html
+++ b/genes/yeast/YAR1/YAR1-ai-review.html
@@ -2458,7 +2458,7 @@
 
                         </span>
 
-                        <div class="finding-text">Falcon literature synthesis supports Yar1 as an Rps3-specific ribosomal protein carrier chaperone.</div>
+                        <div class="finding-text">Yar1 is **not an enzyme** and no catalytic reaction has been assigned in the cited primary literature; rather, it is best understood as an **anti-aggregation, escort-type chaperone** whose function is implemented by **direct binding** to its client ribosomal protein Rps3 (koch2012yar1protectsthe pages 1-2, koch2012yar1protectsthe pages 2-3).</div>
 
                     </li>
 
@@ -4162,7 +4162,12 @@ core_functions:
   - reference_id: PMID:26112308
     supporting_text: Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients (Rpl3, Rpl5, Rpl10 and Rps3).
   - reference_id: file:yeast/YAR1/YAR1-deep-research-falcon.md
-    supporting_text: Falcon literature synthesis supports Yar1 as an Rps3-specific ribosomal protein carrier chaperone.
+    supporting_text: &gt;-
+      Yar1 is **not an enzyme** and no catalytic reaction has been assigned in
+      the cited primary literature; rather, it is best understood as an
+      **anti-aggregation, escort-type chaperone** whose function is implemented
+      by **direct binding** to its client ribosomal protein Rps3
+      (koch2012yar1protectsthe pages 1-2, koch2012yar1protectsthe pages 2-3).
 proposed_new_terms: []
 suggested_questions:
 - question: &gt;-

--- a/genes/yeast/YAR1/YAR1-ai-review.yaml
+++ b/genes/yeast/YAR1/YAR1-ai-review.yaml
@@ -326,7 +326,12 @@ core_functions:
   - reference_id: PMID:26112308
     supporting_text: Affinity purification of four chaperones (Rrb1, Syo1, Sqt1 and Yar1) selectively enriched the mRNAs encoding their specific ribosomal protein clients (Rpl3, Rpl5, Rpl10 and Rps3).
   - reference_id: file:yeast/YAR1/YAR1-deep-research-falcon.md
-    supporting_text: Falcon literature synthesis supports Yar1 as an Rps3-specific ribosomal protein carrier chaperone.
+    supporting_text: >-
+      Yar1 is **not an enzyme** and no catalytic reaction has been assigned in
+      the cited primary literature; rather, it is best understood as an
+      **anti-aggregation, escort-type chaperone** whose function is implemented
+      by **direct binding** to its client ribosomal protein Rps3
+      (koch2012yar1protectsthe pages 1-2, koch2012yar1protectsthe pages 2-3).
 proposed_new_terms: []
 suggested_questions:
 - question: >-


### PR DESCRIPTION
## Summary
- replace a paraphrased YAR1 core-function `file:` support string with a verbatim passage from the Falcon synthesis
- retain deep-research provenance without leaving a best-practices warning
- regenerate the YAR1 HTML page and browser data

## Validation
- whitespace-normalized verbatim substring assertion for the Falcon passage
- `just validate yeast YAR1`
- `just validate-goa yeast YAR1`
- `just render yeast YAR1`
- `just deploy-browser`
- strict duplicate-key YAML parse
- `git diff --check`