### PR TITLE
Fix gene PANTHER family fetch wrapper

### DIFF
--- a/src/ai_gene_review/tools/fetch_gene_panther_family.py
+++ b/src/ai_gene_review/tools/fetch_gene_panther_family.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Fetch the PANTHER family data associated with a cached gene record."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from ai_gene_review.etl.gene import (
+    _extract_panther_family_id,
+    _fetch_panther_family_data,
+)
+
+
+def find_panther_family(
+    organism: str, gene: str, base_path: Path = Path(".")
+) -> str:
+    """Return the PANTHER family recorded in a gene's cached UniProt file."""
+    uniprot_path = base_path / "genes" / organism / gene / f"{gene}-uniprot.txt"
+    if not uniprot_path.is_file():
+        raise FileNotFoundError(f"UniProt record not found: {uniprot_path}")
+
+    family_id = _extract_panther_family_id(
+        uniprot_path.read_text(encoding="utf-8")
+    )
+    if family_id is None:
+        raise ValueError(f"No PANTHER family found in {uniprot_path}")
+    return family_id
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Resolve the gene's PANTHER family and fetch its InterPro artifacts."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("organism", help="Gene organism directory, e.g. yeast")
+    parser.add_argument("gene", help="Gene symbol, e.g. YDJ1")
+    parser.add_argument(
+        "--base-path",
+        type=Path,
+        default=Path("."),
+        help="Repository root (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        family_id = find_panther_family(args.organism, args.gene, args.base_path)
+    except (FileNotFoundError, ValueError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Found PANTHER family {family_id} for {args.organism}/{args.gene}")
+    if not _fetch_panther_family_data(family_id, args.base_path):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fetch_gene_panther_family.py
+++ b/tests/test_fetch_gene_panther_family.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from ai_gene_review.tools import fetch_gene_panther_family
+
+
+def _write_uniprot(base_path: Path, organism: str, gene: str, text: str) -> None:
+    gene_dir = base_path / "genes" / organism / gene
+    gene_dir.mkdir(parents=True)
+    (gene_dir / f"{gene}-uniprot.txt").write_text(text, encoding="utf-8")
+
+
+def test_find_panther_family_reads_cached_uniprot(tmp_path: Path) -> None:
+    _write_uniprot(
+        tmp_path,
+        "yeast",
+        "YDJ1",
+        "DR   PANTHER; PTHR43888; DNAJ-LIKE-2, ISOFORM A-RELATED; 1.\n",
+    )
+
+    assert (
+        fetch_gene_panther_family.find_panther_family("yeast", "YDJ1", tmp_path)
+        == "PTHR43888"
+    )
+
+
+def test_main_fetches_resolved_family(tmp_path: Path, monkeypatch) -> None:
+    _write_uniprot(
+        tmp_path,
+        "yeast",
+        "YDJ1",
+        "DR   PANTHER; PTHR43888; DNAJ-LIKE-2, ISOFORM A-RELATED; 1.\n",
+    )
+    calls = []
+    monkeypatch.setattr(
+        fetch_gene_panther_family,
+        "_fetch_panther_family_data",
+        lambda family_id, base_path: calls.append((family_id, base_path)) or True,
+    )
+
+    result = fetch_gene_panther_family.main(
+        ["yeast", "YDJ1", "--base-path", str(tmp_path)]
+    )
+
+    assert result == 0
+    assert calls == [("PTHR43888", tmp_path)]
+
+
+def test_main_fails_when_uniprot_record_is_missing(
+    tmp_path: Path, capsys
+) -> None:
+    result = fetch_gene_panther_family.main(
+        ["yeast", "YDJ1", "--base-path", str(tmp_path)]
+    )
+
+    assert result == 1
+    assert "UniProt record not found" in capsys.readouterr().err

--- a/tests/test_fetch_gene_panther_family.py
+++ b/tests/test_fetch_gene_panther_family.py
@@ -30,11 +30,16 @@ def test_main_fetches_resolved_family(tmp_path: Path, monkeypatch) -> None:
         "YDJ1",
         "DR   PANTHER; PTHR43888; DNAJ-LIKE-2, ISOFORM A-RELATED; 1.\n",
     )
-    calls = []
+    calls: list[tuple[str, Path]] = []
+
+    def fake_fetch(family_id: str, base_path: Path) -> bool:
+        calls.append((family_id, base_path))
+        return True
+
     monkeypatch.setattr(
         fetch_gene_panther_family,
         "_fetch_panther_family_data",
-        lambda family_id, base_path: calls.append((family_id, base_path)) or True,
+        fake_fetch,
     )
 
     result = fetch_gene_panther_family.main(


### PR DESCRIPTION
## Summary
- restore the missing implementation used by `just fetch-gene-panther-family`
- resolve the family from the cached gene UniProt record and delegate fetching to the existing InterPro family fetcher
- report missing records/families with nonzero exit status
- add focused unit coverage

## Validation
- `uv run pytest tests/test_fetch_gene_panther_family.py -q`
- `just fetch-gene-panther-family yeast YDJ1`
- `just fetch-panther-paint PTHR43888`
- `git diff --check`