### PR TITLE
Complete E. coli HdeB annotation review

### DIFF
--- a/genes/ECOLI/HdeB/HdeB-ai-review.html
+++ b/genes/ECOLI/HdeB/HdeB-ai-review.html
@@ -830,7 +830,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>HdeB is an ATP-independent periplasmic acid-stress chaperone in Escherichia coli that binds acid-unfolding client proteins and prevents their irreversible aggregation in situ, allowing refolding after pH neutralization. It is a paralog of HdeA encoded in the hdeAB operon, but is optimally active at mildly acidic pH (~4-5), where it remains a largely folded, dynamic homodimer; stronger acidification eventually promotes monomerization and unfolding. HdeA predominates at more extreme acidity, while both proteins contribute to survival across periplasmic acid stress. HdeB activation is coupled to pH-tuned conformational dynamics rather than requiring wholesale dimer dissociation.</p>
+        <p>HdeB is an ATP-independent periplasmic acid-stress chaperone in Escherichia coli that binds acid-unfolding client proteins and prevents their irreversible aggregation in situ, allowing refolding after pH neutralization. It is a paralog of HdeA encoded in the hdeAB operon, but is optimally active at mildly acidic pH (~4-5), where it remains a largely folded, dynamic homodimer; stronger acidification eventually promotes monomerization and unfolding. HdeA predominates at more extreme acidity, while both proteins contribute to survival across periplasmic acid stress. HdeB activation is coupled to pH-tuned conformational dynamics rather than requiring wholesale dimer dissociation. Expression is induced by the EvgS/EvgA two-component system and negatively regulated by H-NS and TorS/TorR.</p>
     </div>
 
 
@@ -1072,8 +1072,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
-                                    unfolded protein binding (interim until holdase NTR is created)
+                                <a href="#" target="_blank" class="term-link">
+                                    holdase chaperone activity (NTR needed; GO:0140309 does not fit -- carrier-specific)
                                 </a>
                             </span>
 
@@ -1151,12 +1151,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA annotation from UniRule transfer. HdeB is specifically involved in the cellular stress response to acidic pH, protecting periplasmic proteins from acid-induced aggregation. This term is appropriate and well-supported by the known biology.
+                            <strong>Summary:</strong> IEA annotation from UniRule transfer. HdeB is specifically involved in the cellular stress response to acidic pH, protecting periplasmic proteins from acid-induced aggregation. It is the most specific of the three pH-response terms in this review, below GO:0010447 and GO:0009268.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> This term accurately captures HdeB&#39;s role in the acid stress response. The protein functions specifically as an acid-activated chaperone (PMID:17085547).
+                            <strong>Reason:</strong> This term accurately captures HdeB&#39;s core acid-stress role. Its `involved_in` qualifier is also more direct than the two experimental GO:0010447 rows&#39; inherited `acts_upstream_of_or_within` qualifier; those physical qualifier differences are preserved exactly from GOA.
                         </div>
 
 
@@ -1504,8 +1504,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
-                                    unfolded protein binding (interim until holdase NTR is created)
+                                <a href="#" target="_blank" class="term-link">
+                                    holdase chaperone activity (NTR needed; GO:0140309 does not fit -- carrier-specific)
                                 </a>
                             </span>
 
@@ -1534,6 +1534,101 @@
                     </td>
                 </tr>
 
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                    GO:0050821
+                                </a>
+                            </span>
+                            <span class="term-label">protein stabilization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17085547" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17085547
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Escherichia coli HdeB is an acid stress chaperone.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P0AET2" data-a="GO:0050821" data-r="PMID:17085547" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct aggregation-suppression assays show that HdeB maintains acid-damaged periplasmic proteins in a soluble state, which is protein stabilization rather than active refolding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0050821 is defined around maintaining protein integrity and preventing degradation or aggregation. HdeB directly prevents periplasmic-protein aggregation at acidic pH, making this an evidence-matched BP companion to the interim holdase MF without claiming that HdeB catalyzes refolding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17085547" target="_blank" class="term-link">
+                                        PMID:17085547
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Thus, we can conclude that Escherichia coli possesses two acid stress chaperones that prevent periplasmic-protein aggregation at acidic pH.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25391835" target="_blank" class="term-link">
+                                        PMID:25391835
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Once activated, HdeB binds various unfolding client proteins, prevents their aggregation, and supports their refolding upon subsequent neutralization.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </div>
@@ -1546,8 +1641,8 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>INTERIM ontology representation of HdeB&#39;s ATP-independent in-situ holdase activity. At mildly acidic pH, HdeB binds unfolding periplasmic clients, prevents their irreversible aggregation, and permits refolding after neutralization. No defined acceptor or delivery destination is established, so carrier-specific GO:0140309 does not apply; GO:0051082 is retained only until the general holdase chaperone activity NTR is created.</h3>
-                <span class="vote-buttons" data-g="P0AET2" data-a="FUNCTION: INTERIM ontology representation of HdeB&#39;s ATP-inde..." data-r="" data-act="CORE_FUNCTION">
+                <h3>At mildly acidic pH, HdeB acts as an ATP-independent in-situ holdase that binds unfolding periplasmic clients, prevents their irreversible aggregation, and permits refolding after neutralization. GO:0051082 is used here only as an INTERIM molecular-function representation: no defined acceptor or delivery destination is established, so carrier-specific GO:0140309 does not apply, and the general holdase chaperone activity NTR is still needed.</h3>
+                <span class="vote-buttons" data-g="P0AET2" data-a="FUNCTION: At mildly acidic pH, HdeB acts as an ATP-independe..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -1574,6 +1669,12 @@
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990451" target="_blank" class="term-link">
                                 cellular stress response to acidic pH
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                protein stabilization
                             </a>
                         </span>
 
@@ -2373,6 +2474,14 @@ this with annotations you find in gene/protein databases, but these can be outda
 <li>PMID:26593705 is cached in full text and supports a folded, dynamic-dimer mechanism at mildly acidic pH: “HdeB activation is coupled to its intrinsic dynamics instead of structural changes, and therefore its functional mechanism is apparently different from HdeA.”</li>
 <li>UniProt independently records that HdeB is required for optimal acid-stress protection, prevents aggregation of multiple periplasmic proteins, contains a signal peptide, and localizes to the periplasm. [file:ECOLI/HdeB/HdeB-uniprot.txt]</li>
 </ul>
+<h2 id="pr-2736-review-follow-up">PR #2736 review follow-up</h2>
+<ul>
+<li>Corrected both GO:0051082 <code>MODIFY</code> rows so <code>proposed_replacement_terms</code> now uses the machine-readable CRYAA/project convention <code>id: NTR</code>, <code>label: holdase chaperone activity (NTR needed; GO:0140309 does not fit -- carrier-specific)</code>. The existing physical GO:0051082 rows remain present as interim annotations; they no longer self-replace with their own obsolete ID.</li>
+<li>Reordered the core-function description to lead with HdeB biology and close with the interim ontology caveat.</li>
+<li>Restored the UniProt-supported regulation context to the standalone description: induction by EvgS/EvgA and negative regulation by H-NS and TorS/TorR. [file:ECOLI/HdeB/HdeB-uniprot.txt]</li>
+<li>Added a literature-supported <code>NEW</code> GO:0050821 protein stabilization BP. Direct suppression of periplasmic-protein aggregation fits stabilization and does not imply that HdeB actively catalyzes client refolding. <a href="https://pubmed.ncbi.nlm.nih.gov/17085547" title="Thus, we can conclude that Escherichia coli possesses two acid stress chaperones that prevent periplasmic-protein aggregation at acidic pH.">PMID:17085547</a></li>
+<li>Clarified the BP specificity chain (GO:0009268 response to pH → GO:0010447 response to acidic pH → GO:1990451 cellular stress response to acidic pH) and recorded that the two experimental GO:0010447 rows retain GOA's broader <code>acts_upstream_of_or_within</code> qualifier while GO:1990451 uses <code>involved_in</code>.</li>
+</ul>
             </div>
         </details>
 
@@ -2401,7 +2510,8 @@ description: HdeB is an ATP-independent periplasmic acid-stress chaperone in
   stronger acidification eventually promotes monomerization and unfolding. HdeA
   predominates at more extreme acidity, while both proteins contribute to survival
   across periplasmic acid stress. HdeB activation is coupled to pH-tuned conformational
-  dynamics rather than requiring wholesale dimer dissociation.
+  dynamics rather than requiring wholesale dimer dissociation. Expression is induced
+  by the EvgS/EvgA two-component system and negatively regulated by H-NS and TorS/TorR.
 existing_annotations:
 - term:
     id: GO:0009268
@@ -2452,8 +2562,9 @@ existing_annotations:
       replacement; GO:0051082 is retained only as an explicit interim descriptor
       until that term exists.
     proposed_replacement_terms:
-    - id: GO:0051082
-      label: unfolded protein binding (interim until holdase NTR is created)
+    - id: NTR
+      label: holdase chaperone activity (NTR needed; GO:0140309 does not fit --
+        carrier-specific)
     additional_reference_ids:
     - PMID:25391835
     supported_by:
@@ -2476,12 +2587,13 @@ existing_annotations:
   review:
     summary: IEA annotation from UniRule transfer. HdeB is specifically involved
       in the cellular stress response to acidic pH, protecting periplasmic
-      proteins from acid-induced aggregation. This term is appropriate and
-      well-supported by the known biology.
+      proteins from acid-induced aggregation. It is the most specific of the three
+      pH-response terms in this review, below GO:0010447 and GO:0009268.
     action: ACCEPT
-    reason: This term accurately captures HdeB&#39;s role in the acid stress
-      response. The protein functions specifically as an acid-activated
-      chaperone (PMID:17085547).
+    reason: This term accurately captures HdeB&#39;s core acid-stress role. Its `involved_in`
+      qualifier is also more direct than the two experimental GO:0010447 rows&#39; inherited
+      `acts_upstream_of_or_within` qualifier; those physical qualifier differences are
+      preserved exactly from GOA.
     supported_by:
     - reference_id: PMID:17085547
       supporting_text: the hdeA and hdeB mutants both display reduced viability
@@ -2575,8 +2687,9 @@ existing_annotations:
       holdase chaperone activity NTR captures aggregation prevention without active
       refolding; retain GO:0051082 only as the project-sanctioned interim descriptor.
     proposed_replacement_terms:
-    - id: GO:0051082
-      label: unfolded protein binding (interim until holdase NTR is created)
+    - id: NTR
+      label: holdase chaperone activity (NTR needed; GO:0140309 does not fit --
+        carrier-specific)
     additional_reference_ids:
     - PMID:25391835
     supported_by:
@@ -2586,6 +2699,30 @@ existing_annotations:
         several model substrate proteins at acidic pH supports the hypothesis
         that, in vitro, HdeA plays a major role in protein solubilization at pH
         2 and that both proteins are involved in protein solubilization at pH 3.
+- term:
+    id: GO:0050821
+    label: protein stabilization
+  evidence_type: IDA
+  original_reference_id: PMID:17085547
+  qualifier: involved_in
+  review:
+    summary: Direct aggregation-suppression assays show that HdeB maintains acid-damaged
+      periplasmic proteins in a soluble state, which is protein stabilization rather
+      than active refolding.
+    action: NEW
+    reason: GO:0050821 is defined around maintaining protein integrity and preventing
+      degradation or aggregation. HdeB directly prevents periplasmic-protein aggregation
+      at acidic pH, making this an evidence-matched BP companion to the interim holdase
+      MF without claiming that HdeB catalyzes refolding.
+    additional_reference_ids:
+    - PMID:25391835
+    supported_by:
+    - reference_id: PMID:17085547
+      supporting_text: Thus, we can conclude that Escherichia coli possesses two acid
+        stress chaperones that prevent periplasmic-protein aggregation at acidic pH.
+    - reference_id: PMID:25391835
+      supporting_text: Once activated, HdeB binds various unfolding client proteins,
+        prevents their aggregation, and supports their refolding upon subsequent neutralization.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with
@@ -2716,15 +2853,18 @@ core_functions:
   directly_involved_in:
   - id: GO:1990451
     label: cellular stress response to acidic pH
+  - id: GO:0050821
+    label: protein stabilization
   locations:
   - id: GO:0030288
     label: outer membrane-bounded periplasmic space
-  description: INTERIM ontology representation of HdeB&#39;s ATP-independent in-situ
-    holdase activity. At mildly acidic pH, HdeB binds unfolding periplasmic clients,
-    prevents their irreversible aggregation, and permits refolding after neutralization.
-    No defined acceptor or delivery destination is established, so carrier-specific
-    GO:0140309 does not apply; GO:0051082 is retained only until the general holdase
-    chaperone activity NTR is created.
+  description: &gt;-
+    At mildly acidic pH, HdeB acts as an ATP-independent in-situ holdase
+    that binds unfolding periplasmic clients, prevents their irreversible aggregation,
+    and permits refolding after neutralization. GO:0051082 is used here only as an
+    INTERIM molecular-function representation: no defined acceptor or delivery destination
+    is established, so carrier-specific GO:0140309 does not apply, and the general
+    holdase chaperone activity NTR is still needed.
   supported_by:
   - reference_id: PMID:17085547
     supporting_text: HdeB is more efficient than HdeA in preventing

--- a/genes/ECOLI/HdeB/HdeB-ai-review.html
+++ b/genes/ECOLI/HdeB/HdeB-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -825,17 +825,79 @@
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P0AET2" data-a="DESCRIPTION: HdeB is a periplasmic acid-stress chaperone in E. ..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P0AET2" data-a="DESCRIPTION: HdeB is an ATP-independent periplasmic acid-stress..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>HdeB is a periplasmic acid-stress chaperone in E. coli that functions as an ATP-independent holdase to prevent aggregation of periplasmic proteins under acidic conditions. It is a paralog of HdeA, and both proteins are encoded by the hdeAB acid stress operon. HdeB exists as a homodimer at neutral pH and dissociates into active monomers at acidic pH (complete dissociation at pH 3). While HdeA is more effective at pH 2, HdeB is more effective than HdeA at pH 3, and both are required for optimal protection against acid stress in vivo (PMID:17085547). Subsequent mechanistic work (Dahl et al. 2015, PMID:25391835; Ding et al. 2015, PMID:26593705) places HdeB&#39;s optimal chaperone activity at mildly acidic pH (~4-5), where its activation is coupled to pH-tuned conformational dynamics of a dynamic dimer rather than to wholesale monomerization/unfolding, distinguishing it from HdeA. HdeB exposes hydrophobic surfaces at acidic pH, consistent with its chaperone function. The protein is induced by the EvgS/EvgA two-component system and negatively regulated by H-NS and TorS/TorR.</p>
+        <p>HdeB is an ATP-independent periplasmic acid-stress chaperone in Escherichia coli that binds acid-unfolding client proteins and prevents their irreversible aggregation in situ, allowing refolding after pH neutralization. It is a paralog of HdeA encoded in the hdeAB operon, but is optimally active at mildly acidic pH (~4-5), where it remains a largely folded, dynamic homodimer; stronger acidification eventually promotes monomerization and unfolding. HdeA predominates at more extreme acidity, while both proteins contribute to survival across periplasmic acid stress. HdeB activation is coupled to pH-tuned conformational dynamics rather than requiring wholesale dimer dissociation.</p>
     </div>
 
 
 
 
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>holdase chaperone activity</h3>
+                <span class="vote-buttons" data-g="P0AET2" data-a="holdase chaperone activity" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> Binding to an unfolded or misfolded protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains the client protein in a soluble, folding-competent state.</p>
+
+
+
+            <p><strong>Justification:</strong> HdeB directly prevents aggregation of acid-unfolding periplasmic clients and supports their subsequent refolding after neutralization. This is an in-situ holdase mechanism. Obsolete GO:0051082 describes binding only, GO:0044183 implies assistance with folding, and GO:0140309 requires escort to an acceptor or location that has not been demonstrated for HdeB.</p>
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                    molecular_function
+                </a>
+            </p>
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/17085547" target="_blank" class="term-link">
+                        PMID:17085547
+                    </a>
+
+
+                    : Thus, we can conclude that Escherichia coli possesses two acid stress chaperones that prevent periplasmic-protein aggregation at acidic pH.
+
+                </li>
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/25391835" target="_blank" class="term-link">
+                        PMID:25391835
+                    </a>
+
+
+                    : Once activated, HdeB binds various unfolding client proteins, prevents their aggregation, and supports their refolding upon subsequent neutralization.
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
 
 
 
@@ -996,12 +1058,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA annotation via InterPro mapping. HdeB does bind unfolded/aggregation-prone periplasmic proteins under acidic conditions. However, its function is better described as a holdase chaperone rather than simple binding.
+                            <strong>Summary:</strong> The InterPro IEA captures genuine binding of acid-unfolding periplasmic clients, but GO:0051082 is obsolete and HdeB&#39;s mechanism is an in-situ holdase activity rather than passive binding or carrier-mediated escort.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> HdeB functions as an ATP-independent holdase chaperone that prevents aggregation of periplasmic proteins at acidic pH (PMID:17085547). The term GO:0051082 &#34;unfolded protein binding&#34; describes only the binding aspect, not the chaperone activity. GO:0140309 &#34;unfolded protein carrier activity&#34; (a protein carrier activity that binds a protein in an unfolded state, prevents its aggregation, and escorts it to an acceptor or location) better captures the ATP-independent holdase chaperone function and is well supported by the falcon deep research, which independently characterizes HdeB as an &#34;acid-activated, ATP-independent holdase chaperone&#34; that binds unfolding periplasmic proteins and prevents their irreversible aggregation.
+                            <strong>Reason:</strong> HdeB prevents aggregation of clients within the periplasm and supports refolding after neutralization, but no defined acceptor, destination, or escort step has been demonstrated. Carrier-specific GO:0140309 therefore does not fit. The project-defined general holdase chaperone activity NTR is the correct replacement; GO:0051082 is retained only as an explicit interim descriptor until that term exists.
                         </div>
 
 
@@ -1010,8 +1072,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
-                                    unfolded protein carrier activity
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                                    unfolded protein binding (interim until holdase NTR is created)
                                 </a>
                             </span>
 
@@ -1428,12 +1490,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for unfolded protein binding based on direct experimental evidence. Kern et al. demonstrated that HdeB prevents aggregation of periplasmic proteins at acidic pH, consistent with binding unfolded proteins. However, the function is better described as holdase/chaperone activity rather than simple binding.
+                            <strong>Summary:</strong> Kern et al. directly showed that HdeB prevents aggregation of acid-damaged periplasmic proteins. This supports genuine substrate binding in the context of acid-activated in-situ holdase activity, but the annotated GO term is now obsolete.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> While HdeB does bind unfolded proteins, its function is more accurately described as a holdase chaperone. GO:0140309 &#34;unfolded protein carrier activity&#34; better captures the ATP-independent holdase chaperone function that prevents aggregation and escorts substrates. The experimental evidence from PMID:17085547 demonstrates chaperone-like prevention of aggregation, not just binding. The falcon deep research independently corroborates this holdase characterization, describing HdeB as an acid-activated, ATP-independent holdase chaperone.
+                            <strong>Reason:</strong> The experimental biology is valid and must be retained, but GO:0140309 is not an evidence-matched replacement because HdeB holds clients in situ and no escort to an acceptor or location is established. The proposed general holdase chaperone activity NTR captures aggregation prevention without active refolding; retain GO:0051082 only as the project-sanctioned interim descriptor.
                         </div>
 
 
@@ -1442,8 +1504,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
-                                    unfolded protein carrier activity
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                                    unfolded protein binding (interim until holdase NTR is created)
                                 </a>
                             </span>
 
@@ -1484,8 +1546,8 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>HdeB functions as an ATP-independent holdase chaperone that prevents aggregation of periplasmic proteins under acidic conditions. Optimal activity at mildly acidic pH (~4-5); activation is coupled to pH-tuned conformational dynamics of a dynamic dimer rather than to wholesale monomerization, distinguishing its mechanism from HdeA.</h3>
-                <span class="vote-buttons" data-g="P0AET2" data-a="FUNCTION: HdeB functions as an ATP-independent holdase chape..." data-r="" data-act="CORE_FUNCTION">
+                <h3>INTERIM ontology representation of HdeB&#39;s ATP-independent in-situ holdase activity. At mildly acidic pH, HdeB binds unfolding periplasmic clients, prevents their irreversible aggregation, and permits refolding after neutralization. No defined acceptor or delivery destination is established, so carrier-specific GO:0140309 does not apply; GO:0051082 is retained only until the general holdase chaperone activity NTR is created.</h3>
+                <span class="vote-buttons" data-g="P0AET2" data-a="FUNCTION: INTERIM ontology representation of HdeB&#39;s ATP-inde..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -1497,8 +1559,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
-                            unfolded protein holdase activity
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                            unfolded protein binding
                         </a>
                     </span>
                 </div>
@@ -1855,13 +1917,108 @@
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:projects/UNFOLDED_PROTEIN_BINDING.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Unfolded protein binding annotation review project</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GO:0051082 is obsolete; GO:0140309 is carrier-specific and requires escort to a defined acceptor or location; acid-activated in-situ holdases require the proposed general holdase chaperone activity term.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
 
 
 
 
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
 
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which native periplasmic proteins are direct HdeB clients at pH 4-5, and what sequence or structural features determine their capture?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0AET2" data-a="Q: Which native periplasmic proteins are direct HdeB ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does HdeB release clients directly for spontaneous refolding after neutralization, or hand them to another periplasmic folding factor despite the absence of a demonstrated carrier pathway?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0AET2" data-a="Q: Does HdeB release clients directly for spontaneous..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use a substrate-release-defective HdeB variant and quantitative periplasmic proteomics across pH 7 to 4 to identify physiological clients and distinguish direct binding from downstream acid-stress effects.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: client-trapping proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0AET2" data-a="EXPERIMENT: Use a substrate-release-defective HdeB variant and..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Monitor binding, aggregation suppression, release, and refolding of purified native periplasmic clients during acidification and neutralization, with and without candidate downstream folding factors, to test whether HdeB acts entirely in situ.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: chaperone kinetic assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0AET2" data-a="EXPERIMENT: Monitor binding, aggregation suppression, release,..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
 
 
 
@@ -2183,6 +2340,44 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(HdeB-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P0AET2" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="hdeb-annotation-re-review-2026-08-29">HdeB annotation re-review — 2026-08-29</h1>
+<h2 id="scope-and-physical-row-reconciliation">Scope and physical-row reconciliation</h2>
+<ul>
+<li>Reviewed all 8 current GOA signatures exactly once, qualifier-aware: 2 <code>enables</code>, 2 <code>located_in</code>, 2 <code>involved_in</code>, and 2 <code>acts_upstream_of_or_within</code>.</li>
+<li>Evidence distribution is 4 IEA, 3 IDA, and 1 IMP. There are no IBA annotations and no PTN/WITH-FROM provenance to audit for this gene.</li>
+<li>The two GO:0051082 rows are physical current GOA records (InterPro IEA and EcoCyc IDA); their machine-sourced term IDs are preserved even though live GO now marks the term obsolete.</li>
+</ul>
+<h2 id="holdase-versus-carrier-semantics">Holdase versus carrier semantics</h2>
+<p>HdeB is an acid-activated, ATP-independent in-situ holdase. The direct study reports that “HdeB is more efficient than HdeA in preventing periplasmic-protein aggregation” at pH 3 and concludes that HdeA and HdeB “prevent periplasmic-protein aggregation at acidic pH.” <a href="https://pubmed.ncbi.nlm.nih.gov/17085547">PMID:17085547</a></p>
+<p>Later work refined the activation range and mechanism: “the chaperone function of HdeB is optimal at pH 4, at which HdeB is still fully dimeric and largely folded,” and “Once activated, HdeB binds various unfolding client proteins, prevents their aggregation, and supports their refolding upon subsequent neutralization.” <a href="https://pubmed.ncbi.nlm.nih.gov/25391835">PMID:25391835</a></p>
+<p>No cached experiment identifies a defined acceptor molecule, delivery destination, or escort step. Consequently, GO:0140309 does not satisfy its carrier semantics for HdeB. Both GO:0051082 rows are <code>MODIFY</code>, with GO:0051082 retained explicitly as an interim descriptor until the project-defined general “holdase chaperone activity” NTR is created. [file:projects/UNFOLDED_PROTEIN_BINDING.md]</p>
+<p>GO:0044183 was not substituted: the evidence shows aggregation prevention followed by client refolding upon neutralization, not autonomous catalysis of folding by HdeB. The direct core biology is therefore represented by the interim GO:0051082 slot plus the proposed holdase NTR, in periplasmic acid-stress context.</p>
+<h2 id="evidence-limitations-and-mechanistic-refinement">Evidence limitations and mechanistic refinement</h2>
+<ul>
+<li>PMID:17085547 and PMID:25391835 are abstract-only in the repository cache. Their abstracts directly support the experimental GO rows and core holdase conclusion, so no experimental annotation was overruled from incomplete evidence.</li>
+<li>PMID:26593705 is cached in full text and supports a folded, dynamic-dimer mechanism at mildly acidic pH: “HdeB activation is coupled to its intrinsic dynamics instead of structural changes, and therefore its functional mechanism is apparently different from HdeA.”</li>
+<li>UniProt independently records that HdeB is required for optimal acid-stress protection, prevents aggregation of multiple periplasmic proteins, contains a signal peptide, and localizes to the periplasm. [file:ECOLI/HdeB/HdeB-uniprot.txt]</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2194,32 +2389,26 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P0AET2
 gene_symbol: HdeB
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:83333
   label: Escherichia coli (strain K12)
-description: HdeB is a periplasmic acid-stress chaperone in E. coli that
-  functions as an ATP-independent holdase to prevent aggregation of periplasmic
-  proteins under acidic conditions. It is a paralog of HdeA, and both proteins
-  are encoded by the hdeAB acid stress operon. HdeB exists as a homodimer at
-  neutral pH and dissociates into active monomers at acidic pH (complete
-  dissociation at pH 3). While HdeA is more effective at pH 2, HdeB is more
-  effective than HdeA at pH 3, and both are required for optimal protection
-  against acid stress in vivo (PMID:17085547). Subsequent mechanistic work
-  (Dahl et al. 2015, PMID:25391835; Ding et al. 2015, PMID:26593705) places
-  HdeB&#39;s optimal chaperone activity
-  at mildly acidic pH (~4-5), where its activation is coupled to pH-tuned
-  conformational dynamics of a dynamic dimer rather than to wholesale
-  monomerization/unfolding, distinguishing it from HdeA. HdeB exposes
-  hydrophobic surfaces at acidic pH, consistent with its chaperone function.
-  The protein is induced by the EvgS/EvgA two-component system and negatively
-  regulated by H-NS and TorS/TorR.
+description: HdeB is an ATP-independent periplasmic acid-stress chaperone in
+  Escherichia coli that binds acid-unfolding client proteins and prevents their
+  irreversible aggregation in situ, allowing refolding after pH neutralization.
+  It is a paralog of HdeA encoded in the hdeAB operon, but is optimally active
+  at mildly acidic pH (~4-5), where it remains a largely folded, dynamic homodimer;
+  stronger acidification eventually promotes monomerization and unfolding. HdeA
+  predominates at more extreme acidity, while both proteins contribute to survival
+  across periplasmic acid stress. HdeB activation is coupled to pH-tuned conformational
+  dynamics rather than requiring wholesale dimer dissociation.
 existing_annotations:
 - term:
     id: GO:0009268
     label: response to pH
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: IEA annotation via InterPro mapping. HdeB is indeed involved in the
       cellular response to pH, specifically acidic pH. This is a broader parent
@@ -2235,6 +2424,7 @@ existing_annotations:
     label: periplasmic space
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: located_in
   review:
     summary: IEA annotation for periplasmic space localization. This is
       consistent with the experimentally determined localization (IDA for
@@ -2249,25 +2439,23 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
-    summary: IEA annotation via InterPro mapping. HdeB does bind
-      unfolded/aggregation-prone periplasmic proteins under acidic conditions.
-      However, its function is better described as a holdase chaperone rather
-      than simple binding.
+    summary: The InterPro IEA captures genuine binding of acid-unfolding periplasmic
+      clients, but GO:0051082 is obsolete and HdeB&#39;s mechanism is an in-situ holdase
+      activity rather than passive binding or carrier-mediated escort.
     action: MODIFY
-    reason: HdeB functions as an ATP-independent holdase chaperone that prevents
-      aggregation of periplasmic proteins at acidic pH (PMID:17085547). The term
-      GO:0051082 &#34;unfolded protein binding&#34; describes only the binding aspect,
-      not the chaperone activity. GO:0140309 &#34;unfolded protein carrier activity&#34;
-      (a protein carrier activity that binds a protein in an unfolded state,
-      prevents its aggregation, and escorts it to an acceptor or location) better
-      captures the ATP-independent holdase chaperone function and is well
-      supported by the falcon deep research, which independently characterizes
-      HdeB as an &#34;acid-activated, ATP-independent holdase chaperone&#34; that binds
-      unfolding periplasmic proteins and prevents their irreversible aggregation.
+    reason: HdeB prevents aggregation of clients within the periplasm and supports
+      refolding after neutralization, but no defined acceptor, destination, or escort
+      step has been demonstrated. Carrier-specific GO:0140309 therefore does not
+      fit. The project-defined general holdase chaperone activity NTR is the correct
+      replacement; GO:0051082 is retained only as an explicit interim descriptor
+      until that term exists.
     proposed_replacement_terms:
-    - id: GO:0140309
-      label: unfolded protein carrier activity
+    - id: GO:0051082
+      label: unfolded protein binding (interim until holdase NTR is created)
+    additional_reference_ids:
+    - PMID:25391835
     supported_by:
     - reference_id: PMID:17085547
       supporting_text: HdeB has a molecular mass of 10 kDa... HdeB is more
@@ -2284,6 +2472,7 @@ existing_annotations:
     label: cellular stress response to acidic pH
   evidence_type: IEA
   original_reference_id: GO_REF:0000104
+  qualifier: involved_in
   review:
     summary: IEA annotation from UniRule transfer. HdeB is specifically involved
       in the cellular stress response to acidic pH, protecting periplasmic
@@ -2306,6 +2495,7 @@ existing_annotations:
     label: response to acidic pH
   evidence_type: IDA
   original_reference_id: PMID:17085547
+  qualifier: acts_upstream_of_or_within
   review:
     summary: IDA annotation based on direct experimental evidence from Kern et
       al. (2007). The study demonstrated that HdeB is an acid stress chaperone
@@ -2332,6 +2522,7 @@ existing_annotations:
     label: response to acidic pH
   evidence_type: IMP
   original_reference_id: PMID:17085547
+  qualifier: acts_upstream_of_or_within
   review:
     summary: IMP annotation based on mutant phenotype evidence. hdeB mutants
       display increased sensitivity to acid stress (PMID:17085547). This
@@ -2350,6 +2541,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IDA
   original_reference_id: PMID:17085547
+  qualifier: located_in
   review:
     summary: IDA annotation for localization to the outer membrane-bounded
       periplasmic space. HdeB was extracted from bacteria by the osmotic-shock
@@ -2370,24 +2562,23 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:17085547
+  qualifier: enables
   review:
-    summary: IDA annotation for unfolded protein binding based on direct
-      experimental evidence. Kern et al. demonstrated that HdeB prevents
-      aggregation of periplasmic proteins at acidic pH, consistent with binding
-      unfolded proteins. However, the function is better described as
-      holdase/chaperone activity rather than simple binding.
+    summary: Kern et al. directly showed that HdeB prevents aggregation of acid-damaged
+      periplasmic proteins. This supports genuine substrate binding in the context
+      of acid-activated in-situ holdase activity, but the annotated GO term is now
+      obsolete.
     action: MODIFY
-    reason: While HdeB does bind unfolded proteins, its function is more
-      accurately described as a holdase chaperone. GO:0140309 &#34;unfolded protein
-      carrier activity&#34; better captures the ATP-independent holdase chaperone
-      function that prevents aggregation and escorts substrates. The experimental
-      evidence from PMID:17085547 demonstrates chaperone-like prevention of
-      aggregation, not just binding. The falcon deep research independently
-      corroborates this holdase characterization, describing HdeB as an
-      acid-activated, ATP-independent holdase chaperone.
+    reason: The experimental biology is valid and must be retained, but GO:0140309
+      is not an evidence-matched replacement because HdeB holds clients in situ and
+      no escort to an acceptor or location is established. The proposed general
+      holdase chaperone activity NTR captures aggregation prevention without active
+      refolding; retain GO:0051082 only as the project-sanctioned interim descriptor.
     proposed_replacement_terms:
-    - id: GO:0140309
-      label: unfolded protein carrier activity
+    - id: GO:0051082
+      label: unfolded protein binding (interim until holdase NTR is created)
+    additional_reference_ids:
+    - PMID:25391835
     supported_by:
     - reference_id: PMID:17085547
       supporting_text: At pH 3, however, HdeB is more efficient than HdeA in
@@ -2409,6 +2600,12 @@ references:
   findings: []
 - id: PMID:17085547
   title: Escherichia coli HdeB is an acid stress chaperone.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed/PMC metadata and the cached abstract directly support the
+      EcoCyc acid-response, periplasmic-localization, and aggregation-prevention claims;
+      repository cache is abstract-only despite a PMCID.
   findings:
   - statement: HdeB is a periplasmic acid stress chaperone
   - statement: HdeB is more effective than HdeA at pH 3
@@ -2417,6 +2614,12 @@ references:
   - statement: HdeB dissociates from dimers to monomers at acidic pH
 - id: PMID:25391835
   title: HdeB functions as an acid-protective chaperone in bacteria.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly establishes the pH 4 activity optimum,
+      client binding, aggregation prevention, and refolding after neutralization;
+      full text is unavailable in the repository cache.
   findings:
   - statement: HdeB chaperone function is optimal at pH 4, where it remains fully
       dimeric and largely folded, in contrast to HdeA which is optimal at pH 2 via
@@ -2435,6 +2638,11 @@ references:
       neutralization.
 - id: PMID:26593705
   title: HdeB chaperone activity is coupled to its intrinsic dynamic properties.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached full text directly characterizes the pH-dependent structure
+      and dynamics of E. coli HdeB.
   findings:
   - statement: HdeB has a higher optimal activation pH (pH 4-5) than HdeA, and
       under these conditions maintains a well-folded dimer.
@@ -2448,6 +2656,12 @@ references:
 - id: PMID:22138344
   title: Salt bridges regulate both dimer formation and monomeric flexibility in
     HdeB and may have a role in periplasmic chaperone function.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Cached abstract directly supports HdeB dimer structure, acid-induced
+      monomerization, and enhanced flexibility, but does not itself establish a client
+      delivery mechanism.
   findings:
   - statement: Structural basis for HdeB dimerization and monomer flexibility
 - id: file:ECOLI/HdeB/HdeB-deep-research-falcon.md
@@ -2489,21 +2703,28 @@ references:
     supporting_text: |-
       loss of HdeA/HdeB causes &gt;100- to 1000-fold survival reductions under acid stress
     reference_section_type: OTHER
+- id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+  title: Unfolded protein binding annotation review project
+  findings:
+  - statement: GO:0051082 is obsolete; GO:0140309 is carrier-specific and requires
+      escort to a defined acceptor or location; acid-activated in-situ holdases require
+      the proposed general holdase chaperone activity term.
 core_functions:
 - molecular_function:
-    id: GO:0140309
-    label: unfolded protein holdase activity
+    id: GO:0051082
+    label: unfolded protein binding
   directly_involved_in:
   - id: GO:1990451
     label: cellular stress response to acidic pH
   locations:
   - id: GO:0030288
     label: outer membrane-bounded periplasmic space
-  description: HdeB functions as an ATP-independent holdase chaperone that
-    prevents aggregation of periplasmic proteins under acidic conditions.
-    Optimal activity at mildly acidic pH (~4-5); activation is coupled to
-    pH-tuned conformational dynamics of a dynamic dimer rather than to wholesale
-    monomerization, distinguishing its mechanism from HdeA.
+  description: INTERIM ontology representation of HdeB&#39;s ATP-independent in-situ
+    holdase activity. At mildly acidic pH, HdeB binds unfolding periplasmic clients,
+    prevents their irreversible aggregation, and permits refolding after neutralization.
+    No defined acceptor or delivery destination is established, so carrier-specific
+    GO:0140309 does not apply; GO:0051082 is retained only until the general holdase
+    chaperone activity NTR is created.
   supported_by:
   - reference_id: PMID:17085547
     supporting_text: HdeB is more efficient than HdeA in preventing
@@ -2521,6 +2742,41 @@ core_functions:
     supporting_text: |-
       In vitro, HdeB shows **negligible activity at pH 2**, **modest activity at pH 3**, and **optimal activity near pH ~4**; correspondingly, overexpression phenotypes show that **HdeB supports growth/survival at pH ~4**
     reference_section_type: OTHER
+proposed_new_terms:
+- proposed_name: holdase chaperone activity
+  proposed_definition: Binding to an unfolded or misfolded protein to prevent its
+    aggregation without actively catalyzing refolding. The holdase maintains the client
+    protein in a soluble, folding-competent state.
+  justification: HdeB directly prevents aggregation of acid-unfolding periplasmic
+    clients and supports their subsequent refolding after neutralization. This is
+    an in-situ holdase mechanism. Obsolete GO:0051082 describes binding only, GO:0044183
+    implies assistance with folding, and GO:0140309 requires escort to an acceptor
+    or location that has not been demonstrated for HdeB.
+  proposed_parent:
+    id: GO:0003674
+    label: molecular_function
+  supported_by:
+  - reference_id: PMID:17085547
+    supporting_text: Thus, we can conclude that Escherichia coli possesses two acid
+      stress chaperones that prevent periplasmic-protein aggregation at acidic pH.
+  - reference_id: PMID:25391835
+    supporting_text: Once activated, HdeB binds various unfolding client proteins,
+      prevents their aggregation, and supports their refolding upon subsequent neutralization.
+suggested_questions:
+- question: Which native periplasmic proteins are direct HdeB clients at pH 4-5,
+    and what sequence or structural features determine their capture?
+- question: Does HdeB release clients directly for spontaneous refolding after neutralization,
+    or hand them to another periplasmic folding factor despite the absence of a demonstrated
+    carrier pathway?
+suggested_experiments:
+- experiment_type: client-trapping proteomics
+  description: Use a substrate-release-defective HdeB variant and quantitative periplasmic
+    proteomics across pH 7 to 4 to identify physiological clients and distinguish direct
+    binding from downstream acid-stress effects.
+- experiment_type: chaperone kinetic assay
+  description: Monitor binding, aggregation suppression, release, and refolding of purified
+    native periplasmic clients during acidification and neutralization, with and without
+    candidate downstream folding factors, to test whether HdeB acts entirely in situ.
 </code></pre>
             </div>
         </details>

--- a/genes/ECOLI/HdeB/HdeB-ai-review.yaml
+++ b/genes/ECOLI/HdeB/HdeB-ai-review.yaml
@@ -13,7 +13,8 @@ description: HdeB is an ATP-independent periplasmic acid-stress chaperone in
   stronger acidification eventually promotes monomerization and unfolding. HdeA
   predominates at more extreme acidity, while both proteins contribute to survival
   across periplasmic acid stress. HdeB activation is coupled to pH-tuned conformational
-  dynamics rather than requiring wholesale dimer dissociation.
+  dynamics rather than requiring wholesale dimer dissociation. Expression is induced
+  by the EvgS/EvgA two-component system and negatively regulated by H-NS and TorS/TorR.
 existing_annotations:
 - term:
     id: GO:0009268
@@ -64,8 +65,9 @@ existing_annotations:
       replacement; GO:0051082 is retained only as an explicit interim descriptor
       until that term exists.
     proposed_replacement_terms:
-    - id: GO:0051082
-      label: unfolded protein binding (interim until holdase NTR is created)
+    - id: NTR
+      label: holdase chaperone activity (NTR needed; GO:0140309 does not fit --
+        carrier-specific)
     additional_reference_ids:
     - PMID:25391835
     supported_by:
@@ -88,12 +90,13 @@ existing_annotations:
   review:
     summary: IEA annotation from UniRule transfer. HdeB is specifically involved
       in the cellular stress response to acidic pH, protecting periplasmic 
-      proteins from acid-induced aggregation. This term is appropriate and 
-      well-supported by the known biology.
+      proteins from acid-induced aggregation. It is the most specific of the three
+      pH-response terms in this review, below GO:0010447 and GO:0009268.
     action: ACCEPT
-    reason: This term accurately captures HdeB's role in the acid stress 
-      response. The protein functions specifically as an acid-activated 
-      chaperone (PMID:17085547).
+    reason: This term accurately captures HdeB's core acid-stress role. Its `involved_in`
+      qualifier is also more direct than the two experimental GO:0010447 rows' inherited
+      `acts_upstream_of_or_within` qualifier; those physical qualifier differences are
+      preserved exactly from GOA.
     supported_by:
     - reference_id: PMID:17085547
       supporting_text: the hdeA and hdeB mutants both display reduced viability
@@ -187,8 +190,9 @@ existing_annotations:
       holdase chaperone activity NTR captures aggregation prevention without active
       refolding; retain GO:0051082 only as the project-sanctioned interim descriptor.
     proposed_replacement_terms:
-    - id: GO:0051082
-      label: unfolded protein binding (interim until holdase NTR is created)
+    - id: NTR
+      label: holdase chaperone activity (NTR needed; GO:0140309 does not fit --
+        carrier-specific)
     additional_reference_ids:
     - PMID:25391835
     supported_by:
@@ -198,6 +202,30 @@ existing_annotations:
         several model substrate proteins at acidic pH supports the hypothesis
         that, in vitro, HdeA plays a major role in protein solubilization at pH
         2 and that both proteins are involved in protein solubilization at pH 3.
+- term:
+    id: GO:0050821
+    label: protein stabilization
+  evidence_type: IDA
+  original_reference_id: PMID:17085547
+  qualifier: involved_in
+  review:
+    summary: Direct aggregation-suppression assays show that HdeB maintains acid-damaged
+      periplasmic proteins in a soluble state, which is protein stabilization rather
+      than active refolding.
+    action: NEW
+    reason: GO:0050821 is defined around maintaining protein integrity and preventing
+      degradation or aggregation. HdeB directly prevents periplasmic-protein aggregation
+      at acidic pH, making this an evidence-matched BP companion to the interim holdase
+      MF without claiming that HdeB catalyzes refolding.
+    additional_reference_ids:
+    - PMID:25391835
+    supported_by:
+    - reference_id: PMID:17085547
+      supporting_text: Thus, we can conclude that Escherichia coli possesses two acid
+        stress chaperones that prevent periplasmic-protein aggregation at acidic pH.
+    - reference_id: PMID:25391835
+      supporting_text: Once activated, HdeB binds various unfolding client proteins,
+        prevents their aggregation, and supports their refolding upon subsequent neutralization.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with 
@@ -328,15 +356,18 @@ core_functions:
   directly_involved_in:
   - id: GO:1990451
     label: cellular stress response to acidic pH
+  - id: GO:0050821
+    label: protein stabilization
   locations:
   - id: GO:0030288
     label: outer membrane-bounded periplasmic space
-  description: INTERIM ontology representation of HdeB's ATP-independent in-situ
-    holdase activity. At mildly acidic pH, HdeB binds unfolding periplasmic clients,
-    prevents their irreversible aggregation, and permits refolding after neutralization.
-    No defined acceptor or delivery destination is established, so carrier-specific
-    GO:0140309 does not apply; GO:0051082 is retained only until the general holdase
-    chaperone activity NTR is created.
+  description: >-
+    At mildly acidic pH, HdeB acts as an ATP-independent in-situ holdase
+    that binds unfolding periplasmic clients, prevents their irreversible aggregation,
+    and permits refolding after neutralization. GO:0051082 is used here only as an
+    INTERIM molecular-function representation: no defined acceptor or delivery destination
+    is established, so carrier-specific GO:0140309 does not apply, and the general
+    holdase chaperone activity NTR is still needed.
   supported_by:
   - reference_id: PMID:17085547
     supporting_text: HdeB is more efficient than HdeA in preventing

--- a/genes/ECOLI/HdeB/HdeB-ai-review.yaml
+++ b/genes/ECOLI/HdeB/HdeB-ai-review.yaml
@@ -1,32 +1,26 @@
 id: P0AET2
 gene_symbol: HdeB
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:83333
   label: Escherichia coli (strain K12)
-description: HdeB is a periplasmic acid-stress chaperone in E. coli that 
-  functions as an ATP-independent holdase to prevent aggregation of periplasmic 
-  proteins under acidic conditions. It is a paralog of HdeA, and both proteins 
-  are encoded by the hdeAB acid stress operon. HdeB exists as a homodimer at 
-  neutral pH and dissociates into active monomers at acidic pH (complete 
-  dissociation at pH 3). While HdeA is more effective at pH 2, HdeB is more
-  effective than HdeA at pH 3, and both are required for optimal protection
-  against acid stress in vivo (PMID:17085547). Subsequent mechanistic work
-  (Dahl et al. 2015, PMID:25391835; Ding et al. 2015, PMID:26593705) places
-  HdeB's optimal chaperone activity
-  at mildly acidic pH (~4-5), where its activation is coupled to pH-tuned
-  conformational dynamics of a dynamic dimer rather than to wholesale
-  monomerization/unfolding, distinguishing it from HdeA. HdeB exposes
-  hydrophobic surfaces at acidic pH, consistent with its chaperone function.
-  The protein is induced by the EvgS/EvgA two-component system and negatively
-  regulated by H-NS and TorS/TorR.
+description: HdeB is an ATP-independent periplasmic acid-stress chaperone in
+  Escherichia coli that binds acid-unfolding client proteins and prevents their
+  irreversible aggregation in situ, allowing refolding after pH neutralization.
+  It is a paralog of HdeA encoded in the hdeAB operon, but is optimally active
+  at mildly acidic pH (~4-5), where it remains a largely folded, dynamic homodimer;
+  stronger acidification eventually promotes monomerization and unfolding. HdeA
+  predominates at more extreme acidity, while both proteins contribute to survival
+  across periplasmic acid stress. HdeB activation is coupled to pH-tuned conformational
+  dynamics rather than requiring wholesale dimer dissociation.
 existing_annotations:
 - term:
     id: GO:0009268
     label: response to pH
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: IEA annotation via InterPro mapping. HdeB is indeed involved in the
       cellular response to pH, specifically acidic pH. This is a broader parent 
@@ -42,6 +36,7 @@ existing_annotations:
     label: periplasmic space
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: located_in
   review:
     summary: IEA annotation for periplasmic space localization. This is 
       consistent with the experimentally determined localization (IDA for 
@@ -56,25 +51,23 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: enables
   review:
-    summary: IEA annotation via InterPro mapping. HdeB does bind 
-      unfolded/aggregation-prone periplasmic proteins under acidic conditions. 
-      However, its function is better described as a holdase chaperone rather 
-      than simple binding.
+    summary: The InterPro IEA captures genuine binding of acid-unfolding periplasmic
+      clients, but GO:0051082 is obsolete and HdeB's mechanism is an in-situ holdase
+      activity rather than passive binding or carrier-mediated escort.
     action: MODIFY
-    reason: HdeB functions as an ATP-independent holdase chaperone that prevents
-      aggregation of periplasmic proteins at acidic pH (PMID:17085547). The term
-      GO:0051082 "unfolded protein binding" describes only the binding aspect,
-      not the chaperone activity. GO:0140309 "unfolded protein carrier activity"
-      (a protein carrier activity that binds a protein in an unfolded state,
-      prevents its aggregation, and escorts it to an acceptor or location) better
-      captures the ATP-independent holdase chaperone function and is well
-      supported by the falcon deep research, which independently characterizes
-      HdeB as an "acid-activated, ATP-independent holdase chaperone" that binds
-      unfolding periplasmic proteins and prevents their irreversible aggregation.
+    reason: HdeB prevents aggregation of clients within the periplasm and supports
+      refolding after neutralization, but no defined acceptor, destination, or escort
+      step has been demonstrated. Carrier-specific GO:0140309 therefore does not
+      fit. The project-defined general holdase chaperone activity NTR is the correct
+      replacement; GO:0051082 is retained only as an explicit interim descriptor
+      until that term exists.
     proposed_replacement_terms:
-    - id: GO:0140309
-      label: unfolded protein carrier activity
+    - id: GO:0051082
+      label: unfolded protein binding (interim until holdase NTR is created)
+    additional_reference_ids:
+    - PMID:25391835
     supported_by:
     - reference_id: PMID:17085547
       supporting_text: HdeB has a molecular mass of 10 kDa... HdeB is more
@@ -91,6 +84,7 @@ existing_annotations:
     label: cellular stress response to acidic pH
   evidence_type: IEA
   original_reference_id: GO_REF:0000104
+  qualifier: involved_in
   review:
     summary: IEA annotation from UniRule transfer. HdeB is specifically involved
       in the cellular stress response to acidic pH, protecting periplasmic 
@@ -113,6 +107,7 @@ existing_annotations:
     label: response to acidic pH
   evidence_type: IDA
   original_reference_id: PMID:17085547
+  qualifier: acts_upstream_of_or_within
   review:
     summary: IDA annotation based on direct experimental evidence from Kern et
       al. (2007). The study demonstrated that HdeB is an acid stress chaperone
@@ -139,6 +134,7 @@ existing_annotations:
     label: response to acidic pH
   evidence_type: IMP
   original_reference_id: PMID:17085547
+  qualifier: acts_upstream_of_or_within
   review:
     summary: IMP annotation based on mutant phenotype evidence. hdeB mutants 
       display increased sensitivity to acid stress (PMID:17085547). This 
@@ -157,6 +153,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IDA
   original_reference_id: PMID:17085547
+  qualifier: located_in
   review:
     summary: IDA annotation for localization to the outer membrane-bounded 
       periplasmic space. HdeB was extracted from bacteria by the osmotic-shock 
@@ -177,24 +174,23 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:17085547
+  qualifier: enables
   review:
-    summary: IDA annotation for unfolded protein binding based on direct 
-      experimental evidence. Kern et al. demonstrated that HdeB prevents 
-      aggregation of periplasmic proteins at acidic pH, consistent with binding 
-      unfolded proteins. However, the function is better described as 
-      holdase/chaperone activity rather than simple binding.
+    summary: Kern et al. directly showed that HdeB prevents aggregation of acid-damaged
+      periplasmic proteins. This supports genuine substrate binding in the context
+      of acid-activated in-situ holdase activity, but the annotated GO term is now
+      obsolete.
     action: MODIFY
-    reason: While HdeB does bind unfolded proteins, its function is more
-      accurately described as a holdase chaperone. GO:0140309 "unfolded protein
-      carrier activity" better captures the ATP-independent holdase chaperone
-      function that prevents aggregation and escorts substrates. The experimental
-      evidence from PMID:17085547 demonstrates chaperone-like prevention of
-      aggregation, not just binding. The falcon deep research independently
-      corroborates this holdase characterization, describing HdeB as an
-      acid-activated, ATP-independent holdase chaperone.
+    reason: The experimental biology is valid and must be retained, but GO:0140309
+      is not an evidence-matched replacement because HdeB holds clients in situ and
+      no escort to an acceptor or location is established. The proposed general
+      holdase chaperone activity NTR captures aggregation prevention without active
+      refolding; retain GO:0051082 only as the project-sanctioned interim descriptor.
     proposed_replacement_terms:
-    - id: GO:0140309
-      label: unfolded protein carrier activity
+    - id: GO:0051082
+      label: unfolded protein binding (interim until holdase NTR is created)
+    additional_reference_ids:
+    - PMID:25391835
     supported_by:
     - reference_id: PMID:17085547
       supporting_text: At pH 3, however, HdeB is more efficient than HdeA in
@@ -216,6 +212,12 @@ references:
   findings: []
 - id: PMID:17085547
   title: Escherichia coli HdeB is an acid stress chaperone.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed/PMC metadata and the cached abstract directly support the
+      EcoCyc acid-response, periplasmic-localization, and aggregation-prevention claims;
+      repository cache is abstract-only despite a PMCID.
   findings:
   - statement: HdeB is a periplasmic acid stress chaperone
   - statement: HdeB is more effective than HdeA at pH 3
@@ -224,6 +226,12 @@ references:
   - statement: HdeB dissociates from dimers to monomers at acidic pH
 - id: PMID:25391835
   title: HdeB functions as an acid-protective chaperone in bacteria.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly establishes the pH 4 activity optimum,
+      client binding, aggregation prevention, and refolding after neutralization;
+      full text is unavailable in the repository cache.
   findings:
   - statement: HdeB chaperone function is optimal at pH 4, where it remains fully
       dimeric and largely folded, in contrast to HdeA which is optimal at pH 2 via
@@ -242,6 +250,11 @@ references:
       neutralization.
 - id: PMID:26593705
   title: HdeB chaperone activity is coupled to its intrinsic dynamic properties.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached full text directly characterizes the pH-dependent structure
+      and dynamics of E. coli HdeB.
   findings:
   - statement: HdeB has a higher optimal activation pH (pH 4-5) than HdeA, and
       under these conditions maintains a well-folded dimer.
@@ -255,6 +268,12 @@ references:
 - id: PMID:22138344
   title: Salt bridges regulate both dimer formation and monomeric flexibility in
     HdeB and may have a role in periplasmic chaperone function.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Cached abstract directly supports HdeB dimer structure, acid-induced
+      monomerization, and enhanced flexibility, but does not itself establish a client
+      delivery mechanism.
   findings:
   - statement: Structural basis for HdeB dimerization and monomer flexibility
 - id: file:ECOLI/HdeB/HdeB-deep-research-falcon.md
@@ -296,21 +315,28 @@ references:
     supporting_text: |-
       loss of HdeA/HdeB causes >100- to 1000-fold survival reductions under acid stress
     reference_section_type: OTHER
+- id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+  title: Unfolded protein binding annotation review project
+  findings:
+  - statement: GO:0051082 is obsolete; GO:0140309 is carrier-specific and requires
+      escort to a defined acceptor or location; acid-activated in-situ holdases require
+      the proposed general holdase chaperone activity term.
 core_functions:
 - molecular_function:
-    id: GO:0140309
-    label: unfolded protein holdase activity
+    id: GO:0051082
+    label: unfolded protein binding
   directly_involved_in:
   - id: GO:1990451
     label: cellular stress response to acidic pH
   locations:
   - id: GO:0030288
     label: outer membrane-bounded periplasmic space
-  description: HdeB functions as an ATP-independent holdase chaperone that
-    prevents aggregation of periplasmic proteins under acidic conditions.
-    Optimal activity at mildly acidic pH (~4-5); activation is coupled to
-    pH-tuned conformational dynamics of a dynamic dimer rather than to wholesale
-    monomerization, distinguishing its mechanism from HdeA.
+  description: INTERIM ontology representation of HdeB's ATP-independent in-situ
+    holdase activity. At mildly acidic pH, HdeB binds unfolding periplasmic clients,
+    prevents their irreversible aggregation, and permits refolding after neutralization.
+    No defined acceptor or delivery destination is established, so carrier-specific
+    GO:0140309 does not apply; GO:0051082 is retained only until the general holdase
+    chaperone activity NTR is created.
   supported_by:
   - reference_id: PMID:17085547
     supporting_text: HdeB is more efficient than HdeA in preventing
@@ -328,3 +354,38 @@ core_functions:
     supporting_text: |-
       In vitro, HdeB shows **negligible activity at pH 2**, **modest activity at pH 3**, and **optimal activity near pH ~4**; correspondingly, overexpression phenotypes show that **HdeB supports growth/survival at pH ~4**
     reference_section_type: OTHER
+proposed_new_terms:
+- proposed_name: holdase chaperone activity
+  proposed_definition: Binding to an unfolded or misfolded protein to prevent its
+    aggregation without actively catalyzing refolding. The holdase maintains the client
+    protein in a soluble, folding-competent state.
+  justification: HdeB directly prevents aggregation of acid-unfolding periplasmic
+    clients and supports their subsequent refolding after neutralization. This is
+    an in-situ holdase mechanism. Obsolete GO:0051082 describes binding only, GO:0044183
+    implies assistance with folding, and GO:0140309 requires escort to an acceptor
+    or location that has not been demonstrated for HdeB.
+  proposed_parent:
+    id: GO:0003674
+    label: molecular_function
+  supported_by:
+  - reference_id: PMID:17085547
+    supporting_text: Thus, we can conclude that Escherichia coli possesses two acid
+      stress chaperones that prevent periplasmic-protein aggregation at acidic pH.
+  - reference_id: PMID:25391835
+    supporting_text: Once activated, HdeB binds various unfolding client proteins,
+      prevents their aggregation, and supports their refolding upon subsequent neutralization.
+suggested_questions:
+- question: Which native periplasmic proteins are direct HdeB clients at pH 4-5,
+    and what sequence or structural features determine their capture?
+- question: Does HdeB release clients directly for spontaneous refolding after neutralization,
+    or hand them to another periplasmic folding factor despite the absence of a demonstrated
+    carrier pathway?
+suggested_experiments:
+- experiment_type: client-trapping proteomics
+  description: Use a substrate-release-defective HdeB variant and quantitative periplasmic
+    proteomics across pH 7 to 4 to identify physiological clients and distinguish direct
+    binding from downstream acid-stress effects.
+- experiment_type: chaperone kinetic assay
+  description: Monitor binding, aggregation suppression, release, and refolding of purified
+    native periplasmic clients during acidification and neutralization, with and without
+    candidate downstream folding factors, to test whether HdeB acts entirely in situ.

--- a/genes/ECOLI/HdeB/HdeB-notes.md
+++ b/genes/ECOLI/HdeB/HdeB-notes.md
@@ -1,0 +1,23 @@
+# HdeB annotation re-review — 2026-08-29
+
+## Scope and physical-row reconciliation
+
+- Reviewed all 8 current GOA signatures exactly once, qualifier-aware: 2 `enables`, 2 `located_in`, 2 `involved_in`, and 2 `acts_upstream_of_or_within`.
+- Evidence distribution is 4 IEA, 3 IDA, and 1 IMP. There are no IBA annotations and no PTN/WITH-FROM provenance to audit for this gene.
+- The two GO:0051082 rows are physical current GOA records (InterPro IEA and EcoCyc IDA); their machine-sourced term IDs are preserved even though live GO now marks the term obsolete.
+
+## Holdase versus carrier semantics
+
+HdeB is an acid-activated, ATP-independent in-situ holdase. The direct study reports that “HdeB is more efficient than HdeA in preventing periplasmic-protein aggregation” at pH 3 and concludes that HdeA and HdeB “prevent periplasmic-protein aggregation at acidic pH.” [PMID:17085547]
+
+Later work refined the activation range and mechanism: “the chaperone function of HdeB is optimal at pH 4, at which HdeB is still fully dimeric and largely folded,” and “Once activated, HdeB binds various unfolding client proteins, prevents their aggregation, and supports their refolding upon subsequent neutralization.” [PMID:25391835]
+
+No cached experiment identifies a defined acceptor molecule, delivery destination, or escort step. Consequently, GO:0140309 does not satisfy its carrier semantics for HdeB. Both GO:0051082 rows are `MODIFY`, with GO:0051082 retained explicitly as an interim descriptor until the project-defined general “holdase chaperone activity” NTR is created. [file:projects/UNFOLDED_PROTEIN_BINDING.md]
+
+GO:0044183 was not substituted: the evidence shows aggregation prevention followed by client refolding upon neutralization, not autonomous catalysis of folding by HdeB. The direct core biology is therefore represented by the interim GO:0051082 slot plus the proposed holdase NTR, in periplasmic acid-stress context.
+
+## Evidence limitations and mechanistic refinement
+
+- PMID:17085547 and PMID:25391835 are abstract-only in the repository cache. Their abstracts directly support the experimental GO rows and core holdase conclusion, so no experimental annotation was overruled from incomplete evidence.
+- PMID:26593705 is cached in full text and supports a folded, dynamic-dimer mechanism at mildly acidic pH: “HdeB activation is coupled to its intrinsic dynamics instead of structural changes, and therefore its functional mechanism is apparently different from HdeA.”
+- UniProt independently records that HdeB is required for optimal acid-stress protection, prevents aggregation of multiple periplasmic proteins, contains a signal peptide, and localizes to the periplasm. [file:ECOLI/HdeB/HdeB-uniprot.txt]

--- a/genes/ECOLI/HdeB/HdeB-notes.md
+++ b/genes/ECOLI/HdeB/HdeB-notes.md
@@ -21,3 +21,11 @@ GO:0044183 was not substituted: the evidence shows aggregation prevention follow
 - PMID:17085547 and PMID:25391835 are abstract-only in the repository cache. Their abstracts directly support the experimental GO rows and core holdase conclusion, so no experimental annotation was overruled from incomplete evidence.
 - PMID:26593705 is cached in full text and supports a folded, dynamic-dimer mechanism at mildly acidic pH: “HdeB activation is coupled to its intrinsic dynamics instead of structural changes, and therefore its functional mechanism is apparently different from HdeA.”
 - UniProt independently records that HdeB is required for optimal acid-stress protection, prevents aggregation of multiple periplasmic proteins, contains a signal peptide, and localizes to the periplasm. [file:ECOLI/HdeB/HdeB-uniprot.txt]
+
+## PR #2736 review follow-up
+
+- Corrected both GO:0051082 `MODIFY` rows so `proposed_replacement_terms` now uses the machine-readable CRYAA/project convention `id: NTR`, `label: holdase chaperone activity (NTR needed; GO:0140309 does not fit -- carrier-specific)`. The existing physical GO:0051082 rows remain present as interim annotations; they no longer self-replace with their own obsolete ID.
+- Reordered the core-function description to lead with HdeB biology and close with the interim ontology caveat.
+- Restored the UniProt-supported regulation context to the standalone description: induction by EvgS/EvgA and negative regulation by H-NS and TorS/TorR. [file:ECOLI/HdeB/HdeB-uniprot.txt]
+- Added a literature-supported `NEW` GO:0050821 protein stabilization BP. Direct suppression of periplasmic-protein aggregation fits stabilization and does not imply that HdeB actively catalyzes client refolding. [PMID:17085547 "Thus, we can conclude that Escherichia coli possesses two acid stress chaperones that prevent periplasmic-protein aggregation at acidic pH."]
+- Clarified the BP specificity chain (GO:0009268 response to pH → GO:0010447 response to acidic pH → GO:1990451 cellular stress response to acidic pH) and recorded that the two experimental GO:0010447 rows retain GOA's broader `acts_upstream_of_or_within` qualifier while GO:1990451 uses `involved_in`.


### PR DESCRIPTION
## Summary
- reconcile all 8 qualifier-aware HdeB GOA signatures
- remove unsupported carrier-specific GO:0140309 replacement reasoning
- retain obsolete GO:0051082 only as an explicit interim pending the general in-situ holdase NTR
- preserve acid-activated aggregation-prevention biology and update generated outputs

## Validation
- `just validate ECOLI HdeB`
- `just validate-goa ECOLI HdeB`
- `just render ECOLI HdeB`
- `just deploy-browser`
- `git diff --check`