### PR TITLE
Update unfolded-binding tracker for CpxP

### DIFF
--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -996,7 +996,7 @@ because it has that second term as well; this is not an additional human gene.</
 <td>11</td>
 <td><strong>Periplasmic/envelope chaperones</strong></td>
 <td><a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>, <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>, <a href="../../genes/ECOLI/HdeB/HdeB-ai-review.html">HdeB</a>, <a href="../../genes/ECOLI/SlyD/SlyD-ai-review.html">SlyD</a>, <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a> (E. coli)</td>
-<td>Carrier-holdases <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, and <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>: MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>; <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>/HdeB/Spy/SlyD await the general holdase NTR; <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a> is over-annotated. <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>, <a href="../../genes/ECOLI/HdeB/HdeB-ai-review.html">HdeB</a>, and <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a> re-reviews found no defined acceptor or delivery destination and added <a href="http://amigo.geneontology.org/amigo/term/GO:0050821">GO:0050821</a> protein stabilization</td>
+<td>Carrier-holdases <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, and <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a>: MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a>; <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>/HdeB/Spy/SlyD await the general holdase NTR; <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a> is over-annotated and instead has NEW <a href="http://amigo.geneontology.org/amigo/term/GO:0140767">GO:0140767</a>/<a href="http://amigo.geneontology.org/amigo/term/GO:0070298">GO:0070298</a> plus MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0045862">GO:0045862</a>. <a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a>, <a href="../../genes/ECOLI/HdeB/HdeB-ai-review.html">HdeB</a>, and <a href="../../genes/ECOLI/Spy/Spy-ai-review.html">Spy</a> re-reviews found no defined acceptor or delivery destination and added <a href="http://amigo.geneontology.org/amigo/term/GO:0050821">GO:0050821</a> protein stabilization</td>
 </tr>
 <tr>
 <td>12</td>
@@ -1215,7 +1215,11 @@ established:</p>
    is a secretion-coupled holdase. <a href="../../genes/ECOLI/surA/surA-ai-review.html">SurA</a>, <a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a>, and <a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a> are carrier-holdases that MODIFY →<br />
 <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> because each escorts an unfolded client to a defined acceptor or location;<br />
    the remaining proteins require gene-specific foldase, in-situ holdase, or non-chaperone<br />
-   decisions. These validate the foldase/holdase framework in a phylogenetically distant lineage.</p>
+   decisions. <a href="../../genes/ECOLI/CpxP/CpxP-ai-review.html">CpxP</a> is a non-holdase case: its characterized misfolded-client recognition<br />
+   supports DegP substrate-adaptor activity (<a href="http://amigo.geneontology.org/amigo/term/GO:0140767">GO:0140767</a>) and positive regulation of<br />
+   proteolysis (<a href="http://amigo.geneontology.org/amigo/term/GO:0045862">GO:0045862</a>), while its CpxA interaction supports signaling-receptor<br />
+   inhibition (<a href="http://amigo.geneontology.org/amigo/term/GO:0030547">GO:0030547</a>) and negative regulation of phosphorelay signaling (<a href="http://amigo.geneontology.org/amigo/term/GO:0070298">GO:0070298</a>).<br />
+   These validate the foldase/holdase framework in a phylogenetically distant lineage.</p>
 </li>
 <li>
 <p><strong><a href="../../genes/ECOLI/CnoX/CnoX-ai-review.html">CnoX</a> (E. coli)</strong> — Redox-activated holdase with thioredoxin domain. Interesting<br />
@@ -1430,8 +1434,8 @@ established:</p>
 <td><em>E. coli</em></td>
 <td>P0AE85</td>
 <td>11</td>
-<td>MARK_AS_OVER_ANNOTATED</td>
-<td>Cpx pathway adaptor; <a href="http://amigo.geneontology.org/amigo/term/GO:0030547">GO:0030547</a> for CpxA inhibition</td>
+<td>MARK_AS_OVER_ANNOTATED; NEW <a href="http://amigo.geneontology.org/amigo/term/GO:0140767">GO:0140767</a>, <a href="http://amigo.geneontology.org/amigo/term/GO:0070298">GO:0070298</a>; MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0045862">GO:0045862</a></td>
+<td>DegP substrate adaptor and CpxA inhibitor; weak in-vitro chaperone activity does not establish a general holdase function</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/DnaJ/DnaJ-ai-review.html">DnaJ</a></td>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -366,7 +366,7 @@ All 148 genes organized by mechanism class (human + non-human combined):
 | 8 | **ER quality control** | UGGT1, ERLEC1, SYVN1 (human); Uggt1 (rat); CNE1, EPS1, PDI1, EUG1, ROT1, IRE1 (yeast); IRE1 (T. reesei); CSH3 (C. albicans); Edem2 (fly) | OVER_ANNOTATED or REMOVE (sensors, not chaperones) |
 | 9 | **Mito import/assembly** | TOMM20, GRPEL1 (human); TIM9, TIM10, COX20, PET100, SHY1, ATP10, ATP11 (yeast); Grpel2 (mouse); cia30 (N. crassa) | OVER_ANNOTATED (assembly factors) or MODIFY (TIMs → GO:0140309) |
 | 10 | **Ubiquitin/QC sensor** | SYVN1 (human); SAN1 (yeast); Fbxo2 (mouse); slrP (Salmonella) | REMOVE or MODIFY to GO:0051787 |
-| 11 | **Periplasmic/envelope chaperones** | SurA, Skp, Spy, SecB, HdeA, HdeB, SlyD, CpxP (E. coli) | Carrier-holdases SurA, SecB, and Skp: MODIFY → GO:0140309; HdeA/HdeB/Spy/SlyD await the general holdase NTR; CpxP is over-annotated. HdeA, HdeB, and Spy re-reviews found no defined acceptor or delivery destination and added GO:0050821 protein stabilization |
+| 11 | **Periplasmic/envelope chaperones** | SurA, Skp, Spy, SecB, HdeA, HdeB, SlyD, CpxP (E. coli) | Carrier-holdases SurA, SecB, and Skp: MODIFY → GO:0140309; HdeA/HdeB/Spy/SlyD await the general holdase NTR; CpxP is over-annotated and instead has NEW GO:0140767/GO:0070298 plus MODIFY → GO:0045862. HdeA, HdeB, and Spy re-reviews found no defined acceptor or delivery destination and added GO:0050821 protein stabilization |
 | 12 | **Ribosome assembly** | SQT1, SYO1, YAR1, RRB1, TSR4, PNO1, ACL4, SHQ1, BTT1 (yeast) | MODIFY → GO:0044183 or OVER_ANNOTATED |
 | 13 | **Peroxiredoxin/redox chaperones** | TSA1 (yeast); pmp20, tpx1 (S. pombe); CnoX, RidA (E. coli); PP_1084/PpPrx (*P. putida*, direct literature gap case) | MODIFY → holdase NTR when evidence shows in-situ aggregation prevention without refolding; older GO:0044183 sibling decisions require re-review |
 | 14 | **Membrane protein chaperones** | SHR3, PHO86, GSF2, CHS7, NSG1, NSG2, VMA22, VPS45 (yeast) | MODIFY or OVER_ANNOTATED |
@@ -438,7 +438,11 @@ established:
    is a secretion-coupled holdase. SurA, SecB, and Skp are carrier-holdases that MODIFY →
    GO:0140309 because each escorts an unfolded client to a defined acceptor or location;
    the remaining proteins require gene-specific foldase, in-situ holdase, or non-chaperone
-   decisions. These validate the foldase/holdase framework in a phylogenetically distant lineage.
+   decisions. CpxP is a non-holdase case: its characterized misfolded-client recognition
+   supports DegP substrate-adaptor activity (GO:0140767) and positive regulation of
+   proteolysis (GO:0045862), while its CpxA interaction supports signaling-receptor
+   inhibition (GO:0030547) and negative regulation of phosphorelay signaling (GO:0070298).
+   These validate the foldase/holdase framework in a phylogenetically distant lineage.
 
 3. **CnoX (E. coli)** — Redox-activated holdase with thioredoxin domain. Interesting
    mechanistic variant: becomes an active holdase specifically under oxidative stress when
@@ -488,7 +492,7 @@ established:
 | Nmnat | *D. melanogaster* | Q9VC03 | 32 | MODIFY | Neuroprotective chaperone |
 | Edem2 | *D. melanogaster* | Q9VK27 | 23 | OVER_ANNOTATED | ERAD sensor, not chaperone |
 | CnoX | *E. coli* | P77395 | 12 | MODIFY → GO:0044183 | Redox-activated holdase |
-| CpxP | *E. coli* | P0AE85 | 11 | MARK_AS_OVER_ANNOTATED | Cpx pathway adaptor; GO:0030547 for CpxA inhibition |
+| CpxP | *E. coli* | P0AE85 | 11 | MARK_AS_OVER_ANNOTATED; NEW GO:0140767, GO:0070298; MODIFY → GO:0045862 | DegP substrate adaptor and CpxA inhibitor; weak in-vitro chaperone activity does not establish a general holdase function |
 | DnaJ | *E. coli* | P08622 | 48 | MODIFY → GO:0044183 | J-domain co-chaperone |
 | DnaK | *E. coli* | P0A6Y8 | 61 | MODIFY → GO:0044183 | HSP70 foldase/holdase |
 | GroEL | *E. coli* | P0A6F5 | 64 | MODIFY → GO:0044183 | Chaperonin |


### PR DESCRIPTION
## Summary
- synchronize the unfolded-protein-binding tracker with the merged CpxP review
- record CpxP as a non-holdase DegP substrate adaptor and CpxA inhibitor
- include the NEW GO:0140767 and GO:0070298 annotations and the GO:0045862 replacement
- refresh the rendered project page

## Validation
- `just render-project UNFOLDED_PROTEIN_BINDING`
- `just test` (1799 tests, 154 doctests, mypy, Ruff)