### PR TITLE
Complete PSEPK PP_1084 annotation review

### DIFF
--- a/genes/PSEPK/PP_1084/PP_1084-ai-review.html
+++ b/genes/PSEPK/PP_1084/PP_1084-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -836,6 +836,57 @@
 
 
 
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>holdase chaperone activity</h3>
+                <span class="vote-buttons" data-g="Q88NW9" data-a="holdase chaperone activity" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> Binding to an unfolded or misfolded protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains the client protein in a soluble, folding-competent state.</p>
+
+
+
+            <p><strong>Justification:</strong> Purified PpPrx directly suppresses thermal aggregation of MDH and citrate synthase, while foldase activity was not detected. This is an in-situ holdase activity. The obsolete GO:0051082 lacks a suitable replacement: GO:0044183 implies assistance with folding, and carrier-specific GO:0140309 requires escort to an acceptor or location. A general holdase activity term is therefore required (go-ontology#30552; projects/UNFOLDED_PROTEIN_BINDING.md).</p>
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                    molecular_function
+                </a>
+            </p>
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
+                        PMID:21104173
+                    </a>
+
+
+                    : PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
 
 
 
@@ -2031,10 +2082,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-new">
-                            NEW
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88NW9" data-a="GO:0051082" data-r="PMID:26278368" data-act="NEW">
+                        <span class="vote-buttons" data-g="Q88NW9" data-a="GO:0051082" data-r="PMID:26278368" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2042,15 +2093,26 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PP_1084/PpPrx has experimentally demonstrated molecular chaperone (holdase) activity. In its high-molecular-weight oligomeric state it suppresses thermal aggregation of model substrate proteins, and this chaperone state interconverts with the low-molecular-weight peroxidase-active form under redox control. This dual peroxidase/chaperone function is well documented for this protein but is not captured by any of the existing GOA annotations, so it is proposed as a NEW molecular-function annotation.
+                            <strong>Summary:</strong> This separately reviewed, author-supplied legacy claim is not one of the 13 current GOA signatures. The biology is well supported: purified PpPrx suppresses thermal aggregation of MDH and citrate synthase, the HMW fraction has the stronger chaperone activity, and foldase activity was not detected. GO:0051082 is now formally obsolete, however, and neither official consider target captures this in-situ holdase mechanism.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> An et al. (PMID:26278368, and PMID:21104173) directly show PpPrx (PP_1084) functions as a molecular chaperone in addition to its peroxidase activity, with chaperone activity associated with the HMW oligomeric form. Unfolded protein binding (GO:0051082) is the appropriate molecular-function term for this holdase activity.
+                            <strong>Reason:</strong> Retain GO:0051082 only as an interim obsolete descriptor while requesting a general holdase chaperone activity term. GO:0044183 does not fit because foldase activity was explicitly not detected. GO:0140309 does not fit because its definition requires escort of an unfolded client to an acceptor molecule or location, whereas PpPrx suppresses aggregation in situ. The replacement is therefore an NTR, not an existing GO term (projects/UNFOLDED_PROTEIN_BINDING.md; go-ontology#30552; go-ontology#30962).
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="#" target="_blank" class="term-link">
+                                    holdase chaperone activity
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -2059,26 +2121,26 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26278368" target="_blank" class="term-link">
-                                        PMID:26278368
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
+                                        PMID:21104173
                                     </a>
 
                                 </span>
 
-                                <div class="support-text">PpPrx and PaPrx can alternatively function as a peroxidase and chaperone</div>
+                                <div class="support-text">PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).</div>
 
                             </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26278368" target="_blank" class="term-link">
-                                        PMID:26278368
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
+                                        PMID:21104173
                                     </a>
 
                                 </span>
 
-                                <div class="support-text">PpPrx predominates with a high molecular weight (HMW) complex and</div>
+                                <div class="support-text">The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.</div>
 
                             </div>
 
@@ -2218,8 +2280,8 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Redox-dependent molecular chaperone (holdase) activity. Under oxidative/heat stress PP_1084/PpPrx self-associates into high-molecular-weight oligomeric complexes that suppress aggregation of partially unfolded proteins; this chaperone state interconverts with the low-molecular-weight peroxidase-active form, constituting a redox-controlled peroxidase/chaperone functional switch.</h3>
-                <span class="vote-buttons" data-g="Q88NW9" data-a="FUNCTION: Redox-dependent molecular chaperone (holdase) acti..." data-r="" data-act="CORE_FUNCTION">
+                <h3>Redox-dependent in-situ holdase activity. PpPrx high-molecular-weight oligomers suppress thermal aggregation of model substrates without detectable foldase activity; lower-molecular-weight species have greater peroxidase activity. GO:0051082 is used only as an INTERIM obsolete descriptor pending a general holdase chaperone activity NTR. GO:0140309 is not suitable because no client escort to an acceptor or location was demonstrated, and GO:0044183 is not suitable because foldase activity was absent.</h3>
+                <span class="vote-buttons" data-g="Q88NW9" data-a="FUNCTION: Redox-dependent in-situ holdase activity. PpPrx hi..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -2238,19 +2300,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006979" target="_blank" class="term-link">
-                                response to oxidative stress
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -2281,37 +2330,26 @@
                     <li class="finding-item">
                         <span class="reference-id">
 
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/26278368" target="_blank" class="term-link">
-                                PMID:26278368
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
+                                PMID:21104173
                             </a>
 
                         </span>
 
-                        <div class="finding-text">PpPrx and PaPrx can alternatively function as a peroxidase and chaperone</div>
+                        <div class="finding-text">PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).</div>
 
                     </li>
 
                     <li class="finding-item">
                         <span class="reference-id">
 
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/26278368" target="_blank" class="term-link">
-                                PMID:26278368
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
+                                PMID:21104173
                             </a>
 
                         </span>
 
-                        <div class="finding-text">PpPrx predominates with a high molecular weight (HMW) complex and</div>
-
-                    </li>
-
-                    <li class="finding-item">
-                        <span class="reference-id">
-
-                            file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
-
-                        </span>
-
-                        <div class="finding-text">enriched in **high-molecular-weight (HMW)** oligomeric complexes, demonstrated by suppression of thermal aggregation of model substrates (e.g., malate dehydrogenase), consistent with a</div>
+                        <div class="finding-text">The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.</div>
 
                     </li>
 
@@ -2477,7 +2515,23 @@
                 <ul class="findings-list">
 
                     <li class="finding-item">
-                        <div class="finding-statement">An et al. (2011) directly characterized PP_1084 (PpPrx) of P. putida KT2440 as a typical 2-Cys peroxiredoxin that can act as both a peroxidase and a molecular chaperone; H2O2 exposure converts high-MW chaperone complexes to low-MW peroxidase-active forms, a switch primarily guided by the thioredoxin system.</div>
+                        <div class="finding-statement"></div>
+
+                        <div class="finding-text">"PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown)."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement"></div>
+
+                        <div class="finding-text">"PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement"></div>
+
+                        <div class="finding-text">"The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition. In contrast, the F-2 fraction had more peroxidase activity than the total protein, and the F-1 fraction showed lower peroxidase activity than total protein (Fig.3F)."</div>
 
                     </li>
 
@@ -2504,14 +2558,14 @@
                     <li class="finding-item">
                         <div class="finding-statement"></div>
 
-                        <div class="finding-text">"PpPrx and PaPrx can alternatively function as a peroxidase and chaperone"</div>
+                        <div class="finding-text">"PpPrx and PaPrx can alternatively function as a peroxidase and chaperone."</div>
 
                     </li>
 
                     <li class="finding-item">
                         <div class="finding-statement"></div>
 
-                        <div class="finding-text">"PpPrx predominates with a high molecular weight (HMW) complex and"</div>
+                        <div class="finding-text">"PpPrx predominates with a high molecular weight (HMW) complex and chaperone activity, whereas PaPrx has mainly low molecular weight (LMW) structures and peroxidase activity."</div>
 
                     </li>
 
@@ -3029,6 +3083,82 @@ This cycle is the central biochemical meaning of “thioredoxin peroxidase.” (
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PP_1084-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q88NW9" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pp_1084-tsaa-annotation-audit-notes">PP_1084 / tsaA annotation audit notes</h1>
+<h2 id="2026-08-29-qualifier-aware-re-review">2026-08-29 — qualifier-aware re-review</h2>
+<p>Reviewed <code>PP_1084-goa.tsv</code>, the UniProt Q88NW9 cache, both cached primary<br />
+publications, the Falcon research report, and the current<br />
+<code>projects/UNFOLDED_PROTEIN_BINDING.md</code> policy. The current GOA contains 13<br />
+qualifier-aware signatures: five <code>enables</code>, three <code>located_in</code>, and five<br />
+<code>involved_in</code>. Each is represented exactly once in the YAML. There are no IBA<br />
+annotations. Six IEA rows cite TreeGrafter node <code>PANTHER:PTN002242136</code>, but<br />
+these are TreeGrafter IEA annotations rather than PAINT IBA claims and therefore<br />
+do not receive an IBA propagation review.</p>
+<p>The 13 current rows resolve to 6 ACCEPT, 4 KEEP_AS_NON_CORE, and 3<br />
+MARK_AS_OVER_ANNOTATED. The broad antioxidant activity, oxidoreductase activity,<br />
+and cellular response to stress rows are retained as over-annotations because<br />
+the current GOA already supplies the mechanistically specific peroxiredoxin,<br />
+thioredoxin peroxidase, hydrogen-peroxide catabolism, and oxidant-detoxification<br />
+terms. The self-interaction IPI is retained as non-core: the exact GOA<br />
+WITH/FROM is <code>UniProtKB:Q88NW9</code>, and UniProt records four IntAct self-interaction<br />
+experiments.</p>
+<h2 id="direct-peroxidaseholdase-evidence">Direct peroxidase/holdase evidence</h2>
+<p>PMID:21104173 is cached as full text, not abstract-only. Purified PpPrx reduced<br />
+H2O2 in a thioredoxin-coupled assay and directly suppressed thermal aggregation<br />
+of malate dehydrogenase and citrate synthase. The same paper explicitly reports<br />
+that foldase activity was not detected. It also found substantially greater<br />
+chaperone activity in the HMW fraction and greater peroxidase activity in the<br />
+LMW fraction [PMID:21104173, "PpPrx suppressed the thermal aggregation of the<br />
+model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a<br />
+subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely<br />
+suppressed. PpPrx can also efficiently protect the thermal aggregation of CS<br />
+(Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular<br />
+chaperone. However, foldase activity as another chaperone activity was not<br />
+detected (data not shown)."] [PMID:21104173, "The HMW complex fraction (F-1)<br />
+exhibited high chaperone activity about fivefold compare to LMW fraction (F-2)<br />
+and total protein fraction (Fig.3E), indicating that the chaperone activity of<br />
+PpPrx was significantly affected by the structural composition."]</p>
+<p>PMID:26278368 is abstract-only. Its abstract independently supports that PpPrx<br />
+predominates as an HMW complex with chaperone activity and attributes the<br />
+PpPrx/PaPrx difference to the additional PpPrx cysteine, but assay-level claims<br />
+were anchored to the full-text 2011 study [PMID:26278368, "PpPrx predominates<br />
+with a high molecular weight (HMW) complex and chaperone activity, whereas PaPrx<br />
+has mainly low molecular weight (LMW) structures and peroxidase activity."]</p>
+<h2 id="go0051082-and-ontology-gap">GO:0051082 and ontology gap</h2>
+<p>The author-supplied GO:0051082 claim is not one of the 13 current physical GOA<br />
+rows. It is retained machine-readably as a retired legacy claim and changed from<br />
+NEW to MODIFY toward an NTR. GO:0051082 is formally obsolete. Its two official<br />
+consider targets do not match the direct PpPrx evidence: GO:0044183 protein<br />
+folding chaperone is excluded by the reported absence of foldase activity, and<br />
+GO:0140309 has a carrier-specific definition requiring escort to an acceptor<br />
+molecule or location, which was not demonstrated. The directly supported<br />
+mechanism is aggregation prevention in situ. The review therefore uses<br />
+GO:0051082 only as an explicitly INTERIM core descriptor and proposes the<br />
+project-standard NTR, <strong>holdase chaperone activity</strong>, with the definition in<br />
+<code>projects/UNFOLDED_PROTEIN_BINDING.md</code> (see also go-ontology#30552 and<br />
+go-ontology#30962).</p>
+<p>Evidence is sufficient to mark the one-gene review COMPLETE. Remaining<br />
+uncertainty concerns the in-vivo balance of HMW holdase and LMW peroxidase states<br />
+under physiological stress, not the existence of either biochemical activity.</p>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3040,7 +3170,7 @@ This cycle is the central biochemical meaning of “thioredoxin peroxidase.” (
                 <pre><code>id: Q88NW9
 gene_symbol: tsaA
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:160488
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950 / KT2440)
@@ -3058,6 +3188,7 @@ existing_annotations:
     label: peroxidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: enables
   review:
     summary: Peroxidase activity is correct for this thiol-specific peroxidase, although the peroxiredoxin/thioredoxin peroxidase terms are more informative.
     action: ACCEPT
@@ -3072,6 +3203,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: located_in
   review:
     summary: Cytoplasm is directly supported by the UniProt subcellular-location statement and corroborated by a PSORTb cytoplasmic prediction for KT2440 PP_1084 in the falcon report.
     action: ACCEPT
@@ -3086,6 +3218,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
+  qualifier: located_in
   review:
     summary: Cytosol is compatible with the cytoplasmic location, but it is not the core function. A PSORTb cytoplasmic prediction for KT2440 PP_1084 in the falcon report is consistent with this assignment.
     action: KEEP_AS_NON_CORE
@@ -3100,6 +3233,7 @@ existing_annotations:
     label: response to oxidative stress
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: involved_in
   review:
     summary: Response to oxidative stress is supported but broad relative to direct peroxide detoxification. The falcon report notes the protein was enriched after oxidative treatments (H2O2, gamma rays) in KT2440.
     action: KEEP_AS_NON_CORE
@@ -3116,6 +3250,7 @@ existing_annotations:
     label: thioredoxin peroxidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
+  qualifier: enables
   review:
     summary: Thioredoxin peroxidase activity is the specific catalytic role of TsaA. The falcon report confirms that the directly characterized KT2440 protein (PpPrx) is a thioredoxin-dependent peroxidase assayed with a thioredoxin-coupled system, consistent with this term.
     action: ACCEPT
@@ -3132,6 +3267,7 @@ existing_annotations:
     label: antioxidant activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: Antioxidant activity is true in a broad sense but is less informative than peroxiredoxin and thioredoxin peroxidase activity.
     action: MARK_AS_OVER_ANNOTATED
@@ -3146,6 +3282,7 @@ existing_annotations:
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: Oxidoreductase activity is a broad parent that adds little beyond the specific peroxiredoxin/peroxidase terms.
     action: MARK_AS_OVER_ANNOTATED
@@ -3160,6 +3297,7 @@ existing_annotations:
     label: cellular response to stress
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
+  qualifier: involved_in
   review:
     summary: Cellular response to stress is too broad for an enzyme whose direct role is peroxide reduction.
     action: MARK_AS_OVER_ANNOTATED
@@ -3174,6 +3312,7 @@ existing_annotations:
     label: hydrogen peroxide catabolic process
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
+  qualifier: involved_in
   review:
     summary: Hydrogen peroxide catabolic process is directly supported by the peroxidase reaction described for TsaA. H2O2 is the best-supported, directly assayed substrate for the KT2440 protein per the falcon report.
     action: ACCEPT
@@ -3190,6 +3329,7 @@ existing_annotations:
     label: cell redox homeostasis
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
+  qualifier: involved_in
   review:
     summary: Cell redox homeostasis is consistent with peroxiredoxin function but broader than direct peroxide detoxification. The falcon report notes the thioredoxin system primarily guides the redox-dependent structural/functional switching of PP_1084.
     action: KEEP_AS_NON_CORE
@@ -3206,6 +3346,7 @@ existing_annotations:
     label: peroxiredoxin activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: Peroxiredoxin activity is a specific and supported molecular function for this AhpC/Prx1-family protein. The falcon report confirms the directly studied KT2440 protein PP_1084 (PpPrx) is a 21 kDa AhpC/Tsa-family typical 2-Cys peroxiredoxin, matching the UniProt subfamily assignment.
     action: ACCEPT
@@ -3224,6 +3365,7 @@ existing_annotations:
     label: cellular oxidant detoxification
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: involved_in
   review:
     summary: Cellular oxidant detoxification captures the biological process consequence of peroxide reduction. The falcon report documents that in KT2440 the protein was found among disulfide-bonded proteins enriched after oxidative treatments and detoxifies intracellular peroxides.
     action: ACCEPT
@@ -3240,6 +3382,7 @@ existing_annotations:
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:26278368
+  qualifier: enables
   review:
     summary: Identical protein binding is supported by the IntAct self-interaction record and reflects the homo-oligomerization that is mechanistically central to TsaA/PpPrx function. The falcon report and PMID:26278368 show PP_1084/PpPrx self-associates into high-molecular-weight (HMW, chaperone-active) and low-molecular-weight (LMW, peroxidase-active) forms, so self-association underpins the redox-dependent peroxidase/chaperone switch.
     action: KEEP_AS_NON_CORE
@@ -3256,15 +3399,36 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:26278368
+  retired: true
+  qualifier: enables
   review:
-    summary: PP_1084/PpPrx has experimentally demonstrated molecular chaperone (holdase) activity. In its high-molecular-weight oligomeric state it suppresses thermal aggregation of model substrate proteins, and this chaperone state interconverts with the low-molecular-weight peroxidase-active form under redox control. This dual peroxidase/chaperone function is well documented for this protein but is not captured by any of the existing GOA annotations, so it is proposed as a NEW molecular-function annotation.
-    action: NEW
-    reason: An et al. (PMID:26278368, and PMID:21104173) directly show PpPrx (PP_1084) functions as a molecular chaperone in addition to its peroxidase activity, with chaperone activity associated with the HMW oligomeric form. Unfolded protein binding (GO:0051082) is the appropriate molecular-function term for this holdase activity.
+    summary: &gt;-
+      This separately reviewed, author-supplied legacy claim is not one of the 13 current
+      GOA signatures. The biology is well supported: purified PpPrx suppresses thermal
+      aggregation of MDH and citrate synthase, the HMW fraction has the stronger chaperone
+      activity, and foldase activity was not detected. GO:0051082 is now formally obsolete,
+      however, and neither official consider target captures this in-situ holdase mechanism.
+    action: MODIFY
+    reason: &gt;-
+      Retain GO:0051082 only as an interim obsolete descriptor while requesting a general
+      holdase chaperone activity term. GO:0044183 does not fit because foldase activity was
+      explicitly not detected. GO:0140309 does not fit because its definition requires
+      escort of an unfolded client to an acceptor molecule or location, whereas PpPrx
+      suppresses aggregation in situ. The replacement is therefore an NTR, not an existing GO
+      term (projects/UNFOLDED_PROTEIN_BINDING.md; go-ontology#30552; go-ontology#30962).
+    proposed_replacement_terms:
+    - id: NTR
+      label: holdase chaperone activity
+    additional_reference_ids:
+    - go-ontology#30552
+    - go-ontology#30962
     supported_by:
-    - reference_id: PMID:26278368
-      supporting_text: PpPrx and PaPrx can alternatively function as a peroxidase and chaperone
-    - reference_id: PMID:26278368
-      supporting_text: PpPrx predominates with a high molecular weight (HMW) complex and
+    - reference_id: PMID:21104173
+      supporting_text: &gt;-
+        PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
+    - reference_id: PMID:21104173
+      supporting_text: &gt;-
+        The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -3289,15 +3453,37 @@ references:
   - supporting_text: &#39;Belongs to the peroxiredoxin family. AhpC/Prx1 subfamily&#39;
 - id: PMID:21104173
   title: Functional switching of a novel prokaryotic 2-Cys peroxiredoxin (PpPrx) under oxidative stress
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text is cached. This direct KT2440 PpPrx study establishes peroxidase
+      activity, aggregation suppression without foldase activity, oligomer-state
+      dependence, and thioredoxin-controlled functional switching.
   findings:
-  - statement: An et al. (2011) directly characterized PP_1084 (PpPrx) of P. putida KT2440 as a typical 2-Cys peroxiredoxin that can act as both a peroxidase and a molecular chaperone; H2O2 exposure converts high-MW chaperone complexes to low-MW peroxidase-active forms, a switch primarily guided by the thioredoxin system.
-    full_text_unavailable: true
+  - supporting_text: &gt;-
+      PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
+    reference_section_type: RESULTS
+  - supporting_text: &gt;-
+      PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.
+    reference_section_type: RESULTS
+  - supporting_text: &gt;-
+      The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition. In contrast, the F-2 fraction had more peroxidase activity than the total protein, and the F-1 fraction showed lower peroxidase activity than total protein (Fig.3F).
+    reference_section_type: RESULTS
 - id: PMID:26278368
   title: &#34;An additional cysteine in a typical 2-Cys peroxiredoxin of Pseudomonas promotes functional switching between peroxidase and molecular chaperone.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache. The abstract directly supports PpPrx HMW-complex/chaperone
+      activity and Cys112-dependent functional switching; assay-level interpretation is
+      anchored to the full-text PMID:21104173 study.
   findings:
-  - supporting_text: PpPrx and PaPrx can alternatively function as a peroxidase and chaperone
+  - supporting_text: PpPrx and PaPrx can alternatively function as a peroxidase and chaperone.
     reference_section_type: ABSTRACT
-  - supporting_text: PpPrx predominates with a high molecular weight (HMW) complex and
+  - supporting_text: &gt;-
+      PpPrx predominates with a high molecular weight (HMW) complex and chaperone activity, whereas PaPrx has mainly low molecular weight (LMW) structures and peroxidase activity.
     reference_section_type: ABSTRACT
 - id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
   title: Falcon deep-research report on tsaA / PP_1084 (UniProt Q88NW9)
@@ -3332,24 +3518,44 @@ core_functions:
     supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
   - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
     supporting_text: The best-supported primary substrate in KT2440 experiments is **H2O2**, with broader substrate scope (e.g., organic hydroperoxides, peroxynitrite) supported by strong family-level evidence for typical 2-Cys peroxiredoxins
-- description: Redox-dependent molecular chaperone (holdase) activity. Under oxidative/heat stress PP_1084/PpPrx self-associates into high-molecular-weight oligomeric complexes that suppress aggregation of partially unfolded proteins; this chaperone state interconverts with the low-molecular-weight peroxidase-active form, constituting a redox-controlled peroxidase/chaperone functional switch.
+- description: &gt;-
+    Redox-dependent in-situ holdase activity. PpPrx high-molecular-weight oligomers
+    suppress thermal aggregation of model substrates without detectable foldase activity;
+    lower-molecular-weight species have greater peroxidase activity. GO:0051082 is used
+    only as an INTERIM obsolete descriptor pending a general holdase chaperone activity
+    NTR. GO:0140309 is not suitable because no client escort to an acceptor or location
+    was demonstrated, and GO:0044183 is not suitable because foldase activity was absent.
   molecular_function:
     id: GO:0051082
     label: unfolded protein binding
-  directly_involved_in:
-  - id: GO:0006979
-    label: response to oxidative stress
   locations:
   - id: GO:0005737
     label: cytoplasm
   supported_by:
-  - reference_id: PMID:26278368
-    supporting_text: PpPrx and PaPrx can alternatively function as a peroxidase and chaperone
-  - reference_id: PMID:26278368
-    supporting_text: PpPrx predominates with a high molecular weight (HMW) complex and
-  - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
-    supporting_text: enriched in **high-molecular-weight (HMW)** oligomeric complexes, demonstrated by suppression of thermal aggregation of model substrates (e.g., malate dehydrogenase), consistent with a
-proposed_new_terms: []
+  - reference_id: PMID:21104173
+    supporting_text: &gt;-
+      PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
+  - reference_id: PMID:21104173
+    supporting_text: &gt;-
+      The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.
+proposed_new_terms:
+- proposed_name: holdase chaperone activity
+  proposed_definition: &gt;-
+    Binding to an unfolded or misfolded protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains the client protein in a soluble, folding-competent state.
+  justification: &gt;-
+    Purified PpPrx directly suppresses thermal aggregation of MDH and citrate synthase,
+    while foldase activity was not detected. This is an in-situ holdase activity. The
+    obsolete GO:0051082 lacks a suitable replacement: GO:0044183 implies assistance with
+    folding, and carrier-specific GO:0140309 requires escort to an acceptor or location.
+    A general holdase activity term is therefore required (go-ontology#30552;
+    projects/UNFOLDED_PROTEIN_BINDING.md).
+  proposed_parent:
+    id: GO:0003674
+    label: molecular_function
+  supported_by:
+  - reference_id: PMID:21104173
+    supporting_text: &gt;-
+      PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
 suggested_questions:
 - question: Under which physiological oxidative-stress conditions in KT2440 does TsaA/PpPrx shift between the HMW chaperone-active and LMW peroxidase-active oligomeric states, and what is the in vivo balance of these two functions?
   experts:

--- a/genes/PSEPK/PP_1084/PP_1084-ai-review.html
+++ b/genes/PSEPK/PP_1084/PP_1084-ai-review.html
@@ -825,12 +825,12 @@
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q88NW9" data-a="DESCRIPTION: tsaA (locus PP_1084) encodes a cytoplasmic AhpC/Pr..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q88NW9" data-a="DESCRIPTION: tsaA (locus PP_1084) encodes the cytoplasmic AhpC/..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>tsaA (locus PP_1084) encodes a cytoplasmic AhpC/Prx1-family (typical 2-Cys) thioredoxin peroxidase/peroxiredoxin (PpPrx). Its core role is thioredoxin-dependent reduction and detoxification of hydrogen peroxide (and, by subfamily inference, organic hydroperoxides), contributing to cellular oxidant detoxification and redox stress protection in KT2440. The directly studied KT2440 protein additionally displays a redox-dependent molecular chaperone (holdase) activity; it self-associates into high-molecular-weight oligomers that suppress protein aggregation, and oxidative conditions drive a structural switch toward low-molecular-weight peroxidase-active forms, constituting a peroxidase/chaperone functional switch (PMID:21104173, PMID:26278368).</p>
+        <p>tsaA (locus PP_1084) encodes the cytoplasmic AhpC/Prx1-family typical 2-Cys peroxiredoxin PpPrx, with two directly supported biochemical states. Its thioredoxin-dependent low-molecular-weight state reduces hydrogen peroxide, while high-molecular-weight oligomers act as in-situ holdases that suppress protein aggregation without detectable foldase activity. In direct comparisons, purified PpPrx had relatively low H2O2 peroxidase activity, substantially greater chaperone activity than the yeast peroxiredoxin control, and predominantly formed the HMW chaperone-associated complex. These measurements establish a redox-regulated peroxidase/holdase switch but do not by themselves rank the two activities under physiological KT2440 growth conditions (PMID:21104173; PMID:26278368).</p>
     </div>
 
 
@@ -974,6 +974,19 @@
                                 </span>
 
                                 <div class="support-text">Plays a role in cell protection against oxidative stress</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
+                                        PMID:21104173
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.</div>
 
                             </div>
 
@@ -1319,6 +1332,19 @@
 
                             </div>
 
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
+                                        PMID:21104173
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.</div>
+
+                            </div>
+
                         </div>
 
 
@@ -1647,6 +1673,19 @@
                                 </span>
 
                                 <div class="support-text">The best-supported primary substrate in KT2440 experiments is **H2O2**, with broader substrate scope (e.g., organic hydroperoxides, peroxynitrite) supported by strong family-level evidence for typical 2-Cys peroxiredoxins</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
+                                        PMID:21104173
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.</div>
 
                             </div>
 
@@ -2044,112 +2083,6 @@
                     </td>
                 </tr>
 
-                <tr>
-                    <td>
-                        <div class="term-info">
-
-                            <span class="term-id">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
-                                    GO:0051082
-                                </a>
-                            </span>
-                            <span class="term-label">unfolded protein binding</span>
-
-                        </div>
-                    </td>
-                    <td>
-                        <span class="evidence-code">IDA</span>
-
-
-
-                        <br>
-                        <span style="font-size: 0.75rem;">
-
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/26278368" target="_blank" class="term-link" style="font-size: 0.75rem;">
-                                PMID:26278368
-                            </a>
-
-
-
-                                <br>
-                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
-                                    An additional cysteine in a typical 2-Cys peroxiredoxin of P...
-                                </span>
-
-
-
-                        </span>
-
-                    </td>
-                    <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
-                        </span>
-                        <span class="vote-buttons" data-g="Q88NW9" data-a="GO:0051082" data-r="PMID:26278368" data-act="MODIFY">
-                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
-                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
-                        </span>
-                    </td>
-                    <td>
-
-                        <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This separately reviewed, author-supplied legacy claim is not one of the 13 current GOA signatures. The biology is well supported: purified PpPrx suppresses thermal aggregation of MDH and citrate synthase, the HMW fraction has the stronger chaperone activity, and foldase activity was not detected. GO:0051082 is now formally obsolete, however, and neither official consider target captures this in-situ holdase mechanism.
-                        </div>
-
-
-                        <div>
-                            <strong>Reason:</strong> Retain GO:0051082 only as an interim obsolete descriptor while requesting a general holdase chaperone activity term. GO:0044183 does not fit because foldase activity was explicitly not detected. GO:0140309 does not fit because its definition requires escort of an unfolded client to an acceptor molecule or location, whereas PpPrx suppresses aggregation in situ. The replacement is therefore an NTR, not an existing GO term (projects/UNFOLDED_PROTEIN_BINDING.md; go-ontology#30552; go-ontology#30962).
-                        </div>
-
-
-
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-
-                            <span class="badge">
-                                <a href="#" target="_blank" class="term-link">
-                                    holdase chaperone activity
-                                </a>
-                            </span>
-
-                        </div>
-
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
-                                        PMID:21104173
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
-                                        PMID:21104173
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.</div>
-
-                            </div>
-
-                        </div>
-
-
-                    </td>
-                </tr>
-
             </tbody>
         </table>
     </div>
@@ -2162,125 +2095,7 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Cytoplasmic thioredoxin peroxidase/peroxiredoxin that reduces hydrogen peroxide and organic hydroperoxides to protect cells from oxidative stress.</h3>
-                <span class="vote-buttons" data-g="Q88NW9" data-a="FUNCTION: Cytoplasmic thioredoxin peroxidase/peroxiredoxin t..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-
-
-            <div class="core-function-terms">
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008379" target="_blank" class="term-link">
-                            thioredoxin peroxidase activity
-                        </a>
-                    </span>
-                </div>
-
-
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042744" target="_blank" class="term-link">
-                                hydrogen peroxide catabolic process
-                            </a>
-                        </span>
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098869" target="_blank" class="term-link">
-                                cellular oxidant detoxification
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
-
-
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
-                                cytoplasm
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
-
-
-
-
-
-            </div>
-
-
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-
-                    <li class="finding-item">
-                        <span class="reference-id">
-
-                            file:PSEPK/PP_1084/PP_1084-uniprot.txt
-
-                        </span>
-
-                        <div class="finding-text">Thiol-specific peroxidase that catalyzes the reduction of</div>
-
-                    </li>
-
-                    <li class="finding-item">
-                        <span class="reference-id">
-
-                            file:PSEPK/PP_1084/PP_1084-uniprot.txt
-
-                        </span>
-
-                        <div class="finding-text">Plays a role in cell protection against oxidative stress</div>
-
-                    </li>
-
-                    <li class="finding-item">
-                        <span class="reference-id">
-
-                            file:PSEPK/PP_1084/PP_1084-uniprot.txt
-
-                        </span>
-
-                        <div class="finding-text">SUBCELLULAR LOCATION: Cytoplasm</div>
-
-                    </li>
-
-                    <li class="finding-item">
-                        <span class="reference-id">
-
-                            file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
-
-                        </span>
-
-                        <div class="finding-text">The best-supported primary substrate in KT2440 experiments is **H2O2**, with broader substrate scope (e.g., organic hydroperoxides, peroxynitrite) supported by strong family-level evidence for typical 2-Cys peroxiredoxins</div>
-
-                    </li>
-
-                </ul>
-            </div>
-
-        </div>
-
-        <div class="core-function-card">
-
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Redox-dependent in-situ holdase activity. PpPrx high-molecular-weight oligomers suppress thermal aggregation of model substrates without detectable foldase activity; lower-molecular-weight species have greater peroxidase activity. GO:0051082 is used only as an INTERIM obsolete descriptor pending a general holdase chaperone activity NTR. GO:0140309 is not suitable because no client escort to an acceptor or location was demonstrated, and GO:0044183 is not suitable because foldase activity was absent.</h3>
+                <h3>Redox-dependent in-situ holdase activity. PpPrx high-molecular-weight oligomers suppress thermal aggregation of malate dehydrogenase and citrate synthase without detectable foldase activity. The HMW fraction has substantially greater chaperone activity than the LMW fraction. GO:0051082 is used only as an INTERIM obsolete descriptor pending creation of the proposed general holdase chaperone activity term.</h3>
                 <span class="vote-buttons" data-g="Q88NW9" data-a="FUNCTION: Redox-dependent in-situ holdase activity. PpPrx hi..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -2350,6 +2165,126 @@
                         </span>
 
                         <div class="finding-text">The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Thioredoxin-dependent peroxiredoxin activity in the lower-molecular-weight state, reducing hydrogen peroxide and contributing to cellular oxidant detoxification. Directly measured H2O2 peroxidase activity was lower than that of the yeast thioredoxin-dependent peroxiredoxin control, while UniProt additionally infers reduction of organic hydroperoxides. This is a core biochemical activity, but the available comparative assay does not establish that it is physiologically dominant.</h3>
+                <span class="vote-buttons" data-g="Q88NW9" data-a="FUNCTION: Thioredoxin-dependent peroxiredoxin activity in th..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008379" target="_blank" class="term-link">
+                            thioredoxin peroxidase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042744" target="_blank" class="term-link">
+                                hydrogen peroxide catabolic process
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098869" target="_blank" class="term-link">
+                                cellular oxidant detoxification
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21104173" target="_blank" class="term-link">
+                                PMID:21104173
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:PSEPK/PP_1084/PP_1084-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Thiol-specific peroxidase that catalyzes the reduction of</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:PSEPK/PP_1084/PP_1084-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Plays a role in cell protection against oxidative stress</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:PSEPK/PP_1084/PP_1084-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">SUBCELLULAR LOCATION: Cytoplasm</div>
 
                     </li>
 
@@ -3103,7 +3038,7 @@ This cycle is the central biochemical meaning of “thioredoxin peroxidase.” (
 <p>Reviewed <code>PP_1084-goa.tsv</code>, the UniProt Q88NW9 cache, both cached primary<br />
 publications, the Falcon research report, and the current<br />
 <code>projects/UNFOLDED_PROTEIN_BINDING.md</code> policy. The current GOA contains 13<br />
-qualifier-aware signatures: five <code>enables</code>, three <code>located_in</code>, and five<br />
+qualifier-aware signatures: six <code>enables</code>, two <code>located_in</code>, and five<br />
 <code>involved_in</code>. Each is represented exactly once in the YAML. There are no IBA<br />
 annotations. Six IEA rows cite TreeGrafter node <code>PANTHER:PTN002242136</code>, but<br />
 these are TreeGrafter IEA annotations rather than PAINT IBA claims and therefore<br />
@@ -3140,17 +3075,36 @@ with a high molecular weight (HMW) complex and chaperone activity, whereas PaPrx
 has mainly low molecular weight (LMW) structures and peroxidase activity."]</p>
 <h2 id="go0051082-and-ontology-gap">GO:0051082 and ontology gap</h2>
 <p>The author-supplied GO:0051082 claim is not one of the 13 current physical GOA<br />
-rows. It is retained machine-readably as a retired legacy claim and changed from<br />
-NEW to MODIFY toward an NTR. GO:0051082 is formally obsolete. Its two official<br />
-consider targets do not match the direct PpPrx evidence: GO:0044183 protein<br />
-folding chaperone is excluded by the reported absence of foldase activity, and<br />
-GO:0140309 has a carrier-specific definition requiring escort to an acceptor<br />
-molecule or location, which was not demonstrated. The directly supported<br />
-mechanism is aggregation prevention in situ. The review therefore uses<br />
-GO:0051082 only as an explicitly INTERIM core descriptor and proposes the<br />
-project-standard NTR, <strong>holdase chaperone activity</strong>, with the definition in<br />
-<code>projects/UNFOLDED_PROTEIN_BINDING.md</code> (see also go-ontology#30552 and<br />
-go-ontology#30962).</p>
+rows, and no historical GOA/UniProt annotation was identified for it. The<br />
+synthetic <code>existing_annotations</code> row was therefore removed on follow-up review.<br />
+<code>retired</code> is schema-defined broadly as an annotation that is retired or replaced,<br />
+but using it here would wrongly imply a sourced legacy annotation; <code>NEW</code> would<br />
+instead propose adding an ontology term that is already obsolete. Neither is an<br />
+accurate history. The direct activity is represented in <code>core_functions</code>, and<br />
+the actionable ontology request is represented in <code>proposed_new_terms</code>.</p>
+<p>GO:0051082 is formally obsolete. Its two official consider targets do not match<br />
+the direct PpPrx evidence: GO:0044183 protein folding chaperone is excluded by<br />
+the reported absence of foldase activity, and GO:0140309 has a carrier-specific<br />
+definition requiring escort to an acceptor molecule or location, which was not<br />
+demonstrated. The directly supported mechanism is aggregation prevention in<br />
+situ. The review therefore uses GO:0051082 only as an explicitly INTERIM core<br />
+descriptor and proposes the project-standard NTR, <strong>holdase chaperone activity</strong>,<br />
+with the definition in <code>projects/UNFOLDED_PROTEIN_BINDING.md</code> (see also<br />
+go-ontology#30552 and go-ontology#30962). PMID:21104173, not the abstract-only<br />
+PMID:26278368, is the direct aggregation-suppression evidence for this activity.</p>
+<p>The existing TSA1 and tpx1 reviews currently replace their peroxiredoxin<br />
+GO:0051082 rows with GO:0044183. Their cached sources establish chaperone or<br />
+aggregation-suppression activity but do not report autonomous refolding; the<br />
+tpx1 source is abstract-only. PP_1084 has the stronger discriminator because its<br />
+full text explicitly states that foldase activity was not detected. The project<br />
+mechanism table has been updated to flag the sibling GO:0044183 decisions for<br />
+re-review rather than silently applying two incompatible rules.</p>
+<p>GO:0140824 (thioredoxin-dependent peroxiredoxin activity) was also assessed. It<br />
+is a parent of the already present, H2O2-specific GO:0008379 thioredoxin<br />
+peroxidase activity, not a more specific replacement. The direct PpPrx assay<br />
+used H2O2; the broader organic-hydroperoxide claim is electronic in UniProt.<br />
+Adding GO:0140824 would therefore be a redundant parent NEW annotation rather<br />
+than an evidence-driven improvement.</p>
 <p>Evidence is sufficient to mark the one-gene review COMPLETE. Remaining<br />
 uncertainty concerns the in-vivo balance of HMW holdase and LMW peroxidase states<br />
 under physiological stress, not the existence of either biochemical activity.</p>
@@ -3175,13 +3129,16 @@ taxon:
   id: NCBITaxon:160488
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950 / KT2440)
 description: &gt;-
-  tsaA (locus PP_1084) encodes a cytoplasmic AhpC/Prx1-family (typical 2-Cys) thioredoxin peroxidase/peroxiredoxin
-  (PpPrx). Its core role is thioredoxin-dependent reduction and detoxification of hydrogen peroxide (and, by
-  subfamily inference, organic hydroperoxides), contributing to cellular oxidant detoxification and redox stress
-  protection in KT2440. The directly studied KT2440 protein additionally displays a redox-dependent molecular
-  chaperone (holdase) activity; it self-associates into high-molecular-weight oligomers that suppress protein
-  aggregation, and oxidative conditions drive a structural switch toward low-molecular-weight peroxidase-active
-  forms, constituting a peroxidase/chaperone functional switch (PMID:21104173, PMID:26278368).
+  tsaA (locus PP_1084) encodes the cytoplasmic AhpC/Prx1-family typical 2-Cys
+  peroxiredoxin PpPrx, with two directly supported biochemical states. Its
+  thioredoxin-dependent low-molecular-weight state reduces hydrogen peroxide,
+  while high-molecular-weight oligomers act as in-situ holdases that suppress
+  protein aggregation without detectable foldase activity. In direct comparisons,
+  purified PpPrx had relatively low H2O2 peroxidase activity, substantially greater
+  chaperone activity than the yeast peroxiredoxin control, and predominantly formed
+  the HMW chaperone-associated complex. These measurements establish a redox-regulated
+  peroxidase/holdase switch but do not by themselves rank the two activities under
+  physiological KT2440 growth conditions (PMID:21104173; PMID:26278368).
 existing_annotations:
 - term:
     id: GO:0004601
@@ -3198,6 +3155,9 @@ existing_annotations:
       supporting_text: Thiol-specific peroxidase that catalyzes the reduction of
     - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
       supporting_text: Plays a role in cell protection against oxidative stress
+    - reference_id: PMID:21104173
+      supporting_text: &gt;-
+        PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -3262,6 +3222,9 @@ existing_annotations:
       supporting_text: Plays a role in cell protection against oxidative stress
     - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
       supporting_text: locus **PP_1084** encodes a cytosolic **AhpC/Prx1-family (typical 2-Cys) peroxiredoxin**, experimentally characterized as a **thioredoxin-dependent peroxidase** that can also act as a **stress-responsive molecular chaperone** via oligomerization-dependent functional switching
+    - reference_id: PMID:21104173
+      supporting_text: &gt;-
+        PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.
 - term:
     id: GO:0016209
     label: antioxidant activity
@@ -3324,6 +3287,9 @@ existing_annotations:
       supporting_text: Plays a role in cell protection against oxidative stress
     - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
       supporting_text: The best-supported primary substrate in KT2440 experiments is **H2O2**, with broader substrate scope (e.g., organic hydroperoxides, peroxynitrite) supported by strong family-level evidence for typical 2-Cys peroxiredoxins
+    - reference_id: PMID:21104173
+      supporting_text: &gt;-
+        PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.
 - term:
     id: GO:0045454
     label: cell redox homeostasis
@@ -3394,41 +3360,6 @@ existing_annotations:
       supporting_text: PpPrx and PaPrx can alternatively function as a peroxidase and chaperone
     - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
       supporting_text: PP_1084/PpPrx self-associates into high-molecular-weight (HMW) complexes and lower-molecular-weight (LMW) species
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IDA
-  original_reference_id: PMID:26278368
-  retired: true
-  qualifier: enables
-  review:
-    summary: &gt;-
-      This separately reviewed, author-supplied legacy claim is not one of the 13 current
-      GOA signatures. The biology is well supported: purified PpPrx suppresses thermal
-      aggregation of MDH and citrate synthase, the HMW fraction has the stronger chaperone
-      activity, and foldase activity was not detected. GO:0051082 is now formally obsolete,
-      however, and neither official consider target captures this in-situ holdase mechanism.
-    action: MODIFY
-    reason: &gt;-
-      Retain GO:0051082 only as an interim obsolete descriptor while requesting a general
-      holdase chaperone activity term. GO:0044183 does not fit because foldase activity was
-      explicitly not detected. GO:0140309 does not fit because its definition requires
-      escort of an unfolded client to an acceptor molecule or location, whereas PpPrx
-      suppresses aggregation in situ. The replacement is therefore an NTR, not an existing GO
-      term (projects/UNFOLDED_PROTEIN_BINDING.md; go-ontology#30552; go-ontology#30962).
-    proposed_replacement_terms:
-    - id: NTR
-      label: holdase chaperone activity
-    additional_reference_ids:
-    - go-ontology#30552
-    - go-ontology#30962
-    supported_by:
-    - reference_id: PMID:21104173
-      supporting_text: &gt;-
-        PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
-    - reference_id: PMID:21104173
-      supporting_text: &gt;-
-        The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -3497,34 +3428,12 @@ references:
   - supporting_text: Exposure to **H2O2** drives structural changes and a corresponding functional switch, and the thioredoxin system is described as a primary guide of this switching behavior
   - supporting_text: PP_1084/PpPrx self-associates into high-molecular-weight (HMW) complexes and lower-molecular-weight (LMW) species
 core_functions:
-- description: Cytoplasmic thioredoxin peroxidase/peroxiredoxin that reduces hydrogen peroxide and organic hydroperoxides to protect cells from oxidative stress.
-  molecular_function:
-    id: GO:0008379
-    label: thioredoxin peroxidase activity
-  directly_involved_in:
-  - id: GO:0042744
-    label: hydrogen peroxide catabolic process
-  - id: GO:0098869
-    label: cellular oxidant detoxification
-  locations:
-  - id: GO:0005737
-    label: cytoplasm
-  supported_by:
-  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
-    supporting_text: Thiol-specific peroxidase that catalyzes the reduction of
-  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
-    supporting_text: Plays a role in cell protection against oxidative stress
-  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
-    supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
-  - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
-    supporting_text: The best-supported primary substrate in KT2440 experiments is **H2O2**, with broader substrate scope (e.g., organic hydroperoxides, peroxynitrite) supported by strong family-level evidence for typical 2-Cys peroxiredoxins
 - description: &gt;-
     Redox-dependent in-situ holdase activity. PpPrx high-molecular-weight oligomers
-    suppress thermal aggregation of model substrates without detectable foldase activity;
-    lower-molecular-weight species have greater peroxidase activity. GO:0051082 is used
-    only as an INTERIM obsolete descriptor pending a general holdase chaperone activity
-    NTR. GO:0140309 is not suitable because no client escort to an acceptor or location
-    was demonstrated, and GO:0044183 is not suitable because foldase activity was absent.
+    suppress thermal aggregation of malate dehydrogenase and citrate synthase without
+    detectable foldase activity. The HMW fraction has substantially greater chaperone
+    activity than the LMW fraction. GO:0051082 is used only as an INTERIM obsolete
+    descriptor pending creation of the proposed general holdase chaperone activity term.
   molecular_function:
     id: GO:0051082
     label: unfolded protein binding
@@ -3538,6 +3447,34 @@ core_functions:
   - reference_id: PMID:21104173
     supporting_text: &gt;-
       The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.
+- description: &gt;-
+    Thioredoxin-dependent peroxiredoxin activity in the lower-molecular-weight state,
+    reducing hydrogen peroxide and contributing to cellular oxidant detoxification.
+    Directly measured H2O2 peroxidase activity was lower than that of the yeast
+    thioredoxin-dependent peroxiredoxin control, while UniProt additionally infers
+    reduction of organic hydroperoxides. This is a core biochemical activity, but the
+    available comparative assay does not establish that it is physiologically dominant.
+  molecular_function:
+    id: GO:0008379
+    label: thioredoxin peroxidase activity
+  directly_involved_in:
+  - id: GO:0042744
+    label: hydrogen peroxide catabolic process
+  - id: GO:0098869
+    label: cellular oxidant detoxification
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:21104173
+    supporting_text: &gt;-
+      PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.
+  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
+    supporting_text: Thiol-specific peroxidase that catalyzes the reduction of
+  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
+    supporting_text: Plays a role in cell protection against oxidative stress
+  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
+    supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
 proposed_new_terms:
 - proposed_name: holdase chaperone activity
   proposed_definition: &gt;-

--- a/genes/PSEPK/PP_1084/PP_1084-ai-review.yaml
+++ b/genes/PSEPK/PP_1084/PP_1084-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q88NW9
 gene_symbol: tsaA
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:160488
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950 / KT2440)
@@ -19,6 +19,7 @@ existing_annotations:
     label: peroxidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: enables
   review:
     summary: Peroxidase activity is correct for this thiol-specific peroxidase, although the peroxiredoxin/thioredoxin peroxidase terms are more informative.
     action: ACCEPT
@@ -33,6 +34,7 @@ existing_annotations:
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
+  qualifier: located_in
   review:
     summary: Cytoplasm is directly supported by the UniProt subcellular-location statement and corroborated by a PSORTb cytoplasmic prediction for KT2440 PP_1084 in the falcon report.
     action: ACCEPT
@@ -47,6 +49,7 @@ existing_annotations:
     label: cytosol
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
+  qualifier: located_in
   review:
     summary: Cytosol is compatible with the cytoplasmic location, but it is not the core function. A PSORTb cytoplasmic prediction for KT2440 PP_1084 in the falcon report is consistent with this assignment.
     action: KEEP_AS_NON_CORE
@@ -61,6 +64,7 @@ existing_annotations:
     label: response to oxidative stress
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: involved_in
   review:
     summary: Response to oxidative stress is supported but broad relative to direct peroxide detoxification. The falcon report notes the protein was enriched after oxidative treatments (H2O2, gamma rays) in KT2440.
     action: KEEP_AS_NON_CORE
@@ -77,6 +81,7 @@ existing_annotations:
     label: thioredoxin peroxidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
+  qualifier: enables
   review:
     summary: Thioredoxin peroxidase activity is the specific catalytic role of TsaA. The falcon report confirms that the directly characterized KT2440 protein (PpPrx) is a thioredoxin-dependent peroxidase assayed with a thioredoxin-coupled system, consistent with this term.
     action: ACCEPT
@@ -93,6 +98,7 @@ existing_annotations:
     label: antioxidant activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: Antioxidant activity is true in a broad sense but is less informative than peroxiredoxin and thioredoxin peroxidase activity.
     action: MARK_AS_OVER_ANNOTATED
@@ -107,6 +113,7 @@ existing_annotations:
     label: oxidoreductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: Oxidoreductase activity is a broad parent that adds little beyond the specific peroxiredoxin/peroxidase terms.
     action: MARK_AS_OVER_ANNOTATED
@@ -121,6 +128,7 @@ existing_annotations:
     label: cellular response to stress
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
+  qualifier: involved_in
   review:
     summary: Cellular response to stress is too broad for an enzyme whose direct role is peroxide reduction.
     action: MARK_AS_OVER_ANNOTATED
@@ -135,6 +143,7 @@ existing_annotations:
     label: hydrogen peroxide catabolic process
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
+  qualifier: involved_in
   review:
     summary: Hydrogen peroxide catabolic process is directly supported by the peroxidase reaction described for TsaA. H2O2 is the best-supported, directly assayed substrate for the KT2440 protein per the falcon report.
     action: ACCEPT
@@ -151,6 +160,7 @@ existing_annotations:
     label: cell redox homeostasis
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
+  qualifier: involved_in
   review:
     summary: Cell redox homeostasis is consistent with peroxiredoxin function but broader than direct peroxide detoxification. The falcon report notes the thioredoxin system primarily guides the redox-dependent structural/functional switching of PP_1084.
     action: KEEP_AS_NON_CORE
@@ -167,6 +177,7 @@ existing_annotations:
     label: peroxiredoxin activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: Peroxiredoxin activity is a specific and supported molecular function for this AhpC/Prx1-family protein. The falcon report confirms the directly studied KT2440 protein PP_1084 (PpPrx) is a 21 kDa AhpC/Tsa-family typical 2-Cys peroxiredoxin, matching the UniProt subfamily assignment.
     action: ACCEPT
@@ -185,6 +196,7 @@ existing_annotations:
     label: cellular oxidant detoxification
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: involved_in
   review:
     summary: Cellular oxidant detoxification captures the biological process consequence of peroxide reduction. The falcon report documents that in KT2440 the protein was found among disulfide-bonded proteins enriched after oxidative treatments and detoxifies intracellular peroxides.
     action: ACCEPT
@@ -201,6 +213,7 @@ existing_annotations:
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:26278368
+  qualifier: enables
   review:
     summary: Identical protein binding is supported by the IntAct self-interaction record and reflects the homo-oligomerization that is mechanistically central to TsaA/PpPrx function. The falcon report and PMID:26278368 show PP_1084/PpPrx self-associates into high-molecular-weight (HMW, chaperone-active) and low-molecular-weight (LMW, peroxidase-active) forms, so self-association underpins the redox-dependent peroxidase/chaperone switch.
     action: KEEP_AS_NON_CORE
@@ -217,15 +230,36 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:26278368
+  retired: true
+  qualifier: enables
   review:
-    summary: PP_1084/PpPrx has experimentally demonstrated molecular chaperone (holdase) activity. In its high-molecular-weight oligomeric state it suppresses thermal aggregation of model substrate proteins, and this chaperone state interconverts with the low-molecular-weight peroxidase-active form under redox control. This dual peroxidase/chaperone function is well documented for this protein but is not captured by any of the existing GOA annotations, so it is proposed as a NEW molecular-function annotation.
-    action: NEW
-    reason: An et al. (PMID:26278368, and PMID:21104173) directly show PpPrx (PP_1084) functions as a molecular chaperone in addition to its peroxidase activity, with chaperone activity associated with the HMW oligomeric form. Unfolded protein binding (GO:0051082) is the appropriate molecular-function term for this holdase activity.
+    summary: >-
+      This separately reviewed, author-supplied legacy claim is not one of the 13 current
+      GOA signatures. The biology is well supported: purified PpPrx suppresses thermal
+      aggregation of MDH and citrate synthase, the HMW fraction has the stronger chaperone
+      activity, and foldase activity was not detected. GO:0051082 is now formally obsolete,
+      however, and neither official consider target captures this in-situ holdase mechanism.
+    action: MODIFY
+    reason: >-
+      Retain GO:0051082 only as an interim obsolete descriptor while requesting a general
+      holdase chaperone activity term. GO:0044183 does not fit because foldase activity was
+      explicitly not detected. GO:0140309 does not fit because its definition requires
+      escort of an unfolded client to an acceptor molecule or location, whereas PpPrx
+      suppresses aggregation in situ. The replacement is therefore an NTR, not an existing GO
+      term (projects/UNFOLDED_PROTEIN_BINDING.md; go-ontology#30552; go-ontology#30962).
+    proposed_replacement_terms:
+    - id: NTR
+      label: holdase chaperone activity
+    additional_reference_ids:
+    - go-ontology#30552
+    - go-ontology#30962
     supported_by:
-    - reference_id: PMID:26278368
-      supporting_text: PpPrx and PaPrx can alternatively function as a peroxidase and chaperone
-    - reference_id: PMID:26278368
-      supporting_text: PpPrx predominates with a high molecular weight (HMW) complex and
+    - reference_id: PMID:21104173
+      supporting_text: >-
+        PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
+    - reference_id: PMID:21104173
+      supporting_text: >-
+        The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -250,15 +284,37 @@ references:
   - supporting_text: 'Belongs to the peroxiredoxin family. AhpC/Prx1 subfamily'
 - id: PMID:21104173
   title: Functional switching of a novel prokaryotic 2-Cys peroxiredoxin (PpPrx) under oxidative stress
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Full text is cached. This direct KT2440 PpPrx study establishes peroxidase
+      activity, aggregation suppression without foldase activity, oligomer-state
+      dependence, and thioredoxin-controlled functional switching.
   findings:
-  - statement: An et al. (2011) directly characterized PP_1084 (PpPrx) of P. putida KT2440 as a typical 2-Cys peroxiredoxin that can act as both a peroxidase and a molecular chaperone; H2O2 exposure converts high-MW chaperone complexes to low-MW peroxidase-active forms, a switch primarily guided by the thioredoxin system.
-    full_text_unavailable: true
+  - supporting_text: >-
+      PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
+    reference_section_type: RESULTS
+  - supporting_text: >-
+      PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.
+    reference_section_type: RESULTS
+  - supporting_text: >-
+      The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition. In contrast, the F-2 fraction had more peroxidase activity than the total protein, and the F-1 fraction showed lower peroxidase activity than total protein (Fig.3F).
+    reference_section_type: RESULTS
 - id: PMID:26278368
   title: "An additional cysteine in a typical 2-Cys peroxiredoxin of Pseudomonas promotes functional switching between peroxidase and molecular chaperone."
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      Abstract-only cache. The abstract directly supports PpPrx HMW-complex/chaperone
+      activity and Cys112-dependent functional switching; assay-level interpretation is
+      anchored to the full-text PMID:21104173 study.
   findings:
-  - supporting_text: PpPrx and PaPrx can alternatively function as a peroxidase and chaperone
+  - supporting_text: PpPrx and PaPrx can alternatively function as a peroxidase and chaperone.
     reference_section_type: ABSTRACT
-  - supporting_text: PpPrx predominates with a high molecular weight (HMW) complex and
+  - supporting_text: >-
+      PpPrx predominates with a high molecular weight (HMW) complex and chaperone activity, whereas PaPrx has mainly low molecular weight (LMW) structures and peroxidase activity.
     reference_section_type: ABSTRACT
 - id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
   title: Falcon deep-research report on tsaA / PP_1084 (UniProt Q88NW9)
@@ -293,24 +349,44 @@ core_functions:
     supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm'
   - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
     supporting_text: The best-supported primary substrate in KT2440 experiments is **H2O2**, with broader substrate scope (e.g., organic hydroperoxides, peroxynitrite) supported by strong family-level evidence for typical 2-Cys peroxiredoxins
-- description: Redox-dependent molecular chaperone (holdase) activity. Under oxidative/heat stress PP_1084/PpPrx self-associates into high-molecular-weight oligomeric complexes that suppress aggregation of partially unfolded proteins; this chaperone state interconverts with the low-molecular-weight peroxidase-active form, constituting a redox-controlled peroxidase/chaperone functional switch.
+- description: >-
+    Redox-dependent in-situ holdase activity. PpPrx high-molecular-weight oligomers
+    suppress thermal aggregation of model substrates without detectable foldase activity;
+    lower-molecular-weight species have greater peroxidase activity. GO:0051082 is used
+    only as an INTERIM obsolete descriptor pending a general holdase chaperone activity
+    NTR. GO:0140309 is not suitable because no client escort to an acceptor or location
+    was demonstrated, and GO:0044183 is not suitable because foldase activity was absent.
   molecular_function:
     id: GO:0051082
     label: unfolded protein binding
-  directly_involved_in:
-  - id: GO:0006979
-    label: response to oxidative stress
   locations:
   - id: GO:0005737
     label: cytoplasm
   supported_by:
-  - reference_id: PMID:26278368
-    supporting_text: PpPrx and PaPrx can alternatively function as a peroxidase and chaperone
-  - reference_id: PMID:26278368
-    supporting_text: PpPrx predominates with a high molecular weight (HMW) complex and
-  - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
-    supporting_text: enriched in **high-molecular-weight (HMW)** oligomeric complexes, demonstrated by suppression of thermal aggregation of model substrates (e.g., malate dehydrogenase), consistent with a
-proposed_new_terms: []
+  - reference_id: PMID:21104173
+    supporting_text: >-
+      PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
+  - reference_id: PMID:21104173
+    supporting_text: >-
+      The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.
+proposed_new_terms:
+- proposed_name: holdase chaperone activity
+  proposed_definition: >-
+    Binding to an unfolded or misfolded protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains the client protein in a soluble, folding-competent state.
+  justification: >-
+    Purified PpPrx directly suppresses thermal aggregation of MDH and citrate synthase,
+    while foldase activity was not detected. This is an in-situ holdase activity. The
+    obsolete GO:0051082 lacks a suitable replacement: GO:0044183 implies assistance with
+    folding, and carrier-specific GO:0140309 requires escort to an acceptor or location.
+    A general holdase activity term is therefore required (go-ontology#30552;
+    projects/UNFOLDED_PROTEIN_BINDING.md).
+  proposed_parent:
+    id: GO:0003674
+    label: molecular_function
+  supported_by:
+  - reference_id: PMID:21104173
+    supporting_text: >-
+      PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
 suggested_questions:
 - question: Under which physiological oxidative-stress conditions in KT2440 does TsaA/PpPrx shift between the HMW chaperone-active and LMW peroxidase-active oligomeric states, and what is the in vivo balance of these two functions?
   experts:

--- a/genes/PSEPK/PP_1084/PP_1084-ai-review.yaml
+++ b/genes/PSEPK/PP_1084/PP_1084-ai-review.yaml
@@ -6,13 +6,16 @@ taxon:
   id: NCBITaxon:160488
   label: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950 / KT2440)
 description: >-
-  tsaA (locus PP_1084) encodes a cytoplasmic AhpC/Prx1-family (typical 2-Cys) thioredoxin peroxidase/peroxiredoxin
-  (PpPrx). Its core role is thioredoxin-dependent reduction and detoxification of hydrogen peroxide (and, by
-  subfamily inference, organic hydroperoxides), contributing to cellular oxidant detoxification and redox stress
-  protection in KT2440. The directly studied KT2440 protein additionally displays a redox-dependent molecular
-  chaperone (holdase) activity; it self-associates into high-molecular-weight oligomers that suppress protein
-  aggregation, and oxidative conditions drive a structural switch toward low-molecular-weight peroxidase-active
-  forms, constituting a peroxidase/chaperone functional switch (PMID:21104173, PMID:26278368).
+  tsaA (locus PP_1084) encodes the cytoplasmic AhpC/Prx1-family typical 2-Cys
+  peroxiredoxin PpPrx, with two directly supported biochemical states. Its
+  thioredoxin-dependent low-molecular-weight state reduces hydrogen peroxide,
+  while high-molecular-weight oligomers act as in-situ holdases that suppress
+  protein aggregation without detectable foldase activity. In direct comparisons,
+  purified PpPrx had relatively low H2O2 peroxidase activity, substantially greater
+  chaperone activity than the yeast peroxiredoxin control, and predominantly formed
+  the HMW chaperone-associated complex. These measurements establish a redox-regulated
+  peroxidase/holdase switch but do not by themselves rank the two activities under
+  physiological KT2440 growth conditions (PMID:21104173; PMID:26278368).
 existing_annotations:
 - term:
     id: GO:0004601
@@ -29,6 +32,9 @@ existing_annotations:
       supporting_text: Thiol-specific peroxidase that catalyzes the reduction of
     - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
       supporting_text: Plays a role in cell protection against oxidative stress
+    - reference_id: PMID:21104173
+      supporting_text: >-
+        PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -93,6 +99,9 @@ existing_annotations:
       supporting_text: Plays a role in cell protection against oxidative stress
     - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
       supporting_text: locus **PP_1084** encodes a cytosolic **AhpC/Prx1-family (typical 2-Cys) peroxiredoxin**, experimentally characterized as a **thioredoxin-dependent peroxidase** that can also act as a **stress-responsive molecular chaperone** via oligomerization-dependent functional switching
+    - reference_id: PMID:21104173
+      supporting_text: >-
+        PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.
 - term:
     id: GO:0016209
     label: antioxidant activity
@@ -155,6 +164,9 @@ existing_annotations:
       supporting_text: Plays a role in cell protection against oxidative stress
     - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
       supporting_text: The best-supported primary substrate in KT2440 experiments is **H2O2**, with broader substrate scope (e.g., organic hydroperoxides, peroxynitrite) supported by strong family-level evidence for typical 2-Cys peroxiredoxins
+    - reference_id: PMID:21104173
+      supporting_text: >-
+        PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.
 - term:
     id: GO:0045454
     label: cell redox homeostasis
@@ -225,41 +237,6 @@ existing_annotations:
       supporting_text: PpPrx and PaPrx can alternatively function as a peroxidase and chaperone
     - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
       supporting_text: PP_1084/PpPrx self-associates into high-molecular-weight (HMW) complexes and lower-molecular-weight (LMW) species
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IDA
-  original_reference_id: PMID:26278368
-  retired: true
-  qualifier: enables
-  review:
-    summary: >-
-      This separately reviewed, author-supplied legacy claim is not one of the 13 current
-      GOA signatures. The biology is well supported: purified PpPrx suppresses thermal
-      aggregation of MDH and citrate synthase, the HMW fraction has the stronger chaperone
-      activity, and foldase activity was not detected. GO:0051082 is now formally obsolete,
-      however, and neither official consider target captures this in-situ holdase mechanism.
-    action: MODIFY
-    reason: >-
-      Retain GO:0051082 only as an interim obsolete descriptor while requesting a general
-      holdase chaperone activity term. GO:0044183 does not fit because foldase activity was
-      explicitly not detected. GO:0140309 does not fit because its definition requires
-      escort of an unfolded client to an acceptor molecule or location, whereas PpPrx
-      suppresses aggregation in situ. The replacement is therefore an NTR, not an existing GO
-      term (projects/UNFOLDED_PROTEIN_BINDING.md; go-ontology#30552; go-ontology#30962).
-    proposed_replacement_terms:
-    - id: NTR
-      label: holdase chaperone activity
-    additional_reference_ids:
-    - go-ontology#30552
-    - go-ontology#30962
-    supported_by:
-    - reference_id: PMID:21104173
-      supporting_text: >-
-        PpPrx suppressed the thermal aggregation of the model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely suppressed. PpPrx can also efficiently protect the thermal aggregation of CS (Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular chaperone. However, foldase activity as another chaperone activity was not detected (data not shown).
-    - reference_id: PMID:21104173
-      supporting_text: >-
-        The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -328,34 +305,12 @@ references:
   - supporting_text: Exposure to **H2O2** drives structural changes and a corresponding functional switch, and the thioredoxin system is described as a primary guide of this switching behavior
   - supporting_text: PP_1084/PpPrx self-associates into high-molecular-weight (HMW) complexes and lower-molecular-weight (LMW) species
 core_functions:
-- description: Cytoplasmic thioredoxin peroxidase/peroxiredoxin that reduces hydrogen peroxide and organic hydroperoxides to protect cells from oxidative stress.
-  molecular_function:
-    id: GO:0008379
-    label: thioredoxin peroxidase activity
-  directly_involved_in:
-  - id: GO:0042744
-    label: hydrogen peroxide catabolic process
-  - id: GO:0098869
-    label: cellular oxidant detoxification
-  locations:
-  - id: GO:0005737
-    label: cytoplasm
-  supported_by:
-  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
-    supporting_text: Thiol-specific peroxidase that catalyzes the reduction of
-  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
-    supporting_text: Plays a role in cell protection against oxidative stress
-  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
-    supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm'
-  - reference_id: file:PSEPK/PP_1084/PP_1084-deep-research-falcon.md
-    supporting_text: The best-supported primary substrate in KT2440 experiments is **H2O2**, with broader substrate scope (e.g., organic hydroperoxides, peroxynitrite) supported by strong family-level evidence for typical 2-Cys peroxiredoxins
 - description: >-
     Redox-dependent in-situ holdase activity. PpPrx high-molecular-weight oligomers
-    suppress thermal aggregation of model substrates without detectable foldase activity;
-    lower-molecular-weight species have greater peroxidase activity. GO:0051082 is used
-    only as an INTERIM obsolete descriptor pending a general holdase chaperone activity
-    NTR. GO:0140309 is not suitable because no client escort to an acceptor or location
-    was demonstrated, and GO:0044183 is not suitable because foldase activity was absent.
+    suppress thermal aggregation of malate dehydrogenase and citrate synthase without
+    detectable foldase activity. The HMW fraction has substantially greater chaperone
+    activity than the LMW fraction. GO:0051082 is used only as an INTERIM obsolete
+    descriptor pending creation of the proposed general holdase chaperone activity term.
   molecular_function:
     id: GO:0051082
     label: unfolded protein binding
@@ -369,6 +324,34 @@ core_functions:
   - reference_id: PMID:21104173
     supporting_text: >-
       The HMW complex fraction (F-1) exhibited high chaperone activity about fivefold compare to LMW fraction (F-2) and total protein fraction (Fig.3E), indicating that the chaperone activity of PpPrx was significantly affected by the structural composition.
+- description: >-
+    Thioredoxin-dependent peroxiredoxin activity in the lower-molecular-weight state,
+    reducing hydrogen peroxide and contributing to cellular oxidant detoxification.
+    Directly measured H2O2 peroxidase activity was lower than that of the yeast
+    thioredoxin-dependent peroxiredoxin control, while UniProt additionally infers
+    reduction of organic hydroperoxides. This is a core biochemical activity, but the
+    available comparative assay does not establish that it is physiologically dominant.
+  molecular_function:
+    id: GO:0008379
+    label: thioredoxin peroxidase activity
+  directly_involved_in:
+  - id: GO:0042744
+    label: hydrogen peroxide catabolic process
+  - id: GO:0098869
+    label: cellular oxidant detoxification
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:21104173
+    supporting_text: >-
+      PpPrx exhibited low H2O2catabolic peroxidase activity (Fig.2D), substantially lower than that of yeast Trx-dependent Prx (yTPx), but PpPrx exhibited five times higher the chaperone activity than yTPx, used as a positive control.
+  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
+    supporting_text: Thiol-specific peroxidase that catalyzes the reduction of
+  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
+    supporting_text: Plays a role in cell protection against oxidative stress
+  - reference_id: file:PSEPK/PP_1084/PP_1084-uniprot.txt
+    supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm'
 proposed_new_terms:
 - proposed_name: holdase chaperone activity
   proposed_definition: >-

--- a/genes/PSEPK/PP_1084/PP_1084-notes.md
+++ b/genes/PSEPK/PP_1084/PP_1084-notes.md
@@ -1,0 +1,65 @@
+# PP_1084 / tsaA annotation audit notes
+
+## 2026-08-29 — qualifier-aware re-review
+
+Reviewed `PP_1084-goa.tsv`, the UniProt Q88NW9 cache, both cached primary
+publications, the Falcon research report, and the current
+`projects/UNFOLDED_PROTEIN_BINDING.md` policy. The current GOA contains 13
+qualifier-aware signatures: six `enables`, two `located_in`, and five
+`involved_in`. Each is represented exactly once in the YAML. There are no IBA
+annotations. Six IEA rows cite TreeGrafter node `PANTHER:PTN002242136`, but
+these are TreeGrafter IEA annotations rather than PAINT IBA claims and therefore
+do not receive an IBA propagation review.
+
+The 13 current rows resolve to 6 ACCEPT, 4 KEEP_AS_NON_CORE, and 3
+MARK_AS_OVER_ANNOTATED. The broad antioxidant activity, oxidoreductase activity,
+and cellular response to stress rows are retained as over-annotations because
+the current GOA already supplies the mechanistically specific peroxiredoxin,
+thioredoxin peroxidase, hydrogen-peroxide catabolism, and oxidant-detoxification
+terms. The self-interaction IPI is retained as non-core: the exact GOA
+WITH/FROM is `UniProtKB:Q88NW9`, and UniProt records four IntAct self-interaction
+experiments.
+
+## Direct peroxidase/holdase evidence
+
+PMID:21104173 is cached as full text, not abstract-only. Purified PpPrx reduced
+H2O2 in a thioredoxin-coupled assay and directly suppressed thermal aggregation
+of malate dehydrogenase and citrate synthase. The same paper explicitly reports
+that foldase activity was not detected. It also found substantially greater
+chaperone activity in the HMW fraction and greater peroxidase activity in the
+LMW fraction [PMID:21104173, "PpPrx suppressed the thermal aggregation of the
+model substrate MDH at 43°C in a concentration-dependent manner (Fig.2B). At a
+subunit molar ratio of PpPrx to MDH of 0.5 vs. 1, MDH aggregation was completely
+suppressed. PpPrx can also efficiently protect the thermal aggregation of CS
+(Fig.2C), suggesting that PpPrx can indeed act as an efficient molecular
+chaperone. However, foldase activity as another chaperone activity was not
+detected (data not shown)."] [PMID:21104173, "The HMW complex fraction (F-1)
+exhibited high chaperone activity about fivefold compare to LMW fraction (F-2)
+and total protein fraction (Fig.3E), indicating that the chaperone activity of
+PpPrx was significantly affected by the structural composition."]
+
+PMID:26278368 is abstract-only. Its abstract independently supports that PpPrx
+predominates as an HMW complex with chaperone activity and attributes the
+PpPrx/PaPrx difference to the additional PpPrx cysteine, but assay-level claims
+were anchored to the full-text 2011 study [PMID:26278368, "PpPrx predominates
+with a high molecular weight (HMW) complex and chaperone activity, whereas PaPrx
+has mainly low molecular weight (LMW) structures and peroxidase activity."]
+
+## GO:0051082 and ontology gap
+
+The author-supplied GO:0051082 claim is not one of the 13 current physical GOA
+rows. It is retained machine-readably as a retired legacy claim and changed from
+NEW to MODIFY toward an NTR. GO:0051082 is formally obsolete. Its two official
+consider targets do not match the direct PpPrx evidence: GO:0044183 protein
+folding chaperone is excluded by the reported absence of foldase activity, and
+GO:0140309 has a carrier-specific definition requiring escort to an acceptor
+molecule or location, which was not demonstrated. The directly supported
+mechanism is aggregation prevention in situ. The review therefore uses
+GO:0051082 only as an explicitly INTERIM core descriptor and proposes the
+project-standard NTR, **holdase chaperone activity**, with the definition in
+`projects/UNFOLDED_PROTEIN_BINDING.md` (see also go-ontology#30552 and
+go-ontology#30962).
+
+Evidence is sufficient to mark the one-gene review COMPLETE. Remaining
+uncertainty concerns the in-vivo balance of HMW holdase and LMW peroxidase states
+under physiological stress, not the existence of either biochemical activity.

--- a/genes/PSEPK/PP_1084/PP_1084-notes.md
+++ b/genes/PSEPK/PP_1084/PP_1084-notes.md
@@ -48,17 +48,39 @@ has mainly low molecular weight (LMW) structures and peroxidase activity."]
 ## GO:0051082 and ontology gap
 
 The author-supplied GO:0051082 claim is not one of the 13 current physical GOA
-rows. It is retained machine-readably as a retired legacy claim and changed from
-NEW to MODIFY toward an NTR. GO:0051082 is formally obsolete. Its two official
-consider targets do not match the direct PpPrx evidence: GO:0044183 protein
-folding chaperone is excluded by the reported absence of foldase activity, and
-GO:0140309 has a carrier-specific definition requiring escort to an acceptor
-molecule or location, which was not demonstrated. The directly supported
-mechanism is aggregation prevention in situ. The review therefore uses
-GO:0051082 only as an explicitly INTERIM core descriptor and proposes the
-project-standard NTR, **holdase chaperone activity**, with the definition in
-`projects/UNFOLDED_PROTEIN_BINDING.md` (see also go-ontology#30552 and
-go-ontology#30962).
+rows, and no historical GOA/UniProt annotation was identified for it. The
+synthetic `existing_annotations` row was therefore removed on follow-up review.
+`retired` is schema-defined broadly as an annotation that is retired or replaced,
+but using it here would wrongly imply a sourced legacy annotation; `NEW` would
+instead propose adding an ontology term that is already obsolete. Neither is an
+accurate history. The direct activity is represented in `core_functions`, and
+the actionable ontology request is represented in `proposed_new_terms`.
+
+GO:0051082 is formally obsolete. Its two official consider targets do not match
+the direct PpPrx evidence: GO:0044183 protein folding chaperone is excluded by
+the reported absence of foldase activity, and GO:0140309 has a carrier-specific
+definition requiring escort to an acceptor molecule or location, which was not
+demonstrated. The directly supported mechanism is aggregation prevention in
+situ. The review therefore uses GO:0051082 only as an explicitly INTERIM core
+descriptor and proposes the project-standard NTR, **holdase chaperone activity**,
+with the definition in `projects/UNFOLDED_PROTEIN_BINDING.md` (see also
+go-ontology#30552 and go-ontology#30962). PMID:21104173, not the abstract-only
+PMID:26278368, is the direct aggregation-suppression evidence for this activity.
+
+The existing TSA1 and tpx1 reviews currently replace their peroxiredoxin
+GO:0051082 rows with GO:0044183. Their cached sources establish chaperone or
+aggregation-suppression activity but do not report autonomous refolding; the
+tpx1 source is abstract-only. PP_1084 has the stronger discriminator because its
+full text explicitly states that foldase activity was not detected. The project
+mechanism table has been updated to flag the sibling GO:0044183 decisions for
+re-review rather than silently applying two incompatible rules.
+
+GO:0140824 (thioredoxin-dependent peroxiredoxin activity) was also assessed. It
+is a parent of the already present, H2O2-specific GO:0008379 thioredoxin
+peroxidase activity, not a more specific replacement. The direct PpPrx assay
+used H2O2; the broader organic-hydroperoxide claim is electronic in UniProt.
+Adding GO:0140824 would therefore be a redundant parent NEW annotation rather
+than an evidence-driven improvement.
 
 Evidence is sufficient to mark the one-gene review COMPLETE. Remaining
 uncertainty concerns the in-vivo balance of HMW holdase and LMW peroxidase states

--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -999,8 +999,8 @@ because it has that second term as well; this is not an additional human gene.</
 <tr>
 <td>13</td>
 <td><strong>Peroxiredoxin/redox chaperones</strong></td>
-<td><a href="../../genes/yeast/TSA1/TSA1-ai-review.html">TSA1</a> (yeast); <a href="../../genes/SCHPO/pmp20/pmp20-ai-review.html">pmp20</a>, <a href="../../genes/SCHPO/tpx1/tpx1-ai-review.html">tpx1</a> (S. pombe); <a href="../../genes/ECOLI/CnoX/CnoX-ai-review.html">CnoX</a>, <a href="../../genes/ECOLI/RidA/RidA-ai-review.html">RidA</a> (E. coli)</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a> (stress-activated holdase)</td>
+<td><a href="../../genes/yeast/TSA1/TSA1-ai-review.html">TSA1</a> (yeast); <a href="../../genes/SCHPO/pmp20/pmp20-ai-review.html">pmp20</a>, <a href="../../genes/SCHPO/tpx1/tpx1-ai-review.html">tpx1</a> (S. pombe); <a href="../../genes/ECOLI/CnoX/CnoX-ai-review.html">CnoX</a>, <a href="../../genes/ECOLI/RidA/RidA-ai-review.html">RidA</a> (E. coli); <a href="../../genes/PSEPK/PP_1084/PP_1084-ai-review.html">PP_1084</a>/PpPrx (<em>P. putida</em>, direct literature gap case)</td>
+<td>MODIFY → holdase NTR when evidence shows in-situ aggregation prevention without refolding; older <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a> sibling decisions require re-review</td>
 </tr>
 <tr>
 <td>14</td>
@@ -1225,9 +1225,12 @@ established:</p>
    (IRE1-TRAF2-ASK1 complex) that are biologically impossible in fungi.</p>
 </li>
 <li>
-<p><strong>Peroxiredoxins (<a href="../../genes/yeast/TSA1/TSA1-ai-review.html">TSA1</a>, <a href="../../genes/SCHPO/pmp20/pmp20-ai-review.html">pmp20</a>, <a href="../../genes/SCHPO/tpx1/tpx1-ai-review.html">tpx1</a>)</strong> — Dual-function: peroxidase at low oxidative<br />
-   stress, holdase chaperone at high stress (after overoxidation of catalytic Cys). Confirms<br />
-   that <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> is appropriate for the chaperone function but should become holdase NTR.</p>
+<p><strong>Peroxiredoxins (<a href="../../genes/yeast/TSA1/TSA1-ai-review.html">TSA1</a>, <a href="../../genes/SCHPO/pmp20/pmp20-ai-review.html">pmp20</a>, <a href="../../genes/SCHPO/tpx1/tpx1-ai-review.html">tpx1</a>; <a href="../../genes/PSEPK/PP_1084/PP_1084-ai-review.html">PP_1084</a>/PpPrx as a literature-only gap case)</strong> —<br />
+   Dual-function peroxidase/holdases whose oligomeric state controls aggregation-prevention<br />
+   activity. <a href="../../genes/PSEPK/PP_1084/PP_1084-ai-review.html">PP_1084</a> provides the clearest discriminator: its full text explicitly reports<br />
+   suppression of model-substrate aggregation and failure to detect foldase activity<br />
+   (PMID:21104173). This supports the holdase NTR rather than <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a>; the older<br />
+<a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a> decisions for <a href="../../genes/yeast/TSA1/TSA1-ai-review.html">TSA1</a>, <a href="../../genes/SCHPO/pmp20/pmp20-ai-review.html">pmp20</a> and <a href="../../genes/SCHPO/tpx1/tpx1-ai-review.html">tpx1</a> should be re-reviewed under the same rule.</p>
 </li>
 </ol>
 <details>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -366,7 +366,7 @@ All 148 genes organized by mechanism class (human + non-human combined):
 | 10 | **Ubiquitin/QC sensor** | SYVN1 (human); SAN1 (yeast); Fbxo2 (mouse); slrP (Salmonella) | REMOVE or MODIFY to GO:0051787 |
 | 11 | **Periplasmic chaperones** | SurA, Skp, Spy, SecB, HdeA, HdeB, SlyD, CpxP (E. coli) | MODIFY → GO:0044183 (holdase/chaperone) |
 | 12 | **Ribosome assembly** | SQT1, SYO1, YAR1, RRB1, TSR4, PNO1, ACL4, SHQ1, BTT1 (yeast) | MODIFY → GO:0044183 or OVER_ANNOTATED |
-| 13 | **Peroxiredoxin/redox chaperones** | TSA1 (yeast); pmp20, tpx1 (S. pombe); CnoX, RidA (E. coli) | MODIFY → GO:0044183 (stress-activated holdase) |
+| 13 | **Peroxiredoxin/redox chaperones** | TSA1 (yeast); pmp20, tpx1 (S. pombe); CnoX, RidA (E. coli); PP_1084/PpPrx (*P. putida*, direct literature gap case) | MODIFY → holdase NTR when evidence shows in-situ aggregation prevention without refolding; older GO:0044183 sibling decisions require re-review |
 | 14 | **Membrane protein chaperones** | SHR3, PHO86, GSF2, CHS7, NSG1, NSG2, VMA22, VPS45 (yeast) | MODIFY or OVER_ANNOTATED |
 | 15 | **Other** | NPM1, TMEM67 (human); NAP1, GET3 (yeast); St13, Serpinh1 (mouse/rat); Nmnat (fly); nud-1, hsp-12.3, hsp-12.6 (worm); tigA (A. niger); GIP1 (Arabidopsis) | Gene-specific decisions |
 
@@ -450,9 +450,12 @@ established:
    of OVER_ANNOTATED. The T. reesei review also flagged metazoan-specific GO terms
    (IRE1-TRAF2-ASK1 complex) that are biologically impossible in fungi.
 
-6. **Peroxiredoxins (TSA1, pmp20, tpx1)** — Dual-function: peroxidase at low oxidative
-   stress, holdase chaperone at high stress (after overoxidation of catalytic Cys). Confirms
-   that GO:0051082 is appropriate for the chaperone function but should become holdase NTR.
+6. **Peroxiredoxins (TSA1, pmp20, tpx1; PP_1084/PpPrx as a literature-only gap case)** —
+   Dual-function peroxidase/holdases whose oligomeric state controls aggregation-prevention
+   activity. PP_1084 provides the clearest discriminator: its full text explicitly reports
+   suppression of model-substrate aggregation and failure to detect foldase activity
+   (PMID:21104173). This supports the holdase NTR rather than GO:0044183; the older
+   GO:0044183 decisions for TSA1, pmp20 and tpx1 should be re-reviewed under the same rule.
 
 <details>
 <summary>Full non-human gene table (click to expand)</summary>


### PR DESCRIPTION
Summary:
- reconcile all 13 current qualifier-aware GOA signatures
- replace the retired GO:0051082 author claim with an interim MODIFY-to-holdase-NTR review
- add full-text evidence review, notes, and generated artifacts

Validation:
- just validate PSEPK PP_1084
- just validate-goa PSEPK PP_1084
- just render PSEPK PP_1084
- just deploy-browser
- git diff --check

The single validate warning is expected: retired annotations are excluded when checking the explicitly interim obsolete GO:0051082 core descriptor.