### PR TITLE
Align UPB carrier-holdase decisions

### DIFF
--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -458,10 +458,10 @@ Validate with: <code>just validate-all</code> (writes <code>reports/validation-a
 </tr>
 <tr>
 <td><strong>Carrier-holdase</strong></td>
-<td><a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> unfolded protein carrier activity</td>
-<td>Binds unfolded protein and escorts it between cellular components, preventing aggregation in transit</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> unfolded protein holdase activity</td>
+<td>Binds an unfolded protein and escorts it to a specified location or acceptor molecule, preventing aggregation in transit</td>
 <td>No</td>
-<td>Tim9-Tim10, Tim8-Tim13 (small TIMs)</td>
+<td>Tim9-Tim10, Tim8-Tim13 (small TIMs), <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a></td>
 </tr>
 <tr>
 <td><strong>Foldase/holdase</strong></td>
@@ -540,6 +540,13 @@ Validate with: <code>just validate-all</code> (writes <code>reports/validation-a
 <td>holdase NTR <em>(retain <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> until NTR created)</em></td>
 <td>ATP-independent in-situ aggregation prevention. <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> does not fit — it was created for carrier-holdases (TIM chaperones); see <a href="#holdase-annotation-gap">holdase annotation gap</a></td>
 <td><a href="../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a>, <a href="../../genes/human/HSPB6/HSPB6-ai-review.html">HSPB6</a>, <a href="../../genes/human/CLU/CLU-ai-review.html">CLU</a></td>
+</tr>
+<tr>
+<td>Carrier-holdase</td>
+<td>MODIFY</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> unfolded protein holdase activity</td>
+<td>ATP-independent stabilization of an unfolded client during escort to a specified location or acceptor molecule. This includes delivery within one compartment when a defined acceptor, such as BAM/YaeT, is demonstrated</td>
+<td><a href="../../genes/yeast/TIM9/TIM9-ai-review.html">TIM9</a>/TIM10, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a></td>
 </tr>
 <tr>
 <td>Disaggregase (HSP70 subset)</td>
@@ -988,7 +995,7 @@ because it has that second term as well; this is not an additional human gene.</
 <td>11</td>
 <td><strong>Periplasmic chaperones</strong></td>
 <td><a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>, <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>, <a href="../../genes/ECOLI/HdeB/HdeB-ai-review.html">HdeB</a>, <a href="../../genes/ECOLI/SlyD/SlyD-ai-review.html">SlyD</a>, <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a> (E. coli)</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a> (holdase/chaperone)</td>
+<td>Carrier-holdases <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a> and <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>: MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>; other members require gene-specific foldase, in-situ holdase, or non-chaperone decisions</td>
 </tr>
 <tr>
 <td>12</td>
@@ -1204,8 +1211,10 @@ established:</p>
 <p><strong>E. coli periplasmic chaperones (<a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>, <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a>, <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>/B, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a>, <a href="../../genes/ECOLI/SlyD/SlyD-ai-review.html">SlyD</a>)</strong> —<br />
    Bacterial-specific holdase/chaperone category with no human orthologs. <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a> is a holdase<br />
    that escorts OMPs to the BAM complex; <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a> and <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>/B are acid-activated holdases; <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a><br />
-   is a secretion-coupled holdase. All MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a>. These validate the foldase/holdase<br />
-   framework in a phylogenetically distant lineage.</p>
+   is a secretion-coupled holdase. <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a> and <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a> are carrier-holdases that MODIFY →<br />
+<a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> because each escorts an unfolded client to a defined acceptor or location;<br />
+   the remaining proteins require gene-specific foldase, in-situ holdase, or non-chaperone<br />
+   decisions. These validate the foldase/holdase framework in a phylogenetically distant lineage.</p>
 </li>
 <li>
 <p><strong><a href="../../genes/ECOLI/CnoX/CnoX-ai-review.html">CnoX</a> (E. coli)</strong> — Redox-activated holdase with thioredoxin domain. Interesting<br />
@@ -1476,8 +1485,8 @@ established:</p>
 <td><em>E. coli</em></td>
 <td>P0AG86</td>
 <td>27</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>Secretion chaperone</td>
+<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a></td>
+<td>Secretion carrier-holdase</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a></td>
@@ -1508,8 +1517,8 @@ established:</p>
 <td><em>E. coli</em></td>
 <td>P0ABZ6</td>
 <td>31</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>Periplasmic OMP holdase</td>
+<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a></td>
+<td>Periplasmic OMP carrier-holdase; delivery to BAM/YaeT</td>
 </tr>
 <tr>
 <td><a href="../../genes/mouse/Dnaja3/Dnaja3-ai-review.html">Dnaja3</a></td>

--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -393,7 +393,7 @@ obsolete term with no correct replacement.</strong> This needs escalating upstre
 <a href="https://github.com/geneontology/go-ontology/issues/30552">#30552</a>) rather than resolving gene-by-gene.<br />
 Until then these genes retain <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> as an interim annotation with <code>proposed_replacement_terms: [id: NTR]</code>.</p>
 <p><strong>One detail below has drifted:</strong> this page states that <code>holdase</code> is a <strong>BROAD</strong> synonym on <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>.<br />
-QuickGO now reports all three synonyms (<code>holdase</code>, <code>unfolded protein carrier activity</code>,<br />
+<a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309">QuickGO</a>, rechecked 2026-08-29, reports all three synonyms (<code>holdase</code>, <code>unfolded protein carrier activity</code>,<br />
 <code>holdase-carrier chaperone</code>) as <strong>exact</strong>, and <code>holdase</code> has been promoted to <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>'s <strong>primary<br />
 label</strong> ("unfolded protein holdase activity"). This weakens that particular supporting argument, but<br />
 <strong>not the conclusion</strong> — <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>'s <em>definition</em> is unchanged and still requires escorting the client<br />
@@ -414,7 +414,7 @@ RNA-binding translational repressor, not the ribosome-associated Hsp70. Canonica
 <a href="../../genes/yeast/SSB1/SSB1-ai-review.html">SSB1</a> (P11484) has now been refetched, reviewed, and restored to the cohort as an<br />
 ATP-dependent cotranslational Hsp70 foldase. The aggregate numbers above remain the<br />
 frozen original-audit snapshot rather than a live recount after later identity fixes.<br />
-<strong>Critical finding</strong>: <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> "unfolded protein carrier activity"<br />
+<strong>Critical finding</strong>: <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> "unfolded protein holdase activity"<br />
 was created specifically for TIM carrier-holdases (<a href="https://github.com/geneontology/go-ontology/issues/30552">go-ontology#30552</a>)<br />
 and does <strong>not</strong> fit in-situ holdases (crystallins, sHSPs, <a href="../../genes/human/CLU/CLU-ai-review.html">CLU</a>). A general "holdase chaperone<br />
 activity" term was discussed in #30552 but never created — this is now the primary NTR needed.<br />
@@ -452,7 +452,7 @@ Validate with: <code>just validate-all</code> (writes <code>reports/validation-a
 <tr>
 <td><strong>Holdase</strong></td>
 <td><em>(NTR needed: holdase chaperone activity)</em></td>
-<td>Binds unfolded/misfolded proteins to prevent aggregation in situ; does not actively refold or transport between compartments</td>
+<td>Binds unfolded/misfolded proteins to prevent aggregation in situ; does not actively refold or deliver the client to a defined acceptor or destination</td>
 <td>No</td>
 <td><a href="../../genes/human/CRYAB/CRYAB-ai-review.html">CRYAB</a> (alpha-crystallin), <a href="../../genes/human/CLU/CLU-ai-review.html">CLU</a></td>
 </tr>
@@ -678,7 +678,7 @@ on this.</p>
 <td><a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> unfolded protein binding (IDA, PMID:20159986)</td>
 <td>holdase NTR <em>(retain <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> until created)</em></td>
 <td>IDA</td>
-<td>sHSP holdase; prevents aggregation in situ without active refolding or inter-compartment transport. <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> does not fit (carrier-specific)</td>
+<td>sHSP holdase; prevents aggregation in situ without active refolding or delivery to a defined acceptor/destination. <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> does not fit (carrier-specific)</td>
 </tr>
 <tr>
 <td><a href="../../genes/human/DNAJB1/DNAJB1-ai-review.html">DNAJB1</a></td>
@@ -714,19 +714,19 @@ on this.</p>
 <p>Ontology changes needed to properly annotate genes in this set:</p>
 <ol>
 <li><strong>NTR: general holdase chaperone activity</strong> — The most critical gap. <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a><br />
-   "unfolded protein carrier activity" was created in Nov 2025 specifically for TIM carrier-holdases<br />
+   "unfolded protein holdase activity" was created in Nov 2025 for TIM carrier-holdases<br />
    (Tim9-Tim10, Tim8-Tim13) that escort unfolded proteins across the mitochondrial IMS<br />
    (<a href="https://github.com/geneontology/go-ontology/issues/30552">go-ontology#30552</a>). Its definition<br />
-   requires escort "between two different cellular components" and it is a child of <a href="http://amigo.geneontology.org/amigo/term/GO:0140597">GO:0140597</a><br />
+   now requires escort "to an acceptor molecule or to a specific location" and it is a child of <a href="http://amigo.geneontology.org/amigo/term/GO:0140597">GO:0140597</a><br />
    "protein carrier chaperone." Val and Pascale acknowledged in #30552 that a more general holdase<br />
    term was needed but deferred it: <em>"we thought it would be better to add this specific term as<br />
    it was needed immediately for annotation, and add the more general parent 'holdase' when it was<br />
    requested for annotation"</em> (Val, 2025-11-04). Raymond also flagged that an ER holdase<br />
-   (PMID:30287478) doesn't fit <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>. "holdase" is explicitly a <strong>BROAD</strong> synonym on<br />
-<a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>, confirming it is not the general holdase term.</li>
+   (PMID:30287478) doesn't fit <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>. The current label and exact <code>holdase</code> synonym<br />
+   are broader-sounding than the still carrier-specific definition.</li>
 <li><strong>We are now requesting this term.</strong> 7 genes in this review (<a href="../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a>, <a href="../../genes/human/CRYAB/CRYAB-ai-review.html">CRYAB</a>, <a href="../../genes/human/HSPB6/HSPB6-ai-review.html">HSPB6</a>, <a href="../../genes/human/CLU/CLU-ai-review.html">CLU</a>, <a href="../../genes/human/SCG5/SCG5-ai-review.html">SCG5</a>,<br />
 <a href="../../genes/human/DNAJB6/DNAJB6-ai-review.html">DNAJB6</a>, <a href="../../genes/human/DNAJB8/DNAJB8-ai-review.html">DNAJB8</a>) plus <a href="../../genes/CRIGR/HSPH1/HSPH1-ai-review.html">HSPH1</a> (non-human) are in-situ holdases that prevent aggregation without<br />
-     inter-compartment escort. They cannot be annotated to <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>.</li>
+     delivery to a defined acceptor or destination. They cannot be annotated to <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>.</li>
 <li><strong>Proposed term</strong>: "holdase chaperone activity" — Def: "Binding to an unfolded or misfolded<br />
      protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains<br />
      the client protein in a soluble, folding-competent state." Parent: direct child of<br />
@@ -796,9 +796,9 @@ related but not necessarily in the unfolded/denatured binding annotation set.</p
 </ul>
 <p><strong>Not used</strong> (despite initial consideration):</p>
 <ul>
-<li><strong><a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a></strong> unfolded protein carrier activity — This is a carrier-holdase term created<br />
+<li><strong><a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a></strong> unfolded protein holdase activity — This is a carrier-holdase term created<br />
   specifically for TIM chaperones (<a href="https://github.com/geneontology/go-ontology/issues/30552">go-ontology#30552</a>).<br />
-  Its definition requires escort between cellular components. None of the holdase genes in<br />
+  Its current definition requires escort to an acceptor molecule or specific location. None of the holdase genes in<br />
   this review (crystallins, sHSPs, <a href="../../genes/human/CLU/CLU-ai-review.html">CLU</a>, <a href="../../genes/human/SCG5/SCG5-ai-review.html">SCG5</a>, <a href="../../genes/human/DNAJB6/DNAJB6-ai-review.html">DNAJB6</a>, <a href="../../genes/human/DNAJB8/DNAJB8-ai-review.html">DNAJB8</a>) are carrier-holdases.</li>
 </ul>
 <p>This project focuses on MF replacement for <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a>/<a href="http://amigo.geneontology.org/amigo/term/GO:0031249">GO:0031249</a>. BP terms discussed in<br />
@@ -824,21 +824,21 @@ actively refold substrates. This is mechanistically distinct from the ATP-depend
 activity of HSP70-type chaperones. Some proteins (notably HSP70) can function as both foldase<br />
 and holdase depending on conditions, clients, and whether the context is de novo folding or<br />
 quality control.</p>
-<p><strong><a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> "unfolded protein carrier activity" does not fit these genes.</strong> Review of the<br />
+<p><strong><a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> "unfolded protein holdase activity" does not fit these genes.</strong> Review of the<br />
 original term request (<a href="https://github.com/geneontology/go-ontology/issues/30552">go-ontology#30552</a>)<br />
 shows that <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> was created in Nov 2025 specifically for TIM carrier-holdases (Tim9-Tim10,<br />
 Tim8-Tim13) that escort unfolded proteins across the mitochondrial IMS. Key evidence:</p>
 <ul>
-<li>Its definition requires escort "between two different cellular components"</li>
+<li>Its current definition requires escort "to an acceptor molecule or to a specific location"</li>
 <li>It is a child of <a href="http://amigo.geneontology.org/amigo/term/GO:0140597">GO:0140597</a> "protein carrier chaperone"</li>
-<li>"holdase" is explicitly a <strong>BROAD</strong> synonym (not exact), because not all holdases are carriers</li>
+<li>Its carrier parent and delivery requirement remain restrictive even though <code>holdase</code> is now an exact synonym</li>
 <li>Val (2025-11-04): <em>"we were aware that there were holdases that did not bind to unfolded<br />
   proteins [in transit], but we needed a use case"</em> for the carrier-holdase</li>
 <li>Raymond flagged that an ER holdase (PMID:30287478) doesn't fit <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>; Val agreed a<br />
   separate holdase term is needed</li>
 </ul>
 <p>The holdase genes in this review (<a href="../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a>, <a href="../../genes/human/CRYAB/CRYAB-ai-review.html">CRYAB</a>, <a href="../../genes/human/HSPB6/HSPB6-ai-review.html">HSPB6</a>, <a href="../../genes/human/CLU/CLU-ai-review.html">CLU</a>, <a href="../../genes/human/SCG5/SCG5-ai-review.html">SCG5</a>, <a href="../../genes/human/DNAJB6/DNAJB6-ai-review.html">DNAJB6</a>, <a href="../../genes/human/DNAJB8/DNAJB8-ai-review.html">DNAJB8</a>) all prevent<br />
-aggregation <strong>in situ</strong> — they do not escort substrates between compartments. <a href="../../genes/CRIGR/HSPH1/HSPH1-ai-review.html">HSPH1</a> (non-human)<br />
+aggregation <strong>in situ</strong> — they do not deliver substrates to a defined acceptor or destination. <a href="../../genes/CRIGR/HSPH1/HSPH1-ai-review.html">HSPH1</a> (non-human)<br />
 is likewise an in-situ holdase. These genes require a new general "holdase chaperone activity"<br />
 term (see <a href="#open-ontology-gaps">Open Ontology Gaps</a> item 1).</p>
 <p><strong>Until the holdase NTR is created, these 7 genes should retain <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a></strong> — the obsoletion<br />
@@ -856,7 +856,8 @@ folding chaperone" is used as a pragmatic interim because J-domain proteins do p
 the folding process (as part of the HSP70 machine), but this obscures the co-chaperone<br />
 mechanism. Editor guidance is requested on how to represent this function.</p>
 <p>Note: Some J-domain proteins (<a href="../../genes/human/DNAJB6/DNAJB6-ai-review.html">DNAJB6</a>, <a href="../../genes/human/DNAJB8/DNAJB8-ai-review.html">DNAJB8</a>) have <strong>independent holdase activity</strong> in addition<br />
-to their co-chaperone function — these are annotated to <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> for their holdase activity.</p>
+to their co-chaperone function. They await the general holdase NTR because their clients are<br />
+protected in situ rather than delivered to a defined acceptor or destination.</p>
 <hr />
 <h2 id="human-gene-checklist">Human Gene Checklist</h2>
 <p>33 unique human genes are in scope below. <a href="../../genes/human/HSPA1A/HSPA1A-ai-review.html">HSPA1A</a> appears again in the <a href="http://amigo.geneontology.org/amigo/term/GO:0031249">GO:0031249</a> subsection<br />
@@ -993,9 +994,9 @@ because it has that second term as well; this is not an additional human gene.</
 </tr>
 <tr>
 <td>11</td>
-<td><strong>Periplasmic chaperones</strong></td>
+<td><strong>Periplasmic/envelope chaperones</strong></td>
 <td><a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>, <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>, <a href="../../genes/ECOLI/HdeB/HdeB-ai-review.html">HdeB</a>, <a href="../../genes/ECOLI/SlyD/SlyD-ai-review.html">SlyD</a>, <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a> (E. coli)</td>
-<td>Carrier-holdases <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a> and <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>: MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>; other members require gene-specific foldase, in-situ holdase, or non-chaperone decisions</td>
+<td>Carrier-holdases <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, and <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>: MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>; <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>/Spy/SlyD await the general holdase NTR; <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a> is over-annotated. <a href="../../genes/ECOLI/HdeB/HdeB-ai-review.html">HdeB</a>'s current <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> proposal needs acceptor/destination re-review</td>
 </tr>
 <tr>
 <td>12</td>
@@ -1211,7 +1212,7 @@ established:</p>
 <p><strong>E. coli periplasmic chaperones (<a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>, <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a>, <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>/B, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a>, <a href="../../genes/ECOLI/SlyD/SlyD-ai-review.html">SlyD</a>)</strong> —<br />
    Bacterial-specific holdase/chaperone category with no human orthologs. <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a> is a holdase<br />
    that escorts OMPs to the BAM complex; <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a> and <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>/B are acid-activated holdases; <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a><br />
-   is a secretion-coupled holdase. <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a> and <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a> are carrier-holdases that MODIFY →<br />
+   is a secretion-coupled holdase. <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, and <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a> are carrier-holdases that MODIFY →<br />
 <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> because each escorts an unfolded client to a defined acceptor or location;<br />
    the remaining proteins require gene-specific foldase, in-situ holdase, or non-chaperone<br />
    decisions. These validate the foldase/holdase framework in a phylogenetically distant lineage.</p>
@@ -1429,8 +1430,8 @@ established:</p>
 <td><em>E. coli</em></td>
 <td>P0AE85</td>
 <td>11</td>
-<td>OVER_ANNOTATED</td>
-<td>Cpx pathway adaptor</td>
+<td>MARK_AS_OVER_ANNOTATED</td>
+<td>Cpx pathway adaptor; <a href="http://amigo.geneontology.org/amigo/term/GO:0030547">GO:0030547</a> for CpxA inhibition</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/DnaJ/DnaJ-ai-review.html">DnaJ</a></td>
@@ -1461,16 +1462,16 @@ established:</p>
 <td><em>E. coli</em></td>
 <td>P0AES9</td>
 <td>14</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>Acid-activated holdase</td>
+<td>MODIFY → holdase NTR; retain <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> interim</td>
+<td>Acid-activated in-situ holdase; <a href="http://amigo.geneontology.org/amigo/term/GO:0042026">GO:0042026</a> for refolding process</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/HdeB/HdeB-ai-review.html">HdeB</a></td>
 <td><em>E. coli</em></td>
 <td>P0AET2</td>
 <td>8</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>Acid-activated holdase</td>
+<td>Current review: MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>; re-review needed</td>
+<td>Acid-activated holdase; defined acceptor/destination not yet established</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/RidA/RidA-ai-review.html">RidA</a></td>
@@ -1493,31 +1494,31 @@ established:</p>
 <td><em>E. coli</em></td>
 <td>P0AEU7</td>
 <td>34</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>Periplasmic holdase</td>
+<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a></td>
+<td>Periplasmic OMP carrier-holdase</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/SlyD/SlyD-ai-review.html">SlyD</a></td>
 <td><em>E. coli</em></td>
 <td>P0A9K9</td>
 <td>35</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>FKBP-type PPIase/chaperone</td>
+<td>MODIFY → holdase NTR; retain <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> interim</td>
+<td>FKBP-type PPIase/holdase; <a href="http://amigo.geneontology.org/amigo/term/GO:0170061">GO:0170061</a> for nickel chaperoning</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a></td>
 <td><em>E. coli</em></td>
 <td>P77754</td>
 <td>11</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>Periplasmic holdase</td>
+<td>MODIFY → holdase NTR; retain <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> interim</td>
+<td>Periplasmic in-situ holdase</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/surA/surA-ai-review.html">surA</a></td>
 <td><em>E. coli</em></td>
 <td>P0ABZ6</td>
 <td>31</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a></td>
+<td>Project decision: MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>; gene-review alignment tracked in <a href="https://github.com/ai4curation/ai-gene-review/pull/2732">#2732</a></td>
 <td>Periplasmic OMP carrier-holdase; delivery to BAM/YaeT</td>
 </tr>
 <tr>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -25,7 +25,7 @@ sidecars:
 > Until then these genes retain GO:0051082 as an interim annotation with `proposed_replacement_terms: [id: NTR]`.
 >
 > **One detail below has drifted:** this page states that `holdase` is a **BROAD** synonym on GO:0140309.
-> QuickGO now reports all three synonyms (`holdase`, `unfolded protein carrier activity`,
+> [QuickGO](https://www.ebi.ac.uk/QuickGO/term/GO:0140309), rechecked 2026-08-29, reports all three synonyms (`holdase`, `unfolded protein carrier activity`,
 > `holdase-carrier chaperone`) as **exact**, and `holdase` has been promoted to GO:0140309's **primary
 > label** ("unfolded protein holdase activity"). This weakens that particular supporting argument, but
 > **not the conclusion** — GO:0140309's *definition* is unchanged and still requires escorting the client
@@ -47,7 +47,7 @@ sidecars:
 > SSB1 (P11484) has now been refetched, reviewed, and restored to the cohort as an
 > ATP-dependent cotranslational Hsp70 foldase. The aggregate numbers above remain the
 > frozen original-audit snapshot rather than a live recount after later identity fixes.
-> **Critical finding**: GO:0140309 "unfolded protein carrier activity"
+> **Critical finding**: GO:0140309 "unfolded protein holdase activity"
 > was created specifically for TIM carrier-holdases ([go-ontology#30552](https://github.com/geneontology/go-ontology/issues/30552))
 > and does **not** fit in-situ holdases (crystallins, sHSPs, CLU). A general "holdase chaperone
 > activity" term was discussed in #30552 but never created — this is now the primary NTR needed.
@@ -69,7 +69,7 @@ These mechanism classes are used throughout this document:
 | Term | GO term | Definition | ATP? | Example |
 |------|---------|-----------|------|---------|
 | **Foldase** | GO:0044183 protein folding chaperone | Actively assists protein folding through iterative binding/release cycles | Yes | GroEL/ES, TRiC/CCT |
-| **Holdase** | *(NTR needed: holdase chaperone activity)* | Binds unfolded/misfolded proteins to prevent aggregation in situ; does not actively refold or transport between compartments | No | CRYAB (alpha-crystallin), CLU |
+| **Holdase** | *(NTR needed: holdase chaperone activity)* | Binds unfolded/misfolded proteins to prevent aggregation in situ; does not actively refold or deliver the client to a defined acceptor or destination | No | CRYAB (alpha-crystallin), CLU |
 | **Carrier-holdase** | GO:0140309 unfolded protein holdase activity | Binds an unfolded protein and escorts it to a specified location or acceptor molecule, preventing aggregation in transit | No | Tim9-Tim10, Tim8-Tim13 (small TIMs), SecB, SurA |
 | **Foldase/holdase** | GO:0044183 + holdase NTR | Context-dependent: can function as foldase or holdase depending on conditions, clients, de novo vs quality control | Yes | HSPA1A (HSP70) |
 | **Co-chaperone** | *(see [co-chaperone note](#co-chaperone-note))* | Binds to chaperone to activate its ATPase and/or deliver substrates; does not independently fold proteins | N/A | DNAJB1 (J-domain), AHSA1 (HSP90 activator) |
@@ -126,7 +126,7 @@ Additional non-exclusive co-annotations:
 | Gene | Old annotation | New annotation | Evidence | Rationale |
 |------|---------------|----------------|----------|-----------|
 | HSPA1A | GO:0051082 unfolded protein binding (IDA, PMID:21231916) | GO:0044183 protein folding chaperone (foldase) + GO:0140545 disaggregase | IDA | HSP70 is an ATP-dependent foldase; also disaggregates with DNAJ/HSPH1. Holdase aspect awaits holdase NTR |
-| CRYAB | GO:0051082 unfolded protein binding (IDA, PMID:20159986) | holdase NTR *(retain GO:0051082 until created)* | IDA | sHSP holdase; prevents aggregation in situ without active refolding or inter-compartment transport. GO:0140309 does not fit (carrier-specific) |
+| CRYAB | GO:0051082 unfolded protein binding (IDA, PMID:20159986) | holdase NTR *(retain GO:0051082 until created)* | IDA | sHSP holdase; prevents aggregation in situ without active refolding or delivery to a defined acceptor/destination. GO:0140309 does not fit (carrier-specific) |
 | DNAJB1 | GO:0051082 unfolded protein binding (IDA, PMID:21231916) | GO:0044183 protein folding chaperone *(interim)* | IDA | J-domain co-chaperone: substrate adaptor + HSP70 ATPase activator. Not an independent foldase. GO:0044183 used as interim; see [co-chaperone note](#co-chaperone-note) |
 | SYVN1 | GO:0051082 unfolded protein binding (IDA, PMID:14593114) | REMOVE | IDA | HRD1 is an E3 ubiquitin ligase; recognizes misfolded substrates for degradation, not chaperoning. Candidate for proposed "misfolded protein sensor activity" |
 | UGGT1 | GO:0051082 unfolded protein binding (IDA, PMID:24790089) | MARK_AS_OVER_ANNOTATED | IDA | Glycoprotein quality sensor for GT activity, not a chaperone |
@@ -137,19 +137,19 @@ Additional non-exclusive co-annotations:
 Ontology changes needed to properly annotate genes in this set:
 
 1. **NTR: general holdase chaperone activity** — The most critical gap. GO:0140309
-   "unfolded protein carrier activity" was created in Nov 2025 specifically for TIM carrier-holdases
+   "unfolded protein holdase activity" was created in Nov 2025 for TIM carrier-holdases
    (Tim9-Tim10, Tim8-Tim13) that escort unfolded proteins across the mitochondrial IMS
    ([go-ontology#30552](https://github.com/geneontology/go-ontology/issues/30552)). Its definition
-   requires escort "between two different cellular components" and it is a child of GO:0140597
+   now requires escort "to an acceptor molecule or to a specific location" and it is a child of GO:0140597
    "protein carrier chaperone." Val and Pascale acknowledged in #30552 that a more general holdase
    term was needed but deferred it: *"we thought it would be better to add this specific term as
    it was needed immediately for annotation, and add the more general parent 'holdase' when it was
    requested for annotation"* (Val, 2025-11-04). Raymond also flagged that an ER holdase
-   (PMID:30287478) doesn't fit GO:0140309. "holdase" is explicitly a **BROAD** synonym on
-   GO:0140309, confirming it is not the general holdase term.
+   (PMID:30287478) doesn't fit GO:0140309. The current label and exact `holdase` synonym
+   are broader-sounding than the still carrier-specific definition.
    - **We are now requesting this term.** 7 genes in this review (CRYAA, CRYAB, HSPB6, CLU, SCG5,
      DNAJB6, DNAJB8) plus HSPH1 (non-human) are in-situ holdases that prevent aggregation without
-     inter-compartment escort. They cannot be annotated to GO:0140309.
+     delivery to a defined acceptor or destination. They cannot be annotated to GO:0140309.
    - **Proposed term**: "holdase chaperone activity" — Def: "Binding to an unfolded or misfolded
      protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains
      the client protein in a soluble, folding-competent state." Parent: direct child of
@@ -220,9 +220,9 @@ Existing GO terms used as replacements:
 
 **Not used** (despite initial consideration):
 
-- **GO:0140309** unfolded protein carrier activity — This is a carrier-holdase term created
+- **GO:0140309** unfolded protein holdase activity — This is a carrier-holdase term created
   specifically for TIM chaperones ([go-ontology#30552](https://github.com/geneontology/go-ontology/issues/30552)).
-  Its definition requires escort between cellular components. None of the holdase genes in
+  Its current definition requires escort to an acceptor molecule or specific location. None of the holdase genes in
   this review (crystallins, sHSPs, CLU, SCG5, DNAJB6, DNAJB8) are carrier-holdases.
 
 This project focuses on MF replacement for GO:0051082/GO:0031249. BP terms discussed in
@@ -251,21 +251,21 @@ activity of HSP70-type chaperones. Some proteins (notably HSP70) can function as
 and holdase depending on conditions, clients, and whether the context is de novo folding or
 quality control.
 
-**GO:0140309 "unfolded protein carrier activity" does not fit these genes.** Review of the
+**GO:0140309 "unfolded protein holdase activity" does not fit these genes.** Review of the
 original term request ([go-ontology#30552](https://github.com/geneontology/go-ontology/issues/30552))
 shows that GO:0140309 was created in Nov 2025 specifically for TIM carrier-holdases (Tim9-Tim10,
 Tim8-Tim13) that escort unfolded proteins across the mitochondrial IMS. Key evidence:
 
-- Its definition requires escort "between two different cellular components"
+- Its current definition requires escort "to an acceptor molecule or to a specific location"
 - It is a child of GO:0140597 "protein carrier chaperone"
-- "holdase" is explicitly a **BROAD** synonym (not exact), because not all holdases are carriers
+- Its carrier parent and delivery requirement remain restrictive even though `holdase` is now an exact synonym
 - Val (2025-11-04): *"we were aware that there were holdases that did not bind to unfolded
   proteins [in transit], but we needed a use case"* for the carrier-holdase
 - Raymond flagged that an ER holdase (PMID:30287478) doesn't fit GO:0140309; Val agreed a
   separate holdase term is needed
 
 The holdase genes in this review (CRYAA, CRYAB, HSPB6, CLU, SCG5, DNAJB6, DNAJB8) all prevent
-aggregation **in situ** — they do not escort substrates between compartments. HSPH1 (non-human)
+aggregation **in situ** — they do not deliver substrates to a defined acceptor or destination. HSPH1 (non-human)
 is likewise an in-situ holdase. These genes require a new general "holdase chaperone activity"
 term (see [Open Ontology Gaps](#open-ontology-gaps) item 1).
 
@@ -289,7 +289,8 @@ the folding process (as part of the HSP70 machine), but this obscures the co-cha
 mechanism. Editor guidance is requested on how to represent this function.
 
 Note: Some J-domain proteins (DNAJB6, DNAJB8) have **independent holdase activity** in addition
-to their co-chaperone function — these are annotated to GO:0140309 for their holdase activity.
+to their co-chaperone function. They await the general holdase NTR because their clients are
+protected in situ rather than delivered to a defined acceptor or destination.
 
 ---
 
@@ -365,7 +366,7 @@ All 148 genes organized by mechanism class (human + non-human combined):
 | 8 | **ER quality control** | UGGT1, ERLEC1, SYVN1 (human); Uggt1 (rat); CNE1, EPS1, PDI1, EUG1, ROT1, IRE1 (yeast); IRE1 (T. reesei); CSH3 (C. albicans); Edem2 (fly) | OVER_ANNOTATED or REMOVE (sensors, not chaperones) |
 | 9 | **Mito import/assembly** | TOMM20, GRPEL1 (human); TIM9, TIM10, COX20, PET100, SHY1, ATP10, ATP11 (yeast); Grpel2 (mouse); cia30 (N. crassa) | OVER_ANNOTATED (assembly factors) or MODIFY (TIMs → GO:0140309) |
 | 10 | **Ubiquitin/QC sensor** | SYVN1 (human); SAN1 (yeast); Fbxo2 (mouse); slrP (Salmonella) | REMOVE or MODIFY to GO:0051787 |
-| 11 | **Periplasmic chaperones** | SurA, Skp, Spy, SecB, HdeA, HdeB, SlyD, CpxP (E. coli) | Carrier-holdases SurA and SecB: MODIFY → GO:0140309; other members require gene-specific foldase, in-situ holdase, or non-chaperone decisions |
+| 11 | **Periplasmic/envelope chaperones** | SurA, Skp, Spy, SecB, HdeA, HdeB, SlyD, CpxP (E. coli) | Carrier-holdases SurA, SecB, and Skp: MODIFY → GO:0140309; HdeA/Spy/SlyD await the general holdase NTR; CpxP is over-annotated. HdeB's current GO:0140309 proposal needs acceptor/destination re-review |
 | 12 | **Ribosome assembly** | SQT1, SYO1, YAR1, RRB1, TSR4, PNO1, ACL4, SHQ1, BTT1 (yeast) | MODIFY → GO:0044183 or OVER_ANNOTATED |
 | 13 | **Peroxiredoxin/redox chaperones** | TSA1 (yeast); pmp20, tpx1 (S. pombe); CnoX, RidA (E. coli); PP_1084/PpPrx (*P. putida*, direct literature gap case) | MODIFY → holdase NTR when evidence shows in-situ aggregation prevention without refolding; older GO:0044183 sibling decisions require re-review |
 | 14 | **Membrane protein chaperones** | SHR3, PHO86, GSF2, CHS7, NSG1, NSG2, VMA22, VPS45 (yeast) | MODIFY or OVER_ANNOTATED |
@@ -434,7 +435,7 @@ established:
 2. **E. coli periplasmic chaperones (SurA, Skp, Spy, HdeA/B, SecB, CpxP, SlyD)** —
    Bacterial-specific holdase/chaperone category with no human orthologs. SurA is a holdase
    that escorts OMPs to the BAM complex; Spy and HdeA/B are acid-activated holdases; SecB
-   is a secretion-coupled holdase. SurA and SecB are carrier-holdases that MODIFY →
+   is a secretion-coupled holdase. SurA, SecB, and Skp are carrier-holdases that MODIFY →
    GO:0140309 because each escorts an unfolded client to a defined acceptor or location;
    the remaining proteins require gene-specific foldase, in-situ holdase, or non-chaperone
    decisions. These validate the foldase/holdase framework in a phylogenetically distant lineage.
@@ -487,18 +488,18 @@ established:
 | Nmnat | *D. melanogaster* | Q9VC03 | 32 | MODIFY | Neuroprotective chaperone |
 | Edem2 | *D. melanogaster* | Q9VK27 | 23 | OVER_ANNOTATED | ERAD sensor, not chaperone |
 | CnoX | *E. coli* | P77395 | 12 | MODIFY → GO:0044183 | Redox-activated holdase |
-| CpxP | *E. coli* | P0AE85 | 11 | OVER_ANNOTATED | Cpx pathway adaptor |
+| CpxP | *E. coli* | P0AE85 | 11 | MARK_AS_OVER_ANNOTATED | Cpx pathway adaptor; GO:0030547 for CpxA inhibition |
 | DnaJ | *E. coli* | P08622 | 48 | MODIFY → GO:0044183 | J-domain co-chaperone |
 | DnaK | *E. coli* | P0A6Y8 | 61 | MODIFY → GO:0044183 | HSP70 foldase/holdase |
 | GroEL | *E. coli* | P0A6F5 | 64 | MODIFY → GO:0044183 | Chaperonin |
-| HdeA | *E. coli* | P0AES9 | 14 | MODIFY → GO:0044183 | Acid-activated holdase |
-| HdeB | *E. coli* | P0AET2 | 8 | MODIFY → GO:0044183 | Acid-activated holdase |
+| HdeA | *E. coli* | P0AES9 | 14 | MODIFY → holdase NTR; retain GO:0051082 interim | Acid-activated in-situ holdase; GO:0042026 for refolding process |
+| HdeB | *E. coli* | P0AET2 | 8 | Current review: MODIFY → GO:0140309; re-review needed | Acid-activated holdase; defined acceptor/destination not yet established |
 | RidA | *E. coli* | P0AF93 | 22 | OVER_ANNOTATED | Reactive intermediate deaminase |
 | SecB | *E. coli* | P0AG86 | 27 | MODIFY → GO:0140309 | Secretion carrier-holdase |
-| Skp | *E. coli* | P0AEU7 | 34 | MODIFY → GO:0044183 | Periplasmic holdase |
-| SlyD | *E. coli* | P0A9K9 | 35 | MODIFY → GO:0044183 | FKBP-type PPIase/chaperone |
-| Spy | *E. coli* | P77754 | 11 | MODIFY → GO:0044183 | Periplasmic holdase |
-| surA | *E. coli* | P0ABZ6 | 31 | MODIFY → GO:0140309 | Periplasmic OMP carrier-holdase; delivery to BAM/YaeT |
+| Skp | *E. coli* | P0AEU7 | 34 | MODIFY → GO:0140309 | Periplasmic OMP carrier-holdase |
+| SlyD | *E. coli* | P0A9K9 | 35 | MODIFY → holdase NTR; retain GO:0051082 interim | FKBP-type PPIase/holdase; GO:0170061 for nickel chaperoning |
+| Spy | *E. coli* | P77754 | 11 | MODIFY → holdase NTR; retain GO:0051082 interim | Periplasmic in-situ holdase |
+| surA | *E. coli* | P0ABZ6 | 31 | Project decision: MODIFY → GO:0140309; gene-review alignment tracked in [#2732](https://github.com/ai4curation/ai-gene-review/pull/2732) | Periplasmic OMP carrier-holdase; delivery to BAM/YaeT |
 | Dnaja3 | *M. musculus* | Q99M87 | 81 | MODIFY → GO:0044183 | Mitochondrial J-domain co-chaperone |
 | Dnajb11 | *M. musculus* | Q99KV1 | 33 | MODIFY → GO:0044183 | ER J-domain co-chaperone |
 | Fbxo2 | *M. musculus* | Q80UW2 | 44 | MODIFY | Glycoprotein QC sensor (GO:0031249) |

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -70,7 +70,7 @@ These mechanism classes are used throughout this document:
 |------|---------|-----------|------|---------|
 | **Foldase** | GO:0044183 protein folding chaperone | Actively assists protein folding through iterative binding/release cycles | Yes | GroEL/ES, TRiC/CCT |
 | **Holdase** | *(NTR needed: holdase chaperone activity)* | Binds unfolded/misfolded proteins to prevent aggregation in situ; does not actively refold or transport between compartments | No | CRYAB (alpha-crystallin), CLU |
-| **Carrier-holdase** | GO:0140309 unfolded protein carrier activity | Binds unfolded protein and escorts it between cellular components, preventing aggregation in transit | No | Tim9-Tim10, Tim8-Tim13 (small TIMs) |
+| **Carrier-holdase** | GO:0140309 unfolded protein holdase activity | Binds an unfolded protein and escorts it to a specified location or acceptor molecule, preventing aggregation in transit | No | Tim9-Tim10, Tim8-Tim13 (small TIMs), SecB, SurA |
 | **Foldase/holdase** | GO:0044183 + holdase NTR | Context-dependent: can function as foldase or holdase depending on conditions, clients, de novo vs quality control | Yes | HSPA1A (HSP70) |
 | **Co-chaperone** | *(see [co-chaperone note](#co-chaperone-note))* | Binds to chaperone to activate its ATPase and/or deliver substrates; does not independently fold proteins | N/A | DNAJB1 (J-domain), AHSA1 (HSP90 activator) |
 | **Disaggregase** | GO:0140545 | Solubilizes existing protein aggregates | Yes | HSPA1A (with DNAJ + HSPH1) |
@@ -87,6 +87,7 @@ How GO:0051082 annotations were reclassified:
 | Co-chaperone, J-domain | MODIFY | GO:0044183 *(interim, see [co-chaperone note](#co-chaperone-note))* | J-domain proteins are substrate adaptors and HSP70 ATPase activators, not independent foldases; GO:0044183 used as interim since GO:0003767 "co-chaperone activity" is obsolete | DNAJB1, DNAJA2 |
 | Co-chaperone, J-domain holdase | MODIFY | holdase NTR *(retain GO:0051082 until NTR created)* | J-domain proteins with independent holdase activity (aggregation suppression, no refolding). GO:0140309 is carrier-specific and does not fit; see [holdase annotation gap](#holdase-annotation-gap) | DNAJB6, DNAJB8 |
 | Holdase (sHSP, crystallin, CLU) | MODIFY | holdase NTR *(retain GO:0051082 until NTR created)* | ATP-independent in-situ aggregation prevention. GO:0140309 does not fit — it was created for carrier-holdases (TIM chaperones); see [holdase annotation gap](#holdase-annotation-gap) | CRYAA, HSPB6, CLU |
+| Carrier-holdase | MODIFY | GO:0140309 unfolded protein holdase activity | ATP-independent stabilization of an unfolded client during escort to a specified location or acceptor molecule. This includes delivery within one compartment when a defined acceptor, such as BAM/YaeT, is demonstrated | TIM9/TIM10, SecB, SurA |
 | Disaggregase (HSP70 subset) | MODIFY | GO:0140545 ATP-dependent protein disaggregase activity | Distinct disaggregation activity | HSPA1A, HSPA1B, HSPA8 |
 | Co-chaperone NEF (GrpE-like) | REMOVE | *(none — not direct UPB)* | Regulates HSP70 nucleotide cycle, does not bind unfolded substrate directly | GRPEL1 |
 | ER/quality control sensor | REMOVE or MARK_AS_OVER_ANNOTATED | *(none — not chaperones)* | Substrate recognition for ligase/GT, not chaperoning | SYVN1, ERLEC1, UGGT1 |
@@ -364,7 +365,7 @@ All 148 genes organized by mechanism class (human + non-human combined):
 | 8 | **ER quality control** | UGGT1, ERLEC1, SYVN1 (human); Uggt1 (rat); CNE1, EPS1, PDI1, EUG1, ROT1, IRE1 (yeast); IRE1 (T. reesei); CSH3 (C. albicans); Edem2 (fly) | OVER_ANNOTATED or REMOVE (sensors, not chaperones) |
 | 9 | **Mito import/assembly** | TOMM20, GRPEL1 (human); TIM9, TIM10, COX20, PET100, SHY1, ATP10, ATP11 (yeast); Grpel2 (mouse); cia30 (N. crassa) | OVER_ANNOTATED (assembly factors) or MODIFY (TIMs → GO:0140309) |
 | 10 | **Ubiquitin/QC sensor** | SYVN1 (human); SAN1 (yeast); Fbxo2 (mouse); slrP (Salmonella) | REMOVE or MODIFY to GO:0051787 |
-| 11 | **Periplasmic chaperones** | SurA, Skp, Spy, SecB, HdeA, HdeB, SlyD, CpxP (E. coli) | MODIFY → GO:0044183 (holdase/chaperone) |
+| 11 | **Periplasmic chaperones** | SurA, Skp, Spy, SecB, HdeA, HdeB, SlyD, CpxP (E. coli) | Carrier-holdases SurA and SecB: MODIFY → GO:0140309; other members require gene-specific foldase, in-situ holdase, or non-chaperone decisions |
 | 12 | **Ribosome assembly** | SQT1, SYO1, YAR1, RRB1, TSR4, PNO1, ACL4, SHQ1, BTT1 (yeast) | MODIFY → GO:0044183 or OVER_ANNOTATED |
 | 13 | **Peroxiredoxin/redox chaperones** | TSA1 (yeast); pmp20, tpx1 (S. pombe); CnoX, RidA (E. coli); PP_1084/PpPrx (*P. putida*, direct literature gap case) | MODIFY → holdase NTR when evidence shows in-situ aggregation prevention without refolding; older GO:0044183 sibling decisions require re-review |
 | 14 | **Membrane protein chaperones** | SHR3, PHO86, GSF2, CHS7, NSG1, NSG2, VMA22, VPS45 (yeast) | MODIFY or OVER_ANNOTATED |
@@ -433,8 +434,10 @@ established:
 2. **E. coli periplasmic chaperones (SurA, Skp, Spy, HdeA/B, SecB, CpxP, SlyD)** —
    Bacterial-specific holdase/chaperone category with no human orthologs. SurA is a holdase
    that escorts OMPs to the BAM complex; Spy and HdeA/B are acid-activated holdases; SecB
-   is a secretion-coupled holdase. All MODIFY → GO:0044183. These validate the foldase/holdase
-   framework in a phylogenetically distant lineage.
+   is a secretion-coupled holdase. SurA and SecB are carrier-holdases that MODIFY →
+   GO:0140309 because each escorts an unfolded client to a defined acceptor or location;
+   the remaining proteins require gene-specific foldase, in-situ holdase, or non-chaperone
+   decisions. These validate the foldase/holdase framework in a phylogenetically distant lineage.
 
 3. **CnoX (E. coli)** — Redox-activated holdase with thioredoxin domain. Interesting
    mechanistic variant: becomes an active holdase specifically under oxidative stress when
@@ -491,11 +494,11 @@ established:
 | HdeA | *E. coli* | P0AES9 | 14 | MODIFY → GO:0044183 | Acid-activated holdase |
 | HdeB | *E. coli* | P0AET2 | 8 | MODIFY → GO:0044183 | Acid-activated holdase |
 | RidA | *E. coli* | P0AF93 | 22 | OVER_ANNOTATED | Reactive intermediate deaminase |
-| SecB | *E. coli* | P0AG86 | 27 | MODIFY → GO:0044183 | Secretion chaperone |
+| SecB | *E. coli* | P0AG86 | 27 | MODIFY → GO:0140309 | Secretion carrier-holdase |
 | Skp | *E. coli* | P0AEU7 | 34 | MODIFY → GO:0044183 | Periplasmic holdase |
 | SlyD | *E. coli* | P0A9K9 | 35 | MODIFY → GO:0044183 | FKBP-type PPIase/chaperone |
 | Spy | *E. coli* | P77754 | 11 | MODIFY → GO:0044183 | Periplasmic holdase |
-| surA | *E. coli* | P0ABZ6 | 31 | MODIFY → GO:0044183 | Periplasmic OMP holdase |
+| surA | *E. coli* | P0ABZ6 | 31 | MODIFY → GO:0140309 | Periplasmic OMP carrier-holdase; delivery to BAM/YaeT |
 | Dnaja3 | *M. musculus* | Q99M87 | 81 | MODIFY → GO:0044183 | Mitochondrial J-domain co-chaperone |
 | Dnajb11 | *M. musculus* | Q99KV1 | 33 | MODIFY → GO:0044183 | ER J-domain co-chaperone |
 | Fbxo2 | *M. musculus* | Q80UW2 | 44 | MODIFY | Glycoprotein QC sensor (GO:0031249) |


### PR DESCRIPTION
## Summary
- align GO:0140309 terminology with its current label and acceptor/location semantics
- add an explicit carrier-holdase decision rule
- route SurA and SecB carrier-holdases consistently to GO:0140309
- regenerate the flagship project page

## Context
Separate project-policy dependency requested during review of #2732; no gene review is changed here.

## Validation
- `just render-project UNFOLDED_PROTEIN_BINDING`
- `git diff --check`