### PR TITLE
Align E. coli SurA holdase review

### DIFF
--- a/genes/ECOLI/surA/surA-ai-review.html
+++ b/genes/ECOLI/surA/surA-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -900,6 +900,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN005352065</span>
+
+                                    &middot; PANTHER:PTN005352065
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Current PTHR47637 PAINT retains protein folding at this node, seeded by P0ABZ6&#39;s own experimental evidence; target self-seeding is valid experimental grounding, not circular propagation.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -982,6 +1011,35 @@
                             <strong>Reason:</strong> PPIase activity is experimentally confirmed for SurA (PMID:8985185) and is a real enzymatic activity of this protein, even though it is not essential for SurA&#39;s primary in vivo function. The IBA annotation is appropriate.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN005352065</span>
+
+                                    &middot; PANTHER:PTN005352065
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Current PTHR47637 PAINT retains PPIase activity at this node, seeded by P0ABZ6&#39;s direct activity evidence; target self-seeding is expected and not circular.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
 
@@ -1068,6 +1126,35 @@
 
 
 
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">NO FAILURE CORE</span>
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN005352065</span>
+
+                                    &middot; PANTHER:PTN005352065
+
+
+                                    <span class="badge">SUPPORTS TRANSFER</span>
+
+
+                                    <div class="propagation-comment">Current PTHR47637 PAINT retains this localization at the node, seeded by P0ABZ6&#39;s direct periplasmic-localization evidence.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
@@ -1129,22 +1216,58 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> SurA directly binds unfolded outer membrane proteins in the periplasm. Behrens et al. (PMID:11226178) demonstrated that SurA interacts preferentially (&gt;50-fold) with in vitro synthesized porins over other similarly sized proteins, and this chaperone activity resides in the N-terminal and C-terminal domains independent of PPIase activity. Thoma et al. (PMID:26344570) characterized SurA as a holdase that stabilizes a dynamic unfolded state, preventing misfolding and allowing stepwise beta-hairpin insertion into the membrane. Per the UPB project decision rules, SurA functions as a holdase-type chaperone that prevents aggregation of unfolded OMPs in transit to the BAM complex. It does not actively refold substrates via ATPase cycles. However, because it escorts unfolded OMPs from the Sec translocon to the BAM complex (between two cellular locations), GO:0140309 (unfolded protein carrier activity) could potentially apply. Since the primary mode of action described in the literature is holdase/carrier, not foldase, the most appropriate replacement depends on whether SurA&#39;s escort function qualifies for GO:0140309 or whether a general holdase NTR is needed.
+                            <strong>Summary:</strong> SurA directly binds unfolded outer membrane proteins in the periplasm. Behrens et al. (PMID:11226178) demonstrated that SurA interacts preferentially (&gt;50-fold) with in vitro synthesized porins over other similarly sized proteins, and this chaperone activity resides in the N-terminal and C-terminal domains independent of PPIase activity. Thoma et al. (PMID:26344570) characterized SurA as a holdase that stabilizes a dynamic unfolded state, preventing misfolding and allowing stepwise beta-hairpin insertion into the membrane. Per the UPB project decision rules, SurA functions as a holdase-type chaperone that prevents aggregation of unfolded OMPs in transit to the BAM complex. It does not actively refold substrates via ATPase cycles. Because SurA escorts an unfolded client to the defined YaeT/BAM acceptor, the carrier-specific GO:0140309 definition is satisfied even though movement occurs within one compartment.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is now formally obsolete. SurA is described as a holdase chaperone by Thoma et al. (PMID:26344570), who explicitly titled their paper &#34;Impact of holdase chaperones Skp and SurA on the folding of beta-barrel outer-membrane proteins.&#34; SurA stabilizes unfolded OMPs in a dynamic state without actively refolding them via ATPase cycles, instead allowing stepwise membrane insertion. SurA also escorts OMPs from the Sec translocon across the periplasm to the BAM complex, which constitutes transport between two cellular components. GO:0044183 (protein folding chaperone) could apply if SurA is considered to actively assist folding, but the evidence from PMID:26344570 characterizes it more as a holdase. Given the escort/carrier function, GO:0140309 may be appropriate, but if the carrier semantics do not fit (since SurA acts in a single compartment, the periplasm), then the holdase NTR is needed. As an interim, retain GO:0051082 until the holdase NTR is created.
+                            <strong>Reason:</strong> GO:0051082 is now formally obsolete. SurA is described as a holdase chaperone by Thoma et al. (PMID:26344570), who explicitly titled their paper &#34;Impact of holdase chaperones Skp and SurA on the folding of beta-barrel outer-membrane proteins.&#34; SurA stabilizes unfolded OMPs in a dynamic state without actively refolding them via ATPase cycles, instead allowing stepwise membrane insertion. SurA also escorts OMPs across the periplasm to the YaeT/BAM acceptor. The definition of GO:0140309 requires an acceptor molecule or a specific location, not movement through multiple compartments; BAM/YaeT satisfies that endpoint. GO:0140309 therefore captures the directly demonstrated carrier-holdase mechanism, whereas GO:0044183 is less specific and GO:0051082 is obsolete.
                         </div>
 
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">SOURCE STALE OR MISSING</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">SOURCE EVIDENCE WEAK</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN005352065</span>
+
+                                    &middot; PANTHER:PTN005352065
+
+
+                                    <span class="badge">SOURCE STALE OR MISSING</span>
+
+
+                                    <div class="propagation-comment">GOA still carries the obsolete GO:0051082 IBA from this node, but current PTHR47637 PAINT contains no GO:0051082 IBD row. The replacement is grounded independently in direct SurA experiments.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
 
 
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
 
@@ -1368,10 +1491,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0016853" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0016853" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1384,7 +1507,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> While this is a very broad parent term, it is not incorrect. The more specific GO:0003755 is annotated separately. IEA from keyword mapping is acceptable here as it simply reflects the isomerase classification.
+                            <strong>Reason:</strong> This very broad parent term is true but non-core because the experimentally supported child GO:0003755 identifies the actual isomerase activity.
                         </div>
 
 
@@ -1510,10 +1633,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0042277" data-r="GO_REF:0000002" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0042277" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1526,7 +1649,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> SurA does bind peptide motifs as part of its substrate recognition mechanism. While more specific terms might be preferable, this general IEA annotation is not incorrect. SurA&#39;s N-terminal domain and C-terminal tail form the peptide binding site for OMP recognition.
+                            <strong>Reason:</strong> SurA does bind OMP peptide motifs, so the annotation is retained. It is non-core because the carrier-holdase and PPIase terms convey the functional mechanisms more informatively.
                         </div>
 
 
@@ -1581,10 +1704,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0042597" data-r="GO_REF:0000120" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0042597" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1597,7 +1720,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Correct localization. This is a broader parent of the more specific GO:0030288 which is annotated with experimental evidence. The IEA annotation is acceptable as a general localization.
+                            <strong>Reason:</strong> Correct localization, retained as non-core because it is a broader parent of GO:0030288, which is independently supported by direct evidence.
                         </div>
 
 
@@ -1739,7 +1862,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Consistent with experimental evidence showing SurA prevents OMP degradation and misfolding. Redundant with IMP annotations but acceptable as an IEA.
+                            <strong>Reason:</strong> Consistent with direct IMP evidence that SurA stabilizes OMP clients. The IEA and experimental rows therefore receive the same core action.
                         </div>
 
 
@@ -1810,7 +1933,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Same rationale as the IBA GO:0051082 annotation above. SurA functions as a holdase chaperone for unfolded OMPs. GO:0051082 is now formally obsolete. Replace with GO:0044183 (protein folding chaperone) as the most appropriate existing replacement term, pending creation of holdase NTR.
+                            <strong>Reason:</strong> Same rationale as the IBA GO:0051082 annotation above. SurA functions as a holdase chaperone for unfolded OMPs. GO:0051082 is now formally obsolete. Replace with GO:0140309 because SurA both stabilizes an unfolded OMP and escorts it to the YaeT/BAM acceptor; the carrier definition is satisfied.
                         </div>
 
 
@@ -1819,8 +1942,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
 
@@ -1887,10 +2010,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0005515" data-r="PMID:18165306" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0005515" data-r="PMID:18165306" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1903,7 +2026,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> The generic &#34;protein binding&#34; term is uninformative. SurA&#39;s interaction with BAM complex components is better captured by its biological process annotations (GO:0043165, outer membrane assembly). The specific interaction should be annotated with a more specific molecular function term if available, not the generic protein binding. Per curation guidelines, GO:0005515 should be avoided.
+                            <strong>Reason:</strong> IPI asserts an observed interaction with BamB and there is no contradictory evidence, so the row is retained. Generic protein binding does not express SurA&#39;s carrier-holdase mechanism and is therefore non-core.
                         </div>
 
 
@@ -1969,10 +2092,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0005515" data-r="PMID:22544271" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0005515" data-r="PMID:22544271" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1985,7 +2108,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Generic protein binding is uninformative. SurA&#39;s interaction with BAM complex components reflects its chaperone function in OMP biogenesis, which is captured by more informative annotations. Per curation guidelines, GO:0005515 should be avoided.
+                            <strong>Reason:</strong> IPI asserts an observed BamB interaction and no evidence contradicts it. The generic term is retained as non-core because it does not identify SurA&#39;s carrier-holdase mechanism.
                         </div>
 
 
@@ -2569,10 +2692,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0005515" data-r="PMID:11226178" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0005515" data-r="PMID:11226178" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2585,7 +2708,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Generic protein binding is uninformative. This interaction represents SurA&#39;s chaperone-substrate interaction with OmpF, which is better captured by the unfolded protein binding / chaperone annotations (GO:0051082, GO:0036506, GO:0006457). Per curation guidelines, GO:0005515 should be avoided.
+                            <strong>Reason:</strong> IPI accurately records the experimentally observed OmpF interaction and no evidence contradicts it. It remains non-core because GO:0140309 and GO:0036506 convey the substrate-chaperoning mechanism rather than generic binding.
                         </div>
 
 
@@ -2651,10 +2774,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0005515" data-r="PMID:17908933" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0005515" data-r="PMID:17908933" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2667,7 +2790,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Generic protein binding is uninformative. The SurA-BamA interaction is functionally important for OMP delivery but is better represented by the biological process annotation GO:0043165 (outer membrane assembly). Per curation guidelines, GO:0005515 should be avoided.
+                            <strong>Reason:</strong> IPI accurately records the direct BamA/YaeT interaction and no evidence contradicts it. It is retained as non-core because the interaction is more informatively interpreted through GO:0140309 and outer-membrane assembly.
                         </div>
 
 
@@ -2733,10 +2856,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0005515" data-r="PMID:18165306" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0005515" data-r="PMID:18165306" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2749,7 +2872,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Generic protein binding is uninformative. This is a duplicate reference to the same SurA-BamA interaction captured by the previous PMID:17908933 entry and is better represented by GO:0043165. Per curation guidelines, GO:0005515 should be avoided.
+                            <strong>Reason:</strong> IPI accurately records a BamA/YaeT interaction and no evidence contradicts it. It is retained as non-core because generic binding is less informative than the carrier-holdase and outer-membrane-assembly annotations.
                         </div>
 
 
@@ -3172,7 +3295,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Same rationale as other GO:0051082 annotations. GO:0051082 is now formally obsolete. SurA&#39;s binding to unfolded porins represents its holdase/chaperone activity. Replace with GO:0044183 (protein folding chaperone) as interim, pending holdase NTR creation.
+                            <strong>Reason:</strong> Same rationale as other GO:0051082 annotations. GO:0051082 is now formally obsolete. SurA&#39;s binding to unfolded porins is one component of its carrier-holdase activity, and independent experiments establish escort to YaeT/BAM. Replace with GO:0140309.
                         </div>
 
 
@@ -3181,8 +3304,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
 
@@ -3311,11 +3434,11 @@
                         <div class="term-info">
 
                             <span class="term-id">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    GO:0044183
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    GO:0140309
                                 </a>
                             </span>
-                            <span class="term-label">protein folding chaperone</span>
+                            <span class="term-label">unfolded protein holdase activity</span>
 
                         </div>
                     </td>
@@ -3327,15 +3450,15 @@
                         <br>
                         <span style="font-size: 0.75rem;">
 
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/11226178" target="_blank" class="term-link" style="font-size: 0.75rem;">
-                                PMID:11226178
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26344570" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26344570
                             </a>
 
 
 
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
-                                    The SurA periplasmic PPIase lacking its parvulin domains fun...
+                                    Impact of holdase chaperones Skp and SurA on the folding of ...
                                 </span>
 
 
@@ -3347,7 +3470,7 @@
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0044183" data-r="PMID:11226178" data-act="NEW">
+                        <span class="vote-buttons" data-g="P0ABZ6" data-a="GO:0140309" data-r="PMID:26344570" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3355,12 +3478,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Behrens et al. (PMID:11226178) directly demonstrated that SurA has chaperone activity independent of its PPIase domains. A SurA variant lacking both parvulin domains exhibited PPIase-independent chaperone-like activity in vitro and almost completely complemented full-length SurA function in vivo. SurA preferentially binds in vitro synthesized porins (&gt;50-fold selectivity) through its N-terminal and C-terminal domains. This is the core molecular function of SurA.
+                            <strong>Summary:</strong> Direct biophysical experiments show SurA stabilizing a dynamic unfolded FhuA state during stepwise membrane insertion, while depletion and interaction studies establish delivery of OMPs to YaeT/BAM. BAM is the defined acceptor molecule required by the carrier-specific GO:0140309 definition.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0044183 (protein folding chaperone) is not currently annotated for SurA but is the most appropriate MF term for its primary function. SurA acts as a chaperone that facilitates OMP folding and assembly, with direct in vitro evidence for chaperone activity. This annotation should be added to replace GO:0051082 which is now formally obsolete. Evidence supports both holdase and chaperone mechanisms - SurA prevents aggregation (holdase) and enables stepwise folding (facilitating folding). GO:0044183 is the best available existing term.
+                            <strong>Reason:</strong> GO:0140309 is more specific than GO:0044183 for SurA&#39;s mechanism. It does not require movement between compartments: its definition requires escort to an acceptor molecule or specific location. SurA binds unfolded OMPs, prevents misfolding in transit, and hands them to YaeT/BAM for membrane insertion. The obsolete GO:0051082 author claim is not retained.
                         </div>
 
 
@@ -3372,26 +3495,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11226178" target="_blank" class="term-link">
-                                        PMID:11226178
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">a variant of SurA lacking both parvulin-like domains exhibits a PPIase-independent chaperone-like activity in vitro and almost completely complements the in vivo function of intact SurA</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26344570" target="_blank" class="term-link">
                                         PMID:26344570
                                     </a>
 
                                 </span>
 
-                                <div class="support-text">the SurA-chaperoned FhuA polypeptide inserts beta-hairpins into the membrane in a stepwise manner until the beta-barrel is folded</div>
+                                <div class="support-text">Either chaperone prevents FhuA from misfolding by stabilizing a dynamic, unfolded state, thus allowing the substrate to search for structural intermediates.</div>
 
                             </div>
 
@@ -3405,6 +3515,28 @@
                                 </span>
 
                                 <div class="support-text">SurA is the primary chaperone responsible for the periplasmic transit of the bulk mass of OMPs to the YaeT complex.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:projects/UNFOLDED_PROTEIN_BINDING.md
+
+                                </span>
+
+                                <div class="support-text">to an acceptor molecule or to a specific location</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:ECOLI/surA/surA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SurA protects newly translocated, unfolded OMPs from **aggregation** in the crowded, ATP-free periplasm and **delivers** them to the outer-membrane β-barrel assembly machinery (**BAM** complex) for folding and insertion</div>
 
                             </div>
 
@@ -3426,8 +3558,8 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Chaperone activity -- SurA functions as the primary periplasmic chaperone for outer membrane protein biogenesis. It binds unfolded OMPs via its N-terminal and C-terminal domains (independent of PPIase activity) and escorts them to the BAM complex. SurA acts as a holdase, stabilizing OMPs in a dynamic unfolded state to prevent aggregation while enabling stepwise beta-hairpin membrane insertion.</h3>
-                <span class="vote-buttons" data-g="P0ABZ6" data-a="FUNCTION: Chaperone activity -- SurA functions as the primar..." data-r="" data-act="CORE_FUNCTION">
+                <h3>Carrier-holdase activity -- SurA functions as the primary periplasmic chaperone for outer membrane protein biogenesis. It binds unfolded OMPs via its N-terminal and C-terminal domains (independent of PPIase activity) and escorts them to the BAM complex. SurA acts as a holdase, stabilizing OMPs in a dynamic unfolded state to prevent off-pathway misfolding while enabling stepwise beta-hairpin membrane insertion.</h3>
+                <span class="vote-buttons" data-g="P0ABZ6" data-a="FUNCTION: Carrier-holdase activity -- SurA functions as the ..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -3439,8 +3571,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                            protein folding chaperone
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                            unfolded protein holdase activity
                         </a>
                     </span>
                 </div>
@@ -3534,6 +3666,28 @@
                         </span>
 
                         <div class="finding-text">the SurA-chaperoned FhuA polypeptide inserts beta-hairpins into the membrane in a stepwise manner until the beta-barrel is folded</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:projects/UNFOLDED_PROTEIN_BINDING.md
+
+                        </span>
+
+                        <div class="finding-text">to an acceptor molecule or to a specific location</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:ECOLI/surA/surA-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">SurA protects newly translocated, unfolded OMPs from **aggregation** in the crowded, ATP-free periplasm and **delivers** them to the outer-membrane β-barrel assembly machinery (**BAM** complex) for folding and insertion</div>
 
                     </li>
 
@@ -4070,6 +4224,75 @@
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Current PAINT annotations for PANTHER family PTHR47637</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PTN005352065 currently carries IBD assertions for protein folding, PPIase activity, and periplasmic localization, each seeded by P0ABZ6; it no longer carries GO:0051082.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:projects/UNFOLDED_PROTEIN_BINDING.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Unfolded Protein Binding Annotation Review</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GO:0140309 remains carrier-specific and requires escort of an unfolded client to an acceptor molecule or specific location; SurA satisfies this through delivery to YaeT/BAM.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:ECOLI/surA/surA-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research synthesis for E. coli SurA</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The synthesis independently describes ATP-independent capture of unfolded OMP clients in the periplasm and their delivery to BAM for insertion.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
 
@@ -4422,6 +4645,61 @@ this with annotations you find in gene/protein databases, but these can be outda
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(surA-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P0ABZ6" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="sura-sura-escherichia-coli-k-12">surA (SurA) — <em>Escherichia coli</em> K-12</h1>
+<h2 id="2026-08-29-carrier-holdase-consistency-review">2026-08-29 carrier-holdase consistency review</h2>
+<p>The current GOA contains 30 qualifier-aware physical signatures, all represented<br />
+exactly once in <code>surA-ai-review.yaml</code>: 13 <code>enables</code>, 11 <code>involved_in</code>, five<br />
+<code>located_in</code>, and one <code>is_active_in</code>. The review also contains one author-supplied<br />
+NEW molecular-function proposal. No physical GOA row was deleted or rewritten.</p>
+<h3 id="go0140309-decision">GO:0140309 decision</h3>
+<p>GO:0051082 is obsolete. The earlier review hesitated between GO:0044183 and<br />
+GO:0140309 because SurA moves within the periplasm rather than between compartments.<br />
+That is not a requirement of GO:0140309: the project records that its definition<br />
+requires escort "to an acceptor molecule or to a specific location"<br />
+[<code>projects/UNFOLDED_PROTEIN_BINDING.md</code>]. BAM/YaeT is a defined acceptor molecule<br />
+for SurA-delivered unfolded OMP clients.</p>
+<p>The direct cached evidence supports both components of this interpretation. SurA<br />
+"prevents FhuA from misfolding by stabilizing a dynamic, unfolded state"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26344570">PMID:26344570</a>, and it is "responsible for the periplasmic transit of the bulk mass<br />
+of OMPs to the YaeT complex" <a href="https://pubmed.ncbi.nlm.nih.gov/17908933">PMID:17908933</a>. These records are abstract-only, so<br />
+the review makes no claims beyond their explicit text. The three physical GO:0051082<br />
+rows are therefore MODIFY to GO:0140309, and the former author NEW GO:0044183 row is<br />
+replaced by NEW GO:0140309. GO:0044183 is not asserted as the primary MF because the<br />
+carrier-holdase term describes the observed mechanism more specifically.</p>
+<h3 id="paint-provenance">PAINT provenance</h3>
+<p>All four IBA rows in GOA cite PANTHER:PTN005352065 and include P0ABZ6 itself among<br />
+their WITH/FROM sources. Target self-seeding is legitimate because direct SurA<br />
+evidence grounds the ancestral assertion; it is not circular. Current cached PAINT<br />
+for PTHR47637 retains at PTN005352065 only GO:0006457 protein folding, GO:0003755<br />
+PPIase activity, and GO:0030288 periplasmic localization, all seeded by P0ABZ6<br />
+[<code>interpro/panther/PTHR47637/PTHR47637-paint.tsv</code>]. Those three IBAs remain ACCEPT<br />
+with <code>NO_FAILURE_CORE</code>. GO:0051082 is absent from current PAINT, so its old GOA IBA<br />
+is recorded as <code>SOURCE_STALE_OR_MISSING</code> and MODIFY to GO:0140309 using independent<br />
+direct evidence.</p>
+<h3 id="other-row-level-decisions">Other row-level decisions</h3>
+<p>The five GO:0005515 IPI rows are true observed interactions with OmpF, BamA/YaeT,<br />
+or BamB and have no contradictory evidence. They are retained as KEEP_AS_NON_CORE<br />
+rather than removed merely because <code>protein binding</code> is uninformative. Broad parent<br />
+or supporting IEAs (isomerase activity, peptide binding, and periplasmic space)<br />
+are also retained as non-core. Protein stabilization remains ACCEPT across IEA and<br />
+direct IMP rows because direct experiments establish stabilization of OMP clients.<br />
+Direct folding, OMP assembly, PPIase, maintenance-of-unfolded-protein, and localization<br />
+annotations also remain accepted.</p>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
                     <h3 style="display: inline;">Bioreason Rl Predictions</h3>
                     <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(surA-bioreason-rl-predictions.md)</span>
                 </div>
@@ -4525,7 +4803,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P0ABZ6
 gene_symbol: surA
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:83333
   label: Escherichia coli (strain K12)
@@ -4549,6 +4827,10 @@ existing_annotations:
     label: protein folding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  supporting_entities:
+  - PANTHER:PTN005352065
+  - UniProtKB:P0ABZ6
+  qualifier: involved_in
   review:
     summary: &gt;-
       SurA participates in the maturation of outer membrane porins, which involves
@@ -4563,6 +4845,17 @@ existing_annotations:
       step prior to folded monomer formation (PMID:8985185), and surA mutants
       show defective folding of three outer membrane proteins (PMID:8626309).
       This IBA annotation is well supported.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN005352065
+        source_label: PANTHER:PTN005352065
+        source_status: SUPPORTS_TRANSFER
+        comment: Current PTHR47637 PAINT retains protein folding at this node,
+          seeded by P0ABZ6&#39;s own experimental evidence; target self-seeding is
+          valid experimental grounding, not circular propagation.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
     supported_by:
       - reference_id: PMID:8985185
         supporting_text: &#34;We demonstrate that SurA is involved in the conversion of unfolded monomers into a newly identified intermediate in LamB assembly, which behaves as a folded monomer.&#34;
@@ -4573,6 +4866,10 @@ existing_annotations:
     label: peptidyl-prolyl cis-trans isomerase activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  supporting_entities:
+  - PANTHER:PTN005352065
+  - UniProtKB:P0ABZ6
+  qualifier: enables
   review:
     summary: &gt;-
       SurA has confirmed PPIase activity (EC 5.2.1.8) residing in its second parvulin
@@ -4585,6 +4882,17 @@ existing_annotations:
       PPIase activity is experimentally confirmed for SurA (PMID:8985185) and is
       a real enzymatic activity of this protein, even though it is not essential
       for SurA&#39;s primary in vivo function. The IBA annotation is appropriate.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN005352065
+        source_label: PANTHER:PTN005352065
+        source_status: SUPPORTS_TRANSFER
+        comment: Current PTHR47637 PAINT retains PPIase activity at this node,
+          seeded by P0ABZ6&#39;s direct activity evidence; target self-seeding is
+          expected and not circular.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
     supported_by:
       - reference_id: PMID:8985185
         supporting_text: &#34;SurA, a periplasmic protein with peptidyl-prolyl isomerase activity, participates in the assembly of outer membrane porins.&#34;
@@ -4595,6 +4903,10 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  supporting_entities:
+  - PANTHER:PTN005352065
+  - UniProtKB:P0ABZ6
+  qualifier: is_active_in
   review:
     summary: &gt;-
       SurA is a periplasmic protein with a cleavable signal peptide (residues 1-20).
@@ -4605,6 +4917,16 @@ existing_annotations:
     reason: &gt;-
       Periplasmic localization is firmly established by direct experimental evidence
       (IDA from multiple studies) and is consistent with the IBA annotation.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN005352065
+        source_label: PANTHER:PTN005352065
+        source_status: SUPPORTS_TRANSFER
+        comment: Current PTHR47637 PAINT retains this localization at the node,
+          seeded by P0ABZ6&#39;s direct periplasmic-localization evidence.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
     supported_by:
       - reference_id: PMID:8985185
         supporting_text: &#34;SurA, a periplasmic protein with peptidyl-prolyl isomerase activity&#34;
@@ -4613,6 +4935,10 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  supporting_entities:
+  - PANTHER:PTN005352065
+  - UniProtKB:P0ABZ6
+  qualifier: enables
   review:
     summary: &gt;-
       SurA directly binds unfolded outer membrane proteins in the periplasm. Behrens
@@ -4624,12 +4950,9 @@ existing_annotations:
       stepwise beta-hairpin insertion into the membrane. Per the UPB project decision
       rules, SurA functions as a holdase-type chaperone that prevents aggregation of
       unfolded OMPs in transit to the BAM complex. It does not actively refold substrates
-      via ATPase cycles. However, because it escorts unfolded OMPs from the Sec translocon
-      to the BAM complex (between two cellular locations), GO:0140309 (unfolded protein
-      carrier activity) could potentially apply. Since the primary mode of action
-      described in the literature is holdase/carrier, not foldase, the most appropriate
-      replacement depends on whether SurA&#39;s escort function qualifies for GO:0140309
-      or whether a general holdase NTR is needed.
+      via ATPase cycles. Because SurA escorts an unfolded client to the defined YaeT/BAM
+      acceptor, the carrier-specific GO:0140309 definition is satisfied even though
+      movement occurs within one compartment.
     action: MODIFY
     reason: &gt;-
       GO:0051082 is now formally obsolete. SurA is described as a holdase chaperone
@@ -4637,20 +4960,30 @@ existing_annotations:
       holdase chaperones Skp and SurA on the folding of beta-barrel outer-membrane
       proteins.&#34; SurA stabilizes unfolded OMPs in a dynamic state without actively
       refolding them via ATPase cycles, instead allowing stepwise membrane insertion.
-      SurA also escorts OMPs from the Sec translocon across the periplasm to the BAM
-      complex, which constitutes transport between two cellular components.
-      GO:0044183 (protein folding chaperone) could apply if SurA is considered to
-      actively assist folding, but the evidence from PMID:26344570 characterizes it
-      more as a holdase. Given the escort/carrier function, GO:0140309 may be
-      appropriate, but if the carrier semantics do not fit (since SurA acts in a
-      single compartment, the periplasm), then the holdase NTR is needed. As an
-      interim, retain GO:0051082 until the holdase NTR is created.
+      SurA also escorts OMPs across the periplasm to the YaeT/BAM acceptor. The
+      definition of GO:0140309 requires an acceptor molecule or a specific location,
+      not movement through multiple compartments; BAM/YaeT satisfies that endpoint.
+      GO:0140309 therefore captures the directly demonstrated carrier-holdase
+      mechanism, whereas GO:0044183 is less specific and GO:0051082 is obsolete.
     proposed_replacement_terms:
-      - id: GO:0044183
-        label: protein folding chaperone
+      - id: GO:0140309
+        label: unfolded protein holdase activity
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      failure_modes:
+      - SOURCE_EVIDENCE_WEAK
+      source_entities:
+      - source_id: PANTHER:PTN005352065
+        source_label: PANTHER:PTN005352065
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: GOA still carries the obsolete GO:0051082 IBA from this node,
+          but current PTHR47637 PAINT contains no GO:0051082 IBD row. The replacement
+          is grounded independently in direct SurA experiments.
     additional_reference_ids:
       - PMID:26344570
       - PMID:11226178
+      - file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
+      - file:projects/UNFOLDED_PROTEIN_BINDING.md
     supported_by:
       - reference_id: PMID:26344570
         supporting_text: &#34;Either chaperone prevents FhuA from misfolding by stabilizing a dynamic, unfolded state, thus allowing the substrate to search for structural intermediates.&#34;
@@ -4663,6 +4996,7 @@ existing_annotations:
     label: peptidyl-prolyl cis-trans isomerase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation from InterPro/UniRule based on SurA&#39;s parvulin PPIase domains
@@ -4682,6 +5016,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: involved_in
   review:
     summary: &gt;-
       IEA annotation from InterPro/UniRule. SurA&#39;s involvement in protein folding
@@ -4698,17 +5033,17 @@ existing_annotations:
     label: isomerase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation from UniProtKB-KW (KW-0413 Isomerase). SurA is classified
       as an isomerase based on its PPIase activity (EC 5.2.1.8). This is a parent
       term of GO:0003755 (peptidyl-prolyl cis-trans isomerase activity), which is
       the more specific and informative term.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      While this is a very broad parent term, it is not incorrect. The more specific
-      GO:0003755 is annotated separately. IEA from keyword mapping is acceptable
-      here as it simply reflects the isomerase classification.
+      This very broad parent term is true but non-core because the experimentally
+      supported child GO:0003755 identifies the actual isomerase activity.
     supported_by:
       - reference_id: PMID:8985185
         supporting_text: &#34;SurA, a periplasmic protein with peptidyl-prolyl isomerase activity&#34;
@@ -4717,6 +5052,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: located_in
   review:
     summary: &gt;-
       IEA annotation from InterPro (IPR023034). Consistent with experimentally
@@ -4733,6 +5069,7 @@ existing_annotations:
     label: peptide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation from InterPro (IPR023034). SurA does bind peptide motifs
@@ -4740,12 +5077,11 @@ existing_annotations:
       and McKay (PMID:14506253) showed that SurA binds peptide motifs found in integral
       outer membrane proteins. Hennecke et al. (PMID:15840585) demonstrated selective
       substrate recognition through features characteristic of OMPs.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      SurA does bind peptide motifs as part of its substrate recognition mechanism.
-      While more specific terms might be preferable, this general IEA annotation
-      is not incorrect. SurA&#39;s N-terminal domain and C-terminal tail form the
-      peptide binding site for OMP recognition.
+      SurA does bind OMP peptide motifs, so the annotation is retained. It is
+      non-core because the carrier-holdase and PPIase terms convey the functional
+      mechanisms more informatively.
     supported_by:
       - reference_id: PMID:11226178
         supporting_text: &#34;SurA interacts preferentially (&gt;50-fold) with in vitro synthesized porins over other similarly sized proteins&#34;
@@ -4754,16 +5090,16 @@ existing_annotations:
     label: periplasmic space
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: located_in
   review:
     summary: &gt;-
       IEA annotation from UniProtKB-SubCell (SL-0200). SurA is located in the
       periplasmic space. This is a broader parent of GO:0030288 (outer membrane-bounded
       periplasmic space), which is also annotated. Both are correct.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Correct localization. This is a broader parent of the more specific GO:0030288
-      which is annotated with experimental evidence. The IEA annotation is acceptable
-      as a general localization.
+      Correct localization, retained as non-core because it is a broader parent of
+      GO:0030288, which is independently supported by direct evidence.
     supported_by:
       - reference_id: PMID:8985185
         supporting_text: &#34;SurA, a periplasmic protein with peptidyl-prolyl isomerase activity&#34;
@@ -4772,6 +5108,7 @@ existing_annotations:
     label: Gram-negative-bacterium-type cell outer membrane assembly
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: &gt;-
       IEA annotation from InterPro (IPR023034). SurA is critically involved in
@@ -4790,6 +5127,7 @@ existing_annotations:
     label: protein stabilization
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: &gt;-
       IEA annotation from InterPro (IPR023034). SurA stabilizes unfolded OMPs
@@ -4797,8 +5135,8 @@ existing_annotations:
       PMID:26344570).
     action: ACCEPT
     reason: &gt;-
-      Consistent with experimental evidence showing SurA prevents OMP degradation
-      and misfolding. Redundant with IMP annotations but acceptable as an IEA.
+      Consistent with direct IMP evidence that SurA stabilizes OMP clients. The IEA
+      and experimental rows therefore receive the same core action.
     supported_by:
       - reference_id: PMID:26344570
         supporting_text: &#34;Either chaperone prevents FhuA from misfolding by stabilizing a dynamic, unfolded state&#34;
@@ -4807,6 +5145,7 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: &gt;-
       IEA annotation from InterPro/UniRule. SurA binds unfolded OMPs as demonstrated
@@ -4816,11 +5155,15 @@ existing_annotations:
     reason: &gt;-
       Same rationale as the IBA GO:0051082 annotation above. SurA functions as a
       holdase chaperone for unfolded OMPs. GO:0051082 is now formally obsolete.
-      Replace with GO:0044183 (protein folding chaperone) as the most appropriate
-      existing replacement term, pending creation of holdase NTR.
+      Replace with GO:0140309 because SurA both stabilizes an unfolded OMP and
+      escorts it to the YaeT/BAM acceptor; the carrier definition is satisfied.
     proposed_replacement_terms:
-      - id: GO:0044183
-        label: protein folding chaperone
+      - id: GO:0140309
+        label: unfolded protein holdase activity
+    additional_reference_ids:
+      - PMID:17908933
+      - PMID:26344570
+      - file:projects/UNFOLDED_PROTEIN_BINDING.md
     supported_by:
       - reference_id: PMID:11226178
         supporting_text: &#34;SurA interacts preferentially (&gt;50-fold) with in vitro synthesized porins over other similarly sized proteins&#34;
@@ -4829,6 +5172,9 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18165306
+  supporting_entities:
+  - UniProtKB:P77774
+  qualifier: enables
   review:
     summary: &gt;-
       IntAct-derived annotation showing SurA interacts with BamB (YfgL, P77774).
@@ -4837,13 +5183,11 @@ existing_annotations:
       BamB/YfgL. The interaction with BamB itself is detected by IntAct but the paper
       primarily discusses YfgL-YaeT interactions and shows SurA-YaeT binding is
       independent of YfgL.
-    action: REMOVE
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      The generic &#34;protein binding&#34; term is uninformative. SurA&#39;s interaction with
-      BAM complex components is better captured by its biological process annotations
-      (GO:0043165, outer membrane assembly). The specific interaction should be
-      annotated with a more specific molecular function term if available, not the
-      generic protein binding. Per curation guidelines, GO:0005515 should be avoided.
+      IPI asserts an observed interaction with BamB and there is no contradictory
+      evidence, so the row is retained. Generic protein binding does not express
+      SurA&#39;s carrier-holdase mechanism and is therefore non-core.
     supported_by:
       - reference_id: PMID:18165306
         supporting_text: &#34;SurA binds to YaeT (or another complex member) without going through YfgL.&#34;
@@ -4852,18 +5196,20 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22544271
+  supporting_entities:
+  - UniProtKB:P77774
+  qualifier: enables
   review:
     summary: &gt;-
       IntAct-derived annotation showing SurA interacts with BamB (P77774). Workman
       et al. (PMID:22544271) studied BamA POTRA domain mutations and showed that
       BamA-SurA interactions correlated with improved OMP biogenesis. The SurA-BamB
       interaction is detected but the paper focuses on BamA structure-function.
-    action: REMOVE
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Generic protein binding is uninformative. SurA&#39;s interaction with BAM complex
-      components reflects its chaperone function in OMP biogenesis, which is captured
-      by more informative annotations. Per curation guidelines, GO:0005515 should
-      be avoided.
+      IPI asserts an observed BamB interaction and no evidence contradicts it. The
+      generic term is retained as non-core because it does not identify SurA&#39;s
+      carrier-holdase mechanism.
     supported_by:
       - reference_id: PMID:22544271
         supporting_text: &#34;OMP biogenesis improved dramatically, and this correlated with improved BamA folding, BamA-SurA interactions, and LptD (lipopolysaccharide transporter) biogenesis.&#34;
@@ -4872,6 +5218,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IMP
   original_reference_id: PMID:8626309
+  qualifier: involved_in
   review:
     summary: &gt;-
       Lazar and Kolter (PMID:8626309) used trypsin sensitivity as a folding assay
@@ -4892,6 +5239,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IMP
   original_reference_id: PMID:8985185
+  qualifier: involved_in
   review:
     summary: &gt;-
       Rouviere and Gross (PMID:8985185) demonstrated that SurA is involved in the
@@ -4912,6 +5260,7 @@ existing_annotations:
     label: maintenance of unfolded protein
   evidence_type: IDA
   original_reference_id: PMID:26344570
+  qualifier: involved_in
   review:
     summary: &gt;-
       Thoma et al. (PMID:26344570) used single-molecule force spectroscopy and NMR
@@ -4935,6 +5284,9 @@ existing_annotations:
     label: Gram-negative-bacterium-type cell outer membrane assembly
   evidence_type: IGI
   original_reference_id: PMID:17908933
+  supporting_entities:
+  - UniProtKB:P0AEU7
+  qualifier: involved_in
   review:
     summary: &gt;-
       Sklar et al. (PMID:17908933) used depletion analysis and genetic interactions
@@ -4957,6 +5309,7 @@ existing_annotations:
     label: Gram-negative-bacterium-type cell outer membrane assembly
   evidence_type: IMP
   original_reference_id: PMID:8985185
+  qualifier: involved_in
   review:
     summary: &gt;-
       Rouviere and Gross (PMID:8985185) demonstrated that SurA participates in
@@ -4974,6 +5327,7 @@ existing_annotations:
     label: protein stabilization
   evidence_type: IMP
   original_reference_id: PMID:8626309
+  qualifier: involved_in
   review:
     summary: &gt;-
       Lazar and Kolter (PMID:8626309) showed that SurA is required for maintaining
@@ -4992,17 +5346,19 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:11226178
+  supporting_entities:
+  - UniProtKB:P02932
+  qualifier: enables
   review:
     summary: &gt;-
       Behrens et al. (PMID:11226178) demonstrated that SurA interacts preferentially
       with in vitro synthesized porins (including OmpF, P02932) over other similarly
       sized proteins. This interaction reflects SurA&#39;s chaperone substrate specificity.
-    action: REMOVE
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Generic protein binding is uninformative. This interaction represents SurA&#39;s
-      chaperone-substrate interaction with OmpF, which is better captured by the
-      unfolded protein binding / chaperone annotations (GO:0051082, GO:0036506,
-      GO:0006457). Per curation guidelines, GO:0005515 should be avoided.
+      IPI accurately records the experimentally observed OmpF interaction and no
+      evidence contradicts it. It remains non-core because GO:0140309 and GO:0036506
+      convey the substrate-chaperoning mechanism rather than generic binding.
     supported_by:
       - reference_id: PMID:11226178
         supporting_text: &#34;SurA interacts preferentially (&gt;50-fold) with in vitro synthesized porins over other similarly sized proteins&#34;
@@ -5011,17 +5367,19 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:17908933
+  supporting_entities:
+  - UniProtKB:P0A940
+  qualifier: enables
   review:
     summary: &gt;-
       Sklar et al. (PMID:17908933) demonstrated that SurA and YaeT (BamA, P0A940)
       interact directly in vivo. This interaction is functionally significant as
       SurA delivers OMPs to the YaeT/BAM complex for membrane insertion.
-    action: REMOVE
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Generic protein binding is uninformative. The SurA-BamA interaction is
-      functionally important for OMP delivery but is better represented by the
-      biological process annotation GO:0043165 (outer membrane assembly). Per
-      curation guidelines, GO:0005515 should be avoided.
+      IPI accurately records the direct BamA/YaeT interaction and no evidence
+      contradicts it. It is retained as non-core because the interaction is more
+      informatively interpreted through GO:0140309 and outer-membrane assembly.
     supported_by:
       - reference_id: PMID:17908933
         supporting_text: &#34;we demonstrate that SurA and YaeT interact directly in vivo&#34;
@@ -5030,17 +5388,19 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18165306
+  supporting_entities:
+  - UniProtKB:P0A940
+  qualifier: enables
   review:
     summary: &gt;-
       Vuong et al. (PMID:18165306) from EcoCyc annotation showing SurA binds to
       BamA/YaeT (P0A940). The paper demonstrates that SurA binds to YaeT or another
       BAM complex member independently of YfgL/BamB.
-    action: REMOVE
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Generic protein binding is uninformative. This is a duplicate reference to the
-      same SurA-BamA interaction captured by the previous PMID:17908933 entry and
-      is better represented by GO:0043165. Per curation guidelines, GO:0005515 should
-      be avoided.
+      IPI accurately records a BamA/YaeT interaction and no evidence contradicts it.
+      It is retained as non-core because generic binding is less informative than
+      the carrier-holdase and outer-membrane-assembly annotations.
     supported_by:
       - reference_id: PMID:18165306
         supporting_text: &#34;SurA binds to YaeT (or another complex member) without going through YfgL.&#34;
@@ -5049,6 +5409,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IDA
   original_reference_id: PMID:15911532
+  qualifier: located_in
   review:
     summary: &gt;-
       Lopez-Campistrous et al. (PMID:15911532) identified SurA in the periplasmic
@@ -5066,6 +5427,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IDA
   original_reference_id: PMID:24140104
+  qualifier: located_in
   review:
     summary: &gt;-
       Han et al. (PMID:24140104) identified SurA in the periplasmic proteome of
@@ -5082,6 +5444,7 @@ existing_annotations:
     label: protein stabilization
   evidence_type: IMP
   original_reference_id: PMID:21784935
+  qualifier: involved_in
   review:
     summary: &gt;-
       Palomino et al. (PMID:21784935) demonstrated that FimD protein levels are
@@ -5103,6 +5466,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IDA
   original_reference_id: PMID:8985185
+  qualifier: located_in
   review:
     summary: &gt;-
       Rouviere and Gross (PMID:8985185) characterized SurA as a periplasmic protein
@@ -5119,6 +5483,11 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IPI
   original_reference_id: PMID:11226178
+  supporting_entities:
+  - UniProtKB:P02931
+  - UniProtKB:P02932
+  - UniProtKB:P02943
+  qualifier: enables
   review:
     summary: &gt;-
       Behrens et al. (PMID:11226178) showed that SurA exhibits chaperone activity
@@ -5129,12 +5498,16 @@ existing_annotations:
     action: MODIFY
     reason: &gt;-
       Same rationale as other GO:0051082 annotations. GO:0051082 is now formally
-      obsolete. SurA&#39;s binding to unfolded porins represents its holdase/chaperone
-      activity. Replace with GO:0044183 (protein folding chaperone) as interim,
-      pending holdase NTR creation.
+      obsolete. SurA&#39;s binding to unfolded porins is one component of its
+      carrier-holdase activity, and independent experiments establish escort to
+      YaeT/BAM. Replace with GO:0140309.
     proposed_replacement_terms:
-      - id: GO:0044183
-        label: protein folding chaperone
+      - id: GO:0140309
+        label: unfolded protein holdase activity
+    additional_reference_ids:
+      - PMID:17908933
+      - PMID:26344570
+      - file:projects/UNFOLDED_PROTEIN_BINDING.md
     supported_by:
       - reference_id: PMID:11226178
         supporting_text: &#34;a variant of SurA lacking both parvulin-like domains exhibits a PPIase-independent chaperone-like activity in vitro and almost completely complements the in vivo function of intact SurA&#34;
@@ -5145,6 +5518,7 @@ existing_annotations:
     label: peptidyl-prolyl cis-trans isomerase activity
   evidence_type: IDA
   original_reference_id: PMID:8985185
+  qualifier: enables
   review:
     summary: &gt;-
       Rouviere and Gross (PMID:8985185) demonstrated that SurA has peptidyl-prolyl
@@ -5160,35 +5534,41 @@ existing_annotations:
       - reference_id: PMID:8985185
         supporting_text: &#34;SurA, a periplasmic protein with peptidyl-prolyl isomerase activity, participates in the assembly of outer membrane porins.&#34;
 - term:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140309
+    label: unfolded protein holdase activity
   evidence_type: IDA
-  original_reference_id: PMID:11226178
+  original_reference_id: PMID:26344570
+  qualifier: enables
   review:
     summary: &gt;-
-      Behrens et al. (PMID:11226178) directly demonstrated that SurA has chaperone
-      activity independent of its PPIase domains. A SurA variant lacking both parvulin
-      domains exhibited PPIase-independent chaperone-like activity in vitro and almost
-      completely complemented full-length SurA function in vivo. SurA preferentially
-      binds in vitro synthesized porins (&gt;50-fold selectivity) through its N-terminal
-      and C-terminal domains. This is the core molecular function of SurA.
+      Direct biophysical experiments show SurA stabilizing a dynamic unfolded FhuA
+      state during stepwise membrane insertion, while depletion and interaction
+      studies establish delivery of OMPs to YaeT/BAM. BAM is the defined acceptor
+      molecule required by the carrier-specific GO:0140309 definition.
     action: NEW
     reason: &gt;-
-      GO:0044183 (protein folding chaperone) is not currently annotated for SurA
-      but is the most appropriate MF term for its primary function. SurA acts as a
-      chaperone that facilitates OMP folding and assembly, with direct in vitro
-      evidence for chaperone activity. This annotation should be added to replace
-      GO:0051082 which is now formally obsolete. Evidence supports both holdase
-      and chaperone mechanisms - SurA prevents aggregation (holdase) and enables
-      stepwise folding (facilitating folding). GO:0044183 is the best available
-      existing term.
+      GO:0140309 is more specific than GO:0044183 for SurA&#39;s mechanism. It does not
+      require movement between compartments: its definition requires escort to an
+      acceptor molecule or specific location. SurA binds unfolded OMPs, prevents
+      misfolding in transit, and hands them to YaeT/BAM for membrane insertion.
+      The obsolete GO:0051082 author claim is not retained.
+    additional_reference_ids:
+      - PMID:11226178
+      - PMID:17908933
+      - file:projects/UNFOLDED_PROTEIN_BINDING.md
     supported_by:
-      - reference_id: PMID:11226178
-        supporting_text: &#34;a variant of SurA lacking both parvulin-like domains exhibits a PPIase-independent chaperone-like activity in vitro and almost completely complements the in vivo function of intact SurA&#34;
       - reference_id: PMID:26344570
-        supporting_text: &#34;the SurA-chaperoned FhuA polypeptide inserts beta-hairpins into the membrane in a stepwise manner until the beta-barrel is folded&#34;
+        supporting_text: &#34;Either chaperone prevents FhuA from misfolding by stabilizing a dynamic, unfolded state, thus allowing the substrate to search for structural intermediates.&#34;
+        full_text_unavailable: true
       - reference_id: PMID:17908933
         supporting_text: &#34;SurA is the primary chaperone responsible for the periplasmic transit of the bulk mass of OMPs to the YaeT complex.&#34;
+        full_text_unavailable: true
+      - reference_id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+        supporting_text: to an acceptor molecule or to a specific location
+        reference_section_type: OTHER
+      - reference_id: file:ECOLI/surA/surA-deep-research-falcon.md
+        supporting_text: SurA protects newly translocated, unfolded OMPs from **aggregation** in the crowded, ATP-free periplasm and **delivers** them to the outer-membrane β-barrel assembly machinery (**BAM** complex) for folding and insertion
+        reference_section_type: OTHER
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -5220,6 +5600,12 @@ references:
   title: &gt;-
     Defining the roles of the periplasmic chaperones SurA, Skp, and DegP in
     Escherichia coli.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-cached abstract directly supports SurA-YaeT interaction
+      and periplasmic transit of OMP clients to YaeT/BAM. Only abstract-explicit
+      claims were used because cached full text is unavailable.
   findings:
     - statement: SurA is the primary chaperone for periplasmic transit of OMPs to the BAM complex
     - statement: SurA interacts directly with BamA/YaeT in vivo
@@ -5255,6 +5641,12 @@ references:
   title: &gt;-
     Impact of holdase chaperones Skp and SurA on the folding of β-barrel
     outer-membrane proteins.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-cached abstract directly supports SurA stabilization of
+      a dynamic unfolded FhuA state during stepwise membrane insertion. Only
+      abstract-explicit claims were used.
   findings:
     - statement: SurA characterized as a holdase chaperone
     - statement: SurA stabilizes dynamic unfolded state of FhuA
@@ -5287,17 +5679,34 @@ references:
     outer membrane proteins for selective substrate recognition.
   findings:
     - statement: SurA uses aromatic residue patterns and side chain orientation for OMP recognition
+- id: file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
+  title: Current PAINT annotations for PANTHER family PTHR47637
+  findings:
+  - statement: PTN005352065 currently carries IBD assertions for protein folding,
+      PPIase activity, and periplasmic localization, each seeded by P0ABZ6; it no
+      longer carries GO:0051082.
+- id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+  title: Unfolded Protein Binding Annotation Review
+  findings:
+  - statement: GO:0140309 remains carrier-specific and requires escort of an unfolded
+      client to an acceptor molecule or specific location; SurA satisfies this through
+      delivery to YaeT/BAM.
+- id: file:ECOLI/surA/surA-deep-research-falcon.md
+  title: Deep research synthesis for E. coli SurA
+  findings:
+  - statement: The synthesis independently describes ATP-independent capture of
+      unfolded OMP clients in the periplasm and their delivery to BAM for insertion.
 core_functions:
 - description: &gt;-
-    Chaperone activity -- SurA functions as the primary periplasmic chaperone for
+    Carrier-holdase activity -- SurA functions as the primary periplasmic chaperone for
     outer membrane protein biogenesis. It binds unfolded OMPs via its N-terminal
     and C-terminal domains (independent of PPIase activity) and escorts them to the
     BAM complex. SurA acts as a holdase, stabilizing OMPs in a dynamic unfolded
-    state to prevent aggregation while enabling stepwise beta-hairpin membrane
+    state to prevent off-pathway misfolding while enabling stepwise beta-hairpin membrane
     insertion.
   molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140309
+    label: unfolded protein holdase activity
   directly_involved_in:
     - id: GO:0043165
       label: Gram-negative-bacterium-type cell outer membrane assembly
@@ -5313,8 +5722,16 @@ core_functions:
       supporting_text: &#34;a variant of SurA lacking both parvulin-like domains exhibits a PPIase-independent chaperone-like activity in vitro and almost completely complements the in vivo function of intact SurA&#34;
     - reference_id: PMID:17908933
       supporting_text: &#34;SurA is the primary chaperone responsible for the periplasmic transit of the bulk mass of OMPs to the YaeT complex.&#34;
+      full_text_unavailable: true
     - reference_id: PMID:26344570
       supporting_text: &#34;the SurA-chaperoned FhuA polypeptide inserts beta-hairpins into the membrane in a stepwise manner until the beta-barrel is folded&#34;
+      full_text_unavailable: true
+    - reference_id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+      supporting_text: to an acceptor molecule or to a specific location
+      reference_section_type: OTHER
+    - reference_id: file:ECOLI/surA/surA-deep-research-falcon.md
+      supporting_text: SurA protects newly translocated, unfolded OMPs from **aggregation** in the crowded, ATP-free periplasm and **delivers** them to the outer-membrane β-barrel assembly machinery (**BAM** complex) for folding and insertion
+      reference_section_type: OTHER
 - description: &gt;-
     Peptidyl-prolyl cis-trans isomerase activity -- SurA has PPIase activity
     (EC 5.2.1.8) residing in its second parvulin domain. This is a real enzymatic

--- a/genes/ECOLI/surA/surA-ai-review.html
+++ b/genes/ECOLI/surA/surA-ai-review.html
@@ -1233,13 +1233,6 @@
                                 <span class="badge">SOURCE STALE OR MISSING</span>
                             </div>
 
-                            <div class="propagation-row">
-                                <strong>Failure modes:</strong>
-
-                                <span class="badge">SOURCE EVIDENCE WEAK</span>
-
-                            </div>
-
 
                             <div class="propagation-source">
                                 <strong>Sources checked:</strong>
@@ -3483,7 +3476,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0140309 is more specific than GO:0044183 for SurA&#39;s mechanism. It does not require movement between compartments: its definition requires escort to an acceptor molecule or specific location. SurA binds unfolded OMPs, prevents misfolding in transit, and hands them to YaeT/BAM for membrane insertion. The obsolete GO:0051082 author claim is not retained.
+                            <strong>Reason:</strong> GO:0140309 is more specific than GO:0044183 for SurA&#39;s mechanism. It does not require movement between compartments: its definition requires escort to an acceptor molecule or specific location. SurA binds unfolded OMPs, prevents misfolding in transit, and hands them to YaeT/BAM for membrane insertion. PMID:26344570 supplies the IDA basis by directly demonstrating unfolded-state stabilization and stepwise insertion into the membrane; PMID:17908933 independently supplies the YaeT/BAM acceptor endpoint through depletion and interaction evidence. The obsolete GO:0051082 author claim is not retained.
                         </div>
 
 
@@ -3665,7 +3658,7 @@
 
                         </span>
 
-                        <div class="finding-text">the SurA-chaperoned FhuA polypeptide inserts beta-hairpins into the membrane in a stepwise manner until the beta-barrel is folded</div>
+                        <div class="finding-text">the SurA-chaperoned FhuA polypeptide inserts β-hairpins into the membrane in a stepwise manner until the β-barrel is folded</div>
 
                     </li>
 
@@ -4694,6 +4687,25 @@ are also retained as non-core. Protein stabilization remains ACCEPT across IEA a
 direct IMP rows because direct experiments establish stabilization of OMP clients.<br />
 Direct folding, OMP assembly, PPIase, maintenance-of-unfolded-protein, and localization<br />
 annotations also remain accepted.</p>
+<h2 id="pr-2732-feedback-resolution">PR #2732 feedback resolution</h2>
+<p>Rechecked after the carrier-holdase policy clarification was merged through PR #2733.<br />
+The project now explicitly defines GO:0140309 carrier-holdase activity as escort to<br />
+a specified location or acceptor molecule, includes delivery within one compartment<br />
+when an acceptor such as BAM/YaeT is demonstrated, and lists SurA as an example.<br />
+The gene review is consistent with that policy and contains no remaining dependency<br />
+on the older cross-compartment interpretation or the former "unfolded protein carrier<br />
+activity" label.</p>
+<p>The NEW GO:0140309 evidence boundary is now explicit. PMID:26344570 is the IDA basis:<br />
+it directly demonstrates stabilization of a dynamic unfolded FhuA state and stepwise<br />
+β-hairpin insertion. PMID:17908933 independently corroborates the carrier endpoint by<br />
+showing periplasmic OMP transit to YaeT/BAM and direct SurA-YaeT interaction. Neither<br />
+abstract is made to support the other's experimental component. The core quote now<br />
+preserves the cached publication's Greek <code>β</code> characters verbatim.</p>
+<p>The stale GO:0051082 IBA remains classified <code>SOURCE_STALE_OR_MISSING</code> because current<br />
+PTHR47637 PAINT lacks that node assertion. The former <code>SOURCE_EVIDENCE_WEAK</code> subtype<br />
+was removed: absence from current PAINT establishes staleness, not weakness of the<br />
+historical source evidence, and the GO:0140309 replacement rests on independent direct<br />
+SurA experiments rather than reinterpretation of that retired node claim.</p>
             </div>
         </details>
 
@@ -4970,8 +4982,6 @@ existing_annotations:
         label: unfolded protein holdase activity
     propagation_review:
       root_cause: SOURCE_STALE_OR_MISSING
-      failure_modes:
-      - SOURCE_EVIDENCE_WEAK
       source_entities:
       - source_id: PANTHER:PTN005352065
         source_label: PANTHER:PTN005352065
@@ -5551,6 +5561,9 @@ existing_annotations:
       require movement between compartments: its definition requires escort to an
       acceptor molecule or specific location. SurA binds unfolded OMPs, prevents
       misfolding in transit, and hands them to YaeT/BAM for membrane insertion.
+      PMID:26344570 supplies the IDA basis by directly demonstrating unfolded-state
+      stabilization and stepwise insertion into the membrane; PMID:17908933 independently
+      supplies the YaeT/BAM acceptor endpoint through depletion and interaction evidence.
       The obsolete GO:0051082 author claim is not retained.
     additional_reference_ids:
       - PMID:11226178
@@ -5724,7 +5737,7 @@ core_functions:
       supporting_text: &#34;SurA is the primary chaperone responsible for the periplasmic transit of the bulk mass of OMPs to the YaeT complex.&#34;
       full_text_unavailable: true
     - reference_id: PMID:26344570
-      supporting_text: &#34;the SurA-chaperoned FhuA polypeptide inserts beta-hairpins into the membrane in a stepwise manner until the beta-barrel is folded&#34;
+      supporting_text: &#34;the SurA-chaperoned FhuA polypeptide inserts β-hairpins into the membrane in a stepwise manner until the β-barrel is folded&#34;
       full_text_unavailable: true
     - reference_id: file:projects/UNFOLDED_PROTEIN_BINDING.md
       supporting_text: to an acceptor molecule or to a specific location

--- a/genes/ECOLI/surA/surA-ai-review.yaml
+++ b/genes/ECOLI/surA/surA-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P0ABZ6
 gene_symbol: surA
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:83333
   label: Escherichia coli (strain K12)
@@ -25,6 +25,10 @@ existing_annotations:
     label: protein folding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  supporting_entities:
+  - PANTHER:PTN005352065
+  - UniProtKB:P0ABZ6
+  qualifier: involved_in
   review:
     summary: >-
       SurA participates in the maturation of outer membrane porins, which involves
@@ -39,6 +43,17 @@ existing_annotations:
       step prior to folded monomer formation (PMID:8985185), and surA mutants
       show defective folding of three outer membrane proteins (PMID:8626309).
       This IBA annotation is well supported.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN005352065
+        source_label: PANTHER:PTN005352065
+        source_status: SUPPORTS_TRANSFER
+        comment: Current PTHR47637 PAINT retains protein folding at this node,
+          seeded by P0ABZ6's own experimental evidence; target self-seeding is
+          valid experimental grounding, not circular propagation.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
     supported_by:
       - reference_id: PMID:8985185
         supporting_text: "We demonstrate that SurA is involved in the conversion of unfolded monomers into a newly identified intermediate in LamB assembly, which behaves as a folded monomer."
@@ -49,6 +64,10 @@ existing_annotations:
     label: peptidyl-prolyl cis-trans isomerase activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  supporting_entities:
+  - PANTHER:PTN005352065
+  - UniProtKB:P0ABZ6
+  qualifier: enables
   review:
     summary: >-
       SurA has confirmed PPIase activity (EC 5.2.1.8) residing in its second parvulin
@@ -61,6 +80,17 @@ existing_annotations:
       PPIase activity is experimentally confirmed for SurA (PMID:8985185) and is
       a real enzymatic activity of this protein, even though it is not essential
       for SurA's primary in vivo function. The IBA annotation is appropriate.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN005352065
+        source_label: PANTHER:PTN005352065
+        source_status: SUPPORTS_TRANSFER
+        comment: Current PTHR47637 PAINT retains PPIase activity at this node,
+          seeded by P0ABZ6's direct activity evidence; target self-seeding is
+          expected and not circular.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
     supported_by:
       - reference_id: PMID:8985185
         supporting_text: "SurA, a periplasmic protein with peptidyl-prolyl isomerase activity, participates in the assembly of outer membrane porins."
@@ -71,6 +101,10 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  supporting_entities:
+  - PANTHER:PTN005352065
+  - UniProtKB:P0ABZ6
+  qualifier: is_active_in
   review:
     summary: >-
       SurA is a periplasmic protein with a cleavable signal peptide (residues 1-20).
@@ -81,6 +115,16 @@ existing_annotations:
     reason: >-
       Periplasmic localization is firmly established by direct experimental evidence
       (IDA from multiple studies) and is consistent with the IBA annotation.
+    propagation_review:
+      root_cause: NO_FAILURE_CORE
+      source_entities:
+      - source_id: PANTHER:PTN005352065
+        source_label: PANTHER:PTN005352065
+        source_status: SUPPORTS_TRANSFER
+        comment: Current PTHR47637 PAINT retains this localization at the node,
+          seeded by P0ABZ6's direct periplasmic-localization evidence.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
     supported_by:
       - reference_id: PMID:8985185
         supporting_text: "SurA, a periplasmic protein with peptidyl-prolyl isomerase activity"
@@ -89,6 +133,10 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
+  supporting_entities:
+  - PANTHER:PTN005352065
+  - UniProtKB:P0ABZ6
+  qualifier: enables
   review:
     summary: >-
       SurA directly binds unfolded outer membrane proteins in the periplasm. Behrens
@@ -100,12 +148,9 @@ existing_annotations:
       stepwise beta-hairpin insertion into the membrane. Per the UPB project decision
       rules, SurA functions as a holdase-type chaperone that prevents aggregation of
       unfolded OMPs in transit to the BAM complex. It does not actively refold substrates
-      via ATPase cycles. However, because it escorts unfolded OMPs from the Sec translocon
-      to the BAM complex (between two cellular locations), GO:0140309 (unfolded protein
-      carrier activity) could potentially apply. Since the primary mode of action
-      described in the literature is holdase/carrier, not foldase, the most appropriate
-      replacement depends on whether SurA's escort function qualifies for GO:0140309
-      or whether a general holdase NTR is needed.
+      via ATPase cycles. Because SurA escorts an unfolded client to the defined YaeT/BAM
+      acceptor, the carrier-specific GO:0140309 definition is satisfied even though
+      movement occurs within one compartment.
     action: MODIFY
     reason: >-
       GO:0051082 is now formally obsolete. SurA is described as a holdase chaperone
@@ -113,20 +158,30 @@ existing_annotations:
       holdase chaperones Skp and SurA on the folding of beta-barrel outer-membrane
       proteins." SurA stabilizes unfolded OMPs in a dynamic state without actively
       refolding them via ATPase cycles, instead allowing stepwise membrane insertion.
-      SurA also escorts OMPs from the Sec translocon across the periplasm to the BAM
-      complex, which constitutes transport between two cellular components.
-      GO:0044183 (protein folding chaperone) could apply if SurA is considered to
-      actively assist folding, but the evidence from PMID:26344570 characterizes it
-      more as a holdase. Given the escort/carrier function, GO:0140309 may be
-      appropriate, but if the carrier semantics do not fit (since SurA acts in a
-      single compartment, the periplasm), then the holdase NTR is needed. As an
-      interim, retain GO:0051082 until the holdase NTR is created.
+      SurA also escorts OMPs across the periplasm to the YaeT/BAM acceptor. The
+      definition of GO:0140309 requires an acceptor molecule or a specific location,
+      not movement through multiple compartments; BAM/YaeT satisfies that endpoint.
+      GO:0140309 therefore captures the directly demonstrated carrier-holdase
+      mechanism, whereas GO:0044183 is less specific and GO:0051082 is obsolete.
     proposed_replacement_terms:
-      - id: GO:0044183
-        label: protein folding chaperone
+      - id: GO:0140309
+        label: unfolded protein holdase activity
+    propagation_review:
+      root_cause: SOURCE_STALE_OR_MISSING
+      failure_modes:
+      - SOURCE_EVIDENCE_WEAK
+      source_entities:
+      - source_id: PANTHER:PTN005352065
+        source_label: PANTHER:PTN005352065
+        source_status: SOURCE_STALE_OR_MISSING
+        comment: GOA still carries the obsolete GO:0051082 IBA from this node,
+          but current PTHR47637 PAINT contains no GO:0051082 IBD row. The replacement
+          is grounded independently in direct SurA experiments.
     additional_reference_ids:
       - PMID:26344570
       - PMID:11226178
+      - file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
+      - file:projects/UNFOLDED_PROTEIN_BINDING.md
     supported_by:
       - reference_id: PMID:26344570
         supporting_text: "Either chaperone prevents FhuA from misfolding by stabilizing a dynamic, unfolded state, thus allowing the substrate to search for structural intermediates."
@@ -139,6 +194,7 @@ existing_annotations:
     label: peptidyl-prolyl cis-trans isomerase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: >-
       IEA annotation from InterPro/UniRule based on SurA's parvulin PPIase domains
@@ -158,6 +214,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: involved_in
   review:
     summary: >-
       IEA annotation from InterPro/UniRule. SurA's involvement in protein folding
@@ -174,17 +231,17 @@ existing_annotations:
     label: isomerase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
+  qualifier: enables
   review:
     summary: >-
       IEA annotation from UniProtKB-KW (KW-0413 Isomerase). SurA is classified
       as an isomerase based on its PPIase activity (EC 5.2.1.8). This is a parent
       term of GO:0003755 (peptidyl-prolyl cis-trans isomerase activity), which is
       the more specific and informative term.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      While this is a very broad parent term, it is not incorrect. The more specific
-      GO:0003755 is annotated separately. IEA from keyword mapping is acceptable
-      here as it simply reflects the isomerase classification.
+      This very broad parent term is true but non-core because the experimentally
+      supported child GO:0003755 identifies the actual isomerase activity.
     supported_by:
       - reference_id: PMID:8985185
         supporting_text: "SurA, a periplasmic protein with peptidyl-prolyl isomerase activity"
@@ -193,6 +250,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: located_in
   review:
     summary: >-
       IEA annotation from InterPro (IPR023034). Consistent with experimentally
@@ -209,6 +267,7 @@ existing_annotations:
     label: peptide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
     summary: >-
       IEA annotation from InterPro (IPR023034). SurA does bind peptide motifs
@@ -216,12 +275,11 @@ existing_annotations:
       and McKay (PMID:14506253) showed that SurA binds peptide motifs found in integral
       outer membrane proteins. Hennecke et al. (PMID:15840585) demonstrated selective
       substrate recognition through features characteristic of OMPs.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      SurA does bind peptide motifs as part of its substrate recognition mechanism.
-      While more specific terms might be preferable, this general IEA annotation
-      is not incorrect. SurA's N-terminal domain and C-terminal tail form the
-      peptide binding site for OMP recognition.
+      SurA does bind OMP peptide motifs, so the annotation is retained. It is
+      non-core because the carrier-holdase and PPIase terms convey the functional
+      mechanisms more informatively.
     supported_by:
       - reference_id: PMID:11226178
         supporting_text: "SurA interacts preferentially (>50-fold) with in vitro synthesized porins over other similarly sized proteins"
@@ -230,16 +288,16 @@ existing_annotations:
     label: periplasmic space
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: located_in
   review:
     summary: >-
       IEA annotation from UniProtKB-SubCell (SL-0200). SurA is located in the
       periplasmic space. This is a broader parent of GO:0030288 (outer membrane-bounded
       periplasmic space), which is also annotated. Both are correct.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Correct localization. This is a broader parent of the more specific GO:0030288
-      which is annotated with experimental evidence. The IEA annotation is acceptable
-      as a general localization.
+      Correct localization, retained as non-core because it is a broader parent of
+      GO:0030288, which is independently supported by direct evidence.
     supported_by:
       - reference_id: PMID:8985185
         supporting_text: "SurA, a periplasmic protein with peptidyl-prolyl isomerase activity"
@@ -248,6 +306,7 @@ existing_annotations:
     label: Gram-negative-bacterium-type cell outer membrane assembly
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: >-
       IEA annotation from InterPro (IPR023034). SurA is critically involved in
@@ -266,6 +325,7 @@ existing_annotations:
     label: protein stabilization
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: >-
       IEA annotation from InterPro (IPR023034). SurA stabilizes unfolded OMPs
@@ -273,8 +333,8 @@ existing_annotations:
       PMID:26344570).
     action: ACCEPT
     reason: >-
-      Consistent with experimental evidence showing SurA prevents OMP degradation
-      and misfolding. Redundant with IMP annotations but acceptable as an IEA.
+      Consistent with direct IMP evidence that SurA stabilizes OMP clients. The IEA
+      and experimental rows therefore receive the same core action.
     supported_by:
       - reference_id: PMID:26344570
         supporting_text: "Either chaperone prevents FhuA from misfolding by stabilizing a dynamic, unfolded state"
@@ -283,6 +343,7 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: enables
   review:
     summary: >-
       IEA annotation from InterPro/UniRule. SurA binds unfolded OMPs as demonstrated
@@ -292,11 +353,15 @@ existing_annotations:
     reason: >-
       Same rationale as the IBA GO:0051082 annotation above. SurA functions as a
       holdase chaperone for unfolded OMPs. GO:0051082 is now formally obsolete.
-      Replace with GO:0044183 (protein folding chaperone) as the most appropriate
-      existing replacement term, pending creation of holdase NTR.
+      Replace with GO:0140309 because SurA both stabilizes an unfolded OMP and
+      escorts it to the YaeT/BAM acceptor; the carrier definition is satisfied.
     proposed_replacement_terms:
-      - id: GO:0044183
-        label: protein folding chaperone
+      - id: GO:0140309
+        label: unfolded protein holdase activity
+    additional_reference_ids:
+      - PMID:17908933
+      - PMID:26344570
+      - file:projects/UNFOLDED_PROTEIN_BINDING.md
     supported_by:
       - reference_id: PMID:11226178
         supporting_text: "SurA interacts preferentially (>50-fold) with in vitro synthesized porins over other similarly sized proteins"
@@ -305,6 +370,9 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18165306
+  supporting_entities:
+  - UniProtKB:P77774
+  qualifier: enables
   review:
     summary: >-
       IntAct-derived annotation showing SurA interacts with BamB (YfgL, P77774).
@@ -313,13 +381,11 @@ existing_annotations:
       BamB/YfgL. The interaction with BamB itself is detected by IntAct but the paper
       primarily discusses YfgL-YaeT interactions and shows SurA-YaeT binding is
       independent of YfgL.
-    action: REMOVE
+    action: KEEP_AS_NON_CORE
     reason: >-
-      The generic "protein binding" term is uninformative. SurA's interaction with
-      BAM complex components is better captured by its biological process annotations
-      (GO:0043165, outer membrane assembly). The specific interaction should be
-      annotated with a more specific molecular function term if available, not the
-      generic protein binding. Per curation guidelines, GO:0005515 should be avoided.
+      IPI asserts an observed interaction with BamB and there is no contradictory
+      evidence, so the row is retained. Generic protein binding does not express
+      SurA's carrier-holdase mechanism and is therefore non-core.
     supported_by:
       - reference_id: PMID:18165306
         supporting_text: "SurA binds to YaeT (or another complex member) without going through YfgL."
@@ -328,18 +394,20 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22544271
+  supporting_entities:
+  - UniProtKB:P77774
+  qualifier: enables
   review:
     summary: >-
       IntAct-derived annotation showing SurA interacts with BamB (P77774). Workman
       et al. (PMID:22544271) studied BamA POTRA domain mutations and showed that
       BamA-SurA interactions correlated with improved OMP biogenesis. The SurA-BamB
       interaction is detected but the paper focuses on BamA structure-function.
-    action: REMOVE
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Generic protein binding is uninformative. SurA's interaction with BAM complex
-      components reflects its chaperone function in OMP biogenesis, which is captured
-      by more informative annotations. Per curation guidelines, GO:0005515 should
-      be avoided.
+      IPI asserts an observed BamB interaction and no evidence contradicts it. The
+      generic term is retained as non-core because it does not identify SurA's
+      carrier-holdase mechanism.
     supported_by:
       - reference_id: PMID:22544271
         supporting_text: "OMP biogenesis improved dramatically, and this correlated with improved BamA folding, BamA-SurA interactions, and LptD (lipopolysaccharide transporter) biogenesis."
@@ -348,6 +416,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IMP
   original_reference_id: PMID:8626309
+  qualifier: involved_in
   review:
     summary: >-
       Lazar and Kolter (PMID:8626309) used trypsin sensitivity as a folding assay
@@ -368,6 +437,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IMP
   original_reference_id: PMID:8985185
+  qualifier: involved_in
   review:
     summary: >-
       Rouviere and Gross (PMID:8985185) demonstrated that SurA is involved in the
@@ -388,6 +458,7 @@ existing_annotations:
     label: maintenance of unfolded protein
   evidence_type: IDA
   original_reference_id: PMID:26344570
+  qualifier: involved_in
   review:
     summary: >-
       Thoma et al. (PMID:26344570) used single-molecule force spectroscopy and NMR
@@ -411,6 +482,9 @@ existing_annotations:
     label: Gram-negative-bacterium-type cell outer membrane assembly
   evidence_type: IGI
   original_reference_id: PMID:17908933
+  supporting_entities:
+  - UniProtKB:P0AEU7
+  qualifier: involved_in
   review:
     summary: >-
       Sklar et al. (PMID:17908933) used depletion analysis and genetic interactions
@@ -433,6 +507,7 @@ existing_annotations:
     label: Gram-negative-bacterium-type cell outer membrane assembly
   evidence_type: IMP
   original_reference_id: PMID:8985185
+  qualifier: involved_in
   review:
     summary: >-
       Rouviere and Gross (PMID:8985185) demonstrated that SurA participates in
@@ -450,6 +525,7 @@ existing_annotations:
     label: protein stabilization
   evidence_type: IMP
   original_reference_id: PMID:8626309
+  qualifier: involved_in
   review:
     summary: >-
       Lazar and Kolter (PMID:8626309) showed that SurA is required for maintaining
@@ -468,17 +544,19 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:11226178
+  supporting_entities:
+  - UniProtKB:P02932
+  qualifier: enables
   review:
     summary: >-
       Behrens et al. (PMID:11226178) demonstrated that SurA interacts preferentially
       with in vitro synthesized porins (including OmpF, P02932) over other similarly
       sized proteins. This interaction reflects SurA's chaperone substrate specificity.
-    action: REMOVE
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Generic protein binding is uninformative. This interaction represents SurA's
-      chaperone-substrate interaction with OmpF, which is better captured by the
-      unfolded protein binding / chaperone annotations (GO:0051082, GO:0036506,
-      GO:0006457). Per curation guidelines, GO:0005515 should be avoided.
+      IPI accurately records the experimentally observed OmpF interaction and no
+      evidence contradicts it. It remains non-core because GO:0140309 and GO:0036506
+      convey the substrate-chaperoning mechanism rather than generic binding.
     supported_by:
       - reference_id: PMID:11226178
         supporting_text: "SurA interacts preferentially (>50-fold) with in vitro synthesized porins over other similarly sized proteins"
@@ -487,17 +565,19 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:17908933
+  supporting_entities:
+  - UniProtKB:P0A940
+  qualifier: enables
   review:
     summary: >-
       Sklar et al. (PMID:17908933) demonstrated that SurA and YaeT (BamA, P0A940)
       interact directly in vivo. This interaction is functionally significant as
       SurA delivers OMPs to the YaeT/BAM complex for membrane insertion.
-    action: REMOVE
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Generic protein binding is uninformative. The SurA-BamA interaction is
-      functionally important for OMP delivery but is better represented by the
-      biological process annotation GO:0043165 (outer membrane assembly). Per
-      curation guidelines, GO:0005515 should be avoided.
+      IPI accurately records the direct BamA/YaeT interaction and no evidence
+      contradicts it. It is retained as non-core because the interaction is more
+      informatively interpreted through GO:0140309 and outer-membrane assembly.
     supported_by:
       - reference_id: PMID:17908933
         supporting_text: "we demonstrate that SurA and YaeT interact directly in vivo"
@@ -506,17 +586,19 @@ existing_annotations:
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18165306
+  supporting_entities:
+  - UniProtKB:P0A940
+  qualifier: enables
   review:
     summary: >-
       Vuong et al. (PMID:18165306) from EcoCyc annotation showing SurA binds to
       BamA/YaeT (P0A940). The paper demonstrates that SurA binds to YaeT or another
       BAM complex member independently of YfgL/BamB.
-    action: REMOVE
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Generic protein binding is uninformative. This is a duplicate reference to the
-      same SurA-BamA interaction captured by the previous PMID:17908933 entry and
-      is better represented by GO:0043165. Per curation guidelines, GO:0005515 should
-      be avoided.
+      IPI accurately records a BamA/YaeT interaction and no evidence contradicts it.
+      It is retained as non-core because generic binding is less informative than
+      the carrier-holdase and outer-membrane-assembly annotations.
     supported_by:
       - reference_id: PMID:18165306
         supporting_text: "SurA binds to YaeT (or another complex member) without going through YfgL."
@@ -525,6 +607,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IDA
   original_reference_id: PMID:15911532
+  qualifier: located_in
   review:
     summary: >-
       Lopez-Campistrous et al. (PMID:15911532) identified SurA in the periplasmic
@@ -542,6 +625,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IDA
   original_reference_id: PMID:24140104
+  qualifier: located_in
   review:
     summary: >-
       Han et al. (PMID:24140104) identified SurA in the periplasmic proteome of
@@ -558,6 +642,7 @@ existing_annotations:
     label: protein stabilization
   evidence_type: IMP
   original_reference_id: PMID:21784935
+  qualifier: involved_in
   review:
     summary: >-
       Palomino et al. (PMID:21784935) demonstrated that FimD protein levels are
@@ -579,6 +664,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IDA
   original_reference_id: PMID:8985185
+  qualifier: located_in
   review:
     summary: >-
       Rouviere and Gross (PMID:8985185) characterized SurA as a periplasmic protein
@@ -595,6 +681,11 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IPI
   original_reference_id: PMID:11226178
+  supporting_entities:
+  - UniProtKB:P02931
+  - UniProtKB:P02932
+  - UniProtKB:P02943
+  qualifier: enables
   review:
     summary: >-
       Behrens et al. (PMID:11226178) showed that SurA exhibits chaperone activity
@@ -605,12 +696,16 @@ existing_annotations:
     action: MODIFY
     reason: >-
       Same rationale as other GO:0051082 annotations. GO:0051082 is now formally
-      obsolete. SurA's binding to unfolded porins represents its holdase/chaperone
-      activity. Replace with GO:0044183 (protein folding chaperone) as interim,
-      pending holdase NTR creation.
+      obsolete. SurA's binding to unfolded porins is one component of its
+      carrier-holdase activity, and independent experiments establish escort to
+      YaeT/BAM. Replace with GO:0140309.
     proposed_replacement_terms:
-      - id: GO:0044183
-        label: protein folding chaperone
+      - id: GO:0140309
+        label: unfolded protein holdase activity
+    additional_reference_ids:
+      - PMID:17908933
+      - PMID:26344570
+      - file:projects/UNFOLDED_PROTEIN_BINDING.md
     supported_by:
       - reference_id: PMID:11226178
         supporting_text: "a variant of SurA lacking both parvulin-like domains exhibits a PPIase-independent chaperone-like activity in vitro and almost completely complements the in vivo function of intact SurA"
@@ -621,6 +716,7 @@ existing_annotations:
     label: peptidyl-prolyl cis-trans isomerase activity
   evidence_type: IDA
   original_reference_id: PMID:8985185
+  qualifier: enables
   review:
     summary: >-
       Rouviere and Gross (PMID:8985185) demonstrated that SurA has peptidyl-prolyl
@@ -636,35 +732,41 @@ existing_annotations:
       - reference_id: PMID:8985185
         supporting_text: "SurA, a periplasmic protein with peptidyl-prolyl isomerase activity, participates in the assembly of outer membrane porins."
 - term:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140309
+    label: unfolded protein holdase activity
   evidence_type: IDA
-  original_reference_id: PMID:11226178
+  original_reference_id: PMID:26344570
+  qualifier: enables
   review:
     summary: >-
-      Behrens et al. (PMID:11226178) directly demonstrated that SurA has chaperone
-      activity independent of its PPIase domains. A SurA variant lacking both parvulin
-      domains exhibited PPIase-independent chaperone-like activity in vitro and almost
-      completely complemented full-length SurA function in vivo. SurA preferentially
-      binds in vitro synthesized porins (>50-fold selectivity) through its N-terminal
-      and C-terminal domains. This is the core molecular function of SurA.
+      Direct biophysical experiments show SurA stabilizing a dynamic unfolded FhuA
+      state during stepwise membrane insertion, while depletion and interaction
+      studies establish delivery of OMPs to YaeT/BAM. BAM is the defined acceptor
+      molecule required by the carrier-specific GO:0140309 definition.
     action: NEW
     reason: >-
-      GO:0044183 (protein folding chaperone) is not currently annotated for SurA
-      but is the most appropriate MF term for its primary function. SurA acts as a
-      chaperone that facilitates OMP folding and assembly, with direct in vitro
-      evidence for chaperone activity. This annotation should be added to replace
-      GO:0051082 which is now formally obsolete. Evidence supports both holdase
-      and chaperone mechanisms - SurA prevents aggregation (holdase) and enables
-      stepwise folding (facilitating folding). GO:0044183 is the best available
-      existing term.
+      GO:0140309 is more specific than GO:0044183 for SurA's mechanism. It does not
+      require movement between compartments: its definition requires escort to an
+      acceptor molecule or specific location. SurA binds unfolded OMPs, prevents
+      misfolding in transit, and hands them to YaeT/BAM for membrane insertion.
+      The obsolete GO:0051082 author claim is not retained.
+    additional_reference_ids:
+      - PMID:11226178
+      - PMID:17908933
+      - file:projects/UNFOLDED_PROTEIN_BINDING.md
     supported_by:
-      - reference_id: PMID:11226178
-        supporting_text: "a variant of SurA lacking both parvulin-like domains exhibits a PPIase-independent chaperone-like activity in vitro and almost completely complements the in vivo function of intact SurA"
       - reference_id: PMID:26344570
-        supporting_text: "the SurA-chaperoned FhuA polypeptide inserts beta-hairpins into the membrane in a stepwise manner until the beta-barrel is folded"
+        supporting_text: "Either chaperone prevents FhuA from misfolding by stabilizing a dynamic, unfolded state, thus allowing the substrate to search for structural intermediates."
+        full_text_unavailable: true
       - reference_id: PMID:17908933
         supporting_text: "SurA is the primary chaperone responsible for the periplasmic transit of the bulk mass of OMPs to the YaeT complex."
+        full_text_unavailable: true
+      - reference_id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+        supporting_text: to an acceptor molecule or to a specific location
+        reference_section_type: OTHER
+      - reference_id: file:ECOLI/surA/surA-deep-research-falcon.md
+        supporting_text: SurA protects newly translocated, unfolded OMPs from **aggregation** in the crowded, ATP-free periplasm and **delivers** them to the outer-membrane β-barrel assembly machinery (**BAM** complex) for folding and insertion
+        reference_section_type: OTHER
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -696,6 +798,12 @@ references:
   title: >-
     Defining the roles of the periplasmic chaperones SurA, Skp, and DegP in
     Escherichia coli.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-cached abstract directly supports SurA-YaeT interaction
+      and periplasmic transit of OMP clients to YaeT/BAM. Only abstract-explicit
+      claims were used because cached full text is unavailable.
   findings:
     - statement: SurA is the primary chaperone for periplasmic transit of OMPs to the BAM complex
     - statement: SurA interacts directly with BamA/YaeT in vivo
@@ -731,6 +839,12 @@ references:
   title: >-
     Impact of holdase chaperones Skp and SurA on the folding of β-barrel
     outer-membrane proteins.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-cached abstract directly supports SurA stabilization of
+      a dynamic unfolded FhuA state during stepwise membrane insertion. Only
+      abstract-explicit claims were used.
   findings:
     - statement: SurA characterized as a holdase chaperone
     - statement: SurA stabilizes dynamic unfolded state of FhuA
@@ -763,17 +877,34 @@ references:
     outer membrane proteins for selective substrate recognition.
   findings:
     - statement: SurA uses aromatic residue patterns and side chain orientation for OMP recognition
+- id: file:interpro/panther/PTHR47637/PTHR47637-paint.tsv
+  title: Current PAINT annotations for PANTHER family PTHR47637
+  findings:
+  - statement: PTN005352065 currently carries IBD assertions for protein folding,
+      PPIase activity, and periplasmic localization, each seeded by P0ABZ6; it no
+      longer carries GO:0051082.
+- id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+  title: Unfolded Protein Binding Annotation Review
+  findings:
+  - statement: GO:0140309 remains carrier-specific and requires escort of an unfolded
+      client to an acceptor molecule or specific location; SurA satisfies this through
+      delivery to YaeT/BAM.
+- id: file:ECOLI/surA/surA-deep-research-falcon.md
+  title: Deep research synthesis for E. coli SurA
+  findings:
+  - statement: The synthesis independently describes ATP-independent capture of
+      unfolded OMP clients in the periplasm and their delivery to BAM for insertion.
 core_functions:
 - description: >-
-    Chaperone activity -- SurA functions as the primary periplasmic chaperone for
+    Carrier-holdase activity -- SurA functions as the primary periplasmic chaperone for
     outer membrane protein biogenesis. It binds unfolded OMPs via its N-terminal
     and C-terminal domains (independent of PPIase activity) and escorts them to the
     BAM complex. SurA acts as a holdase, stabilizing OMPs in a dynamic unfolded
-    state to prevent aggregation while enabling stepwise beta-hairpin membrane
+    state to prevent off-pathway misfolding while enabling stepwise beta-hairpin membrane
     insertion.
   molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140309
+    label: unfolded protein holdase activity
   directly_involved_in:
     - id: GO:0043165
       label: Gram-negative-bacterium-type cell outer membrane assembly
@@ -789,8 +920,16 @@ core_functions:
       supporting_text: "a variant of SurA lacking both parvulin-like domains exhibits a PPIase-independent chaperone-like activity in vitro and almost completely complements the in vivo function of intact SurA"
     - reference_id: PMID:17908933
       supporting_text: "SurA is the primary chaperone responsible for the periplasmic transit of the bulk mass of OMPs to the YaeT complex."
+      full_text_unavailable: true
     - reference_id: PMID:26344570
       supporting_text: "the SurA-chaperoned FhuA polypeptide inserts beta-hairpins into the membrane in a stepwise manner until the beta-barrel is folded"
+      full_text_unavailable: true
+    - reference_id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+      supporting_text: to an acceptor molecule or to a specific location
+      reference_section_type: OTHER
+    - reference_id: file:ECOLI/surA/surA-deep-research-falcon.md
+      supporting_text: SurA protects newly translocated, unfolded OMPs from **aggregation** in the crowded, ATP-free periplasm and **delivers** them to the outer-membrane β-barrel assembly machinery (**BAM** complex) for folding and insertion
+      reference_section_type: OTHER
 - description: >-
     Peptidyl-prolyl cis-trans isomerase activity -- SurA has PPIase activity
     (EC 5.2.1.8) residing in its second parvulin domain. This is a real enzymatic

--- a/genes/ECOLI/surA/surA-ai-review.yaml
+++ b/genes/ECOLI/surA/surA-ai-review.yaml
@@ -168,8 +168,6 @@ existing_annotations:
         label: unfolded protein holdase activity
     propagation_review:
       root_cause: SOURCE_STALE_OR_MISSING
-      failure_modes:
-      - SOURCE_EVIDENCE_WEAK
       source_entities:
       - source_id: PANTHER:PTN005352065
         source_label: PANTHER:PTN005352065
@@ -749,6 +747,9 @@ existing_annotations:
       require movement between compartments: its definition requires escort to an
       acceptor molecule or specific location. SurA binds unfolded OMPs, prevents
       misfolding in transit, and hands them to YaeT/BAM for membrane insertion.
+      PMID:26344570 supplies the IDA basis by directly demonstrating unfolded-state
+      stabilization and stepwise insertion into the membrane; PMID:17908933 independently
+      supplies the YaeT/BAM acceptor endpoint through depletion and interaction evidence.
       The obsolete GO:0051082 author claim is not retained.
     additional_reference_ids:
       - PMID:11226178
@@ -922,7 +923,7 @@ core_functions:
       supporting_text: "SurA is the primary chaperone responsible for the periplasmic transit of the bulk mass of OMPs to the YaeT complex."
       full_text_unavailable: true
     - reference_id: PMID:26344570
-      supporting_text: "the SurA-chaperoned FhuA polypeptide inserts beta-hairpins into the membrane in a stepwise manner until the beta-barrel is folded"
+      supporting_text: "the SurA-chaperoned FhuA polypeptide inserts β-hairpins into the membrane in a stepwise manner until the β-barrel is folded"
       full_text_unavailable: true
     - reference_id: file:projects/UNFOLDED_PROTEIN_BINDING.md
       supporting_text: to an acceptor molecule or to a specific location

--- a/genes/ECOLI/surA/surA-notes.md
+++ b/genes/ECOLI/surA/surA-notes.md
@@ -1,0 +1,49 @@
+# surA (SurA) — *Escherichia coli* K-12
+
+## 2026-08-29 carrier-holdase consistency review
+
+The current GOA contains 30 qualifier-aware physical signatures, all represented
+exactly once in `surA-ai-review.yaml`: 13 `enables`, 11 `involved_in`, five
+`located_in`, and one `is_active_in`. The review also contains one author-supplied
+NEW molecular-function proposal. No physical GOA row was deleted or rewritten.
+
+### GO:0140309 decision
+
+GO:0051082 is obsolete. The earlier review hesitated between GO:0044183 and
+GO:0140309 because SurA moves within the periplasm rather than between compartments.
+That is not a requirement of GO:0140309: the project records that its definition
+requires escort "to an acceptor molecule or to a specific location"
+[`projects/UNFOLDED_PROTEIN_BINDING.md`]. BAM/YaeT is a defined acceptor molecule
+for SurA-delivered unfolded OMP clients.
+
+The direct cached evidence supports both components of this interpretation. SurA
+"prevents FhuA from misfolding by stabilizing a dynamic, unfolded state"
+[PMID:26344570], and it is "responsible for the periplasmic transit of the bulk mass
+of OMPs to the YaeT complex" [PMID:17908933]. These records are abstract-only, so
+the review makes no claims beyond their explicit text. The three physical GO:0051082
+rows are therefore MODIFY to GO:0140309, and the former author NEW GO:0044183 row is
+replaced by NEW GO:0140309. GO:0044183 is not asserted as the primary MF because the
+carrier-holdase term describes the observed mechanism more specifically.
+
+### PAINT provenance
+
+All four IBA rows in GOA cite PANTHER:PTN005352065 and include P0ABZ6 itself among
+their WITH/FROM sources. Target self-seeding is legitimate because direct SurA
+evidence grounds the ancestral assertion; it is not circular. Current cached PAINT
+for PTHR47637 retains at PTN005352065 only GO:0006457 protein folding, GO:0003755
+PPIase activity, and GO:0030288 periplasmic localization, all seeded by P0ABZ6
+[`interpro/panther/PTHR47637/PTHR47637-paint.tsv`]. Those three IBAs remain ACCEPT
+with `NO_FAILURE_CORE`. GO:0051082 is absent from current PAINT, so its old GOA IBA
+is recorded as `SOURCE_STALE_OR_MISSING` and MODIFY to GO:0140309 using independent
+direct evidence.
+
+### Other row-level decisions
+
+The five GO:0005515 IPI rows are true observed interactions with OmpF, BamA/YaeT,
+or BamB and have no contradictory evidence. They are retained as KEEP_AS_NON_CORE
+rather than removed merely because `protein binding` is uninformative. Broad parent
+or supporting IEAs (isomerase activity, peptide binding, and periplasmic space)
+are also retained as non-core. Protein stabilization remains ACCEPT across IEA and
+direct IMP rows because direct experiments establish stabilization of OMP clients.
+Direct folding, OMP assembly, PPIase, maintenance-of-unfolded-protein, and localization
+annotations also remain accepted.

--- a/genes/ECOLI/surA/surA-notes.md
+++ b/genes/ECOLI/surA/surA-notes.md
@@ -47,3 +47,26 @@ are also retained as non-core. Protein stabilization remains ACCEPT across IEA a
 direct IMP rows because direct experiments establish stabilization of OMP clients.
 Direct folding, OMP assembly, PPIase, maintenance-of-unfolded-protein, and localization
 annotations also remain accepted.
+
+## PR #2732 feedback resolution
+
+Rechecked after the carrier-holdase policy clarification was merged through PR #2733.
+The project now explicitly defines GO:0140309 carrier-holdase activity as escort to
+a specified location or acceptor molecule, includes delivery within one compartment
+when an acceptor such as BAM/YaeT is demonstrated, and lists SurA as an example.
+The gene review is consistent with that policy and contains no remaining dependency
+on the older cross-compartment interpretation or the former "unfolded protein carrier
+activity" label.
+
+The NEW GO:0140309 evidence boundary is now explicit. PMID:26344570 is the IDA basis:
+it directly demonstrates stabilization of a dynamic unfolded FhuA state and stepwise
+β-hairpin insertion. PMID:17908933 independently corroborates the carrier endpoint by
+showing periplasmic OMP transit to YaeT/BAM and direct SurA-YaeT interaction. Neither
+abstract is made to support the other's experimental component. The core quote now
+preserves the cached publication's Greek `β` characters verbatim.
+
+The stale GO:0051082 IBA remains classified `SOURCE_STALE_OR_MISSING` because current
+PTHR47637 PAINT lacks that node assertion. The former `SOURCE_EVIDENCE_WEAK` subtype
+was removed: absence from current PAINT establishes staleness, not weakness of the
+historical source evidence, and the GO:0140309 replacement rests on independent direct
+SurA experiments rather than reinterpretation of that retired node claim.


### PR DESCRIPTION
## Summary
- reconcile all 30 qualifier-aware E. coli SurA GOA signatures
- replace obsolete GO:0051082 decisions with GO:0140309 using direct holdase and YaeT/BAM acceptor evidence
- audit current PAINT provenance and retain generic experimental interactions as non-core
- update notes, rendered review, and browser data

## Context
This is the separate donor-review dependency requested during review of #2731. It preserves the repository one-gene-per-PR rule.

## Validation
- `just validate ECOLI surA`
- `just validate-goa ECOLI surA`
- `just render ECOLI surA`
- `just deploy-browser`
- `git diff --check`