### PR TITLE
Update unfolded-binding tracker for Spy

### DIFF
--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -996,7 +996,7 @@ because it has that second term as well; this is not an additional human gene.</
 <td>11</td>
 <td><strong>Periplasmic/envelope chaperones</strong></td>
 <td><a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>, <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>, <a href="../../genes/ECOLI/HdeB/HdeB-ai-review.html">HdeB</a>, <a href="../../genes/ECOLI/SlyD/SlyD-ai-review.html">SlyD</a>, <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a> (E. coli)</td>
-<td>Carrier-holdases <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, and <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>: MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>; <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>/HdeB/Spy/SlyD await the general holdase NTR; <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a> is over-annotated. <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a> and <a href="../../genes/ECOLI/HdeB/HdeB-ai-review.html">HdeB</a> re-reviews found no defined acceptor or delivery destination and added <a href="http://amigo.geneontology.org/amigo/term/GO:0050821">GO:0050821</a> protein stabilization</td>
+<td>Carrier-holdases <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, and <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>: MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>; <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>/HdeB/Spy/SlyD await the general holdase NTR; <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a> is over-annotated. <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>, <a href="../../genes/ECOLI/HdeB/HdeB-ai-review.html">HdeB</a>, and <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a> re-reviews found no defined acceptor or delivery destination and added <a href="http://amigo.geneontology.org/amigo/term/GO:0050821">GO:0050821</a> protein stabilization</td>
 </tr>
 <tr>
 <td>12</td>
@@ -1510,8 +1510,8 @@ established:</p>
 <td><em>E. coli</em></td>
 <td>P77754</td>
 <td>11</td>
-<td>MODIFY → holdase NTR; retain <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> interim</td>
-<td>Periplasmic in-situ holdase</td>
+<td>MODIFY → holdase NTR; retain <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> interim; NEW <a href="http://amigo.geneontology.org/amigo/term/GO:0050821">GO:0050821</a></td>
+<td>Periplasmic in-situ holdase; no defined acceptor or delivery destination; <a href="http://amigo.geneontology.org/amigo/term/GO:0042026">GO:0042026</a> for refolding process</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/surA/surA-ai-review.html">surA</a></td>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -366,7 +366,7 @@ All 148 genes organized by mechanism class (human + non-human combined):
 | 8 | **ER quality control** | UGGT1, ERLEC1, SYVN1 (human); Uggt1 (rat); CNE1, EPS1, PDI1, EUG1, ROT1, IRE1 (yeast); IRE1 (T. reesei); CSH3 (C. albicans); Edem2 (fly) | OVER_ANNOTATED or REMOVE (sensors, not chaperones) |
 | 9 | **Mito import/assembly** | TOMM20, GRPEL1 (human); TIM9, TIM10, COX20, PET100, SHY1, ATP10, ATP11 (yeast); Grpel2 (mouse); cia30 (N. crassa) | OVER_ANNOTATED (assembly factors) or MODIFY (TIMs → GO:0140309) |
 | 10 | **Ubiquitin/QC sensor** | SYVN1 (human); SAN1 (yeast); Fbxo2 (mouse); slrP (Salmonella) | REMOVE or MODIFY to GO:0051787 |
-| 11 | **Periplasmic/envelope chaperones** | SurA, Skp, Spy, SecB, HdeA, HdeB, SlyD, CpxP (E. coli) | Carrier-holdases SurA, SecB, and Skp: MODIFY → GO:0140309; HdeA/HdeB/Spy/SlyD await the general holdase NTR; CpxP is over-annotated. HdeA and HdeB re-reviews found no defined acceptor or delivery destination and added GO:0050821 protein stabilization |
+| 11 | **Periplasmic/envelope chaperones** | SurA, Skp, Spy, SecB, HdeA, HdeB, SlyD, CpxP (E. coli) | Carrier-holdases SurA, SecB, and Skp: MODIFY → GO:0140309; HdeA/HdeB/Spy/SlyD await the general holdase NTR; CpxP is over-annotated. HdeA, HdeB, and Spy re-reviews found no defined acceptor or delivery destination and added GO:0050821 protein stabilization |
 | 12 | **Ribosome assembly** | SQT1, SYO1, YAR1, RRB1, TSR4, PNO1, ACL4, SHQ1, BTT1 (yeast) | MODIFY → GO:0044183 or OVER_ANNOTATED |
 | 13 | **Peroxiredoxin/redox chaperones** | TSA1 (yeast); pmp20, tpx1 (S. pombe); CnoX, RidA (E. coli); PP_1084/PpPrx (*P. putida*, direct literature gap case) | MODIFY → holdase NTR when evidence shows in-situ aggregation prevention without refolding; older GO:0044183 sibling decisions require re-review |
 | 14 | **Membrane protein chaperones** | SHR3, PHO86, GSF2, CHS7, NSG1, NSG2, VMA22, VPS45 (yeast) | MODIFY or OVER_ANNOTATED |
@@ -498,7 +498,7 @@ established:
 | SecB | *E. coli* | P0AG86 | 27 | MODIFY → GO:0140309 | Secretion carrier-holdase |
 | Skp | *E. coli* | P0AEU7 | 34 | MODIFY → GO:0140309 | Periplasmic OMP carrier-holdase |
 | SlyD | *E. coli* | P0A9K9 | 35 | MODIFY → holdase NTR; retain GO:0051082 interim | FKBP-type PPIase/holdase; GO:0170061 for nickel chaperoning |
-| Spy | *E. coli* | P77754 | 11 | MODIFY → holdase NTR; retain GO:0051082 interim | Periplasmic in-situ holdase |
+| Spy | *E. coli* | P77754 | 11 | MODIFY → holdase NTR; retain GO:0051082 interim; NEW GO:0050821 | Periplasmic in-situ holdase; no defined acceptor or delivery destination; GO:0042026 for refolding process |
 | surA | *E. coli* | P0ABZ6 | 31 | Project decision: MODIFY → GO:0140309; gene-review alignment tracked in [#2732](https://github.com/ai4curation/ai-gene-review/pull/2732) | Periplasmic OMP carrier-holdase; delivery to BAM/YaeT |
 | Dnaja3 | *M. musculus* | Q99M87 | 81 | MODIFY → GO:0044183 | Mitochondrial J-domain co-chaperone |
 | Dnajb11 | *M. musculus* | Q99KV1 | 33 | MODIFY → GO:0044183 | ER J-domain co-chaperone |


### PR DESCRIPTION
Align the unfolded-protein-binding project tracker with merged Spy review #2744.

- records the holdase NTR routing and interim GO:0051082 retention
- adds the authored GO:0050821 protein-stabilization proposal
- records the lack of a defined acceptor/delivery destination and GO:0042026 refolding-process refinement
- updates the periplasmic-chaperone category summary

Rendered through `just render-project UNFOLDED_PROTEIN_BINDING`; `git diff --check` passes.