### PR TITLE
Fix single-module render wrapper path

### DIFF
--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -3066,9 +3066,22 @@ def render_modules(
         typer.echo(f"\nRendered {len(output_paths)} module page(s) to {output_dir}")
     elif files:
         total_warnings = []
-        for module_file in files:
+        had_errors = False
+        for requested_file in files:
+            module_file = requested_file
+            if not module_file.exists() and module_file.parent == Path("."):
+                filename = (
+                    module_file.name
+                    if module_file.suffix == ".yaml"
+                    else f"{module_file.name}.yaml"
+                )
+                candidate = modules_dir / filename
+                if candidate.exists():
+                    module_file = candidate
+
             if not module_file.exists():
-                typer.echo(f"Error: File not found: {module_file}", err=True)
+                typer.echo(f"Error: File not found: {requested_file}", err=True)
+                had_errors = True
                 continue
 
             try:
@@ -3087,9 +3100,12 @@ def render_modules(
                     typer.echo(f"Rendered {module_file} -> {output_path}")
             except Exception as error:
                 typer.echo(f"Error rendering {module_file}: {error}", err=True)
+                had_errors = True
 
         if total_warnings and not verbose:
             typer.echo(f"\n{len(total_warnings)} warnings total (use --verbose to see all)")
+        if had_errors:
+            raise typer.Exit(code=1)
     else:
         typer.echo("Please specify file(s) or use --all to render all modules", err=True)
         raise typer.Exit(code=1)

--- a/tests/test_render_modules_cli.py
+++ b/tests/test_render_modules_cli.py
@@ -1,0 +1,75 @@
+"""CLI tests for rendering individual module documents."""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from ai_gene_review.cli import app
+
+
+runner = CliRunner()
+
+
+def _stub_renderer(monkeypatch, output_dir: Path):
+    rendered: list[Path] = []
+
+    def render_module(module_file: Path, **kwargs):
+        rendered.append(module_file)
+        return output_dir / f"{module_file.stem}.html", []
+
+    monkeypatch.setattr("ai_gene_review.render_modules.render_module", render_module)
+    return rendered
+
+
+def test_render_modules_accepts_module_stem(tmp_path, monkeypatch):
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    module_file = modules_dir / "example.yaml"
+    module_file.write_text("id: MODULE:example\n")
+    output_dir = tmp_path / "output"
+    rendered = _stub_renderer(monkeypatch, output_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "render-modules",
+            "example",
+            "--modules-dir",
+            str(modules_dir),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert rendered == [module_file]
+
+
+def test_render_modules_accepts_full_path(tmp_path, monkeypatch):
+    module_file = tmp_path / "example.yaml"
+    module_file.write_text("id: MODULE:example\n")
+    output_dir = tmp_path / "output"
+    rendered = _stub_renderer(monkeypatch, output_dir)
+
+    result = runner.invoke(
+        app,
+        ["render-modules", str(module_file), "--output-dir", str(output_dir)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert rendered == [module_file]
+
+
+def test_render_modules_missing_file_fails(tmp_path):
+    result = runner.invoke(
+        app,
+        [
+            "render-modules",
+            "missing",
+            "--modules-dir",
+            str(tmp_path / "modules"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Error: File not found: missing" in result.output


### PR DESCRIPTION
## Summary

Fix the public `just render-module <module>` wrapper so its documented stem argument resolves to `modules/<module>.yaml`, matching the `render-modules` CLI contract.

Previously, `just render-module complex_i_assembly_factors` passed the bare stem and always failed with `Error: File not found: complex_i_assembly_factors`.

## Validation

- `just render-module complex_i_assembly_factors` — passed and rendered `pages/modules/complex_i_assembly_factors.html`
- `git diff --check` — passed
