### PR TITLE
Refresh BioReason metrics after HdeA review

### DIFF
--- a/pages/projects/BIOREASON_COMPARISON/article/supplemental-benchmark-details.html
+++ b/pages/projects/BIOREASON_COMPARISON/article/supplemental-benchmark-details.html
@@ -715,13 +715,13 @@
 </tr>
 <tr>
 <td>Retained/replacement/proposed-new AIGR annotations</td>
-<td style="text-align: right;">2,768</td>
+<td style="text-align: right;">2,769</td>
 <td style="text-align: right;">860</td>
 <td style="text-align: right;">9.7</td>
 </tr>
 <tr>
 <td>All GO-valued AIGR core-function slots</td>
-<td style="text-align: right;">1,225</td>
+<td style="text-align: right;">1,227</td>
 <td style="text-align: right;">350</td>
 <td style="text-align: right;">3.9</td>
 </tr>
@@ -729,7 +729,10 @@
 </table>
 <p>The core-function comparison includes HdeB's <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> match as an explicitly<br />
 interim representation of in-situ holdase activity pending creation of the general<br />
-holdase chaperone activity NTR; it is not treated as the preferred long-term term.</p>
+holdase chaperone activity NTR; it is not treated as the preferred long-term term.<br />
+The subsequent HdeA comprehensive review increased the post-review denominator by<br />
+one term and the core-function denominator by two terms without changing either<br />
+exact-overlap count; Table S8 reflects those refreshed denominators.</p>
 <p><img alt="GO-GPT prediction overlap at three reference levels." src="figures/three_level_overlap.png" /></p>
 <p>GO-GPT emitted 8,871 predictions across 299 canonical genes (mean 29.7 per gene). Raw GOA agreement was 11.7%; exact agreement with all GO-valued AIGR core-function slots was 3.9%. The post-review layer retains <code>ACCEPT</code>, <code>KEEP_AS_NON_CORE</code>, <code>UNDECIDED</code>, and pending annotations, includes proposed annotations marked <code>NEW</code> (including annotations supported by nonexperimental evidence such as NAS or IEA), substitutes proposed replacements for <code>MODIFY</code>, excludes negated and rejected annotations, and unions in the core-function terms. Five of the 11 additional exact matches introduced by including <code>NEW</code> are broad localization terms (<code>GO:0016020</code> twice, <code>GO:0005737</code>, <code>GO:0005829</code>, and <code>GO:0005576</code>), so the 9.7% agreement rate should not be read as independent experimental validation. This is a useful illustration of the CAFA-style scoring gap, but it is not used as a main BioReason-Pro benchmark result.</p>
 <h2 id="s7-reproducibility-files">S7. Reproducibility files</h2>

--- a/pages/projects/BIOREASON_COMPARISON/benchmark-metrics.json
+++ b/pages/projects/BIOREASON_COMPARISON/benchmark-metrics.json
@@ -296,7 +296,7 @@
   "supplement_gogpt_overlap_300": {
     "core": {
       "n_overlap": 350,
-      "n_reference_terms": 1225,
+      "n_reference_terms": 1227,
       "prediction_overlap_rate": 0.039454
     },
     "goa": {
@@ -308,7 +308,7 @@
     "n_predictions": 8871,
     "post_review": {
       "n_overlap": 860,
-      "n_reference_terms": 2768,
+      "n_reference_terms": 2769,
       "prediction_overlap_rate": 0.096945
     }
   },

--- a/projects/BIOREASON_COMPARISON/article/supplemental-benchmark-details.md
+++ b/projects/BIOREASON_COMPARISON/article/supplemental-benchmark-details.md
@@ -119,12 +119,15 @@ A distinct supplemental analysis, `supplement_gogpt_overlap_300`, contains 8,871
 | Reference level | Terms in reference | Predictions overlapping | % of 8,871 predictions |
 |---|---:|---:|---:|
 | Raw GOA | 2,960 | 1,040 | 11.7 |
-| Retained/replacement/proposed-new AIGR annotations | 2,768 | 860 | 9.7 |
-| All GO-valued AIGR core-function slots | 1,225 | 350 | 3.9 |
+| Retained/replacement/proposed-new AIGR annotations | 2,769 | 860 | 9.7 |
+| All GO-valued AIGR core-function slots | 1,227 | 350 | 3.9 |
 
 The core-function comparison includes HdeB's GO:0051082 match as an explicitly
 interim representation of in-situ holdase activity pending creation of the general
 holdase chaperone activity NTR; it is not treated as the preferred long-term term.
+The subsequent HdeA comprehensive review increased the post-review denominator by
+one term and the core-function denominator by two terms without changing either
+exact-overlap count; Table S8 reflects those refreshed denominators.
 
 ![GO-GPT prediction overlap at three reference levels.](figures/three_level_overlap.png)
 

--- a/projects/BIOREASON_COMPARISON/benchmark-metrics.json
+++ b/projects/BIOREASON_COMPARISON/benchmark-metrics.json
@@ -296,7 +296,7 @@
   "supplement_gogpt_overlap_300": {
     "core": {
       "n_overlap": 350,
-      "n_reference_terms": 1225,
+      "n_reference_terms": 1227,
       "prediction_overlap_rate": 0.039454
     },
     "goa": {
@@ -308,7 +308,7 @@
     "n_predictions": 8871,
     "post_review": {
       "n_overlap": 860,
-      "n_reference_terms": 2768,
+      "n_reference_terms": 2769,
       "prediction_overlap_rate": 0.096945
     }
   },

--- a/reports/gogpt-comparison-levels.json
+++ b/reports/gogpt-comparison-levels.json
@@ -5453,9 +5453,9 @@
     "preds": 18,
     "goa_terms": 9,
     "goa_overlap": 5,
-    "post_review_terms": 8,
+    "post_review_terms": 9,
     "post_review_overlap": 4,
-    "core_terms": 4,
+    "core_terms": 6,
     "core_overlap": 2,
     "goa_overlap_terms": [
       "GO:0030288",

--- a/tests/test_gogpt_compare_levels.py
+++ b/tests/test_gogpt_compare_levels.py
@@ -118,15 +118,17 @@ def test_committed_three_level_report_matches_current_reviews() -> None:
     assert len(details) == 299
     assert stats == {
         "goa": {"overlap": 1040, "total": 2960, "pred": 8871},
-        # Two upstream reviews moved these levels. The HdeB re-review retains
+        # Three upstream reviews moved these levels. The HdeB re-review retains
         # GO:0051082 as an explicit interim post-review/core term (+1 to both
         # post_review and core). Separately, surA now retains GO:0005515
-        # post-review (+1 post_review only) and its status advanced to COMPLETE,
-        # which moves the reference-status distribution 67->68 COMPLETE in the
-        # benchmark sidecars. GOA is unaffected, distinguishing upstream review
-        # edits from a comparison regression.
-        "post_review": {"overlap": 860, "total": 2768, "pred": 8871},
-        "core": {"overlap": 350, "total": 1225, "pred": 8871},
+        # post-review (+1 post_review only), while the HdeA comprehensive review
+        # adds one post-review term and two GO-valued core slots without changing
+        # either overlap count. surA's status also advanced to COMPLETE, which
+        # moves the reference-status distribution 67->68 COMPLETE in the benchmark
+        # sidecars. GOA is unaffected, distinguishing upstream review edits from a
+        # comparison regression.
+        "post_review": {"overlap": 860, "total": 2769, "pred": 8871},
+        "core": {"overlap": 350, "total": 1227, "pred": 8871},
     }
 
 


### PR DESCRIPTION
## Summary
- refresh GO-GPT three-level comparison after the merged HdeA comprehensive review
- update benchmark sidecars and publication denominator table with explicit HdeA provenance
- update pinned generated-report expectations and rendered project artifacts

## Verification
- `just -f projects/BIOREASON_COMPARISON/justfile gogpt-overlap`
- `just refresh-bioreason-benchmark-sidecars`
- `just -f projects/BIOREASON_COMPARISON/justfile slides`
- `just render-project BIOREASON_COMPARISON`
- `just test` (1799 tests, 154 doctests, mypy, ruff)
- `git diff --check`