### PR TITLE
Complete E. coli HdeA annotation review

### DIFF
--- a/genes/ECOLI/HdeA/HdeA-ai-review.html
+++ b/genes/ECOLI/HdeA/HdeA-ai-review.html
@@ -785,8 +785,8 @@
 
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
 
@@ -836,6 +836,68 @@
 
 
 
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>holdase chaperone activity</h3>
+                <span class="vote-buttons" data-g="P0AES9" data-a="holdase chaperone activity" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> Binding to an unfolded or misfolded protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains the client protein in a soluble, folding-competent state.</p>
+
+
+
+            <p><strong>Justification:</strong> HdeA directly binds acid-denatured periplasmic clients and prevents their aggregation in situ. Obsolete GO:0051082 captures binding only, GO:0044183 describes assistance with folding, and carrier-specific GO:0140309 requires escort to an acceptor or location not demonstrated for HdeA.</p>
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                    molecular_function
+                </a>
+            </p>
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/10623550" target="_blank" class="term-link">
+                        PMID:10623550
+                    </a>
+
+
+                    : Functional studies demonstrate that HDEA is activated by a dimer-to-monomer transition at acidic pH, leading to suppression of aggregation by acid-denatured proteins.
+
+                </li>
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/15911614" target="_blank" class="term-link">
+                        PMID:15911614
+                    </a>
+
+
+                    : our data indicate that HdeA exposes hydrophobic surfaces that appear to be involved in the binding of denatured substrate proteins at extremely low pH values
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
 
 
 
@@ -1272,7 +1334,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> HdeA does not actively catalyze protein folding in the conventional sense (it is ATP- independent and lacks foldase activity). Its primary function is preventing aggregation of acid-denatured proteins (holdase activity). While PMID:20080625 showed it facilitates refolding upon pH neutralization, this is achieved through passive slow release of substrates rather than active folding assistance. The BP term &#34;protein folding&#34; overstates HdeA&#39;s role. A more appropriate term would capture the chaperone-mediated protein refolding or protein stabilization aspect. However, given that refolding does occur as a consequence of HdeA activity (PMID:20080625), the annotation is not entirely wrong -- it is the process outcome rather than the mechanism.
+                            <strong>Reason:</strong> HdeA does not actively catalyze protein folding in the conventional sense (it is ATP-independent and lacks an ATP-driven foldase cycle). Its primary function is preventing aggregation of acid-denatured proteins (holdase activity). While PMID:20080625 showed it facilitates refolding upon pH neutralization, this is achieved through passive slow release of substrates rather than active folding assistance. The BP term &#34;protein folding&#34; overstates HdeA&#39;s role. A more appropriate term is GO:0042026 protein refolding: HdeA&#39;s pH-triggered slow-release cycle directly facilitates refolding while keeping aggregation-sensitive intermediates below their aggregation threshold. This is a process-level role, not a claim that HdeA catalyzes folding chemistry.
                         </div>
 
 
@@ -1866,12 +1928,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation from EcoCyc based on PMID:15911614 which demonstrated that HdeA binds acid-denatured proteins at low pH. The study showed HdeA transforms into a disordered conformation at pH below 3 and exposes hydrophobic surfaces that bind denatured substrates, suppressing their aggregation. GO:0051082 &#34;unfolded protein binding&#34; is now formally obsolete (go-ontology#30962). HdeA is an ATP-independent, in-situ holdase that prevents aggregation of acid-denatured periplasmic proteins. The most mechanistically appropriate replacement is GO:0140309 &#34;unfolded protein carrier activity,&#34; which was created for holdase-type chaperones. However, there is a caveat: GO:0140309 was created specifically for TIM carrier-holdases that escort unfolded proteins between cellular compartments (go-ontology#30552), and its definition requires escort &#34;between two different cellular components.&#34; HdeA functions in situ in the periplasm and does not escort proteins between compartments. A general &#34;holdase chaperone activity&#34; NTR would be the ideal replacement (see UNFOLDED_PROTEIN_BINDING.md).
+                            <strong>Summary:</strong> PMID:15911614 directly demonstrates binding of acid-denatured proteins after HdeA&#39;s low-pH order-to-disorder transition. The biology is an ATP-independent, in-situ holdase activity, but GO:0051082 is now obsolete.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is now formally obsolete. HdeA is a well-characterized holdase: it binds acid-denatured proteins at low pH, prevents their aggregation in the periplasm, and facilitates refolding upon pH neutralization by slow substrate release (PMID:15911614, PMID:20080625). It is ATP-independent, consistent with the periplasm lacking ATP. GO:0140309 &#34;unfolded protein carrier activity&#34; captures the holdase mechanism but its definition strictly requires escort between cellular components, which HdeA does not perform. Until a general holdase NTR is created, GO:0140309 is the closest available term. The existing GO:0044183 annotations also partially capture HdeA&#39;s function but from the foldase perspective.
+                            <strong>Reason:</strong> GO:0051082 is obsolete, but the experimental holdase biology remains valid. HdeA binds and protects acid-denatured clients within the periplasm and releases them after neutralization; no defined acceptor molecule, delivery destination, or escort step is demonstrated. Carrier-specific GO:0140309 therefore does not fit. The general holdase chaperone activity NTR is the correct replacement, while the physical GO:0051082 annotation remains as an explicit interim descriptor.
                         </div>
 
 
@@ -1880,8 +1942,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
-                                    unfolded protein binding (retain until holdase NTR is created)
+                                <a href="#" target="_blank" class="term-link">
+                                    holdase chaperone activity (NTR needed; GO:0140309 does not fit -- carrier-specific)
                                 </a>
                             </span>
 
@@ -2135,6 +2197,101 @@
                     </td>
                 </tr>
 
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                    GO:0050821
+                                </a>
+                            </span>
+                            <span class="term-label">protein stabilization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10623550" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10623550
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    HDEA, a periplasmic protein that supports acid resistance in...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P0AES9" data-a="GO:0050821" data-r="PMID:10623550" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HdeA directly suppresses aggregation of acid-denatured proteins and maintains clients in a recoverable state during low-pH stress.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0050821 captures maintaining protein integrity and preventing aggregation. This is directly demonstrated for HdeA and complements the holdase NTR without asserting active catalysis of folding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10623550" target="_blank" class="term-link">
+                                        PMID:10623550
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Functional studies demonstrate that HDEA is activated by a dimer-to-monomer transition at acidic pH, leading to suppression of aggregation by acid-denatured proteins.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20080625" target="_blank" class="term-link">
+                                        PMID:20080625
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">HdeA stably binds substrates at low pH, thereby preventing their irreversible aggregation.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </div>
@@ -2147,8 +2304,8 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Acid-activated periplasmic holdase chaperone that prevents irreversible aggregation of acid-denatured periplasmic proteins during gastric transit (pH &lt; 3)</h3>
-                <span class="vote-buttons" data-g="P0AES9" data-a="FUNCTION: Acid-activated periplasmic holdase chaperone that ..." data-r="" data-act="CORE_FUNCTION">
+                <h3>At pH below 3, HdeA converts from an inactive folded dimer to an active disordered monomer that binds acid-denatured periplasmic clients and prevents their irreversible aggregation in situ. GO:0051082 is used only as an INTERIM MF representation pending the general holdase chaperone activity NTR; carrier-specific GO:0140309 does not fit because no acceptor or delivery destination is demonstrated.</h3>
+                <span class="vote-buttons" data-g="P0AES9" data-a="FUNCTION: At pH below 3, HdeA converts from an inactive fold..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -2160,8 +2317,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                            protein folding chaperone
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
+                            unfolded protein binding
                         </a>
                     </span>
                 </div>
@@ -2175,6 +2332,12 @@
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990451" target="_blank" class="term-link">
                                 cellular stress response to acidic pH
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                protein stabilization
                             </a>
                         </span>
 
@@ -2203,12 +2366,45 @@
             </div>
 
 
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15911614" target="_blank" class="term-link">
+                                PMID:15911614
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">our data indicate that HdeA exposes hydrophobic surfaces that appear to be involved in the binding of denatured substrate proteins at extremely low pH values</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10623550" target="_blank" class="term-link">
+                                PMID:10623550
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Functional studies demonstrate that HDEA is activated by a dimer-to-monomer transition at acidic pH, leading to suppression of aggregation by acid-denatured proteins.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
         </div>
 
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Facilitates refolding of acid-denatured periplasmic proteins upon return to neutral pH via slow ATP-independent substrate release</h3>
+                <h3>Facilitates refolding of acid-denatured periplasmic proteins upon return to neutral pH via a single slow ATP-independent substrate binding-release cycle; this is chaperone assistance in the refolding process, not active catalysis of folding chemistry.</h3>
                 <span class="vote-buttons" data-g="P0AES9" data-a="FUNCTION: Facilitates refolding of acid-denatured periplasmi..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -2263,6 +2459,39 @@
 
             </div>
 
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20080625" target="_blank" class="term-link">
+                                PMID:20080625
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">This provides a straightforward and ATP-independent mechanism that allows HdeA to facilitate protein refolding.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20080625" target="_blank" class="term-link">
+                                PMID:20080625
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Unlike previously characterized chaperones, HdeA appears to facilitate protein folding by using a single substrate binding-release cycle.</div>
+
+                    </li>
+
+                </ul>
+            </div>
 
         </div>
 
@@ -2672,13 +2901,108 @@ removal/down-weighting of any enzymatic or transport interpretation.</div>
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:projects/UNFOLDED_PROTEIN_BINDING.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Unfolded protein binding annotation review project</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GO:0051082 is obsolete; in-situ holdases such as HdeA retain it only as an interim descriptor with a general holdase chaperone activity NTR, because GO:0140309 requires escort to a defined acceptor or location.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
 
 
 
 
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
 
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which structural or kinetic features determine whether an acid-denatured periplasmic client is captured by HdeA, HdeB, or both?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0AES9" data-a="Q: Which structural or kinetic features determine whe..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How do DegP and SurA participate after HdeA releases clients during neutralization, and does any physical handoff occur despite the absence of an established carrier endpoint?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0AES9" data-a="Q: How do DegP and SurA participate after HdeA releas..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Measure HdeA-client binding, release, aggregation, and refolding during controlled acidification and neutralization to distinguish spontaneous client refolding from downstream assistance by DegP or SurA.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: client-release kinetics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0AES9" data-a="EXPERIMENT: Measure HdeA-client binding, release, aggregation,..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare wild-type HdeA with substrate-binding and release-defective variants using periplasmic crosslinking proteomics across acid stress and recovery to define direct clients and temporal chaperone cooperation.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vivo client-trapping proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P0AES9" data-a="EXPERIMENT: Compare wild-type HdeA with substrate-binding and ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
 
 
 
@@ -3073,6 +3397,46 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(HdeA-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P0AES9" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="hdea-qualifier-aware-annotation-re-review-2026-08-29">HdeA qualifier-aware annotation re-review — 2026-08-29</h1>
+<h2 id="coverage-and-provenance">Coverage and provenance</h2>
+<ul>
+<li>Reconciled all 14 current physical GOA signatures exactly once: 6 <code>enables</code>, 4 <code>located_in</code>, 3 <code>involved_in</code>, and 1 <code>acts_upstream_of_or_within</code>.</li>
+<li>Evidence distribution is 4 IEA, 5 IDA, 2 EXP, 1 IPI, 1 IMP, and 1 RCA, totaling 14 physical rows. There are no IBA rows and therefore no PTN/WITH-FROM propagation claim to audit.</li>
+<li>All six GOA PMID sources are abstract-only in the repository cache. Experimental rows were retained or refined only where their cached abstracts directly support the interpretation; none was removed for lack of full text.</li>
+</ul>
+<h2 id="holdase-and-ontology-decision">Holdase and ontology decision</h2>
+<p>HdeA is an ATP-independent, acid-activated in-situ holdase. At neutral pH it is an inactive folded dimer; below pH 3 it becomes a disordered client-binding monomer. [PMID:15911614 “it possesses an ordered conformation that is unable to bind denatured substrate proteins under normal physiological conditions (i.e. at neutral pH) and transforms into a globally disordered conformation that is able to bind substrate proteins under stress conditions (i.e. at a pH below 3)”]</p>
+<p>No cached study demonstrates escort to a defined acceptor molecule or destination. HdeA binds clients within the periplasm, prevents aggregation, then releases them when pH is neutralized. Therefore carrier-specific GO:0140309 does not fit. The physical GO:0051082 IDA row is retained as an interim annotation but <code>MODIFY</code> now points machine-readably to <code>NTR</code> holdase chaperone activity, following the CRYAA/project convention. [file:projects/UNFOLDED_PROTEIN_BINDING.md]</p>
+<p>GO:0050821 protein stabilization is added as a NEW BP because aggregation suppression is direct: “Functional studies demonstrate that HDEA is activated by a dimer-to-monomer transition at acidic pH, leading to suppression of aggregation by acid-denatured proteins.” <a href="https://pubmed.ncbi.nlm.nih.gov/10623550">PMID:10623550</a></p>
+<h2 id="refolding-decision">Refolding decision</h2>
+<p>GO:0042026 protein refolding is retained as the replacement for the broad physical GO:0006457 protein folding row. The BP does not imply that HdeA catalyzes folding chemistry. PMID:20080625 directly states that HdeA “is capable of independently facilitating the refolding of acid-denatured proteins” and explains that slow release keeps aggregation-sensitive intermediates below their aggregation threshold. This supports involvement in refolding through an environmentally regulated binding-release cycle.</p>
+<p>The three experimental GO:0044183 protein folding chaperone rows are retained. Although HdeA is mechanistically a holdase, the direct evidence shows that its binding-release cycle assists the folding process. The core-function prose now separates this refolding assistance from the primary in-situ aggregation-prevention activity.</p>
+<h2 id="other-annotation-decisions">Other annotation decisions</h2>
+<ul>
+<li>GO:0042802 identical protein binding remains <code>MARK_AS_OVER_ANNOTATED</code> because the specific physical GO:0042803 homodimerization activity is present and experimentally supported.</li>
+<li>Broad and specific periplasm/local acid-response rows remain accepted; their exact GOA qualifiers are now explicit in YAML.</li>
+<li>The standalone description remains biological and project-independent, covering compartment, pH-dependent activation, aggregation prevention, controlled release, and cooperation with HdeB/DegP/SurA.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3084,7 +3448,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P0AES9
 gene_symbol: HdeA
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:83333
   label: Escherichia coli (strain K12)
@@ -3108,6 +3472,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: located_in
   review:
     summary: IEA annotation based on InterPro domain matches (IPR024972, IPR036831).
       HdeA is well-established as a periplasmic protein with a cleavable signal peptide
@@ -3127,6 +3492,7 @@ existing_annotations:
     label: periplasmic space
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: located_in
   review:
     summary: IEA annotation from UniProt subcellular location mapping (UniProtKB-SubCell:SL-0200).
       GO:0042597 &#34;periplasmic space&#34; is a more general term than GO:0030288 &#34;outer
@@ -3149,6 +3515,7 @@ existing_annotations:
     label: cellular response to acidic pH
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: IEA annotation from InterPro domain matches. HdeA is a core component
       of the E. coli acid stress response, activated exclusively at pH below 3 (PMID:15911614).
@@ -3172,6 +3539,7 @@ existing_annotations:
     label: cellular stress response to acidic pH
   evidence_type: IEA
   original_reference_id: GO_REF:0000104
+  qualifier: involved_in
   review:
     summary: IEA annotation transferred from manual annotations via shared sequence
       features (UniRule:UR000106130). GO:1990451 is a child of GO:0071468 &#34;cellular
@@ -3191,6 +3559,7 @@ existing_annotations:
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:20080625
+  qualifier: enables
   review:
     summary: IPI annotation from IntAct based on physical interaction data (HdeA self-interaction).
       HdeA forms a homodimer at neutral pH that dissociates into active monomers at
@@ -3213,6 +3582,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IDA
   original_reference_id: PMID:10623550
+  qualifier: involved_in
   review:
     summary: IDA annotation for involvement in protein folding from EcoCyc, based
       on the demonstration that HdeA suppresses aggregation of acid-denatured proteins
@@ -3222,16 +3592,17 @@ existing_annotations:
       via slow substrate release, but this is a passive mechanism distinct from active
       foldase activity.
     action: MODIFY
-    reason: HdeA does not actively catalyze protein folding in the conventional sense
-      (it is ATP- independent and lacks foldase activity). Its primary function is
+    reason: &gt;-
+      HdeA does not actively catalyze protein folding in the conventional sense
+      (it is ATP-independent and lacks an ATP-driven foldase cycle). Its primary function is
       preventing aggregation of acid-denatured proteins (holdase activity). While
       PMID:20080625 showed it facilitates refolding upon pH neutralization, this is
       achieved through passive slow release of substrates rather than active folding
       assistance. The BP term &#34;protein folding&#34; overstates HdeA&#39;s role. A more appropriate
-      term would capture the chaperone-mediated protein refolding or protein stabilization
-      aspect. However, given that refolding does occur as a consequence of HdeA activity
-      (PMID:20080625), the annotation is not entirely wrong -- it is the process outcome
-      rather than the mechanism.
+      term is GO:0042026 protein refolding: HdeA&#39;s pH-triggered slow-release cycle
+      directly facilitates refolding while keeping aggregation-sensitive intermediates
+      below their aggregation threshold. This is a process-level role, not a claim
+      that HdeA catalyzes folding chemistry.
     proposed_replacement_terms:
     - id: GO:0042026
       label: protein refolding
@@ -3252,6 +3623,7 @@ existing_annotations:
     label: protein folding chaperone
   evidence_type: EXP
   original_reference_id: PMID:10623550
+  qualifier: enables
   review:
     summary: EXP annotation from DisProt for protein folding chaperone activity based
       on PMID:10623550. The crystal structure study demonstrated that HdeA suppresses
@@ -3286,6 +3658,7 @@ existing_annotations:
     label: protein folding chaperone
   evidence_type: IDA
   original_reference_id: PMID:10623550
+  qualifier: enables
   review:
     summary: IDA annotation from DisProt for the same term and reference as the EXP
       annotation above. This is a duplicate with a different evidence code (IDA vs
@@ -3304,6 +3677,7 @@ existing_annotations:
     label: protein folding chaperone
   evidence_type: EXP
   original_reference_id: PMID:30573682
+  qualifier: enables
   review:
     summary: &#39;EXP annotation from DisProt based on PMID:30573682. This study used
       advanced NMR methods to characterize HdeA&#39;&#39;s activated-state conformation under
@@ -3326,6 +3700,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IDA
   original_reference_id: PMID:9298646
+  qualifier: located_in
   review:
     summary: IDA annotation from EcoCyc based on the Link et al. (1997) proteomics
       study which identified HdeA by 2-DE and Edman sequencing from periplasmic fractions.
@@ -3351,6 +3726,7 @@ existing_annotations:
     label: protein homodimerization activity
   evidence_type: IDA
   original_reference_id: PMID:10623550
+  qualifier: enables
   review:
     summary: IDA annotation from EcoCyc. The crystal structure of HdeA at 2.0 A resolution
       (PMID:10623550) revealed that HdeA forms a homodimer at neutral pH. The dimer-to-
@@ -3378,34 +3754,22 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:15911614
+  qualifier: enables
   review:
-    summary: &#39;IDA annotation from EcoCyc based on PMID:15911614 which demonstrated
-      that HdeA binds acid-denatured proteins at low pH. The study showed HdeA transforms
-      into a disordered conformation at pH below 3 and exposes hydrophobic surfaces
-      that bind denatured substrates, suppressing their aggregation. GO:0051082 &#34;unfolded
-      protein binding&#34; is now formally obsolete (go-ontology#30962). HdeA is an
-      ATP-independent, in-situ holdase that prevents aggregation of acid-denatured
-      periplasmic proteins. The most mechanistically appropriate replacement is GO:0140309
-      &#34;unfolded protein carrier activity,&#34; which was created for holdase-type chaperones.
-      However, there is a caveat: GO:0140309 was created specifically for TIM carrier-holdases
-      that escort unfolded proteins between cellular compartments (go-ontology#30552),
-      and its definition requires escort &#34;between two different cellular components.&#34;
-      HdeA functions in situ in the periplasm and does not escort proteins between
-      compartments. A general &#34;holdase chaperone activity&#34; NTR would be the ideal
-      replacement (see UNFOLDED_PROTEIN_BINDING.md).&#39;
+    summary: PMID:15911614 directly demonstrates binding of acid-denatured proteins
+      after HdeA&#39;s low-pH order-to-disorder transition. The biology is an ATP-independent,
+      in-situ holdase activity, but GO:0051082 is now obsolete.
     action: MODIFY
-    reason: &#39;GO:0051082 is now formally obsolete. HdeA is a well-characterized holdase:
-      it binds acid-denatured proteins at low pH, prevents their aggregation in the
-      periplasm, and facilitates refolding upon pH neutralization by slow substrate
-      release (PMID:15911614, PMID:20080625). It is ATP-independent, consistent with
-      the periplasm lacking ATP. GO:0140309 &#34;unfolded protein carrier activity&#34; captures
-      the holdase mechanism but its definition strictly requires escort between cellular
-      components, which HdeA does not perform. Until a general holdase NTR is created,
-      GO:0140309 is the closest available term. The existing GO:0044183 annotations
-      also partially capture HdeA&#39;&#39;s function but from the foldase perspective.&#39;
+    reason: GO:0051082 is obsolete, but the experimental holdase biology remains valid.
+      HdeA binds and protects acid-denatured clients within the periplasm and releases
+      them after neutralization; no defined acceptor molecule, delivery destination,
+      or escort step is demonstrated. Carrier-specific GO:0140309 therefore does not
+      fit. The general holdase chaperone activity NTR is the correct replacement,
+      while the physical GO:0051082 annotation remains as an explicit interim descriptor.
     proposed_replacement_terms:
-    - id: GO:0051082
-      label: unfolded protein binding (retain until holdase NTR is created)
+    - id: NTR
+      label: holdase chaperone activity (NTR needed; GO:0140309 does not fit --
+        carrier-specific)
     additional_reference_ids:
     - PMID:20080625
     - PMID:30573682
@@ -3432,6 +3796,7 @@ existing_annotations:
     label: cellular stress response to acidic pH
   evidence_type: IMP
   original_reference_id: PMID:10623550
+  qualifier: acts_upstream_of_or_within
   review:
     summary: IMP annotation from EcoCyc. PMID:10623550 demonstrated that HdeA supports
       acid resistance in pathogenic enteric bacteria. The crystal structure study
@@ -3459,6 +3824,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: RCA
   original_reference_id: PMID:8455549
+  qualifier: located_in
   review:
     summary: RCA annotation from EcoCyc based on PMID:8455549 (Yoshida et al., 1993),
       which originally identified the hdeA gene (then called 10K-S or yhiB) as part
@@ -3476,6 +3842,29 @@ existing_annotations:
       supporting_text: The genes coding for the other two proteins, 10K-L and 10K-S,
         are located at 77.5 min on the genetic map. Their nucleotide sequences were
         determined
+- term:
+    id: GO:0050821
+    label: protein stabilization
+  evidence_type: IDA
+  original_reference_id: PMID:10623550
+  qualifier: involved_in
+  review:
+    summary: HdeA directly suppresses aggregation of acid-denatured proteins and
+      maintains clients in a recoverable state during low-pH stress.
+    action: NEW
+    reason: GO:0050821 captures maintaining protein integrity and preventing aggregation.
+      This is directly demonstrated for HdeA and complements the holdase NTR without
+      asserting active catalysis of folding.
+    additional_reference_ids:
+    - PMID:20080625
+    supported_by:
+    - reference_id: PMID:10623550
+      supporting_text: Functional studies demonstrate that HDEA is activated by a
+        dimer-to-monomer transition at acidic pH, leading to suppression of aggregation
+        by acid-denatured proteins.
+    - reference_id: PMID:20080625
+      supporting_text: HdeA stably binds substrates at low pH, thereby preventing
+        their irreversible aggregation.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -3544,6 +3933,12 @@ references:
 - id: PMID:8455549
   title: &#39;Function of the Escherichia coli nucleoid protein, H-NS: molecular analysis
     of a subset of proteins whose expression is enhanced in a hns deletion mutant.&#39;
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Cached abstract verifies identification and sequencing of the 10K-S/HdeA
+      locus and H-NS-sensitive expression; it provides sequence-based rather than direct
+      localization evidence.
   findings:
   - statement: Original identification of the hdeA gene (10K-S) as part of an operon
       at 77.5 min whose expression is enhanced in hns deletion mutants.
@@ -3553,6 +3948,11 @@ references:
 - id: PMID:9298646
   title: Comparing the predicted and observed properties of proteins encoded in the
     genome of Escherichia coli K-12.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract and UniProt citation metadata support the experimental
+      proteomic identification and periplasmic fractionation context; cache is abstract-only.
   findings:
   - statement: Identified HdeA as a highly abundant periplasmic protein by 2-DE and
       Edman sequencing. Confirmed signal peptide cleavage and periplasmic localization.
@@ -3563,6 +3963,11 @@ references:
 - id: PMID:9731767
   title: Crystal structure of Escherichia coli HdeA.
   full_text_unavailable: true
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Cached abstract verifies the HdeA crystal-structure paper; it is
+      contextual corroboration rather than the primary annotation source.
   findings:
   - statement: First crystal structure of HdeA at 2.2 A resolution. Identified the
       intramolecular disulfide bond (Cys39-Cys87).
@@ -3570,6 +3975,11 @@ references:
 - id: PMID:10623550
   title: HDEA, a periplasmic protein that supports acid resistance in pathogenic enteric
     bacteria.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly supports periplasmic localization, acid-resistance
+      function, dimer-to-monomer activation, and aggregation suppression; cache is abstract-only.
   findings:
   - statement: Crystal structure at 2.0 A resolution. Demonstrated HdeA is a homodimer
       that dissociates at acidic pH. Showed HdeA suppresses aggregation of acid-denatured
@@ -3580,6 +3990,11 @@ references:
 - id: PMID:15911614
   title: Periplasmic protein HdeA exhibits chaperone-like activity exclusively within
     stomach pH range by transforming into disordered conformation.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly supports low-pH disordering and binding
+      of denatured substrates; cache is abstract-only.
   findings:
   - statement: Key mechanistic study. HdeA transforms from ordered conformation (inactive,
       neutral pH) to globally disordered conformation (active, pH &lt; 3). Exposes hydrophobic
@@ -3592,6 +4007,11 @@ references:
       under stress conditions (i.e. at a pH below 3)&#39;
 - id: PMID:17085547
   title: Escherichia coli HdeB is an acid stress chaperone.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Cached abstract directly compares HdeA and HdeB aggregation suppression
+      and acid-survival phenotypes; relevant corroboration despite its HdeB focus.
   findings:
   - statement: Demonstrated HdeA and HdeB both required for optimal acid stress protection.
       HdeA more efficient at pH 2, HdeB at pH 3. Confirmed periplasmic localization.
@@ -3602,6 +4022,11 @@ references:
 - id: PMID:18359765
   title: Solubilization of protein aggregates by the acid stress chaperones HdeA and
     HdeB.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly reports HdeA/HdeB-mediated aggregate solubilization
+      and renaturation after neutralization; cache is abstract-only.
   findings:
   - statement: HdeA promotes solubilization of protein aggregates at neutral pH after
       acid treatment.
@@ -3611,6 +4036,11 @@ references:
       aggregates formed at acidic pH
 - id: PMID:20080625
   title: Protein refolding by pH-triggered chaperone binding and release.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly establishes HdeA&#39;s ATP-independent binding-release
+      mechanism and facilitation of client refolding; cache is abstract-only despite a PMCID.
   findings:
   - statement: &#39;Demonstrated HdeA facilitates refolding of acid-denatured proteins
       via pH-triggered binding and release cycle. ATP-independent mechanism: stable
@@ -3625,6 +4055,11 @@ references:
 - id: PMID:21892184
   title: A genetically incorporated crosslinker reveals chaperone cooperation in acid
     resistance.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly identifies physiological HdeA clients and
+      cooperation with DegP and SurA during recovery; cache is abstract-only.
   findings:
   - statement: Demonstrated cooperation between HdeA and other periplasmic chaperones
       (DegP, SurA) during acid stress recovery using in vivo crosslinking.
@@ -3636,6 +4071,11 @@ references:
 - id: PMID:30573682
   title: Structural basis and mechanism of the unfolding-induced activation of HdeA,
     a bacterial acid response chaperone.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly characterizes the activated disordered
+      conformation and client-binding patches; cache is abstract-only despite a PMCID.
   findings:
   - statement: NMR characterization of activated HdeA. Identified two hydrophobic
       patches essential for client interactions and three acid-sensitive structural
@@ -3645,21 +4085,43 @@ references:
       three acid-sensitive regions that act as structural locks in regulating the
       exposure of the two client-binding sites during the activation process, revealing
       a multistep activation mechanism
+- id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+  title: Unfolded protein binding annotation review project
+  findings:
+  - statement: GO:0051082 is obsolete; in-situ holdases such as HdeA retain it only
+      as an interim descriptor with a general holdase chaperone activity NTR, because
+      GO:0140309 requires escort to a defined acceptor or location.
 core_functions:
-- description: Acid-activated periplasmic holdase chaperone that prevents irreversible
-    aggregation of acid-denatured periplasmic proteins during gastric transit (pH
-    &lt; 3)
+- description: At pH below 3, HdeA converts from an inactive folded dimer to an
+    active disordered monomer that binds acid-denatured periplasmic clients and
+    prevents their irreversible aggregation in situ. GO:0051082 is used only as
+    an INTERIM MF representation pending the general holdase chaperone activity NTR;
+    carrier-specific GO:0140309 does not fit because no acceptor or delivery destination
+    is demonstrated.
   molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0051082
+    label: unfolded protein binding
   directly_involved_in:
   - id: GO:1990451
     label: cellular stress response to acidic pH
+  - id: GO:0050821
+    label: protein stabilization
   locations:
   - id: GO:0030288
     label: outer membrane-bounded periplasmic space
+  supported_by:
+  - reference_id: PMID:15911614
+    supporting_text: our data indicate that HdeA exposes hydrophobic surfaces that
+      appear to be involved in the binding of denatured substrate proteins at extremely
+      low pH values
+  - reference_id: PMID:10623550
+    supporting_text: Functional studies demonstrate that HDEA is activated by a
+      dimer-to-monomer transition at acidic pH, leading to suppression of aggregation
+      by acid-denatured proteins.
 - description: Facilitates refolding of acid-denatured periplasmic proteins upon return
-    to neutral pH via slow ATP-independent substrate release
+    to neutral pH via a single slow ATP-independent substrate binding-release cycle;
+    this is chaperone assistance in the refolding process, not active catalysis of
+    folding chemistry.
   molecular_function:
     id: GO:0044183
     label: protein folding chaperone
@@ -3669,6 +4131,48 @@ core_functions:
   locations:
   - id: GO:0030288
     label: outer membrane-bounded periplasmic space
+  supported_by:
+  - reference_id: PMID:20080625
+    supporting_text: This provides a straightforward and ATP-independent mechanism
+      that allows HdeA to facilitate protein refolding.
+  - reference_id: PMID:20080625
+    supporting_text: Unlike previously characterized chaperones, HdeA appears to
+      facilitate protein folding by using a single substrate binding-release cycle.
+proposed_new_terms:
+- proposed_name: holdase chaperone activity
+  proposed_definition: Binding to an unfolded or misfolded protein to prevent its
+    aggregation without actively catalyzing refolding. The holdase maintains the client
+    protein in a soluble, folding-competent state.
+  justification: HdeA directly binds acid-denatured periplasmic clients and prevents
+    their aggregation in situ. Obsolete GO:0051082 captures binding only, GO:0044183
+    describes assistance with folding, and carrier-specific GO:0140309 requires escort
+    to an acceptor or location not demonstrated for HdeA.
+  proposed_parent:
+    id: GO:0003674
+    label: molecular_function
+  supported_by:
+  - reference_id: PMID:10623550
+    supporting_text: Functional studies demonstrate that HDEA is activated by a
+      dimer-to-monomer transition at acidic pH, leading to suppression of aggregation
+      by acid-denatured proteins.
+  - reference_id: PMID:15911614
+    supporting_text: our data indicate that HdeA exposes hydrophobic surfaces that
+      appear to be involved in the binding of denatured substrate proteins at extremely
+      low pH values
+suggested_questions:
+- question: Which structural or kinetic features determine whether an acid-denatured
+    periplasmic client is captured by HdeA, HdeB, or both?
+- question: How do DegP and SurA participate after HdeA releases clients during neutralization,
+    and does any physical handoff occur despite the absence of an established carrier endpoint?
+suggested_experiments:
+- experiment_type: client-release kinetics
+  description: Measure HdeA-client binding, release, aggregation, and refolding during
+    controlled acidification and neutralization to distinguish spontaneous client refolding
+    from downstream assistance by DegP or SurA.
+- experiment_type: in vivo client-trapping proteomics
+  description: Compare wild-type HdeA with substrate-binding and release-defective variants
+    using periplasmic crosslinking proteomics across acid stress and recovery to define
+    direct clients and temporal chaperone cooperation.
 </code></pre>
             </div>
         </details>

--- a/genes/ECOLI/HdeA/HdeA-ai-review.yaml
+++ b/genes/ECOLI/HdeA/HdeA-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P0AES9
 gene_symbol: HdeA
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:83333
   label: Escherichia coli (strain K12)
@@ -25,6 +25,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: located_in
   review:
     summary: IEA annotation based on InterPro domain matches (IPR024972, IPR036831).
       HdeA is well-established as a periplasmic protein with a cleavable signal peptide
@@ -44,6 +45,7 @@ existing_annotations:
     label: periplasmic space
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
+  qualifier: located_in
   review:
     summary: IEA annotation from UniProt subcellular location mapping (UniProtKB-SubCell:SL-0200).
       GO:0042597 "periplasmic space" is a more general term than GO:0030288 "outer
@@ -66,6 +68,7 @@ existing_annotations:
     label: cellular response to acidic pH
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
+  qualifier: involved_in
   review:
     summary: IEA annotation from InterPro domain matches. HdeA is a core component
       of the E. coli acid stress response, activated exclusively at pH below 3 (PMID:15911614).
@@ -89,6 +92,7 @@ existing_annotations:
     label: cellular stress response to acidic pH
   evidence_type: IEA
   original_reference_id: GO_REF:0000104
+  qualifier: involved_in
   review:
     summary: IEA annotation transferred from manual annotations via shared sequence
       features (UniRule:UR000106130). GO:1990451 is a child of GO:0071468 "cellular
@@ -108,6 +112,7 @@ existing_annotations:
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:20080625
+  qualifier: enables
   review:
     summary: IPI annotation from IntAct based on physical interaction data (HdeA self-interaction).
       HdeA forms a homodimer at neutral pH that dissociates into active monomers at
@@ -130,6 +135,7 @@ existing_annotations:
     label: protein folding
   evidence_type: IDA
   original_reference_id: PMID:10623550
+  qualifier: involved_in
   review:
     summary: IDA annotation for involvement in protein folding from EcoCyc, based
       on the demonstration that HdeA suppresses aggregation of acid-denatured proteins
@@ -139,16 +145,17 @@ existing_annotations:
       via slow substrate release, but this is a passive mechanism distinct from active
       foldase activity.
     action: MODIFY
-    reason: HdeA does not actively catalyze protein folding in the conventional sense
-      (it is ATP- independent and lacks foldase activity). Its primary function is
+    reason: >-
+      HdeA does not actively catalyze protein folding in the conventional sense
+      (it is ATP-independent and lacks an ATP-driven foldase cycle). Its primary function is
       preventing aggregation of acid-denatured proteins (holdase activity). While
       PMID:20080625 showed it facilitates refolding upon pH neutralization, this is
       achieved through passive slow release of substrates rather than active folding
       assistance. The BP term "protein folding" overstates HdeA's role. A more appropriate
-      term would capture the chaperone-mediated protein refolding or protein stabilization
-      aspect. However, given that refolding does occur as a consequence of HdeA activity
-      (PMID:20080625), the annotation is not entirely wrong -- it is the process outcome
-      rather than the mechanism.
+      term is GO:0042026 protein refolding: HdeA's pH-triggered slow-release cycle
+      directly facilitates refolding while keeping aggregation-sensitive intermediates
+      below their aggregation threshold. This is a process-level role, not a claim
+      that HdeA catalyzes folding chemistry.
     proposed_replacement_terms:
     - id: GO:0042026
       label: protein refolding
@@ -169,6 +176,7 @@ existing_annotations:
     label: protein folding chaperone
   evidence_type: EXP
   original_reference_id: PMID:10623550
+  qualifier: enables
   review:
     summary: EXP annotation from DisProt for protein folding chaperone activity based
       on PMID:10623550. The crystal structure study demonstrated that HdeA suppresses
@@ -203,6 +211,7 @@ existing_annotations:
     label: protein folding chaperone
   evidence_type: IDA
   original_reference_id: PMID:10623550
+  qualifier: enables
   review:
     summary: IDA annotation from DisProt for the same term and reference as the EXP
       annotation above. This is a duplicate with a different evidence code (IDA vs
@@ -221,6 +230,7 @@ existing_annotations:
     label: protein folding chaperone
   evidence_type: EXP
   original_reference_id: PMID:30573682
+  qualifier: enables
   review:
     summary: 'EXP annotation from DisProt based on PMID:30573682. This study used
       advanced NMR methods to characterize HdeA''s activated-state conformation under
@@ -243,6 +253,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: IDA
   original_reference_id: PMID:9298646
+  qualifier: located_in
   review:
     summary: IDA annotation from EcoCyc based on the Link et al. (1997) proteomics
       study which identified HdeA by 2-DE and Edman sequencing from periplasmic fractions.
@@ -268,6 +279,7 @@ existing_annotations:
     label: protein homodimerization activity
   evidence_type: IDA
   original_reference_id: PMID:10623550
+  qualifier: enables
   review:
     summary: IDA annotation from EcoCyc. The crystal structure of HdeA at 2.0 A resolution
       (PMID:10623550) revealed that HdeA forms a homodimer at neutral pH. The dimer-to-
@@ -295,34 +307,22 @@ existing_annotations:
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:15911614
+  qualifier: enables
   review:
-    summary: 'IDA annotation from EcoCyc based on PMID:15911614 which demonstrated
-      that HdeA binds acid-denatured proteins at low pH. The study showed HdeA transforms
-      into a disordered conformation at pH below 3 and exposes hydrophobic surfaces
-      that bind denatured substrates, suppressing their aggregation. GO:0051082 "unfolded
-      protein binding" is now formally obsolete (go-ontology#30962). HdeA is an
-      ATP-independent, in-situ holdase that prevents aggregation of acid-denatured
-      periplasmic proteins. The most mechanistically appropriate replacement is GO:0140309
-      "unfolded protein carrier activity," which was created for holdase-type chaperones.
-      However, there is a caveat: GO:0140309 was created specifically for TIM carrier-holdases
-      that escort unfolded proteins between cellular compartments (go-ontology#30552),
-      and its definition requires escort "between two different cellular components."
-      HdeA functions in situ in the periplasm and does not escort proteins between
-      compartments. A general "holdase chaperone activity" NTR would be the ideal
-      replacement (see UNFOLDED_PROTEIN_BINDING.md).'
+    summary: PMID:15911614 directly demonstrates binding of acid-denatured proteins
+      after HdeA's low-pH order-to-disorder transition. The biology is an ATP-independent,
+      in-situ holdase activity, but GO:0051082 is now obsolete.
     action: MODIFY
-    reason: 'GO:0051082 is now formally obsolete. HdeA is a well-characterized holdase:
-      it binds acid-denatured proteins at low pH, prevents their aggregation in the
-      periplasm, and facilitates refolding upon pH neutralization by slow substrate
-      release (PMID:15911614, PMID:20080625). It is ATP-independent, consistent with
-      the periplasm lacking ATP. GO:0140309 "unfolded protein carrier activity" captures
-      the holdase mechanism but its definition strictly requires escort between cellular
-      components, which HdeA does not perform. Until a general holdase NTR is created,
-      GO:0140309 is the closest available term. The existing GO:0044183 annotations
-      also partially capture HdeA''s function but from the foldase perspective.'
+    reason: GO:0051082 is obsolete, but the experimental holdase biology remains valid.
+      HdeA binds and protects acid-denatured clients within the periplasm and releases
+      them after neutralization; no defined acceptor molecule, delivery destination,
+      or escort step is demonstrated. Carrier-specific GO:0140309 therefore does not
+      fit. The general holdase chaperone activity NTR is the correct replacement,
+      while the physical GO:0051082 annotation remains as an explicit interim descriptor.
     proposed_replacement_terms:
-    - id: GO:0051082
-      label: unfolded protein binding (retain until holdase NTR is created)
+    - id: NTR
+      label: holdase chaperone activity (NTR needed; GO:0140309 does not fit --
+        carrier-specific)
     additional_reference_ids:
     - PMID:20080625
     - PMID:30573682
@@ -349,6 +349,7 @@ existing_annotations:
     label: cellular stress response to acidic pH
   evidence_type: IMP
   original_reference_id: PMID:10623550
+  qualifier: acts_upstream_of_or_within
   review:
     summary: IMP annotation from EcoCyc. PMID:10623550 demonstrated that HdeA supports
       acid resistance in pathogenic enteric bacteria. The crystal structure study
@@ -376,6 +377,7 @@ existing_annotations:
     label: outer membrane-bounded periplasmic space
   evidence_type: RCA
   original_reference_id: PMID:8455549
+  qualifier: located_in
   review:
     summary: RCA annotation from EcoCyc based on PMID:8455549 (Yoshida et al., 1993),
       which originally identified the hdeA gene (then called 10K-S or yhiB) as part
@@ -393,6 +395,29 @@ existing_annotations:
       supporting_text: The genes coding for the other two proteins, 10K-L and 10K-S,
         are located at 77.5 min on the genetic map. Their nucleotide sequences were
         determined
+- term:
+    id: GO:0050821
+    label: protein stabilization
+  evidence_type: IDA
+  original_reference_id: PMID:10623550
+  qualifier: involved_in
+  review:
+    summary: HdeA directly suppresses aggregation of acid-denatured proteins and
+      maintains clients in a recoverable state during low-pH stress.
+    action: NEW
+    reason: GO:0050821 captures maintaining protein integrity and preventing aggregation.
+      This is directly demonstrated for HdeA and complements the holdase NTR without
+      asserting active catalysis of folding.
+    additional_reference_ids:
+    - PMID:20080625
+    supported_by:
+    - reference_id: PMID:10623550
+      supporting_text: Functional studies demonstrate that HDEA is activated by a
+        dimer-to-monomer transition at acidic pH, leading to suppression of aggregation
+        by acid-denatured proteins.
+    - reference_id: PMID:20080625
+      supporting_text: HdeA stably binds substrates at low pH, thereby preventing
+        their irreversible aggregation.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -461,6 +486,12 @@ references:
 - id: PMID:8455549
   title: 'Function of the Escherichia coli nucleoid protein, H-NS: molecular analysis
     of a subset of proteins whose expression is enhanced in a hns deletion mutant.'
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Cached abstract verifies identification and sequencing of the 10K-S/HdeA
+      locus and H-NS-sensitive expression; it provides sequence-based rather than direct
+      localization evidence.
   findings:
   - statement: Original identification of the hdeA gene (10K-S) as part of an operon
       at 77.5 min whose expression is enhanced in hns deletion mutants.
@@ -470,6 +501,11 @@ references:
 - id: PMID:9298646
   title: Comparing the predicted and observed properties of proteins encoded in the
     genome of Escherichia coli K-12.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract and UniProt citation metadata support the experimental
+      proteomic identification and periplasmic fractionation context; cache is abstract-only.
   findings:
   - statement: Identified HdeA as a highly abundant periplasmic protein by 2-DE and
       Edman sequencing. Confirmed signal peptide cleavage and periplasmic localization.
@@ -480,6 +516,11 @@ references:
 - id: PMID:9731767
   title: Crystal structure of Escherichia coli HdeA.
   full_text_unavailable: true
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Cached abstract verifies the HdeA crystal-structure paper; it is
+      contextual corroboration rather than the primary annotation source.
   findings:
   - statement: First crystal structure of HdeA at 2.2 A resolution. Identified the
       intramolecular disulfide bond (Cys39-Cys87).
@@ -487,6 +528,11 @@ references:
 - id: PMID:10623550
   title: HDEA, a periplasmic protein that supports acid resistance in pathogenic enteric
     bacteria.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly supports periplasmic localization, acid-resistance
+      function, dimer-to-monomer activation, and aggregation suppression; cache is abstract-only.
   findings:
   - statement: Crystal structure at 2.0 A resolution. Demonstrated HdeA is a homodimer
       that dissociates at acidic pH. Showed HdeA suppresses aggregation of acid-denatured
@@ -497,6 +543,11 @@ references:
 - id: PMID:15911614
   title: Periplasmic protein HdeA exhibits chaperone-like activity exclusively within
     stomach pH range by transforming into disordered conformation.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly supports low-pH disordering and binding
+      of denatured substrates; cache is abstract-only.
   findings:
   - statement: Key mechanistic study. HdeA transforms from ordered conformation (inactive,
       neutral pH) to globally disordered conformation (active, pH < 3). Exposes hydrophobic
@@ -509,6 +560,11 @@ references:
       under stress conditions (i.e. at a pH below 3)'
 - id: PMID:17085547
   title: Escherichia coli HdeB is an acid stress chaperone.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Cached abstract directly compares HdeA and HdeB aggregation suppression
+      and acid-survival phenotypes; relevant corroboration despite its HdeB focus.
   findings:
   - statement: Demonstrated HdeA and HdeB both required for optimal acid stress protection.
       HdeA more efficient at pH 2, HdeB at pH 3. Confirmed periplasmic localization.
@@ -519,6 +575,11 @@ references:
 - id: PMID:18359765
   title: Solubilization of protein aggregates by the acid stress chaperones HdeA and
     HdeB.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly reports HdeA/HdeB-mediated aggregate solubilization
+      and renaturation after neutralization; cache is abstract-only.
   findings:
   - statement: HdeA promotes solubilization of protein aggregates at neutral pH after
       acid treatment.
@@ -528,6 +589,11 @@ references:
       aggregates formed at acidic pH
 - id: PMID:20080625
   title: Protein refolding by pH-triggered chaperone binding and release.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly establishes HdeA's ATP-independent binding-release
+      mechanism and facilitation of client refolding; cache is abstract-only despite a PMCID.
   findings:
   - statement: 'Demonstrated HdeA facilitates refolding of acid-denatured proteins
       via pH-triggered binding and release cycle. ATP-independent mechanism: stable
@@ -542,6 +608,11 @@ references:
 - id: PMID:21892184
   title: A genetically incorporated crosslinker reveals chaperone cooperation in acid
     resistance.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly identifies physiological HdeA clients and
+      cooperation with DegP and SurA during recovery; cache is abstract-only.
   findings:
   - statement: Demonstrated cooperation between HdeA and other periplasmic chaperones
       (DegP, SurA) during acid stress recovery using in vivo crosslinking.
@@ -553,6 +624,11 @@ references:
 - id: PMID:30573682
   title: Structural basis and mechanism of the unfolding-induced activation of HdeA,
     a bacterial acid response chaperone.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cached abstract directly characterizes the activated disordered
+      conformation and client-binding patches; cache is abstract-only despite a PMCID.
   findings:
   - statement: NMR characterization of activated HdeA. Identified two hydrophobic
       patches essential for client interactions and three acid-sensitive structural
@@ -562,21 +638,43 @@ references:
       three acid-sensitive regions that act as structural locks in regulating the
       exposure of the two client-binding sites during the activation process, revealing
       a multistep activation mechanism
+- id: file:projects/UNFOLDED_PROTEIN_BINDING.md
+  title: Unfolded protein binding annotation review project
+  findings:
+  - statement: GO:0051082 is obsolete; in-situ holdases such as HdeA retain it only
+      as an interim descriptor with a general holdase chaperone activity NTR, because
+      GO:0140309 requires escort to a defined acceptor or location.
 core_functions:
-- description: Acid-activated periplasmic holdase chaperone that prevents irreversible
-    aggregation of acid-denatured periplasmic proteins during gastric transit (pH
-    < 3)
+- description: At pH below 3, HdeA converts from an inactive folded dimer to an
+    active disordered monomer that binds acid-denatured periplasmic clients and
+    prevents their irreversible aggregation in situ. GO:0051082 is used only as
+    an INTERIM MF representation pending the general holdase chaperone activity NTR;
+    carrier-specific GO:0140309 does not fit because no acceptor or delivery destination
+    is demonstrated.
   molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0051082
+    label: unfolded protein binding
   directly_involved_in:
   - id: GO:1990451
     label: cellular stress response to acidic pH
+  - id: GO:0050821
+    label: protein stabilization
   locations:
   - id: GO:0030288
     label: outer membrane-bounded periplasmic space
+  supported_by:
+  - reference_id: PMID:15911614
+    supporting_text: our data indicate that HdeA exposes hydrophobic surfaces that
+      appear to be involved in the binding of denatured substrate proteins at extremely
+      low pH values
+  - reference_id: PMID:10623550
+    supporting_text: Functional studies demonstrate that HDEA is activated by a
+      dimer-to-monomer transition at acidic pH, leading to suppression of aggregation
+      by acid-denatured proteins.
 - description: Facilitates refolding of acid-denatured periplasmic proteins upon return
-    to neutral pH via slow ATP-independent substrate release
+    to neutral pH via a single slow ATP-independent substrate binding-release cycle;
+    this is chaperone assistance in the refolding process, not active catalysis of
+    folding chemistry.
   molecular_function:
     id: GO:0044183
     label: protein folding chaperone
@@ -586,3 +684,45 @@ core_functions:
   locations:
   - id: GO:0030288
     label: outer membrane-bounded periplasmic space
+  supported_by:
+  - reference_id: PMID:20080625
+    supporting_text: This provides a straightforward and ATP-independent mechanism
+      that allows HdeA to facilitate protein refolding.
+  - reference_id: PMID:20080625
+    supporting_text: Unlike previously characterized chaperones, HdeA appears to
+      facilitate protein folding by using a single substrate binding-release cycle.
+proposed_new_terms:
+- proposed_name: holdase chaperone activity
+  proposed_definition: Binding to an unfolded or misfolded protein to prevent its
+    aggregation without actively catalyzing refolding. The holdase maintains the client
+    protein in a soluble, folding-competent state.
+  justification: HdeA directly binds acid-denatured periplasmic clients and prevents
+    their aggregation in situ. Obsolete GO:0051082 captures binding only, GO:0044183
+    describes assistance with folding, and carrier-specific GO:0140309 requires escort
+    to an acceptor or location not demonstrated for HdeA.
+  proposed_parent:
+    id: GO:0003674
+    label: molecular_function
+  supported_by:
+  - reference_id: PMID:10623550
+    supporting_text: Functional studies demonstrate that HDEA is activated by a
+      dimer-to-monomer transition at acidic pH, leading to suppression of aggregation
+      by acid-denatured proteins.
+  - reference_id: PMID:15911614
+    supporting_text: our data indicate that HdeA exposes hydrophobic surfaces that
+      appear to be involved in the binding of denatured substrate proteins at extremely
+      low pH values
+suggested_questions:
+- question: Which structural or kinetic features determine whether an acid-denatured
+    periplasmic client is captured by HdeA, HdeB, or both?
+- question: How do DegP and SurA participate after HdeA releases clients during neutralization,
+    and does any physical handoff occur despite the absence of an established carrier endpoint?
+suggested_experiments:
+- experiment_type: client-release kinetics
+  description: Measure HdeA-client binding, release, aggregation, and refolding during
+    controlled acidification and neutralization to distinguish spontaneous client refolding
+    from downstream assistance by DegP or SurA.
+- experiment_type: in vivo client-trapping proteomics
+  description: Compare wild-type HdeA with substrate-binding and release-defective variants
+    using periplasmic crosslinking proteomics across acid stress and recovery to define
+    direct clients and temporal chaperone cooperation.

--- a/genes/ECOLI/HdeA/HdeA-notes.md
+++ b/genes/ECOLI/HdeA/HdeA-notes.md
@@ -1,0 +1,27 @@
+# HdeA qualifier-aware annotation re-review — 2026-08-29
+
+## Coverage and provenance
+
+- Reconciled all 14 current physical GOA signatures exactly once: 6 `enables`, 4 `located_in`, 3 `involved_in`, and 1 `acts_upstream_of_or_within`.
+- Evidence distribution is 4 IEA, 5 IDA, 2 EXP, 1 IPI, 1 IMP, and 1 RCA, totaling 14 physical rows. There are no IBA rows and therefore no PTN/WITH-FROM propagation claim to audit.
+- All six GOA PMID sources are abstract-only in the repository cache. Experimental rows were retained or refined only where their cached abstracts directly support the interpretation; none was removed for lack of full text.
+
+## Holdase and ontology decision
+
+HdeA is an ATP-independent, acid-activated in-situ holdase. At neutral pH it is an inactive folded dimer; below pH 3 it becomes a disordered client-binding monomer. [PMID:15911614 “it possesses an ordered conformation that is unable to bind denatured substrate proteins under normal physiological conditions (i.e. at neutral pH) and transforms into a globally disordered conformation that is able to bind substrate proteins under stress conditions (i.e. at a pH below 3)”]
+
+No cached study demonstrates escort to a defined acceptor molecule or destination. HdeA binds clients within the periplasm, prevents aggregation, then releases them when pH is neutralized. Therefore carrier-specific GO:0140309 does not fit. The physical GO:0051082 IDA row is retained as an interim annotation but `MODIFY` now points machine-readably to `NTR` holdase chaperone activity, following the CRYAA/project convention. [file:projects/UNFOLDED_PROTEIN_BINDING.md]
+
+GO:0050821 protein stabilization is added as a NEW BP because aggregation suppression is direct: “Functional studies demonstrate that HDEA is activated by a dimer-to-monomer transition at acidic pH, leading to suppression of aggregation by acid-denatured proteins.” [PMID:10623550]
+
+## Refolding decision
+
+GO:0042026 protein refolding is retained as the replacement for the broad physical GO:0006457 protein folding row. The BP does not imply that HdeA catalyzes folding chemistry. PMID:20080625 directly states that HdeA “is capable of independently facilitating the refolding of acid-denatured proteins” and explains that slow release keeps aggregation-sensitive intermediates below their aggregation threshold. This supports involvement in refolding through an environmentally regulated binding-release cycle.
+
+The three experimental GO:0044183 protein folding chaperone rows are retained. Although HdeA is mechanistically a holdase, the direct evidence shows that its binding-release cycle assists the folding process. The core-function prose now separates this refolding assistance from the primary in-situ aggregation-prevention activity.
+
+## Other annotation decisions
+
+- GO:0042802 identical protein binding remains `MARK_AS_OVER_ANNOTATED` because the specific physical GO:0042803 homodimerization activity is present and experimentally supported.
+- Broad and specific periplasm/local acid-response rows remain accepted; their exact GOA qualifiers are now explicit in YAML.
+- The standalone description remains biological and project-independent, covering compartment, pH-dependent activation, aggregation prevention, controlled release, and cooperation with HdeB/DegP/SurA.


### PR DESCRIPTION
## Summary
- complete qualifier-aware review of all 14 physical HdeA GOA rows
- replace obsolete GO:0051082 machine-readably with the general holdase NTR while retaining the physical row as interim
- reject carrier-specific GO:0140309 because no acceptor or destination is demonstrated
- distinguish passive pH-triggered refolding assistance from active foldase catalysis
- add evidence-backed GO:0050821 protein stabilization and a provenance notes journal

## Decisions
- physical rows: 11 ACCEPT, 2 MODIFY, 1 MARK_AS_OVER_ANNOTATED
- author proposal: 1 NEW
- no IBA/PTN, PENDING, UNDECIDED, REMOVE, or GOA signature mismatch

## Validation
- `just validate ECOLI HdeA` (passes; one expected interim GO:0051082 core warning)
- `just validate-goa ECOLI HdeA`
- `just render ECOLI HdeA`
- `just deploy-browser`
- `git diff --check`