### PR TITLE
Re-review human DNAJC4 annotations

### DIFF
--- a/genes/human/DNAJC4/DNAJC4-ai-review.html
+++ b/genes/human/DNAJC4/DNAJC4-ai-review.html
@@ -959,10 +959,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NNZ3" data-a="GO:0005515" data-r="PMID:17500595" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="Q9NNZ3" data-a="GO:0005515" data-r="PMID:17500595" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -975,7 +975,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Records a real but uninformative high-throughput interaction with huntingtin; per curation guidelines, bare protein binding is not elevated to core and there is no specific informative MF that this single interaction establishes for DNAJC4.
+                            <strong>Reason:</strong> Records a real but uninformative high-throughput interaction with huntingtin; per curation guidelines, bare protein binding overstates functional information, and there is no specific informative MF that this interaction establishes for DNAJC4.
                         </div>
 
 
@@ -1039,10 +1039,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NNZ3" data-a="GO:0005515" data-r="PMID:32814053" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="Q9NNZ3" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1050,12 +1050,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Neurodegeneration-focused interactome screen capturing a DNAJC4-WFS1 (wolframin) interaction. Bare protein binding is uninformative.
+                            <strong>Summary:</strong> Neurodegeneration-focused interactome screen capturing a DNAJC4-WFS1 (wolframin) and DNAJC4-HTT interaction signature. Bare protein binding is uninformative, and the abstract does not identify DNAJC4 individually.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Records a real high-throughput interaction (with WFS1) but is uninformative as a molecular function; not elevated to core.
+                            <strong>Reason:</strong> Retain the interaction provenance, but mark the generic molecular-function assertion as over-annotated because these high-throughput partner detections do not define DNAJC4&#39;s mechanism or establish a specific chaperone activity.
                         </div>
 
 
@@ -1147,11 +1147,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:human/DNAJC4/DNAJC4-uniprot.txt
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9473517" target="_blank" class="term-link">
+                                        PMID:9473517
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">DnaJ-like protein HSPF2</div>
+                                <div class="support-text">We report the characterisation of a human gene, designated MCG18 (multiple endocrine neoplasia type 1 candidate gene 18), that encodes a new member of the DnaJ family of proteins.</div>
 
                             </div>
 
@@ -1227,11 +1229,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:human/DNAJC4/DNAJC4-uniprot.txt
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9473517" target="_blank" class="term-link">
+                                        PMID:9473517
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">Single-pass membrane protein</div>
+                                <div class="support-text">However, MCG18 has greatest similarity to a functionally undefined protein from Caenorhabditis elegans, both of which are predicted to have a membrane-spanning region adjacent to their J domains.</div>
 
                             </div>
 
@@ -1307,11 +1311,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:human/DNAJC4/DNAJC4-uniprot.txt
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9473517" target="_blank" class="term-link">
+                                        PMID:9473517
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">DnaJ-like protein HSPF2</div>
+                                <div class="support-text">The MCG18 cDNA is predicted to encode a 241 amino acid product that has partial homology to Escherichia coli dnaJ in that it contains the J domain.</div>
 
                             </div>
 
@@ -1387,11 +1393,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:human/DNAJC4/DNAJC4-uniprot.txt
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9473517" target="_blank" class="term-link">
+                                        PMID:9473517
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">Single-pass membrane protein</div>
+                                <div class="support-text">However, MCG18 has greatest similarity to a functionally undefined protein from Caenorhabditis elegans, both of which are predicted to have a membrane-spanning region adjacent to their J domains.</div>
 
                             </div>
 
@@ -1406,77 +1414,6 @@
     </div>
 
 
-
-    <div class="section">
-        <h2 class="section-title">Core Functions</h2>
-
-        <div class="core-function-card">
-
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Predicted HSP70 (DnaJ/HSP40) co-chaperone, defined by an N-terminal J domain that in characterized family members engages and stimulates HSP70 chaperones. No direct experimental characterization of DNAJC4&#39;s activity or clients exists, so this is a family-level molecular assignment rather than a verified function.</h3>
-                <span class="vote-buttons" data-g="Q9NNZ3" data-a="FUNCTION: Predicted HSP70 (DnaJ/HSP40) co-chaperone, defined..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-
-
-            <div class="core-function-terms">
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
-                            unfolded protein binding
-                        </a>
-                    </span>
-                </div>
-
-
-
-
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
-                                membrane
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
-
-
-
-
-
-            </div>
-
-
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-
-                    <li class="finding-item">
-                        <span class="reference-id">
-
-                            file:human/DNAJC4/DNAJC4-uniprot.txt
-
-                        </span>
-
-                        <div class="finding-text">DnaJ-like protein HSPF2</div>
-
-                    </li>
-
-                </ul>
-            </div>
-
-        </div>
-
-    </div>
 
 
 
@@ -1689,14 +1626,14 @@
         </p>
 
         <div class="question-card">
-            <p><strong>Gap:</strong> DNAJC4&#39;s HSP70 co-chaperone activity is unverified. It is unresolved whether DNAJC4&#39;s J domain stimulates ATPase activity of a specific HSP70 paralog, what clients it recruits, and whether Hsp70 protein binding (GO:0030544) or unfolded protein binding (GO:0051082) is the better curation target for this family-level prediction.</p>
+            <p><strong>Gap:</strong> DNAJC4&#39;s HSP70 co-chaperone activity is unverified. It is unresolved whether DNAJC4&#39;s J domain stimulates ATPase activity of a specific HSP70 paralog, what clients it recruits, and whether Hsp70 protein binding (GO:0030544) or ATPase activator activity (GO:0001671) can be demonstrated experimentally.</p>
             <p style="margin-top: 0.4rem;">
                 <span class="badge">OPEN</span>
                 <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
                 <span class="badge">MF_DARK</span>
             </p>
 
-            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DNAJC4 has a predicted J domain and is annotated as a DnaJ-like HSPF2 protein, so an HSP70 co-chaperone role is plausible by family. Existing GO process terms for protein folding and unfolded-protein response are inference-level, and the observed HTT/WFS1 protein-binding annotations do not establish a client repertoire or chaperone mechanism.</p>
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DNAJC4 has a predicted J domain and is annotated as a DnaJ-like HSPF2 protein, so an HSP70 co-chaperone role is plausible by family. Existing GO process terms for protein folding and unfolded-protein response are inference-level. The observed HTT/WFS1 interactions do not establish a client repertoire or chaperone mechanism, and neither current GO:0051082 consider term is supported.</p>
 
 
             <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the core dark-function issue for DNAJC4: without direct biochemical evidence, the review can only record a cautious family-level molecular-function prediction rather than a verified HSP70 co-chaperone activity.</p>
@@ -2397,7 +2334,13 @@
 <h2 id="function-status">Function status</h2>
 <ul>
 <li>A J-domain protein, so by family it is an HSP70 (DnaJ/HSP40) co-chaperone, but there is essentially NO direct experimental characterization of its activity. UniProt does not even provide a FUNCTION comment.</li>
-<li>The original cloning paper <a href="https://pubmed.ncbi.nlm.nih.gov/9473517" title="Characterisation of a new human and murine member of the DnaJ family of proteins">PMID:9473517</a> is the basis for the NAS protein-folding and TAS response-to-unfolded-protein / membrane annotations. These are family/inference-level, not demonstrated for DNAJC4 specifically.</li>
+<li>The original cloning paper is available only as a cached abstract. It establishes<br />
+  that MCG18/DNAJC4 contains a J domain and predicts a membrane-spanning region, but<br />
+  reports no folding, unfolded-protein-response, client-binding, HSP70-binding, or<br />
+  ATPase assay [PMID:9473517, "The MCG18 cDNA is predicted to encode a 241 amino acid<br />
+  product that has partial homology to Escherichia coli dnaJ in that it contains the<br />
+  J domain."]. The NAS/TAS process annotations are therefore retained cautiously as<br />
+  non-core family-level assertions, not as demonstrated DNAJC4 activities.</li>
 </ul>
 <h2 id="interactions-goa-intact">Interactions (GOA / IntAct)</h2>
 <ul>
@@ -2407,10 +2350,35 @@
 </ul>
 <h2 id="curation-judgment">Curation judgment</h2>
 <ul>
-<li>Core MF: J-domain co-chaperone presumed to be an HSP70 ATPase activator, but NOT experimentally supported -&gt; cannot assert ATPase activator as a <em>verified</em> core; the only experimentally-supportable molecular role is the J domain unfolded-protein-binding / Hsp70-cochaperone family assignment. Use unfolded protein binding (GO:0051082) cautiously (NAS family-level). Avoid overstating.</li>
+<li>No core molecular function is asserted. GO:0051082 is formally obsolete, and its<br />
+  current consider terms, GO:0044183 protein folding chaperone and GO:0140309<br />
+  unfolded protein holdase activity, require activities that have not been assayed<br />
+  for DNAJC4. A J domain makes HSP70 binding/ATPase stimulation plausible, but neither<br />
+  GO:0030544 nor GO:0001671 is established for this protein. This is an explicit<br />
+  no-term recommendation pending direct biochemical evidence.</li>
 <li>Membrane localization: predicted single-pass TM; reasonable to KEEP_AS_NON_CORE / ACCEPT as predicted.</li>
-<li>protein binding IPI (HTT, WFS1): KEEP_AS_NON_CORE (records real interactions but uninformative; not core).</li>
+<li>Protein binding IPI (HTT, WFS1): MARK_AS_OVER_ANNOTATED because the generic term<br />
+  adds no mechanistic information, while preserving the interaction provenance.</li>
 <li>response to unfolded protein (TAS) and protein folding (NAS): family/inference-level; keep as non-core.</li>
+</ul>
+<h2 id="2026-08-28-dedicated-annotation-re-review">2026-08-28 dedicated annotation re-review</h2>
+<ul>
+<li>The current GOA export has 8 physical rows and 7 exact qualifier-aware<br />
+  signatures: 3 membrane-localization signatures, 2 protein-binding signatures,<br />
+  and 2 process signatures. The PMID:32814053 signature collapses two physical IPI<br />
+  rows with different WITH/FROM partners (WFS1 and HTT). Every signature is reviewed<br />
+  exactly once, with no pending or undecided action.</li>
+<li>DNAJC4 is a member of PANTHER PTHR44825:SF1. The current family cache contains<br />
+  human DNAJC4, mouse Dnajc4, and Drosophila DnaJ-60, but has no PAINT annotation<br />
+  file; GOA contains no IBA row or PTN identifier for DNAJC4. No phylogenetic<br />
+  function was inferred from the family name or its unchecked generated description.</li>
+<li>PMID:17500595 has cached full text and supports a large-scale HTT-interactor<br />
+  screen. PMID:32814053 is abstract-only and describes the network-level screen but<br />
+  does not name DNAJC4 in the abstract. The IPI rows were not rejected; only the<br />
+  uninformative generic <code>protein binding</code> function was marked over-annotated.</li>
+<li>PMID:9473517 is now cached abstract-only, correcting the earlier note that it was<br />
+  unavailable. Its identifier and title are verified, and its evidentiary boundary<br />
+  is recorded explicitly in the review.</li>
 </ul>
             </div>
         </details>
@@ -2563,10 +2531,10 @@ existing_annotations:
     summary: IntAct capture of a DNAJC4-HTT (huntingtin) interaction from a huntingtin-interactor
       screen. The bare protein binding term is uninformative and the partner does
       not define a chaperone function for DNAJC4.
-    action: KEEP_AS_NON_CORE
+    action: MARK_AS_OVER_ANNOTATED
     reason: Records a real but uninformative high-throughput interaction with huntingtin;
-      per curation guidelines, bare protein binding is not elevated to core and there
-      is no specific informative MF that this single interaction establishes for DNAJC4.
+      per curation guidelines, bare protein binding overstates functional information,
+      and there is no specific informative MF that this interaction establishes for DNAJC4.
     supported_by:
     - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
       supporting_text: &#39;Q9NNZ3; P42858: HTT; NbExp=12&#39;
@@ -2578,10 +2546,12 @@ existing_annotations:
   qualifier: enables
   review:
     summary: Neurodegeneration-focused interactome screen capturing a DNAJC4-WFS1
-      (wolframin) interaction. Bare protein binding is uninformative.
-    action: KEEP_AS_NON_CORE
-    reason: Records a real high-throughput interaction (with WFS1) but is uninformative
-      as a molecular function; not elevated to core.
+      (wolframin) and DNAJC4-HTT interaction signature. Bare protein binding is
+      uninformative, and the abstract does not identify DNAJC4 individually.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Retain the interaction provenance, but mark the generic molecular-function
+      assertion as over-annotated because these high-throughput partner detections do
+      not define DNAJC4&#39;s mechanism or establish a specific chaperone activity.
     supported_by:
     - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
       supporting_text: &#39;Q9NNZ3; O76024: WFS1; NbExp=3&#39;
@@ -2599,8 +2569,11 @@ existing_annotations:
     reason: Plausible family-level inference from the DnaJ/HSP40 assignment but not
       experimentally demonstrated for DNAJC4; retained as a non-core process.
     supported_by:
-    - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
-      supporting_text: DnaJ-like protein HSPF2
+    - reference_id: PMID:9473517
+      supporting_text: &gt;-
+        We report the characterisation of a human gene, designated MCG18 (multiple
+        endocrine neoplasia type 1 candidate gene 18), that encodes a new member of the
+        DnaJ family of proteins.
 - term:
     id: GO:0016020
     label: membrane
@@ -2615,8 +2588,11 @@ existing_annotations:
     reason: Agrees with the predicted single-pass transmembrane segment and UniProt
       membrane assignment.
     supported_by:
-    - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
-      supporting_text: Single-pass membrane protein
+    - reference_id: PMID:9473517
+      supporting_text: &gt;-
+        However, MCG18 has greatest similarity to a functionally undefined protein from
+        Caenorhabditis elegans, both of which are predicted to have a membrane-spanning
+        region adjacent to their J domains.
 - term:
     id: GO:0006457
     label: protein folding
@@ -2632,8 +2608,10 @@ existing_annotations:
       J-domain co-chaperones assist; it is a plausible but non-core, inference-level
       annotation for this uncharacterized protein.
     supported_by:
-    - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
-      supporting_text: DnaJ-like protein HSPF2
+    - reference_id: PMID:9473517
+      supporting_text: &gt;-
+        The MCG18 cDNA is predicted to encode a 241 amino acid product that has partial
+        homology to Escherichia coli dnaJ in that it contains the J domain.
 - term:
     id: GO:0016020
     label: membrane
@@ -2647,8 +2625,11 @@ existing_annotations:
     reason: Consistent with the predicted transmembrane helix and UniProt membrane
       assignment.
     supported_by:
-    - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
-      supporting_text: Single-pass membrane protein
+    - reference_id: PMID:9473517
+      supporting_text: &gt;-
+        However, MCG18 has greatest similarity to a functionally undefined protein from
+        Caenorhabditis elegans, both of which are predicted to have a membrane-spanning
+        region adjacent to their J domains.
 references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
@@ -2664,12 +2645,11 @@ references:
   title: Characterisation of a new human and murine member of the DnaJ family of proteins.
   reference_review:
     relevance: HIGH
-    correctness: UNVERIFIED
-    review_notes: &#34;Primary reference establishing DNAJC4/HSPF2 as a new DnaJ/HSP40
-      family member; the family assignment underlies the inferred HSP70 co-chaperone
-      molecular function and membrane localization. Not cached in publications/, so
-      the identifier and supporting content could not be checked against a PubMed/
-      cached anchor; title is consistent with the claim but left UNVERIFIED.&#34;
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Cached abstract verified. It establishes MCG18/DNAJC4 as a J-domain family member
+      and predicts a membrane-spanning region, but reports no DNAJC4-specific folding,
+      unfolded-protein-response, client-binding, HSP70-binding, or ATPase assay.
   findings:
   - statement: DNAJC4/HSPF2 was identified as a new member of the DnaJ/HSP40 family;
       assignment to this family is the basis for its inferred protein-folding/unfolded-protein-response
@@ -2692,33 +2672,19 @@ references:
       and unverified experimentally, and that mitochondrial-branch placement is
       unsupported by the dossier.
     reference_section_type: OTHER
-core_functions:
-- description: Predicted HSP70 (DnaJ/HSP40) co-chaperone, defined by an N-terminal
-    J domain that in characterized family members engages and stimulates HSP70 chaperones.
-    No direct experimental characterization of DNAJC4&#39;s activity or clients exists,
-    so this is a family-level molecular assignment rather than a verified function.
-  molecular_function:
-    id: GO:0051082
-    label: unfolded protein binding
-  locations:
-  - id: GO:0016020
-    label: membrane
-  supported_by:
-  - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
-    supporting_text: DnaJ-like protein HSPF2
+core_functions: []
 knowledge_gaps:
 - gap_statement: &gt;-
     DNAJC4&#39;s HSP70 co-chaperone activity is unverified. It is unresolved whether
     DNAJC4&#39;s J domain stimulates ATPase activity of a specific HSP70 paralog, what
-    clients it recruits, and whether Hsp70 protein binding (GO:0030544) or unfolded
-    protein binding (GO:0051082) is the better curation target for this family-level
-    prediction.
+    clients it recruits, and whether Hsp70 protein binding (GO:0030544) or ATPase
+    activator activity (GO:0001671) can be demonstrated experimentally.
   boundary: &gt;-
     DNAJC4 has a predicted J domain and is annotated as a DnaJ-like HSPF2 protein,
     so an HSP70 co-chaperone role is plausible by family. Existing GO process terms
-    for protein folding and unfolded-protein response are inference-level, and the
-    observed HTT/WFS1 protein-binding annotations do not establish a client
-    repertoire or chaperone mechanism.
+    for protein folding and unfolded-protein response are inference-level. The
+    observed HTT/WFS1 interactions do not establish a client repertoire or chaperone
+    mechanism, and neither current GO:0051082 consider term is supported.
   gap_kind:
   - BIOLOGY
   - ONTOLOGY

--- a/genes/human/DNAJC4/DNAJC4-ai-review.html
+++ b/genes/human/DNAJC4/DNAJC4-ai-review.html
@@ -1075,6 +1075,17 @@
 
                             </div>
 
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DNAJC4/DNAJC4-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Q9NNZ3; P42858: HTT; NbExp=12</div>
+
+                            </div>
+
                         </div>
 
 
@@ -1414,6 +1425,101 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Predicted membrane-associated HSP70 co-chaperone. DNAJC4 contains a canonical J domain with an intact HPD motif, supporting a family/structure-level prediction that it binds an Hsp70-family chaperone. No direct DNAJC4 Hsp70-binding or ATPase- stimulation assay has been reported, so the molecular function and generic membrane location remain predictions rather than biochemically validated properties.</h3>
+                <span class="vote-buttons" data-g="Q9NNZ3" data-a="FUNCTION: Predicted membrane-associated HSP70 co-chaperone. ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
+                            Hsp70 protein binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9473517" target="_blank" class="term-link">
+                                PMID:9473517
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The MCG18 cDNA is predicted to encode a 241 amino acid product that has partial homology to Escherichia coli dnaJ in that it contains the J domain.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/DNAJC4/DNAJC4-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">DOMAIN          34..99</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/DNAJC4/DNAJC4-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">LHPDRDPGNP</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
 
 
 
@@ -2350,12 +2456,14 @@
 </ul>
 <h2 id="curation-judgment">Curation judgment</h2>
 <ul>
-<li>No core molecular function is asserted. GO:0051082 is formally obsolete, and its<br />
+<li>GO:0030544 Hsp70 protein binding is retained as a deliberately hedged core<br />
+  prediction from the canonical J domain and intact HPD motif, consistent with the<br />
+  treatment of similarly uncharacterized J proteins in this repository. It is not a<br />
+  claim of direct biochemical validation [file:human/DNAJC4/DNAJC4-uniprot.txt<br />
+  "LHPDRDPGNP"]. GO:0051082 is formally obsolete, and its<br />
   current consider terms, GO:0044183 protein folding chaperone and GO:0140309<br />
   unfolded protein holdase activity, require activities that have not been assayed<br />
-  for DNAJC4. A J domain makes HSP70 binding/ATPase stimulation plausible, but neither<br />
-  GO:0030544 nor GO:0001671 is established for this protein. This is an explicit<br />
-  no-term recommendation pending direct biochemical evidence.</li>
+  for DNAJC4. GO:0001671 ATPase activator activity also remains unverified.</li>
 <li>Membrane localization: predicted single-pass TM; reasonable to KEEP_AS_NON_CORE / ACCEPT as predicted.</li>
 <li>Protein binding IPI (HTT, WFS1): MARK_AS_OVER_ANNOTATED because the generic term<br />
   adds no mechanistic information, while preserving the interaction provenance.</li>
@@ -2555,6 +2663,8 @@ existing_annotations:
     supported_by:
     - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
       supporting_text: &#39;Q9NNZ3; O76024: WFS1; NbExp=3&#39;
+    - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
+      supporting_text: &#39;Q9NNZ3; P42858: HTT; NbExp=12&#39;
 - term:
     id: GO:0006986
     label: response to unfolded protein
@@ -2672,7 +2782,28 @@ references:
       and unverified experimentally, and that mitochondrial-branch placement is
       unsupported by the dossier.
     reference_section_type: OTHER
-core_functions: []
+core_functions:
+- description: &gt;-
+    Predicted membrane-associated HSP70 co-chaperone. DNAJC4 contains a canonical
+    J domain with an intact HPD motif, supporting a family/structure-level prediction
+    that it binds an Hsp70-family chaperone. No direct DNAJC4 Hsp70-binding or ATPase-
+    stimulation assay has been reported, so the molecular function and generic membrane
+    location remain predictions rather than biochemically validated properties.
+  molecular_function:
+    id: GO:0030544
+    label: Hsp70 protein binding
+  locations:
+  - id: GO:0016020
+    label: membrane
+  supported_by:
+  - reference_id: PMID:9473517
+    supporting_text: &gt;-
+      The MCG18 cDNA is predicted to encode a 241 amino acid product that has partial
+      homology to Escherichia coli dnaJ in that it contains the J domain.
+  - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
+    supporting_text: &#39;DOMAIN          34..99&#39;
+  - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
+    supporting_text: LHPDRDPGNP
 knowledge_gaps:
 - gap_statement: &gt;-
     DNAJC4&#39;s HSP70 co-chaperone activity is unverified. It is unresolved whether

--- a/genes/human/DNAJC4/DNAJC4-ai-review.yaml
+++ b/genes/human/DNAJC4/DNAJC4-ai-review.yaml
@@ -65,6 +65,8 @@ existing_annotations:
     supported_by:
     - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
       supporting_text: 'Q9NNZ3; O76024: WFS1; NbExp=3'
+    - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
+      supporting_text: 'Q9NNZ3; P42858: HTT; NbExp=12'
 - term:
     id: GO:0006986
     label: response to unfolded protein
@@ -182,7 +184,28 @@ references:
       and unverified experimentally, and that mitochondrial-branch placement is
       unsupported by the dossier.
     reference_section_type: OTHER
-core_functions: []
+core_functions:
+- description: >-
+    Predicted membrane-associated HSP70 co-chaperone. DNAJC4 contains a canonical
+    J domain with an intact HPD motif, supporting a family/structure-level prediction
+    that it binds an Hsp70-family chaperone. No direct DNAJC4 Hsp70-binding or ATPase-
+    stimulation assay has been reported, so the molecular function and generic membrane
+    location remain predictions rather than biochemically validated properties.
+  molecular_function:
+    id: GO:0030544
+    label: Hsp70 protein binding
+  locations:
+  - id: GO:0016020
+    label: membrane
+  supported_by:
+  - reference_id: PMID:9473517
+    supporting_text: >-
+      The MCG18 cDNA is predicted to encode a 241 amino acid product that has partial
+      homology to Escherichia coli dnaJ in that it contains the J domain.
+  - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
+    supporting_text: 'DOMAIN          34..99'
+  - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
+    supporting_text: LHPDRDPGNP
 knowledge_gaps:
 - gap_statement: >-
     DNAJC4's HSP70 co-chaperone activity is unverified. It is unresolved whether

--- a/genes/human/DNAJC4/DNAJC4-ai-review.yaml
+++ b/genes/human/DNAJC4/DNAJC4-ai-review.yaml
@@ -41,10 +41,10 @@ existing_annotations:
     summary: IntAct capture of a DNAJC4-HTT (huntingtin) interaction from a huntingtin-interactor
       screen. The bare protein binding term is uninformative and the partner does
       not define a chaperone function for DNAJC4.
-    action: KEEP_AS_NON_CORE
+    action: MARK_AS_OVER_ANNOTATED
     reason: Records a real but uninformative high-throughput interaction with huntingtin;
-      per curation guidelines, bare protein binding is not elevated to core and there
-      is no specific informative MF that this single interaction establishes for DNAJC4.
+      per curation guidelines, bare protein binding overstates functional information,
+      and there is no specific informative MF that this interaction establishes for DNAJC4.
     supported_by:
     - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
       supporting_text: 'Q9NNZ3; P42858: HTT; NbExp=12'
@@ -56,10 +56,12 @@ existing_annotations:
   qualifier: enables
   review:
     summary: Neurodegeneration-focused interactome screen capturing a DNAJC4-WFS1
-      (wolframin) interaction. Bare protein binding is uninformative.
-    action: KEEP_AS_NON_CORE
-    reason: Records a real high-throughput interaction (with WFS1) but is uninformative
-      as a molecular function; not elevated to core.
+      (wolframin) and DNAJC4-HTT interaction signature. Bare protein binding is
+      uninformative, and the abstract does not identify DNAJC4 individually.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Retain the interaction provenance, but mark the generic molecular-function
+      assertion as over-annotated because these high-throughput partner detections do
+      not define DNAJC4's mechanism or establish a specific chaperone activity.
     supported_by:
     - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
       supporting_text: 'Q9NNZ3; O76024: WFS1; NbExp=3'
@@ -77,8 +79,11 @@ existing_annotations:
     reason: Plausible family-level inference from the DnaJ/HSP40 assignment but not
       experimentally demonstrated for DNAJC4; retained as a non-core process.
     supported_by:
-    - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
-      supporting_text: DnaJ-like protein HSPF2
+    - reference_id: PMID:9473517
+      supporting_text: >-
+        We report the characterisation of a human gene, designated MCG18 (multiple
+        endocrine neoplasia type 1 candidate gene 18), that encodes a new member of the
+        DnaJ family of proteins.
 - term:
     id: GO:0016020
     label: membrane
@@ -93,8 +98,11 @@ existing_annotations:
     reason: Agrees with the predicted single-pass transmembrane segment and UniProt
       membrane assignment.
     supported_by:
-    - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
-      supporting_text: Single-pass membrane protein
+    - reference_id: PMID:9473517
+      supporting_text: >-
+        However, MCG18 has greatest similarity to a functionally undefined protein from
+        Caenorhabditis elegans, both of which are predicted to have a membrane-spanning
+        region adjacent to their J domains.
 - term:
     id: GO:0006457
     label: protein folding
@@ -110,8 +118,10 @@ existing_annotations:
       J-domain co-chaperones assist; it is a plausible but non-core, inference-level
       annotation for this uncharacterized protein.
     supported_by:
-    - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
-      supporting_text: DnaJ-like protein HSPF2
+    - reference_id: PMID:9473517
+      supporting_text: >-
+        The MCG18 cDNA is predicted to encode a 241 amino acid product that has partial
+        homology to Escherichia coli dnaJ in that it contains the J domain.
 - term:
     id: GO:0016020
     label: membrane
@@ -125,8 +135,11 @@ existing_annotations:
     reason: Consistent with the predicted transmembrane helix and UniProt membrane
       assignment.
     supported_by:
-    - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
-      supporting_text: Single-pass membrane protein
+    - reference_id: PMID:9473517
+      supporting_text: >-
+        However, MCG18 has greatest similarity to a functionally undefined protein from
+        Caenorhabditis elegans, both of which are predicted to have a membrane-spanning
+        region adjacent to their J domains.
 references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
@@ -142,12 +155,11 @@ references:
   title: Characterisation of a new human and murine member of the DnaJ family of proteins.
   reference_review:
     relevance: HIGH
-    correctness: UNVERIFIED
-    review_notes: "Primary reference establishing DNAJC4/HSPF2 as a new DnaJ/HSP40
-      family member; the family assignment underlies the inferred HSP70 co-chaperone
-      molecular function and membrane localization. Not cached in publications/, so
-      the identifier and supporting content could not be checked against a PubMed/
-      cached anchor; title is consistent with the claim but left UNVERIFIED."
+    correctness: VERIFIED
+    review_notes: >-
+      Cached abstract verified. It establishes MCG18/DNAJC4 as a J-domain family member
+      and predicts a membrane-spanning region, but reports no DNAJC4-specific folding,
+      unfolded-protein-response, client-binding, HSP70-binding, or ATPase assay.
   findings:
   - statement: DNAJC4/HSPF2 was identified as a new member of the DnaJ/HSP40 family;
       assignment to this family is the basis for its inferred protein-folding/unfolded-protein-response
@@ -170,33 +182,19 @@ references:
       and unverified experimentally, and that mitochondrial-branch placement is
       unsupported by the dossier.
     reference_section_type: OTHER
-core_functions:
-- description: Predicted HSP70 (DnaJ/HSP40) co-chaperone, defined by an N-terminal
-    J domain that in characterized family members engages and stimulates HSP70 chaperones.
-    No direct experimental characterization of DNAJC4's activity or clients exists,
-    so this is a family-level molecular assignment rather than a verified function.
-  molecular_function:
-    id: GO:0051082
-    label: unfolded protein binding
-  locations:
-  - id: GO:0016020
-    label: membrane
-  supported_by:
-  - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
-    supporting_text: DnaJ-like protein HSPF2
+core_functions: []
 knowledge_gaps:
 - gap_statement: >-
     DNAJC4's HSP70 co-chaperone activity is unverified. It is unresolved whether
     DNAJC4's J domain stimulates ATPase activity of a specific HSP70 paralog, what
-    clients it recruits, and whether Hsp70 protein binding (GO:0030544) or unfolded
-    protein binding (GO:0051082) is the better curation target for this family-level
-    prediction.
+    clients it recruits, and whether Hsp70 protein binding (GO:0030544) or ATPase
+    activator activity (GO:0001671) can be demonstrated experimentally.
   boundary: >-
     DNAJC4 has a predicted J domain and is annotated as a DnaJ-like HSPF2 protein,
     so an HSP70 co-chaperone role is plausible by family. Existing GO process terms
-    for protein folding and unfolded-protein response are inference-level, and the
-    observed HTT/WFS1 protein-binding annotations do not establish a client
-    repertoire or chaperone mechanism.
+    for protein folding and unfolded-protein response are inference-level. The
+    observed HTT/WFS1 interactions do not establish a client repertoire or chaperone
+    mechanism, and neither current GO:0051082 consider term is supported.
   gap_kind:
   - BIOLOGY
   - ONTOLOGY

--- a/genes/human/DNAJC4/DNAJC4-notes.md
+++ b/genes/human/DNAJC4/DNAJC4-notes.md
@@ -9,7 +9,13 @@
 
 ## Function status
 - A J-domain protein, so by family it is an HSP70 (DnaJ/HSP40) co-chaperone, but there is essentially NO direct experimental characterization of its activity. UniProt does not even provide a FUNCTION comment.
-- The original cloning paper [PMID:9473517 "Characterisation of a new human and murine member of the DnaJ family of proteins"] is the basis for the NAS protein-folding and TAS response-to-unfolded-protein / membrane annotations. These are family/inference-level, not demonstrated for DNAJC4 specifically.
+- The original cloning paper is available only as a cached abstract. It establishes
+  that MCG18/DNAJC4 contains a J domain and predicts a membrane-spanning region, but
+  reports no folding, unfolded-protein-response, client-binding, HSP70-binding, or
+  ATPase assay [PMID:9473517, "The MCG18 cDNA is predicted to encode a 241 amino acid
+  product that has partial homology to Escherichia coli dnaJ in that it contains the
+  J domain."]. The NAS/TAS process annotations are therefore retained cautiously as
+  non-core family-level assertions, not as demonstrated DNAJC4 activities.
 
 ## Interactions (GOA / IntAct)
 - HTT (huntingtin, P42858); NbExp=12 [file:human/DNAJC4/DNAJC4-uniprot.txt "Q9NNZ3; P42858: HTT; NbExp=12"]. From Huntingtin-interactome screens (PMID:17500595 = Kaltenbach et al., HTT interactors).
@@ -17,7 +23,32 @@
 - These are high-throughput / focused interactome screens; "protein binding" (GO:0005515) is uninformative; partners (HTT, WFS1) do not define a chaperone client repertoire.
 
 ## Curation judgment
-- Core MF: J-domain co-chaperone presumed to be an HSP70 ATPase activator, but NOT experimentally supported -> cannot assert ATPase activator as a *verified* core; the only experimentally-supportable molecular role is the J domain unfolded-protein-binding / Hsp70-cochaperone family assignment. Use unfolded protein binding (GO:0051082) cautiously (NAS family-level). Avoid overstating.
+- No core molecular function is asserted. GO:0051082 is formally obsolete, and its
+  current consider terms, GO:0044183 protein folding chaperone and GO:0140309
+  unfolded protein holdase activity, require activities that have not been assayed
+  for DNAJC4. A J domain makes HSP70 binding/ATPase stimulation plausible, but neither
+  GO:0030544 nor GO:0001671 is established for this protein. This is an explicit
+  no-term recommendation pending direct biochemical evidence.
 - Membrane localization: predicted single-pass TM; reasonable to KEEP_AS_NON_CORE / ACCEPT as predicted.
-- protein binding IPI (HTT, WFS1): KEEP_AS_NON_CORE (records real interactions but uninformative; not core).
+- Protein binding IPI (HTT, WFS1): MARK_AS_OVER_ANNOTATED because the generic term
+  adds no mechanistic information, while preserving the interaction provenance.
 - response to unfolded protein (TAS) and protein folding (NAS): family/inference-level; keep as non-core.
+
+## 2026-08-28 dedicated annotation re-review
+
+- The current GOA export has 8 physical rows and 7 exact qualifier-aware
+  signatures: 3 membrane-localization signatures, 2 protein-binding signatures,
+  and 2 process signatures. The PMID:32814053 signature collapses two physical IPI
+  rows with different WITH/FROM partners (WFS1 and HTT). Every signature is reviewed
+  exactly once, with no pending or undecided action.
+- DNAJC4 is a member of PANTHER PTHR44825:SF1. The current family cache contains
+  human DNAJC4, mouse Dnajc4, and Drosophila DnaJ-60, but has no PAINT annotation
+  file; GOA contains no IBA row or PTN identifier for DNAJC4. No phylogenetic
+  function was inferred from the family name or its unchecked generated description.
+- PMID:17500595 has cached full text and supports a large-scale HTT-interactor
+  screen. PMID:32814053 is abstract-only and describes the network-level screen but
+  does not name DNAJC4 in the abstract. The IPI rows were not rejected; only the
+  uninformative generic `protein binding` function was marked over-annotated.
+- PMID:9473517 is now cached abstract-only, correcting the earlier note that it was
+  unavailable. Its identifier and title are verified, and its evidentiary boundary
+  is recorded explicitly in the review.

--- a/genes/human/DNAJC4/DNAJC4-notes.md
+++ b/genes/human/DNAJC4/DNAJC4-notes.md
@@ -23,12 +23,14 @@
 - These are high-throughput / focused interactome screens; "protein binding" (GO:0005515) is uninformative; partners (HTT, WFS1) do not define a chaperone client repertoire.
 
 ## Curation judgment
-- No core molecular function is asserted. GO:0051082 is formally obsolete, and its
+- GO:0030544 Hsp70 protein binding is retained as a deliberately hedged core
+  prediction from the canonical J domain and intact HPD motif, consistent with the
+  treatment of similarly uncharacterized J proteins in this repository. It is not a
+  claim of direct biochemical validation [file:human/DNAJC4/DNAJC4-uniprot.txt
+  "LHPDRDPGNP"]. GO:0051082 is formally obsolete, and its
   current consider terms, GO:0044183 protein folding chaperone and GO:0140309
   unfolded protein holdase activity, require activities that have not been assayed
-  for DNAJC4. A J domain makes HSP70 binding/ATPase stimulation plausible, but neither
-  GO:0030544 nor GO:0001671 is established for this protein. This is an explicit
-  no-term recommendation pending direct biochemical evidence.
+  for DNAJC4. GO:0001671 ATPase activator activity also remains unverified.
 - Membrane localization: predicted single-pass TM; reasonable to KEEP_AS_NON_CORE / ACCEPT as predicted.
 - Protein binding IPI (HTT, WFS1): MARK_AS_OVER_ANNOTATED because the generic term
   adds no mechanistic information, while preserving the interaction provenance.


### PR DESCRIPTION
## Summary
- re-review all seven qualifier-aware DNAJC4 GOA signatures
- remove obsolete GO:0051082 from author-supplied core functions without guessing a replacement
- retain family-level process annotations as non-core and mark generic protein-binding assertions over-annotated
- document the evidence boundary from the cached PMID:9473517 abstract
- regenerate the gene page and browser data

## Validation
- `just validate human DNAJC4` (passes; expected warning: no core functions defined)
- `just validate-goa human DNAJC4`
- `just render human DNAJC4`
- `just deploy-browser`