### PR TITLE
Clarify HdeA review evidence wording

### DIFF
--- a/genes/ECOLI/HdeA/HdeA-ai-review.html
+++ b/genes/ECOLI/HdeA/HdeA-ai-review.html
@@ -1334,7 +1334,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> HdeA does not actively catalyze protein folding in the conventional sense (it is ATP-independent and lacks an ATP-driven foldase cycle). Its primary function is preventing aggregation of acid-denatured proteins (holdase activity). While PMID:20080625 showed it facilitates refolding upon pH neutralization, this is achieved through passive slow release of substrates rather than active folding assistance. The BP term &#34;protein folding&#34; overstates HdeA&#39;s role. A more appropriate term is GO:0042026 protein refolding: HdeA&#39;s pH-triggered slow-release cycle directly facilitates refolding while keeping aggregation-sensitive intermediates below their aggregation threshold. This is a process-level role, not a claim that HdeA catalyzes folding chemistry.
+                            <strong>Reason:</strong> HdeA does not actively catalyze protein folding in the conventional sense (it is ATP-independent and lacks an ATP-driven foldase cycle). Its primary function is preventing aggregation of acid-denatured proteins (holdase activity). While PMID:20080625 showed it facilitates refolding upon pH neutralization, this is achieved through passive slow release of substrates rather than active folding assistance. The BP term &#34;protein folding&#34; is too general and uninformative about the demonstrated refolding mechanism. A more appropriate term is GO:0042026 protein refolding: HdeA&#39;s pH-triggered slow-release cycle directly facilitates refolding while keeping aggregation-sensitive intermediates below their aggregation threshold. This is a process-level role, not a claim that HdeA catalyzes folding chemistry.
                         </div>
 
 
@@ -3432,6 +3432,11 @@ this with annotations you find in gene/protein databases, but these can be outda
 <li>Broad and specific periplasm/local acid-response rows remain accepted; their exact GOA qualifiers are now explicit in YAML.</li>
 <li>The standalone description remains biological and project-independent, covering compartment, pH-dependent activation, aggregation prevention, controlled release, and cooperation with HdeB/DegP/SurA.</li>
 </ul>
+<h2 id="pr-2740-follow-up-2026-08-29">PR #2740 follow-up — 2026-08-29</h2>
+<ul>
+<li>Revised the GO:0006457 <code>MODIFY</code> rationale to describe the parent term as too general and uninformative about HdeA's demonstrated pH-triggered refolding mechanism, while retaining GO:0042026 and the distinction between process involvement and folding catalysis.</li>
+<li>Narrowed the PMID:9298646 and PMID:9731767 reference-review notes to claims visible in their abstract-only caches. <code>correctness: VERIFIED</code> remains appropriate for verified citation identity and the explicitly available abstract claims; it does not assert verification of inaccessible full-text assay details.</li>
+</ul>
             </div>
         </details>
 
@@ -3598,8 +3603,9 @@ existing_annotations:
       preventing aggregation of acid-denatured proteins (holdase activity). While
       PMID:20080625 showed it facilitates refolding upon pH neutralization, this is
       achieved through passive slow release of substrates rather than active folding
-      assistance. The BP term &#34;protein folding&#34; overstates HdeA&#39;s role. A more appropriate
-      term is GO:0042026 protein refolding: HdeA&#39;s pH-triggered slow-release cycle
+      assistance. The BP term &#34;protein folding&#34; is too general and uninformative
+      about the demonstrated refolding mechanism. A more appropriate term is GO:0042026
+      protein refolding: HdeA&#39;s pH-triggered slow-release cycle
       directly facilitates refolding while keeping aggregation-sensitive intermediates
       below their aggregation threshold. This is a process-level role, not a claim
       that HdeA catalyzes folding chemistry.
@@ -3951,8 +3957,11 @@ references:
   reference_review:
     relevance: HIGH
     correctness: VERIFIED
-    review_notes: Cached abstract and UniProt citation metadata support the experimental
-      proteomic identification and periplasmic fractionation context; cache is abstract-only.
+    review_notes: The cached abstract verifies the citation and reports 2-DE/Edman
+      proteomic identification of HdeA, enrichment by subcellular location, and a
+      covalent-homomultimer inference. It does not identify HdeA&#39;s specific cellular
+      location or verify its signal-peptide cleavage in the accessible text; the cache
+      is abstract-only.
   findings:
   - statement: Identified HdeA as a highly abundant periplasmic protein by 2-DE and
       Edman sequencing. Confirmed signal peptide cleavage and periplasmic localization.
@@ -3966,8 +3975,10 @@ references:
   reference_review:
     relevance: MEDIUM
     correctness: VERIFIED
-    review_notes: Cached abstract verifies the HdeA crystal-structure paper; it is
-      contextual corroboration rather than the primary annotation source.
+    review_notes: The abstract-only cached record verifies the citation identity and
+      title as an HdeA crystal-structure paper, but contains no result text with which
+      to verify resolution, disulfide, or other structural details. It is contextual
+      corroboration rather than a primary annotation source here.
   findings:
   - statement: First crystal structure of HdeA at 2.2 A resolution. Identified the
       intramolecular disulfide bond (Cys39-Cys87).

--- a/genes/ECOLI/HdeA/HdeA-ai-review.html
+++ b/genes/ECOLI/HdeA/HdeA-ai-review.html
@@ -952,12 +952,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA annotation based on InterPro domain matches (IPR024972, IPR036831). HdeA is well-established as a periplasmic protein with a cleavable signal peptide (residues 1-21) (PMID:8455549, PMID:9298646). This IEA is consistent with and subsumed by the IDA annotation to the same term from PMID:9298646.
+                            <strong>Summary:</strong> IEA annotation based on InterPro domain matches (IPR024972, IPR036831). HdeA is well-established as a periplasmic protein with a cleavable signal peptide (residues 1-21). UniProt attributes direct sequencing of residues 22-33 and the signal-peptide boundary to PMID:9298646; the cached abstract itself does not specify HdeA&#39;s compartment. This IEA is consistent with and subsumed by the IDA annotation to the same term from PMID:9298646.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Correct localization. HdeA is a secreted periplasmic protein. Multiple studies confirm periplasmic localization including direct protein sequencing from periplasmic fractions (PMID:9298646) and UniProt annotation with signal peptide (residues 1-21). The IEA is redundant with the IDA but not incorrect.
+                            <strong>Reason:</strong> Correct localization. HdeA is a secreted periplasmic protein. Multiple UniProt records a signal peptide at residues 1-21 and attributes direct sequencing of the mature N terminus (residues 22-33) to PMID:9298646. This establishes signal-peptide cleavage but is not, by itself, direct compartment evidence from the abstract. The IEA is redundant with the IDA but not incorrect.
                         </div>
 
 
@@ -976,6 +976,39 @@
                                 </span>
 
                                 <div class="support-text">enriched for proteins based on subcellular location and found several proteins in unexpected subcellular locations</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:ECOLI/HdeA/HdeA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PROTEIN SEQUENCE OF 22-33.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:ECOLI/HdeA/HdeA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SIGNAL          1..21</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:ECOLI/HdeA/HdeA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ECO:0000269|PubMed:9298646,</div>
 
                             </div>
 
@@ -1334,7 +1367,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> HdeA does not actively catalyze protein folding in the conventional sense (it is ATP-independent and lacks an ATP-driven foldase cycle). Its primary function is preventing aggregation of acid-denatured proteins (holdase activity). While PMID:20080625 showed it facilitates refolding upon pH neutralization, this is achieved through passive slow release of substrates rather than active folding assistance. The BP term &#34;protein folding&#34; is too general and uninformative about the demonstrated refolding mechanism. A more appropriate term is GO:0042026 protein refolding: HdeA&#39;s pH-triggered slow-release cycle directly facilitates refolding while keeping aggregation-sensitive intermediates below their aggregation threshold. This is a process-level role, not a claim that HdeA catalyzes folding chemistry.
+                            <strong>Reason:</strong> The BP term &#34;protein folding&#34; is too general and uninformative about the demonstrated mechanism. PMID:20080625 showed that HdeA facilitates refolding upon pH neutralization through slow substrate release. GO:0042026 protein refolding is therefore the more specific term: HdeA&#39;s pH-triggered release cycle directly facilitates refolding while keeping aggregation-sensitive intermediates below their aggregation threshold. This is a process-level role, not a claim that HdeA catalyzes folding chemistry.
                         </div>
 
 
@@ -1716,12 +1749,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation from EcoCyc based on the Link et al. (1997) proteomics study which identified HdeA by 2-DE and Edman sequencing from periplasmic fractions. The study confirmed that HdeA (then &#34;10K-S&#34;) is a periplasmic protein with a cleaved signal peptide.
+                            <strong>Summary:</strong> IDA annotation from EcoCyc based on the Link et al. (1997) proteomics study, whose cached abstract identifies HdeA by 2-DE and Edman sequencing but does not explicitly assign HdeA to a compartment. UniProt attributes direct sequencing of residues 22-33 and the signal peptide at residues 1-21 to this PMID, independently anchoring cleavage of the precursor.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Well-supported localization. The study used subcellular fractionation and protein identification by sequencing to confirm HdeA is in the periplasm. Additionally confirmed by UniProt signal peptide annotation (residues 1-21) and subsequent studies (PMID:17085547).
+                            <strong>Reason:</strong> The experimental localization annotation is consistent with HdeA&#39;s established periplasmic biology. The abstract-only cache describes subcellular-location enrichment but does not expose the HdeA-specific compartment result. UniProt attributes mature N-terminal sequencing (residues 22-33) and the signal peptide boundary (residues 1-21) to PMID:9298646, directly supporting precursor cleavage; subsequent work independently places HdeA in the periplasm (PMID:17085547).
                         </div>
 
 
@@ -1753,6 +1786,39 @@
                                 </span>
 
                                 <div class="support-text">We enriched for proteins based on subcellular location</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:ECOLI/HdeA/HdeA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PROTEIN SEQUENCE OF 22-33.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:ECOLI/HdeA/HdeA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SIGNAL          1..21</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:ECOLI/HdeA/HdeA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ECO:0000269|PubMed:9298646,</div>
 
                             </div>
 
@@ -2677,7 +2743,7 @@ removal/down-weighting of any enzymatic or transport interpretation.</div>
                 <ul class="findings-list">
 
                     <li class="finding-item">
-                        <div class="finding-statement">Identified HdeA as a highly abundant periplasmic protein by 2-DE and Edman sequencing. Confirmed signal peptide cleavage and periplasmic localization. Noted HdeA exists as a covalent homomultimer.</div>
+                        <div class="finding-statement">The cached abstract reports 2-DE/Edman identification of HdeA and suggests that HdeA exists as a covalent homomultimer. UniProt separately attributes sequencing of the mature N terminus and the SIGNAL 1..21 feature to this PMID; the abstract does not itself expose HdeA-specific compartment evidence.</div>
 
                         <div class="finding-text">"We identified several highly abundant proteins, YjbJ, YjbP, YggX, HdeA, and AhpC, which would not have been predicted from the genomic sequence alone ...Our data suggest that AhpC, CspC, and HdeA exist as covalent homomultimers"</div>
 
@@ -2704,7 +2770,7 @@ removal/down-weighting of any enzymatic or transport interpretation.</div>
                 <ul class="findings-list">
 
                     <li class="finding-item">
-                        <div class="finding-statement">First crystal structure of HdeA at 2.2 A resolution. Identified the intramolecular disulfide bond (Cys39-Cys87).</div>
+                        <div class="finding-statement">UniProt attributes 2.2-A X-ray crystallography and the intramolecular Cys39-Cys87 disulfide to PMID:9731767; these details are not present in the abstract-only publication cache.</div>
 
                     </li>
 
@@ -2894,6 +2960,52 @@ removal/down-weighting of any enzymatic or transport interpretation.</div>
                         <div class="finding-statement">NMR characterization of activated HdeA. Identified two hydrophobic patches essential for client interactions and three acid-sensitive structural locks regulating activation. Revealed multistep activation mechanism.</div>
 
                         <div class="finding-text">"the structure of activated HdeA becomes largely disordered and exposes two hydrophobic patches essential for client interactions...we identified three acid-sensitive regions that act as structural locks in regulating the exposure of the two client-binding sites during the activation process, revealing a multistep activation mechanism"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:ECOLI/HdeA/HdeA-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry for Escherichia coli HdeA (P0AES9)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt attributes direct sequencing of residues 22-33 and the SIGNAL 1..21 feature to PMID:9298646.</div>
+
+                        <div class="finding-text">"PROTEIN SEQUENCE OF 22-33."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The UniProt SIGNAL feature carries a direct experimental-evidence attribution to PMID:9298646.</div>
+
+                        <div class="finding-text">"ECO:0000269|PubMed:9298646,"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt attributes 2.2-A X-ray crystallography and the Cys39-Cys87 disulfide to PMID:9731767.</div>
+
+                        <div class="finding-text">"X-RAY CRYSTALLOGRAPHY (2.2 ANGSTROMS), AND DISULFIDE BOND."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The UniProt disulfide feature carries a direct experimental-evidence attribution to PMID:9731767.</div>
+
+                        <div class="finding-text">"ECO:0000269|PubMed:9731767&#34;"</div>
 
                     </li>
 
@@ -3437,6 +3549,12 @@ this with annotations you find in gene/protein databases, but these can be outda
 <li>Revised the GO:0006457 <code>MODIFY</code> rationale to describe the parent term as too general and uninformative about HdeA's demonstrated pH-triggered refolding mechanism, while retaining GO:0042026 and the distinction between process involvement and folding catalysis.</li>
 <li>Narrowed the PMID:9298646 and PMID:9731767 reference-review notes to claims visible in their abstract-only caches. <code>correctness: VERIFIED</code> remains appropriate for verified citation identity and the explicitly available abstract claims; it does not assert verification of inaccessible full-text assay details.</li>
 </ul>
+<h2 id="pr-2741-follow-up-2026-08-29">PR #2741 follow-up — 2026-08-29</h2>
+<ul>
+<li>Anchored the PMID:9298646 signal-peptide claim to the UniProt record's <code>PROTEIN SEQUENCE OF 22-33</code> attribution and <code>SIGNAL 1..21</code> feature, while keeping the abstract's limited subcellular-location wording separate and not treating it as HdeA-specific compartment proof.</li>
+<li>Recorded that the cached PMID:9731767 entry contains no result-bearing abstract, whereas UniProt explicitly attributes 2.2-A crystallography and the Cys39-Cys87 disulfide to that PMID.</li>
+<li>Simplified the GO:0006457 BP rationale to the specificity argument: the parent is too general, GO:0042026 captures the demonstrated neutralization-triggered refolding process, and this does not imply that HdeA catalyzes folding chemistry.</li>
+</ul>
             </div>
         </details>
 
@@ -3481,17 +3599,26 @@ existing_annotations:
   review:
     summary: IEA annotation based on InterPro domain matches (IPR024972, IPR036831).
       HdeA is well-established as a periplasmic protein with a cleavable signal peptide
-      (residues 1-21) (PMID:8455549, PMID:9298646). This IEA is consistent with and
-      subsumed by the IDA annotation to the same term from PMID:9298646.
+      (residues 1-21). UniProt attributes direct sequencing of residues 22-33 and
+      the signal-peptide boundary to PMID:9298646; the cached abstract itself does
+      not specify HdeA&#39;s compartment. This IEA is consistent with and subsumed by
+      the IDA annotation to the same term from PMID:9298646.
     action: ACCEPT
     reason: Correct localization. HdeA is a secreted periplasmic protein. Multiple
-      studies confirm periplasmic localization including direct protein sequencing
-      from periplasmic fractions (PMID:9298646) and UniProt annotation with signal
-      peptide (residues 1-21). The IEA is redundant with the IDA but not incorrect.
+      UniProt records a signal peptide at residues 1-21 and attributes direct sequencing
+      of the mature N terminus (residues 22-33) to PMID:9298646. This establishes
+      signal-peptide cleavage but is not, by itself, direct compartment evidence from
+      the abstract. The IEA is redundant with the IDA but not incorrect.
     supported_by:
     - reference_id: PMID:9298646
       supporting_text: enriched for proteins based on subcellular location and found
         several proteins in unexpected subcellular locations
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: PROTEIN SEQUENCE OF 22-33.
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: SIGNAL          1..21
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: ECO:0000269|PubMed:9298646,
 - term:
     id: GO:0042597
     label: periplasmic space
@@ -3598,14 +3725,10 @@ existing_annotations:
       foldase activity.
     action: MODIFY
     reason: &gt;-
-      HdeA does not actively catalyze protein folding in the conventional sense
-      (it is ATP-independent and lacks an ATP-driven foldase cycle). Its primary function is
-      preventing aggregation of acid-denatured proteins (holdase activity). While
-      PMID:20080625 showed it facilitates refolding upon pH neutralization, this is
-      achieved through passive slow release of substrates rather than active folding
-      assistance. The BP term &#34;protein folding&#34; is too general and uninformative
-      about the demonstrated refolding mechanism. A more appropriate term is GO:0042026
-      protein refolding: HdeA&#39;s pH-triggered slow-release cycle
+      The BP term &#34;protein folding&#34; is too general and uninformative about the
+      demonstrated mechanism. PMID:20080625 showed that HdeA facilitates refolding
+      upon pH neutralization through slow substrate release. GO:0042026 protein
+      refolding is therefore the more specific term: HdeA&#39;s pH-triggered release cycle
       directly facilitates refolding while keeping aggregation-sensitive intermediates
       below their aggregation threshold. This is a process-level role, not a claim
       that HdeA catalyzes folding chemistry.
@@ -3709,14 +3832,17 @@ existing_annotations:
   qualifier: located_in
   review:
     summary: IDA annotation from EcoCyc based on the Link et al. (1997) proteomics
-      study which identified HdeA by 2-DE and Edman sequencing from periplasmic fractions.
-      The study confirmed that HdeA (then &#34;10K-S&#34;) is a periplasmic protein with a
-      cleaved signal peptide.
+      study, whose cached abstract identifies HdeA by 2-DE and Edman sequencing but
+      does not explicitly assign HdeA to a compartment. UniProt attributes direct
+      sequencing of residues 22-33 and the signal peptide at residues 1-21 to this
+      PMID, independently anchoring cleavage of the precursor.
     action: ACCEPT
-    reason: Well-supported localization. The study used subcellular fractionation
-      and protein identification by sequencing to confirm HdeA is in the periplasm.
-      Additionally confirmed by UniProt signal peptide annotation (residues 1-21)
-      and subsequent studies (PMID:17085547).
+    reason: The experimental localization annotation is consistent with HdeA&#39;s
+      established periplasmic biology. The abstract-only cache describes subcellular-location
+      enrichment but does not expose the HdeA-specific compartment result. UniProt
+      attributes mature N-terminal sequencing (residues 22-33) and the signal peptide
+      boundary (residues 1-21) to PMID:9298646, directly supporting precursor cleavage;
+      subsequent work independently places HdeA in the periplasm (PMID:17085547).
     supported_by:
     - reference_id: PMID:9298646
       supporting_text: We identified several highly abundant proteins, YjbJ, YjbP,
@@ -3724,6 +3850,12 @@ existing_annotations:
         sequence alone
     - reference_id: PMID:9298646
       supporting_text: We enriched for proteins based on subcellular location
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: PROTEIN SEQUENCE OF 22-33.
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: SIGNAL          1..21
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: ECO:0000269|PubMed:9298646,
     - reference_id: file:ECOLI/HdeA/HdeA-deep-research-falcon.md
       supporting_text: |-
         HdeA operates in the **periplasm**, where it interacts with periplasmic proteins that are prone to acid denaturation/aggregation when external pH drops.
@@ -3960,12 +4092,15 @@ references:
     review_notes: The cached abstract verifies the citation and reports 2-DE/Edman
       proteomic identification of HdeA, enrichment by subcellular location, and a
       covalent-homomultimer inference. It does not identify HdeA&#39;s specific cellular
-      location or verify its signal-peptide cleavage in the accessible text; the cache
-      is abstract-only.
+      location or signal-peptide cleavage; the cache is abstract-only. Separately,
+      the UniProt record attributes protein sequencing of residues 22-33 and its
+      SIGNAL 1..21 feature to PMID:9298646, supporting cleavage without treating the
+      abstract as direct compartment evidence.
   findings:
-  - statement: Identified HdeA as a highly abundant periplasmic protein by 2-DE and
-      Edman sequencing. Confirmed signal peptide cleavage and periplasmic localization.
-      Noted HdeA exists as a covalent homomultimer.
+  - statement: The cached abstract reports 2-DE/Edman identification of HdeA and
+      suggests that HdeA exists as a covalent homomultimer. UniProt separately attributes
+      sequencing of the mature N terminus and the SIGNAL 1..21 feature to this PMID;
+      the abstract does not itself expose HdeA-specific compartment evidence.
     supporting_text: We identified several highly abundant proteins, YjbJ, YjbP, YggX,
       HdeA, and AhpC, which would not have been predicted from the genomic sequence
       alone ...Our data suggest that AhpC, CspC, and HdeA exist as covalent homomultimers
@@ -3977,11 +4112,13 @@ references:
     correctness: VERIFIED
     review_notes: The abstract-only cached record verifies the citation identity and
       title as an HdeA crystal-structure paper, but contains no result text with which
-      to verify resolution, disulfide, or other structural details. It is contextual
-      corroboration rather than a primary annotation source here.
+      to verify resolution, disulfide, or other structural details. Separately, UniProt
+      attributes 2.2-A X-ray crystallography and the Cys39-Cys87 disulfide to PMID:9731767.
+      It is contextual corroboration rather than a primary annotation source here.
   findings:
-  - statement: First crystal structure of HdeA at 2.2 A resolution. Identified the
-      intramolecular disulfide bond (Cys39-Cys87).
+  - statement: UniProt attributes 2.2-A X-ray crystallography and the intramolecular
+      Cys39-Cys87 disulfide to PMID:9731767; these details are not present in the
+      abstract-only publication cache.
     full_text_unavailable: true
 - id: PMID:10623550
   title: HDEA, a periplasmic protein that supports acid resistance in pathogenic enteric
@@ -4096,6 +4233,21 @@ references:
       three acid-sensitive regions that act as structural locks in regulating the
       exposure of the two client-binding sites during the activation process, revealing
       a multistep activation mechanism
+- id: file:ECOLI/HdeA/HdeA-uniprot.txt
+  title: UniProtKB entry for Escherichia coli HdeA (P0AES9)
+  findings:
+  - statement: UniProt attributes direct sequencing of residues 22-33 and the SIGNAL
+      1..21 feature to PMID:9298646.
+    supporting_text: PROTEIN SEQUENCE OF 22-33.
+  - statement: The UniProt SIGNAL feature carries a direct experimental-evidence
+      attribution to PMID:9298646.
+    supporting_text: ECO:0000269|PubMed:9298646,
+  - statement: UniProt attributes 2.2-A X-ray crystallography and the Cys39-Cys87
+      disulfide to PMID:9731767.
+    supporting_text: X-RAY CRYSTALLOGRAPHY (2.2 ANGSTROMS), AND DISULFIDE BOND.
+  - statement: The UniProt disulfide feature carries a direct experimental-evidence
+      attribution to PMID:9731767.
+    supporting_text: ECO:0000269|PubMed:9731767&#34;
 - id: file:projects/UNFOLDED_PROTEIN_BINDING.md
   title: Unfolded protein binding annotation review project
   findings:

--- a/genes/ECOLI/HdeA/HdeA-ai-review.html
+++ b/genes/ECOLI/HdeA/HdeA-ai-review.html
@@ -957,7 +957,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Correct localization. HdeA is a secreted periplasmic protein. Multiple UniProt records a signal peptide at residues 1-21 and attributes direct sequencing of the mature N terminus (residues 22-33) to PMID:9298646. This establishes signal-peptide cleavage but is not, by itself, direct compartment evidence from the abstract. The IEA is redundant with the IDA but not incorrect.
+                            <strong>Reason:</strong> Correct localization. HdeA is a secreted periplasmic protein. UniProt records a signal peptide at residues 1-21 and attributes direct sequencing of the mature N terminus (residues 22-33) to PMID:9298646. This establishes signal-peptide cleavage but is not, by itself, direct compartment evidence from the abstract. The IEA is redundant with the IDA but not incorrect.
                         </div>
 
 
@@ -3604,8 +3604,8 @@ existing_annotations:
       not specify HdeA&#39;s compartment. This IEA is consistent with and subsumed by
       the IDA annotation to the same term from PMID:9298646.
     action: ACCEPT
-    reason: Correct localization. HdeA is a secreted periplasmic protein. Multiple
-      UniProt records a signal peptide at residues 1-21 and attributes direct sequencing
+    reason: Correct localization. HdeA is a secreted periplasmic protein. UniProt
+      records a signal peptide at residues 1-21 and attributes direct sequencing
       of the mature N terminus (residues 22-33) to PMID:9298646. This establishes
       signal-peptide cleavage but is not, by itself, direct compartment evidence from
       the abstract. The IEA is redundant with the IDA but not incorrect.

--- a/genes/ECOLI/HdeA/HdeA-ai-review.yaml
+++ b/genes/ECOLI/HdeA/HdeA-ai-review.yaml
@@ -29,17 +29,26 @@ existing_annotations:
   review:
     summary: IEA annotation based on InterPro domain matches (IPR024972, IPR036831).
       HdeA is well-established as a periplasmic protein with a cleavable signal peptide
-      (residues 1-21) (PMID:8455549, PMID:9298646). This IEA is consistent with and
-      subsumed by the IDA annotation to the same term from PMID:9298646.
+      (residues 1-21). UniProt attributes direct sequencing of residues 22-33 and
+      the signal-peptide boundary to PMID:9298646; the cached abstract itself does
+      not specify HdeA's compartment. This IEA is consistent with and subsumed by
+      the IDA annotation to the same term from PMID:9298646.
     action: ACCEPT
     reason: Correct localization. HdeA is a secreted periplasmic protein. Multiple
-      studies confirm periplasmic localization including direct protein sequencing
-      from periplasmic fractions (PMID:9298646) and UniProt annotation with signal
-      peptide (residues 1-21). The IEA is redundant with the IDA but not incorrect.
+      UniProt records a signal peptide at residues 1-21 and attributes direct sequencing
+      of the mature N terminus (residues 22-33) to PMID:9298646. This establishes
+      signal-peptide cleavage but is not, by itself, direct compartment evidence from
+      the abstract. The IEA is redundant with the IDA but not incorrect.
     supported_by:
     - reference_id: PMID:9298646
       supporting_text: enriched for proteins based on subcellular location and found
         several proteins in unexpected subcellular locations
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: PROTEIN SEQUENCE OF 22-33.
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: SIGNAL          1..21
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: ECO:0000269|PubMed:9298646,
 - term:
     id: GO:0042597
     label: periplasmic space
@@ -146,14 +155,10 @@ existing_annotations:
       foldase activity.
     action: MODIFY
     reason: >-
-      HdeA does not actively catalyze protein folding in the conventional sense
-      (it is ATP-independent and lacks an ATP-driven foldase cycle). Its primary function is
-      preventing aggregation of acid-denatured proteins (holdase activity). While
-      PMID:20080625 showed it facilitates refolding upon pH neutralization, this is
-      achieved through passive slow release of substrates rather than active folding
-      assistance. The BP term "protein folding" is too general and uninformative
-      about the demonstrated refolding mechanism. A more appropriate term is GO:0042026
-      protein refolding: HdeA's pH-triggered slow-release cycle
+      The BP term "protein folding" is too general and uninformative about the
+      demonstrated mechanism. PMID:20080625 showed that HdeA facilitates refolding
+      upon pH neutralization through slow substrate release. GO:0042026 protein
+      refolding is therefore the more specific term: HdeA's pH-triggered release cycle
       directly facilitates refolding while keeping aggregation-sensitive intermediates
       below their aggregation threshold. This is a process-level role, not a claim
       that HdeA catalyzes folding chemistry.
@@ -257,14 +262,17 @@ existing_annotations:
   qualifier: located_in
   review:
     summary: IDA annotation from EcoCyc based on the Link et al. (1997) proteomics
-      study which identified HdeA by 2-DE and Edman sequencing from periplasmic fractions.
-      The study confirmed that HdeA (then "10K-S") is a periplasmic protein with a
-      cleaved signal peptide.
+      study, whose cached abstract identifies HdeA by 2-DE and Edman sequencing but
+      does not explicitly assign HdeA to a compartment. UniProt attributes direct
+      sequencing of residues 22-33 and the signal peptide at residues 1-21 to this
+      PMID, independently anchoring cleavage of the precursor.
     action: ACCEPT
-    reason: Well-supported localization. The study used subcellular fractionation
-      and protein identification by sequencing to confirm HdeA is in the periplasm.
-      Additionally confirmed by UniProt signal peptide annotation (residues 1-21)
-      and subsequent studies (PMID:17085547).
+    reason: The experimental localization annotation is consistent with HdeA's
+      established periplasmic biology. The abstract-only cache describes subcellular-location
+      enrichment but does not expose the HdeA-specific compartment result. UniProt
+      attributes mature N-terminal sequencing (residues 22-33) and the signal peptide
+      boundary (residues 1-21) to PMID:9298646, directly supporting precursor cleavage;
+      subsequent work independently places HdeA in the periplasm (PMID:17085547).
     supported_by:
     - reference_id: PMID:9298646
       supporting_text: We identified several highly abundant proteins, YjbJ, YjbP,
@@ -272,6 +280,12 @@ existing_annotations:
         sequence alone
     - reference_id: PMID:9298646
       supporting_text: We enriched for proteins based on subcellular location
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: PROTEIN SEQUENCE OF 22-33.
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: SIGNAL          1..21
+    - reference_id: file:ECOLI/HdeA/HdeA-uniprot.txt
+      supporting_text: ECO:0000269|PubMed:9298646,
     - reference_id: file:ECOLI/HdeA/HdeA-deep-research-falcon.md
       supporting_text: |-
         HdeA operates in the **periplasm**, where it interacts with periplasmic proteins that are prone to acid denaturation/aggregation when external pH drops.
@@ -508,12 +522,15 @@ references:
     review_notes: The cached abstract verifies the citation and reports 2-DE/Edman
       proteomic identification of HdeA, enrichment by subcellular location, and a
       covalent-homomultimer inference. It does not identify HdeA's specific cellular
-      location or verify its signal-peptide cleavage in the accessible text; the cache
-      is abstract-only.
+      location or signal-peptide cleavage; the cache is abstract-only. Separately,
+      the UniProt record attributes protein sequencing of residues 22-33 and its
+      SIGNAL 1..21 feature to PMID:9298646, supporting cleavage without treating the
+      abstract as direct compartment evidence.
   findings:
-  - statement: Identified HdeA as a highly abundant periplasmic protein by 2-DE and
-      Edman sequencing. Confirmed signal peptide cleavage and periplasmic localization.
-      Noted HdeA exists as a covalent homomultimer.
+  - statement: The cached abstract reports 2-DE/Edman identification of HdeA and
+      suggests that HdeA exists as a covalent homomultimer. UniProt separately attributes
+      sequencing of the mature N terminus and the SIGNAL 1..21 feature to this PMID;
+      the abstract does not itself expose HdeA-specific compartment evidence.
     supporting_text: We identified several highly abundant proteins, YjbJ, YjbP, YggX,
       HdeA, and AhpC, which would not have been predicted from the genomic sequence
       alone ...Our data suggest that AhpC, CspC, and HdeA exist as covalent homomultimers
@@ -525,11 +542,13 @@ references:
     correctness: VERIFIED
     review_notes: The abstract-only cached record verifies the citation identity and
       title as an HdeA crystal-structure paper, but contains no result text with which
-      to verify resolution, disulfide, or other structural details. It is contextual
-      corroboration rather than a primary annotation source here.
+      to verify resolution, disulfide, or other structural details. Separately, UniProt
+      attributes 2.2-A X-ray crystallography and the Cys39-Cys87 disulfide to PMID:9731767.
+      It is contextual corroboration rather than a primary annotation source here.
   findings:
-  - statement: First crystal structure of HdeA at 2.2 A resolution. Identified the
-      intramolecular disulfide bond (Cys39-Cys87).
+  - statement: UniProt attributes 2.2-A X-ray crystallography and the intramolecular
+      Cys39-Cys87 disulfide to PMID:9731767; these details are not present in the
+      abstract-only publication cache.
     full_text_unavailable: true
 - id: PMID:10623550
   title: HDEA, a periplasmic protein that supports acid resistance in pathogenic enteric
@@ -644,6 +663,21 @@ references:
       three acid-sensitive regions that act as structural locks in regulating the
       exposure of the two client-binding sites during the activation process, revealing
       a multistep activation mechanism
+- id: file:ECOLI/HdeA/HdeA-uniprot.txt
+  title: UniProtKB entry for Escherichia coli HdeA (P0AES9)
+  findings:
+  - statement: UniProt attributes direct sequencing of residues 22-33 and the SIGNAL
+      1..21 feature to PMID:9298646.
+    supporting_text: PROTEIN SEQUENCE OF 22-33.
+  - statement: The UniProt SIGNAL feature carries a direct experimental-evidence
+      attribution to PMID:9298646.
+    supporting_text: ECO:0000269|PubMed:9298646,
+  - statement: UniProt attributes 2.2-A X-ray crystallography and the Cys39-Cys87
+      disulfide to PMID:9731767.
+    supporting_text: X-RAY CRYSTALLOGRAPHY (2.2 ANGSTROMS), AND DISULFIDE BOND.
+  - statement: The UniProt disulfide feature carries a direct experimental-evidence
+      attribution to PMID:9731767.
+    supporting_text: ECO:0000269|PubMed:9731767"
 - id: file:projects/UNFOLDED_PROTEIN_BINDING.md
   title: Unfolded protein binding annotation review project
   findings:

--- a/genes/ECOLI/HdeA/HdeA-ai-review.yaml
+++ b/genes/ECOLI/HdeA/HdeA-ai-review.yaml
@@ -151,8 +151,9 @@ existing_annotations:
       preventing aggregation of acid-denatured proteins (holdase activity). While
       PMID:20080625 showed it facilitates refolding upon pH neutralization, this is
       achieved through passive slow release of substrates rather than active folding
-      assistance. The BP term "protein folding" overstates HdeA's role. A more appropriate
-      term is GO:0042026 protein refolding: HdeA's pH-triggered slow-release cycle
+      assistance. The BP term "protein folding" is too general and uninformative
+      about the demonstrated refolding mechanism. A more appropriate term is GO:0042026
+      protein refolding: HdeA's pH-triggered slow-release cycle
       directly facilitates refolding while keeping aggregation-sensitive intermediates
       below their aggregation threshold. This is a process-level role, not a claim
       that HdeA catalyzes folding chemistry.
@@ -504,8 +505,11 @@ references:
   reference_review:
     relevance: HIGH
     correctness: VERIFIED
-    review_notes: Cached abstract and UniProt citation metadata support the experimental
-      proteomic identification and periplasmic fractionation context; cache is abstract-only.
+    review_notes: The cached abstract verifies the citation and reports 2-DE/Edman
+      proteomic identification of HdeA, enrichment by subcellular location, and a
+      covalent-homomultimer inference. It does not identify HdeA's specific cellular
+      location or verify its signal-peptide cleavage in the accessible text; the cache
+      is abstract-only.
   findings:
   - statement: Identified HdeA as a highly abundant periplasmic protein by 2-DE and
       Edman sequencing. Confirmed signal peptide cleavage and periplasmic localization.
@@ -519,8 +523,10 @@ references:
   reference_review:
     relevance: MEDIUM
     correctness: VERIFIED
-    review_notes: Cached abstract verifies the HdeA crystal-structure paper; it is
-      contextual corroboration rather than the primary annotation source.
+    review_notes: The abstract-only cached record verifies the citation identity and
+      title as an HdeA crystal-structure paper, but contains no result text with which
+      to verify resolution, disulfide, or other structural details. It is contextual
+      corroboration rather than a primary annotation source here.
   findings:
   - statement: First crystal structure of HdeA at 2.2 A resolution. Identified the
       intramolecular disulfide bond (Cys39-Cys87).

--- a/genes/ECOLI/HdeA/HdeA-ai-review.yaml
+++ b/genes/ECOLI/HdeA/HdeA-ai-review.yaml
@@ -34,8 +34,8 @@ existing_annotations:
       not specify HdeA's compartment. This IEA is consistent with and subsumed by
       the IDA annotation to the same term from PMID:9298646.
     action: ACCEPT
-    reason: Correct localization. HdeA is a secreted periplasmic protein. Multiple
-      UniProt records a signal peptide at residues 1-21 and attributes direct sequencing
+    reason: Correct localization. HdeA is a secreted periplasmic protein. UniProt
+      records a signal peptide at residues 1-21 and attributes direct sequencing
       of the mature N terminus (residues 22-33) to PMID:9298646. This establishes
       signal-peptide cleavage but is not, by itself, direct compartment evidence from
       the abstract. The IEA is redundant with the IDA but not incorrect.

--- a/genes/ECOLI/HdeA/HdeA-notes.md
+++ b/genes/ECOLI/HdeA/HdeA-notes.md
@@ -25,3 +25,8 @@ The three experimental GO:0044183 protein folding chaperone rows are retained. A
 - GO:0042802 identical protein binding remains `MARK_AS_OVER_ANNOTATED` because the specific physical GO:0042803 homodimerization activity is present and experimentally supported.
 - Broad and specific periplasm/local acid-response rows remain accepted; their exact GOA qualifiers are now explicit in YAML.
 - The standalone description remains biological and project-independent, covering compartment, pH-dependent activation, aggregation prevention, controlled release, and cooperation with HdeB/DegP/SurA.
+
+## PR #2740 follow-up — 2026-08-29
+
+- Revised the GO:0006457 `MODIFY` rationale to describe the parent term as too general and uninformative about HdeA's demonstrated pH-triggered refolding mechanism, while retaining GO:0042026 and the distinction between process involvement and folding catalysis.
+- Narrowed the PMID:9298646 and PMID:9731767 reference-review notes to claims visible in their abstract-only caches. `correctness: VERIFIED` remains appropriate for verified citation identity and the explicitly available abstract claims; it does not assert verification of inaccessible full-text assay details.

--- a/genes/ECOLI/HdeA/HdeA-notes.md
+++ b/genes/ECOLI/HdeA/HdeA-notes.md
@@ -30,3 +30,9 @@ The three experimental GO:0044183 protein folding chaperone rows are retained. A
 
 - Revised the GO:0006457 `MODIFY` rationale to describe the parent term as too general and uninformative about HdeA's demonstrated pH-triggered refolding mechanism, while retaining GO:0042026 and the distinction between process involvement and folding catalysis.
 - Narrowed the PMID:9298646 and PMID:9731767 reference-review notes to claims visible in their abstract-only caches. `correctness: VERIFIED` remains appropriate for verified citation identity and the explicitly available abstract claims; it does not assert verification of inaccessible full-text assay details.
+
+## PR #2741 follow-up — 2026-08-29
+
+- Anchored the PMID:9298646 signal-peptide claim to the UniProt record's `PROTEIN SEQUENCE OF 22-33` attribution and `SIGNAL 1..21` feature, while keeping the abstract's limited subcellular-location wording separate and not treating it as HdeA-specific compartment proof.
+- Recorded that the cached PMID:9731767 entry contains no result-bearing abstract, whereas UniProt explicitly attributes 2.2-A crystallography and the Cys39-Cys87 disulfide to that PMID.
+- Simplified the GO:0006457 BP rationale to the specificity argument: the parent is too general, GO:0042026 captures the demonstrated neutralization-triggered refolding process, and this does not imply that HdeA catalyzes folding chemistry.


### PR DESCRIPTION
## Summary
- describe GO:0006457 as too general rather than overstating HdeA when replacing it with the more specific GO:0042026
- limit PMID:9298646 and PMID:9731767 reference-review notes to what their abstract-only caches actually verify
- append follow-up provenance to the HdeA notes journal

## Validation
- `just validate ECOLI HdeA` (passes; expected interim GO:0051082 warning)
- `just validate-goa ECOLI HdeA`
- `just render ECOLI HdeA`
- `just deploy-browser` (no payload change)
- `git diff --check`

This addresses non-blocking evidence/prose findings from merged PR #2740 in a separate one-gene follow-up.