### PR TITLE
Complete PSEPK surA annotation review

### DIFF
--- a/genes/PSEPK/surA/surA-ai-review.html
+++ b/genes/PSEPK/surA/surA-ai-review.html
@@ -1389,15 +1389,15 @@
                         <br>
                         <span style="font-size: 0.75rem;">
 
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/17908933" target="_blank" class="term-link" style="font-size: 0.75rem;">
-                                PMID:17908933
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26344570" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26344570
                             </a>
 
 
 
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
-                                    Defining the roles of the periplasmic chaperones SurA, Skp, ...
+                                    Impact of holdase chaperones Skp and SurA on the folding of ...
                                 </span>
 
 
@@ -1409,7 +1409,7 @@
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="Q88QT4" data-a="GO:0140309" data-r="PMID:17908933" data-act="NEW">
+                        <span class="vote-buttons" data-g="Q88QT4" data-a="GO:0140309" data-r="PMID:26344570" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1422,7 +1422,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is obsolete and is therefore not retained as an author-supplied NEW annotation. GO:0140309 is carrier-specific, and SurA fits its definition: direct experiments on E. coli SurA (UniProtKB:P0ABZ6) show periplasmic transit of OMP clients to the YaeT/BAM acceptor and stabilization of an unfolded client during membrane insertion. ISS records the orthology boundary because the P. putida protein has no direct experimental study in the cached literature.
+                            <strong>Reason:</strong> GO:0051082 is obsolete and is therefore not retained as an author-supplied NEW annotation. GO:0140309 is carrier-specific: its definition requires escort to an acceptor molecule or specific location, not movement between compartments. E. coli SurA (UniProtKB:P0ABZ6) stabilizes an unfolded OMP during stepwise membrane insertion and delivers OMP clients to the defined YaeT/BAM acceptor. The completed donor review now asserts the same current GO:0140309 term using PMID:26344570 as the direct IDA basis and PMID:17908933 as acceptor-endpoint corroboration. ISS preserves the orthology boundary because the P. putida protein has no direct experimental study in the cached literature.
                         </div>
 
 
@@ -1454,6 +1454,28 @@
                                 </span>
 
                                 <div class="support-text">Either chaperone prevents FhuA from misfolding by stabilizing a dynamic, unfolded state, thus allowing the substrate to search for structural intermediates.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:projects/UNFOLDED_PROTEIN_BINDING.md
+
+                                </span>
+
+                                <div class="support-text">to an acceptor molecule or to a specific location</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:ECOLI/surA/surA-ai-review.yaml
+
+                                </span>
+
+                                <div class="support-text">GO:0140309 is more specific than GO:0044183 for SurA&#39;s mechanism.</div>
 
                             </div>
 
@@ -1783,6 +1805,52 @@
                 <div class="reference-header">
                     <span class="reference-id">
 
+                        file:projects/UNFOLDED_PROTEIN_BINDING.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Unfolded Protein Binding Annotation Review</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Current project policy classifies SurA as a carrier-holdase because it escorts unfolded OMP clients to the defined YaeT/BAM acceptor, even though the delivery occurs within the periplasm.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:ECOLI/surA/surA-ai-review.yaml
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Completed E. coli SurA annotation review</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The experimentally characterized P0ABZ6 donor now asserts NEW GO:0140309 using PMID:26344570 as the IDA basis and PMID:17908933 as independent evidence for the YaeT/BAM acceptor endpoint.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         file:PSEPK/surA/surA-uniprot.txt
 
                     </span>
@@ -2076,6 +2144,20 @@ one KEEP_AS_NON_CORE. The extra author-supplied current-term proposal is one NEW
 Direct biochemical confirmation of Q88QT4 carrier-holdase and PPIase activities remains<br />
 desirable because its UniProt evidence level is PE=3 and no P. putida-specific<br />
 experimental publication was identified in the cache.</p>
+<h2 id="pr-2731-dependency-resolution">PR #2731 dependency resolution</h2>
+<p>The two external dependencies that originally blocked the ISS proposal are now<br />
+resolved. Merged project policy explicitly classifies SurA as a carrier-holdase:<br />
+GO:0140309 requires escort "to an acceptor molecule or to a specific location," and<br />
+delivery within one compartment is sufficient when a defined acceptor such as<br />
+YaeT/BAM is demonstrated [<code>projects/UNFOLDED_PROTEIN_BINDING.md</code>]. The aligned<br />
+E. coli donor review now independently asserts NEW GO:0140309 for P0ABZ6<br />
+[<code>genes/ECOLI/surA/surA-ai-review.yaml</code>].</p>
+<p>The P. putida annotation remains ISS rather than direct experimental evidence.<br />
+PMID:26344570 supplies the donor's IDA basis for stabilizing an unfolded FhuA state<br />
+during stepwise membrane insertion, while PMID:17908933 independently supplies the<br />
+YaeT/BAM acceptor endpoint. P0ABZ6 is recorded machine-readably in<br />
+<code>supporting_entities</code>; Q88QT4 itself has no direct organism-specific assay in the<br />
+cached literature. The seven physical GOA decisions are unchanged.</p>
             </div>
         </details>
 
@@ -2235,7 +2317,7 @@ existing_annotations:
     id: GO:0140309
     label: unfolded protein holdase activity
   evidence_type: ISS
-  original_reference_id: PMID:17908933
+  original_reference_id: PMID:26344570
   supporting_entities:
   - UniProtKB:P0ABZ6
   qualifier: enables
@@ -2247,11 +2329,18 @@ existing_annotations:
     action: NEW
     reason: &gt;-
       GO:0051082 is obsolete and is therefore not retained as an author-supplied
-      NEW annotation. GO:0140309 is carrier-specific, and SurA fits its definition:
-      direct experiments on E. coli SurA (UniProtKB:P0ABZ6) show periplasmic transit
-      of OMP clients to the YaeT/BAM acceptor and stabilization of an unfolded client
-      during membrane insertion. ISS records the orthology boundary because the
-      P. putida protein has no direct experimental study in the cached literature.
+      NEW annotation. GO:0140309 is carrier-specific: its definition requires escort
+      to an acceptor molecule or specific location, not movement between compartments.
+      E. coli SurA (UniProtKB:P0ABZ6) stabilizes an unfolded OMP during stepwise
+      membrane insertion and delivers OMP clients to the defined YaeT/BAM acceptor.
+      The completed donor review now asserts the same current GO:0140309 term using
+      PMID:26344570 as the direct IDA basis and PMID:17908933 as acceptor-endpoint
+      corroboration. ISS preserves the orthology boundary because the P. putida
+      protein has no direct experimental study in the cached literature.
+    additional_reference_ids:
+    - PMID:17908933
+    - file:projects/UNFOLDED_PROTEIN_BINDING.md
+    - file:ECOLI/surA/surA-ai-review.yaml
     supported_by:
     - reference_id: PMID:17908933
       supporting_text: SurA is the primary chaperone responsible for the periplasmic
@@ -2262,6 +2351,12 @@ existing_annotations:
         a dynamic, unfolded state, thus allowing the substrate to search for structural
         intermediates.
       full_text_unavailable: true
+    - reference_id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+      supporting_text: to an acceptor molecule or to a specific location
+      reference_section_type: OTHER
+    - reference_id: file:ECOLI/surA/surA-ai-review.yaml
+      supporting_text: GO:0140309 is more specific than GO:0044183 for SurA&#39;s mechanism.
+      reference_section_type: OTHER
 core_functions:
 - description: Holdase chaperone activity toward unfolded outer membrane proteins,
     binding nascent OMPs in the periplasm and maintaining them in a folding-competent
@@ -2366,6 +2461,18 @@ references:
   findings:
   - statement: SurA prevents FhuA misfolding by stabilizing a dynamic unfolded state
       during its search for membrane-insertion intermediates.
+- id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+  title: Unfolded Protein Binding Annotation Review
+  findings:
+  - statement: Current project policy classifies SurA as a carrier-holdase because
+      it escorts unfolded OMP clients to the defined YaeT/BAM acceptor, even though
+      the delivery occurs within the periplasm.
+- id: file:ECOLI/surA/surA-ai-review.yaml
+  title: Completed E. coli SurA annotation review
+  findings:
+  - statement: The experimentally characterized P0ABZ6 donor now asserts NEW
+      GO:0140309 using PMID:26344570 as the IDA basis and PMID:17908933 as independent
+      evidence for the YaeT/BAM acceptor endpoint.
 - id: file:PSEPK/surA/surA-uniprot.txt
   title: UniProt entry SURA_PSEPK (Q88QT4)
   findings:

--- a/genes/PSEPK/surA/surA-ai-review.html
+++ b/genes/PSEPK/surA/surA-ai-review.html
@@ -1130,12 +1130,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> SurA recognizes aromatic peptide motifs in OMP substrates, but peptide binding is a generic supporting term. The informative molecular functions are the PPIase activity and the unfolded protein binding / holdase chaperone activity.
+                            <strong>Summary:</strong> SurA recognizes aromatic peptide motifs in OMP substrates, but peptide binding is a generic supporting term. The informative molecular functions are the PPIase activity and the carrier-holdase chaperone activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Generic binding term that is subsumed by the more specific and informative chaperone (unfolded protein binding) and PPIase activities already annotated.
+                            <strong>Reason:</strong> Generic binding term that is subsumed by the more specific and informative unfolded-protein carrier-holdase and PPIase activities.
                         </div>
 
 
@@ -1373,23 +1373,34 @@
                         <div class="term-info">
 
                             <span class="term-id">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
-                                    GO:0051082
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    GO:0140309
                                 </a>
                             </span>
-                            <span class="term-label">unfolded protein binding</span>
+                            <span class="term-label">unfolded protein holdase activity</span>
 
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">IEA</span>
+                        <span class="evidence-code">ISS</span>
 
 
 
                         <br>
                         <span style="font-size: 0.75rem;">
 
-                            GO_REF:0000120
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17908933" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17908933
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the roles of the periplasmic chaperones SurA, Skp, ...
+                                </span>
+
+
 
                         </span>
 
@@ -1398,7 +1409,7 @@
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="Q88QT4" data-a="GO:0051082" data-r="GO_REF:0000120" data-act="NEW">
+                        <span class="vote-buttons" data-g="Q88QT4" data-a="GO:0140309" data-r="PMID:17908933" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1406,12 +1417,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> SurA is a holdase chaperone that binds unfolded outer membrane proteins in the periplasm; unfolded protein binding is the most informative molecular function for this activity and is the primary in vivo role of the protein. This term is assigned to SurA orthologs by UniRule but is absent from the P. putida GOA file, so it is proposed as a NEW annotation.
+                            <strong>Summary:</strong> SurA is a carrier-holdase that binds unfolded outer membrane proteins and escorts them across the periplasm to the BAM complex while preventing off-pathway misfolding. This current term captures that activity more precisely than generic peptide binding.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Captures the core holdase chaperone molecular function of SurA, which is more informative than the generic peptide binding term and is the primary in vivo activity. UniRule MF_01183 assigns this term to SurA orthologs.
+                            <strong>Reason:</strong> GO:0051082 is obsolete and is therefore not retained as an author-supplied NEW annotation. GO:0140309 is carrier-specific, and SurA fits its definition: direct experiments on E. coli SurA (UniProtKB:P0ABZ6) show periplasmic transit of OMP clients to the YaeT/BAM acceptor and stabilization of an unfolded client during membrane insertion. ISS records the orthology boundary because the P. putida protein has no direct experimental study in the cached literature.
                         </div>
 
 
@@ -1423,22 +1434,26 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:PSEPK/surA/surA-uniprot.txt
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17908933" target="_blank" class="term-link">
+                                        PMID:17908933
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">Chaperone involved in the correct folding and assembly of outer membrane proteins.</div>
+                                <div class="support-text">SurA is the primary chaperone responsible for the periplasmic transit of the bulk mass of OMPs to the YaeT complex.</div>
 
                             </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:PSEPK/surA/surA-uniprot.txt
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26344570" target="_blank" class="term-link">
+                                        PMID:26344570
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">The N-terminal region and the C-terminal tail are necessary and sufficient for the chaperone activity of SurA.</div>
+                                <div class="support-text">Either chaperone prevents FhuA from misfolding by stabilizing a dynamic, unfolded state, thus allowing the substrate to search for structural intermediates.</div>
 
                             </div>
 
@@ -1473,8 +1488,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
-                            unfolded protein binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                            unfolded protein holdase activity
                         </a>
                     </span>
                 </div>
@@ -1545,6 +1560,32 @@
                         </span>
 
                         <div class="finding-text">The N-terminal region and the C-terminal tail are necessary and sufficient for the chaperone activity of SurA.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17908933" target="_blank" class="term-link">
+                                PMID:17908933
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">SurA is the primary chaperone responsible for the periplasmic transit of the bulk mass of OMPs to the YaeT complex.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26344570" target="_blank" class="term-link">
+                                PMID:26344570
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Either chaperone prevents FhuA from misfolding by stabilizing a dynamic, unfolded state, thus allowing the substrate to search for structural intermediates.</div>
 
                     </li>
 
@@ -1680,7 +1721,57 @@
                 <ul class="findings-list">
 
                     <li class="finding-item">
-                        <div class="finding-statement">UniRule MF_01183 assigns PPIase activity, unfolded protein binding, protein folding, and periplasmic localization to SurA orthologs.</div>
+                        <div class="finding-statement">UniRule MF_01183 assigns PPIase activity, protein folding, and periplasmic localization to SurA orthologs; its legacy GO:0051082 assignment is absent from the current GOA and the term is obsolete.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17908933" target="_blank" class="term-link">
+                            PMID:17908933
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the roles of the periplasmic chaperones SurA, Skp, and DegP in Escherichia coli.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">E. coli SurA is the primary periplasmic route for delivery of bulk OMPs to the YaeT/BAM complex.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26344570" target="_blank" class="term-link">
+                            PMID:26344570
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Impact of holdase chaperones Skp and SurA on the folding of β-barrel outer-membrane proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SurA prevents FhuA misfolding by stabilizing a dynamic unfolded state during its search for membrane-insertion intermediates.</div>
 
                     </li>
 
@@ -1764,7 +1855,7 @@
                 <ul class="findings-list">
 
                     <li class="finding-item">
-                        <div class="finding-statement">Functional understanding of P. putida SurA derives from the HAMAP rule MF_01183 and the well-characterized E. coli ortholog; no organism-specific experimental publications exist.</div>
+                        <div class="finding-statement">Functional understanding of P. putida SurA derives from the HAMAP rule MF_01183 and the well-characterized E. coli ortholog; no organism-specific experimental publications were identified in the cached evidence.</div>
 
                     </li>
 
@@ -1948,10 +2039,11 @@ family PTHR47637 (CHAPERONE SURA).</p>
 <ul>
 <li>MF core: PPIase activity (GO:0003755) — real enzymatic activity per the family<br />
   rule (EC 5.2.1.8), confirmed in the ortholog; retain as a (secondary) core MF.</li>
-<li>MF core: chaperone / unfolded protein binding — SurA's primary in vivo function<br />
-  is holdase chaperone activity toward unfolded OMPs. GO:0051082 (unfolded protein<br />
-  binding) captures this; GO:0044183 (protein folding chaperone) is the more<br />
-  appropriate MF for the chaperone activity (proposed as a new MF term to add).</li>
+<li>MF core: carrier-holdase activity — SurA binds unfolded OMPs and escorts them across<br />
+  the periplasm to BAM while preventing off-pathway misfolding. GO:0051082 is now<br />
+  obsolete. GO:0140309 (unfolded protein holdase activity) is carrier-specific and<br />
+  fits SurA because its client is delivered to a defined acceptor/location; this is<br />
+  unlike an in-situ holdase for which the term would be inappropriate.</li>
 <li>BP: protein folding (GO:0006457) and Gram-negative-bacterium-type cell outer<br />
   membrane assembly (GO:0043165) are well supported and core.</li>
 <li>BP: protein stabilization (GO:0050821) is a broad, mechanistically-implied<br />
@@ -1964,6 +2056,26 @@ family PTHR47637 (CHAPERONE SURA).</p>
   recognize OMP peptide motifs, but the more informative MF terms are the chaperone<br />
   and PPIase terms. Mark as over-annotated.</li>
 </ul>
+<h2 id="2026-08-29-dedicated-re-review">2026-08-29 dedicated re-review</h2>
+<p>The current QuickGO export contains seven qualifier-aware signatures, each reviewed<br />
+exactly once: two <code>enables</code>, three <code>involved_in</code>, and two <code>located_in</code>. All are IEA;<br />
+there are no IBA annotations and therefore no PTN/PAINT node to audit. The PANTHER<br />
+family entry is classification evidence, not an IBA provenance claim.</p>
+<p>The former author-supplied NEW GO:0051082 row was not a current physical GOA signature.<br />
+It reflected a legacy UniRule assignment that remains visible in the UniProt flat file,<br />
+but GO:0051082 is obsolete. It was replaced by a NEW GO:0140309 ISS annotation with<br />
+the experimentally characterized E. coli SurA (UniProtKB:P0ABZ6) recorded as the<br />
+supporting entity. This is an evidence-specific replacement: E. coli SurA is reported<br />
+as responsible for "the periplasmic transit of the bulk mass of OMPs to the YaeT<br />
+complex" <a href="https://pubmed.ncbi.nlm.nih.gov/17908933">PMID:17908933</a>, and SurA prevents FhuA misfolding by "stabilizing a dynamic,<br />
+unfolded state" during stepwise membrane insertion <a href="https://pubmed.ncbi.nlm.nih.gov/26344570">PMID:26344570</a>. These cached<br />
+records are abstract-only, so the review uses only their explicit abstract claims and<br />
+does not convert them into direct P. putida evidence.</p>
+<p>The seven current GOA decisions remain four ACCEPT, two MARK_AS_OVER_ANNOTATED, and<br />
+one KEEP_AS_NON_CORE. The extra author-supplied current-term proposal is one NEW.<br />
+Direct biochemical confirmation of Q88QT4 carrier-holdase and PPIase activities remains<br />
+desirable because its UniProt evidence level is PE=3 and no P. putida-specific<br />
+experimental publication was identified in the cache.</p>
             </div>
         </details>
 
@@ -2062,10 +2174,10 @@ existing_annotations:
   review:
     summary: SurA recognizes aromatic peptide motifs in OMP substrates, but peptide
       binding is a generic supporting term. The informative molecular functions are
-      the PPIase activity and the unfolded protein binding / holdase chaperone activity.
+      the PPIase activity and the carrier-holdase chaperone activity.
     action: MARK_AS_OVER_ANNOTATED
     reason: Generic binding term that is subsumed by the more specific and informative
-      chaperone (unfolded protein binding) and PPIase activities already annotated.
+      unfolded-protein carrier-holdase and PPIase activities.
     supported_by:
     - reference_id: file:PSEPK/surA/surA-uniprot.txt
       supporting_text: Recognizes specific patterns of aromatic residues and the orientation
@@ -2120,35 +2232,43 @@ existing_annotations:
       supporting_text: The N-terminal region and the C-terminal tail are necessary and
         sufficient for the chaperone activity of SurA.
 - term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
+    id: GO:0140309
+    label: unfolded protein holdase activity
+  evidence_type: ISS
+  original_reference_id: PMID:17908933
+  supporting_entities:
+  - UniProtKB:P0ABZ6
   qualifier: enables
   review:
-    summary: SurA is a holdase chaperone that binds unfolded outer membrane proteins
-      in the periplasm; unfolded protein binding is the most informative molecular
-      function for this activity and is the primary in vivo role of the protein. This
-      term is assigned to SurA orthologs by UniRule but is absent from the P. putida
-      GOA file, so it is proposed as a NEW annotation.
+    summary: SurA is a carrier-holdase that binds unfolded outer membrane proteins
+      and escorts them across the periplasm to the BAM complex while preventing
+      off-pathway misfolding. This current term captures that activity more precisely
+      than generic peptide binding.
     action: NEW
-    reason: Captures the core holdase chaperone molecular function of SurA, which is
-      more informative than the generic peptide binding term and is the primary in
-      vivo activity. UniRule MF_01183 assigns this term to SurA orthologs.
+    reason: &gt;-
+      GO:0051082 is obsolete and is therefore not retained as an author-supplied
+      NEW annotation. GO:0140309 is carrier-specific, and SurA fits its definition:
+      direct experiments on E. coli SurA (UniProtKB:P0ABZ6) show periplasmic transit
+      of OMP clients to the YaeT/BAM acceptor and stabilization of an unfolded client
+      during membrane insertion. ISS records the orthology boundary because the
+      P. putida protein has no direct experimental study in the cached literature.
     supported_by:
-    - reference_id: file:PSEPK/surA/surA-uniprot.txt
-      supporting_text: Chaperone involved in the correct folding and assembly of outer
-        membrane proteins.
-    - reference_id: file:PSEPK/surA/surA-uniprot.txt
-      supporting_text: The N-terminal region and the C-terminal tail are necessary and
-        sufficient for the chaperone activity of SurA.
+    - reference_id: PMID:17908933
+      supporting_text: SurA is the primary chaperone responsible for the periplasmic
+        transit of the bulk mass of OMPs to the YaeT complex.
+      full_text_unavailable: true
+    - reference_id: PMID:26344570
+      supporting_text: Either chaperone prevents FhuA from misfolding by stabilizing
+        a dynamic, unfolded state, thus allowing the substrate to search for structural
+        intermediates.
+      full_text_unavailable: true
 core_functions:
 - description: Holdase chaperone activity toward unfolded outer membrane proteins,
     binding nascent OMPs in the periplasm and maintaining them in a folding-competent
     state for delivery to the BAM complex.
   molecular_function:
-    id: GO:0051082
-    label: unfolded protein binding
+    id: GO:0140309
+    label: unfolded protein holdase activity
   directly_involved_in:
   - id: GO:0043165
     label: Gram-negative-bacterium-type cell outer membrane assembly
@@ -2164,6 +2284,15 @@ core_functions:
   - reference_id: file:PSEPK/surA/surA-uniprot.txt
     supporting_text: The N-terminal region and the C-terminal tail are necessary and
       sufficient for the chaperone activity of SurA.
+  - reference_id: PMID:17908933
+    supporting_text: SurA is the primary chaperone responsible for the periplasmic
+      transit of the bulk mass of OMPs to the YaeT complex.
+    full_text_unavailable: true
+  - reference_id: PMID:26344570
+    supporting_text: Either chaperone prevents FhuA from misfolding by stabilizing
+      a dynamic, unfolded state, thus allowing the substrate to search for structural
+      intermediates.
+    full_text_unavailable: true
 - description: Parvulin-type peptidyl-prolyl cis-trans isomerase activity catalyzing
     cis-trans isomerization of peptidyl-prolyl bonds; the activity resides in the second
     parvulin domain and is dispensable for the chaperone function.
@@ -2210,8 +2339,33 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings:
-  - statement: UniRule MF_01183 assigns PPIase activity, unfolded protein binding,
-      protein folding, and periplasmic localization to SurA orthologs.
+  - statement: UniRule MF_01183 assigns PPIase activity, protein folding, and periplasmic
+      localization to SurA orthologs; its legacy GO:0051082 assignment is absent from
+      the current GOA and the term is obsolete.
+- id: PMID:17908933
+  title: Defining the roles of the periplasmic chaperones SurA, Skp, and DegP in Escherichia
+    coli.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Direct E. coli SurA experiments establish interaction with YaeT and
+      transit of OMP clients to that outer-membrane assembly complex; used by ISS for
+      the P. putida ortholog.
+  findings:
+  - statement: E. coli SurA is the primary periplasmic route for delivery of bulk OMPs
+      to the YaeT/BAM complex.
+- id: PMID:26344570
+  title: Impact of holdase chaperones Skp and SurA on the folding of β-barrel outer-membrane
+    proteins.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Direct E. coli biophysical experiments show SurA stabilizing an
+      unfolded OMP state and supporting stepwise membrane insertion; used by ISS for
+      the P. putida ortholog.
+  findings:
+  - statement: SurA prevents FhuA misfolding by stabilizing a dynamic unfolded state
+      during its search for membrane-insertion intermediates.
 - id: file:PSEPK/surA/surA-uniprot.txt
   title: UniProt entry SURA_PSEPK (Q88QT4)
   findings:
@@ -2236,7 +2390,7 @@ references:
   findings:
   - statement: Functional understanding of P. putida SurA derives from the HAMAP rule
       MF_01183 and the well-characterized E. coli ortholog; no organism-specific experimental
-      publications exist.
+      publications were identified in the cached evidence.
 </code></pre>
             </div>
         </details>

--- a/genes/PSEPK/surA/surA-ai-review.yaml
+++ b/genes/PSEPK/surA/surA-ai-review.yaml
@@ -83,10 +83,10 @@ existing_annotations:
   review:
     summary: SurA recognizes aromatic peptide motifs in OMP substrates, but peptide
       binding is a generic supporting term. The informative molecular functions are
-      the PPIase activity and the unfolded protein binding / holdase chaperone activity.
+      the PPIase activity and the carrier-holdase chaperone activity.
     action: MARK_AS_OVER_ANNOTATED
     reason: Generic binding term that is subsumed by the more specific and informative
-      chaperone (unfolded protein binding) and PPIase activities already annotated.
+      unfolded-protein carrier-holdase and PPIase activities.
     supported_by:
     - reference_id: file:PSEPK/surA/surA-uniprot.txt
       supporting_text: Recognizes specific patterns of aromatic residues and the orientation
@@ -141,35 +141,43 @@ existing_annotations:
       supporting_text: The N-terminal region and the C-terminal tail are necessary and
         sufficient for the chaperone activity of SurA.
 - term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
+    id: GO:0140309
+    label: unfolded protein holdase activity
+  evidence_type: ISS
+  original_reference_id: PMID:17908933
+  supporting_entities:
+  - UniProtKB:P0ABZ6
   qualifier: enables
   review:
-    summary: SurA is a holdase chaperone that binds unfolded outer membrane proteins
-      in the periplasm; unfolded protein binding is the most informative molecular
-      function for this activity and is the primary in vivo role of the protein. This
-      term is assigned to SurA orthologs by UniRule but is absent from the P. putida
-      GOA file, so it is proposed as a NEW annotation.
+    summary: SurA is a carrier-holdase that binds unfolded outer membrane proteins
+      and escorts them across the periplasm to the BAM complex while preventing
+      off-pathway misfolding. This current term captures that activity more precisely
+      than generic peptide binding.
     action: NEW
-    reason: Captures the core holdase chaperone molecular function of SurA, which is
-      more informative than the generic peptide binding term and is the primary in
-      vivo activity. UniRule MF_01183 assigns this term to SurA orthologs.
+    reason: >-
+      GO:0051082 is obsolete and is therefore not retained as an author-supplied
+      NEW annotation. GO:0140309 is carrier-specific, and SurA fits its definition:
+      direct experiments on E. coli SurA (UniProtKB:P0ABZ6) show periplasmic transit
+      of OMP clients to the YaeT/BAM acceptor and stabilization of an unfolded client
+      during membrane insertion. ISS records the orthology boundary because the
+      P. putida protein has no direct experimental study in the cached literature.
     supported_by:
-    - reference_id: file:PSEPK/surA/surA-uniprot.txt
-      supporting_text: Chaperone involved in the correct folding and assembly of outer
-        membrane proteins.
-    - reference_id: file:PSEPK/surA/surA-uniprot.txt
-      supporting_text: The N-terminal region and the C-terminal tail are necessary and
-        sufficient for the chaperone activity of SurA.
+    - reference_id: PMID:17908933
+      supporting_text: SurA is the primary chaperone responsible for the periplasmic
+        transit of the bulk mass of OMPs to the YaeT complex.
+      full_text_unavailable: true
+    - reference_id: PMID:26344570
+      supporting_text: Either chaperone prevents FhuA from misfolding by stabilizing
+        a dynamic, unfolded state, thus allowing the substrate to search for structural
+        intermediates.
+      full_text_unavailable: true
 core_functions:
 - description: Holdase chaperone activity toward unfolded outer membrane proteins,
     binding nascent OMPs in the periplasm and maintaining them in a folding-competent
     state for delivery to the BAM complex.
   molecular_function:
-    id: GO:0051082
-    label: unfolded protein binding
+    id: GO:0140309
+    label: unfolded protein holdase activity
   directly_involved_in:
   - id: GO:0043165
     label: Gram-negative-bacterium-type cell outer membrane assembly
@@ -185,6 +193,15 @@ core_functions:
   - reference_id: file:PSEPK/surA/surA-uniprot.txt
     supporting_text: The N-terminal region and the C-terminal tail are necessary and
       sufficient for the chaperone activity of SurA.
+  - reference_id: PMID:17908933
+    supporting_text: SurA is the primary chaperone responsible for the periplasmic
+      transit of the bulk mass of OMPs to the YaeT complex.
+    full_text_unavailable: true
+  - reference_id: PMID:26344570
+    supporting_text: Either chaperone prevents FhuA from misfolding by stabilizing
+      a dynamic, unfolded state, thus allowing the substrate to search for structural
+      intermediates.
+    full_text_unavailable: true
 - description: Parvulin-type peptidyl-prolyl cis-trans isomerase activity catalyzing
     cis-trans isomerization of peptidyl-prolyl bonds; the activity resides in the second
     parvulin domain and is dispensable for the chaperone function.
@@ -231,8 +248,33 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings:
-  - statement: UniRule MF_01183 assigns PPIase activity, unfolded protein binding,
-      protein folding, and periplasmic localization to SurA orthologs.
+  - statement: UniRule MF_01183 assigns PPIase activity, protein folding, and periplasmic
+      localization to SurA orthologs; its legacy GO:0051082 assignment is absent from
+      the current GOA and the term is obsolete.
+- id: PMID:17908933
+  title: Defining the roles of the periplasmic chaperones SurA, Skp, and DegP in Escherichia
+    coli.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Direct E. coli SurA experiments establish interaction with YaeT and
+      transit of OMP clients to that outer-membrane assembly complex; used by ISS for
+      the P. putida ortholog.
+  findings:
+  - statement: E. coli SurA is the primary periplasmic route for delivery of bulk OMPs
+      to the YaeT/BAM complex.
+- id: PMID:26344570
+  title: Impact of holdase chaperones Skp and SurA on the folding of β-barrel outer-membrane
+    proteins.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Direct E. coli biophysical experiments show SurA stabilizing an
+      unfolded OMP state and supporting stepwise membrane insertion; used by ISS for
+      the P. putida ortholog.
+  findings:
+  - statement: SurA prevents FhuA misfolding by stabilizing a dynamic unfolded state
+      during its search for membrane-insertion intermediates.
 - id: file:PSEPK/surA/surA-uniprot.txt
   title: UniProt entry SURA_PSEPK (Q88QT4)
   findings:
@@ -257,4 +299,4 @@ references:
   findings:
   - statement: Functional understanding of P. putida SurA derives from the HAMAP rule
       MF_01183 and the well-characterized E. coli ortholog; no organism-specific experimental
-      publications exist.
+      publications were identified in the cached evidence.

--- a/genes/PSEPK/surA/surA-ai-review.yaml
+++ b/genes/PSEPK/surA/surA-ai-review.yaml
@@ -144,7 +144,7 @@ existing_annotations:
     id: GO:0140309
     label: unfolded protein holdase activity
   evidence_type: ISS
-  original_reference_id: PMID:17908933
+  original_reference_id: PMID:26344570
   supporting_entities:
   - UniProtKB:P0ABZ6
   qualifier: enables
@@ -156,11 +156,18 @@ existing_annotations:
     action: NEW
     reason: >-
       GO:0051082 is obsolete and is therefore not retained as an author-supplied
-      NEW annotation. GO:0140309 is carrier-specific, and SurA fits its definition:
-      direct experiments on E. coli SurA (UniProtKB:P0ABZ6) show periplasmic transit
-      of OMP clients to the YaeT/BAM acceptor and stabilization of an unfolded client
-      during membrane insertion. ISS records the orthology boundary because the
-      P. putida protein has no direct experimental study in the cached literature.
+      NEW annotation. GO:0140309 is carrier-specific: its definition requires escort
+      to an acceptor molecule or specific location, not movement between compartments.
+      E. coli SurA (UniProtKB:P0ABZ6) stabilizes an unfolded OMP during stepwise
+      membrane insertion and delivers OMP clients to the defined YaeT/BAM acceptor.
+      The completed donor review now asserts the same current GO:0140309 term using
+      PMID:26344570 as the direct IDA basis and PMID:17908933 as acceptor-endpoint
+      corroboration. ISS preserves the orthology boundary because the P. putida
+      protein has no direct experimental study in the cached literature.
+    additional_reference_ids:
+    - PMID:17908933
+    - file:projects/UNFOLDED_PROTEIN_BINDING.md
+    - file:ECOLI/surA/surA-ai-review.yaml
     supported_by:
     - reference_id: PMID:17908933
       supporting_text: SurA is the primary chaperone responsible for the periplasmic
@@ -171,6 +178,12 @@ existing_annotations:
         a dynamic, unfolded state, thus allowing the substrate to search for structural
         intermediates.
       full_text_unavailable: true
+    - reference_id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+      supporting_text: to an acceptor molecule or to a specific location
+      reference_section_type: OTHER
+    - reference_id: file:ECOLI/surA/surA-ai-review.yaml
+      supporting_text: GO:0140309 is more specific than GO:0044183 for SurA's mechanism.
+      reference_section_type: OTHER
 core_functions:
 - description: Holdase chaperone activity toward unfolded outer membrane proteins,
     binding nascent OMPs in the periplasm and maintaining them in a folding-competent
@@ -275,6 +288,18 @@ references:
   findings:
   - statement: SurA prevents FhuA misfolding by stabilizing a dynamic unfolded state
       during its search for membrane-insertion intermediates.
+- id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+  title: Unfolded Protein Binding Annotation Review
+  findings:
+  - statement: Current project policy classifies SurA as a carrier-holdase because
+      it escorts unfolded OMP clients to the defined YaeT/BAM acceptor, even though
+      the delivery occurs within the periplasm.
+- id: file:ECOLI/surA/surA-ai-review.yaml
+  title: Completed E. coli SurA annotation review
+  findings:
+  - statement: The experimentally characterized P0ABZ6 donor now asserts NEW
+      GO:0140309 using PMID:26344570 as the IDA basis and PMID:17908933 as independent
+      evidence for the YaeT/BAM acceptor endpoint.
 - id: file:PSEPK/surA/surA-uniprot.txt
   title: UniProt entry SURA_PSEPK (Q88QT4)
   findings:

--- a/genes/PSEPK/surA/surA-notes.md
+++ b/genes/PSEPK/surA/surA-notes.md
@@ -53,10 +53,11 @@ SurA is a periplasmic protein bearing a cleavable N-terminal signal peptide
 
 - MF core: PPIase activity (GO:0003755) — real enzymatic activity per the family
   rule (EC 5.2.1.8), confirmed in the ortholog; retain as a (secondary) core MF.
-- MF core: chaperone / unfolded protein binding — SurA's primary in vivo function
-  is holdase chaperone activity toward unfolded OMPs. GO:0051082 (unfolded protein
-  binding) captures this; GO:0044183 (protein folding chaperone) is the more
-  appropriate MF for the chaperone activity (proposed as a new MF term to add).
+- MF core: carrier-holdase activity — SurA binds unfolded OMPs and escorts them across
+  the periplasm to BAM while preventing off-pathway misfolding. GO:0051082 is now
+  obsolete. GO:0140309 (unfolded protein holdase activity) is carrier-specific and
+  fits SurA because its client is delivered to a defined acceptor/location; this is
+  unlike an in-situ holdase for which the term would be inappropriate.
 - BP: protein folding (GO:0006457) and Gram-negative-bacterium-type cell outer
   membrane assembly (GO:0043165) are well supported and core.
 - BP: protein stabilization (GO:0050821) is a broad, mechanistically-implied
@@ -68,3 +69,27 @@ SurA is a periplasmic protein bearing a cleavable N-terminal signal peptide
 - MF: peptide binding (GO:0042277) is a generic supporting binding term; SurA does
   recognize OMP peptide motifs, but the more informative MF terms are the chaperone
   and PPIase terms. Mark as over-annotated.
+
+## 2026-08-29 dedicated re-review
+
+The current QuickGO export contains seven qualifier-aware signatures, each reviewed
+exactly once: two `enables`, three `involved_in`, and two `located_in`. All are IEA;
+there are no IBA annotations and therefore no PTN/PAINT node to audit. The PANTHER
+family entry is classification evidence, not an IBA provenance claim.
+
+The former author-supplied NEW GO:0051082 row was not a current physical GOA signature.
+It reflected a legacy UniRule assignment that remains visible in the UniProt flat file,
+but GO:0051082 is obsolete. It was replaced by a NEW GO:0140309 ISS annotation with
+the experimentally characterized E. coli SurA (UniProtKB:P0ABZ6) recorded as the
+supporting entity. This is an evidence-specific replacement: E. coli SurA is reported
+as responsible for "the periplasmic transit of the bulk mass of OMPs to the YaeT
+complex" [PMID:17908933], and SurA prevents FhuA misfolding by "stabilizing a dynamic,
+unfolded state" during stepwise membrane insertion [PMID:26344570]. These cached
+records are abstract-only, so the review uses only their explicit abstract claims and
+does not convert them into direct P. putida evidence.
+
+The seven current GOA decisions remain four ACCEPT, two MARK_AS_OVER_ANNOTATED, and
+one KEEP_AS_NON_CORE. The extra author-supplied current-term proposal is one NEW.
+Direct biochemical confirmation of Q88QT4 carrier-holdase and PPIase activities remains
+desirable because its UniProt evidence level is PE=3 and no P. putida-specific
+experimental publication was identified in the cache.

--- a/genes/PSEPK/surA/surA-notes.md
+++ b/genes/PSEPK/surA/surA-notes.md
@@ -93,3 +93,20 @@ one KEEP_AS_NON_CORE. The extra author-supplied current-term proposal is one NEW
 Direct biochemical confirmation of Q88QT4 carrier-holdase and PPIase activities remains
 desirable because its UniProt evidence level is PE=3 and no P. putida-specific
 experimental publication was identified in the cache.
+
+## PR #2731 dependency resolution
+
+The two external dependencies that originally blocked the ISS proposal are now
+resolved. Merged project policy explicitly classifies SurA as a carrier-holdase:
+GO:0140309 requires escort "to an acceptor molecule or to a specific location," and
+delivery within one compartment is sufficient when a defined acceptor such as
+YaeT/BAM is demonstrated [`projects/UNFOLDED_PROTEIN_BINDING.md`]. The aligned
+E. coli donor review now independently asserts NEW GO:0140309 for P0ABZ6
+[`genes/ECOLI/surA/surA-ai-review.yaml`].
+
+The P. putida annotation remains ISS rather than direct experimental evidence.
+PMID:26344570 supplies the donor's IDA basis for stabilizing an unfolded FhuA state
+during stepwise membrane insertion, while PMID:17908933 independently supplies the
+YaeT/BAM acceptor endpoint. P0ABZ6 is recorded machine-readably in
+`supporting_entities`; Q88QT4 itself has no direct organism-specific assay in the
+cached literature. The seven physical GOA decisions are unchanged.


### PR DESCRIPTION
## Summary
- reconcile all 7 current qualifier-aware GOA annotations
- replace obsolete synthetic GO:0051082 with ISS GO:0140309 from experimentally characterized E. coli SurA
- update core functions, evidence reviews, notes, rendered review, and browser data

## Validation
- `just validate PSEPK surA`
- `just validate-goa PSEPK surA`
- `just render PSEPK surA`
- `just deploy-browser`
- `git diff --check`