### PR TITLE
Respect citation provenance in SFT conflict checks

### DIFF
--- a/scripts/auto_review_sft_predictions.py
+++ b/scripts/auto_review_sft_predictions.py
@@ -17,7 +17,7 @@ import argparse
 import copy
 import csv
 import re
-from collections import Counter, defaultdict
+from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, MutableMapping
@@ -26,6 +26,12 @@ import yaml as pyyaml
 from ruamel.yaml import YAML
 
 from ai_gene_review.bioreason_ontology import FROZEN_GO_ADAPTER, get_go_adapter
+from ai_gene_review.sft_prediction_evidence import (
+    NEGATIVE_ACTIONS,
+    POSITIVE_ACTIONS,
+    PROVENANCE_LIMITED_NEGATIVE,
+    load_aigr_term_actions,
+)
 
 
 DEFAULT_COHORT = Path("projects/BIOREASON_COMPARISON/genes.csv")
@@ -38,8 +44,6 @@ ONTOLOGY_PAIR_AUDIT = (
     / "argo95-ontology-pair-adjudication.tsv"
 )
 
-POSITIVE_ACTIONS = {"ACCEPT", "KEEP_AS_NON_CORE"}
-NEGATIVE_ACTIONS = {"REMOVE", "MARK_AS_OVER_ANNOTATED"}
 INCORRECT_ASSESSMENTS = {"NPI", "PLI", "REP"}
 EXPECTED_CONFIDENCE = {
     "COR": 2,
@@ -535,23 +539,6 @@ def load_goa_terms(goa_file: Path) -> set[str]:
     return terms
 
 
-def load_aigr_term_actions(review_file: Path) -> dict[str, set[str]]:
-    """Return every AIGR action for each GO ID without flattening mixed decisions."""
-    actions: dict[str, set[str]] = defaultdict(set)
-    if not review_file.exists():
-        return actions
-
-    yaml = YAML(typ="safe")
-    with review_file.open() as handle:
-        doc = yaml.load(handle) or {}
-    for annotation in doc.get("existing_annotations", []):
-        go_id = annotation.get("term", {}).get("id", "")
-        action = annotation.get("review", {}).get("action", "")
-        if go_id.startswith("GO:") and action:
-            actions[go_id].add(action)
-    return actions
-
-
 def load_aigr_core_terms(review_file: Path) -> set[str]:
     """Return GO IDs used in AIGR core functions."""
     terms: set[str] = set()
@@ -588,24 +575,34 @@ def auto_assess(
 ) -> tuple[str, int, str]:
     """Create a schema-valid initial assessment from exact local evidence."""
     actions = aigr_actions.get(go_id, set())
+    biological_actions = actions - {PROVENANCE_LIMITED_NEGATIVE}
 
-    if actions and actions <= NEGATIVE_ACTIONS:
+    if biological_actions and biological_actions <= NEGATIVE_ACTIONS:
         return (
             "NPI",
             0,
             "The exact AIGR actions are "
-            f"{', '.join(sorted(actions))}; the prediction reproduces an annotation "
+            f"{', '.join(sorted(biological_actions))}; the prediction reproduces an annotation "
             "that the current review rejects or marks as over-annotated.",
         )
-    if actions & POSITIVE_ACTIONS:
+    if biological_actions & POSITIVE_ACTIONS:
         return (
             "CNN",
             2,
             "The exact term is already present in AIGR with a positive action "
-            f"({', '.join(sorted(actions & POSITIVE_ACTIONS))}). Correct but not novel.",
+            f"({', '.join(sorted(biological_actions & POSITIVE_ACTIONS))}). Correct but not novel.",
+        )
+    if not biological_actions and PROVENANCE_LIMITED_NEGATIVE in actions:
+        return (
+            "UNC",
+            1,
+            "The exact AIGR annotation has a negative action tied to a reference "
+            "adjudicated as miscited or wrongly identified. That decision rejects "
+            "the cited evidence but does not by itself validate or refute the "
+            "biological prediction.",
         )
     if go_id in goa_terms:
-        if actions == {"MODIFY"}:
+        if biological_actions == {"MODIFY"}:
             return (
                 "LSP",
                 2,
@@ -635,7 +632,8 @@ def deterministic_reclassification(
     actions: set[str],
 ) -> tuple[str, str] | None:
     """Return a correction only for an exact, unambiguous contradiction."""
-    if actions and actions <= NEGATIVE_ACTIONS:
+    biological_actions = actions - {PROVENANCE_LIMITED_NEGATIVE}
+    if biological_actions and biological_actions <= NEGATIVE_ACTIONS:
         if current_assessment in {"PLI", "REP"}:
             return None
         if go_id == "GO:0005515":
@@ -647,15 +645,15 @@ def deterministic_reclassification(
             return (
                 "NPI",
                 "all exact AIGR actions are negative "
-                f"({', '.join(sorted(actions))})",
+                f"({', '.join(sorted(biological_actions))})",
             )
         return None
 
-    if actions & POSITIVE_ACTIONS and current_assessment in {"NPI", "UNC"}:
+    if biological_actions & POSITIVE_ACTIONS and current_assessment in {"NPI", "UNC"}:
         return (
             "CNN",
             "the current AIGR contains a positive exact action "
-            f"({', '.join(sorted(actions & POSITIVE_ACTIONS))})",
+            f"({', '.join(sorted(biological_actions & POSITIVE_ACTIONS))})",
         )
 
     if go_id in goa_terms and current_assessment == "COR":
@@ -896,6 +894,7 @@ def remaining_conflicts(
     actions: set[str],
 ) -> Iterable[str]:
     assessment = review.get("assessment", "")
+    biological_actions = actions - {PROVENANCE_LIMITED_NEGATIVE}
     confidence = review.get("confidence_score")
     if EXPECTED_CONFIDENCE.get(assessment) != confidence:
         yield "assessment_confidence"
@@ -915,9 +914,9 @@ def remaining_conflicts(
         )
         if not any(marker in rationale for marker in non_novel_markers):
             yield "CNN_without_GOA_or_non_novel_basis"
-    if actions and actions <= NEGATIVE_ACTIONS and assessment in {"COR", "CNN", "LSP", "UNC"}:
+    if biological_actions and biological_actions <= NEGATIVE_ACTIONS and assessment in {"COR", "CNN", "LSP", "UNC"}:
         yield "nonnegative_assessment_vs_negative_AIGR"
-    if actions & POSITIVE_ACTIONS and assessment in {"NPI", "UNC"}:
+    if biological_actions & POSITIVE_ACTIONS and assessment in {"NPI", "UNC"}:
         yield "NPI_or_UNC_vs_positive_AIGR"
     error_type = review.get("error_type")
     if error_type and assessment not in INCORRECT_ASSESSMENTS:

--- a/scripts/gogpt_predict.py
+++ b/scripts/gogpt_predict.py
@@ -20,13 +20,20 @@ import json
 import os
 import re
 import sys
-from collections import Counter, defaultdict
+from collections import Counter
 from pathlib import Path
 from typing import Any, Callable
 
 import yaml
 
 from ai_gene_review.bioreason_ontology import FROZEN_GO_ADAPTER, get_go_adapter
+from ai_gene_review.sft_prediction_evidence import (
+    NEGATED_ACTION_PREFIX,
+    NEGATIVE_ACTIONS,
+    POSITIVE_ACTIONS,
+    PROVENANCE_LIMITED_NEGATIVE,
+    load_aigr_term_actions,
+)
 
 
 BIOREASON_REF = "doi:10.64898/2026.03.19.712954"
@@ -79,9 +86,6 @@ BIOREASON_ASPECTS = {
     "Cellular Component": "CC",
 }
 
-POSITIVE_ACTIONS = {"ACCEPT", "KEEP_AS_NON_CORE"}
-NEGATIVE_ACTIONS = {"REMOVE", "MARK_AS_OVER_ANNOTATED"}
-NEGATED_ACTION_PREFIX = "NOT:"
 CONFIDENCE_BY_ASSESSMENT = {
     "COR": 2,
     "CNN": 2,
@@ -154,19 +158,7 @@ def extract_accession(uniprot_file: Path) -> str:
 
 def load_review_decisions(review_file: Path) -> dict[str, set[str]]:
     """Load exact GO ID to AIGR action mappings from existing annotations."""
-    review = yaml.safe_load(review_file.read_text()) or {}
-    decisions: dict[str, set[str]] = defaultdict(set)
-    for annotation in review.get("existing_annotations", []) or []:
-        go_id = (annotation.get("term") or {}).get("id", "")
-        action = (annotation.get("review") or {}).get("action")
-        if GO_ID_RE.fullmatch(go_id) and action:
-            decision = (
-                f"{NEGATED_ACTION_PREFIX}{action}"
-                if annotation.get("negated")
-                else action
-            )
-            decisions[go_id].add(decision)
-    return dict(decisions)
+    return dict(load_aigr_term_actions(review_file, preserve_negated=True))
 
 
 def load_review_terms(review_file: Path) -> dict[str, set[str]]:
@@ -304,11 +296,12 @@ def deterministic_assessment(
 ) -> tuple[str, str]:
     """Classify only exact, unambiguous current AIGR action matches."""
     actions = set((review_decisions or {}).get(go_id, set()))
-    action_text = ", ".join(sorted(actions))
+    biological_actions = actions - {PROVENANCE_LIMITED_NEGATIVE}
+    action_text = ", ".join(sorted(biological_actions))
 
     # A retained annotation is sufficient evidence that the exact prediction is
     # correct-not-novel, even if another evidence line has a different action.
-    positive = sorted(actions & POSITIVE_ACTIONS)
+    positive = sorted(biological_actions & POSITIVE_ACTIONS)
     if positive:
         return (
             "CNN",
@@ -319,7 +312,7 @@ def deterministic_assessment(
 
     accepted_negations = sorted(
         action.removeprefix(NEGATED_ACTION_PREFIX)
-        for action in actions
+        for action in biological_actions
         if action.startswith(NEGATED_ACTION_PREFIX)
         and action.removeprefix(NEGATED_ACTION_PREFIX) in POSITIVE_ACTIONS
     )
@@ -335,12 +328,21 @@ def deterministic_assessment(
     # Only a pure negative decision set is auto-classified. Mixed REMOVE/PENDING,
     # MODIFY, and UNDECIDED cases remain unresolved. REP is never inferred from a
     # generic REMOVE because frequency bias requires separate evidence.
-    if actions and actions <= NEGATIVE_ACTIONS:
+    if biological_actions and biological_actions <= NEGATIVE_ACTIONS:
         return (
             "NPI",
             "Deterministic exact-match comparison: current AIGR action(s) "
             f"{action_text} reject or flag this exact GO term as over-annotated; "
             "classified as nonparalog incorrect.",
+        )
+
+    if not biological_actions and PROVENANCE_LIMITED_NEGATIVE in actions:
+        return (
+            "UNC",
+            "The exact AIGR annotation has a negative action tied to a reference "
+            "adjudicated as miscited or wrongly identified. That provenance decision "
+            "does not by itself validate or refute this prediction. "
+            f"{MANUAL_ASSESSMENT_MARKER}.",
         )
 
     return (

--- a/scripts/hf_to_sft_predictions.py
+++ b/scripts/hf_to_sft_predictions.py
@@ -22,6 +22,12 @@ import duckdb
 import yaml
 
 from ai_gene_review.bioreason_ontology import FROZEN_GO_ADAPTER, get_go_adapter
+from ai_gene_review.sft_prediction_evidence import (
+    NEGATIVE_ACTIONS,
+    POSITIVE_ACTIONS,
+    PROVENANCE_LIMITED_NEGATIVE,
+    load_aigr_term_actions,
+)
 
 
 DB_PATH = Path("data/bioreason-hf/protein_catalogue.ddb")
@@ -32,8 +38,6 @@ HF_PARQUET_URLS = [
 ]
 SOURCE_REFERENCE_ID = "doi:10.64898/2026.03.19.712954"
 DEFAULT_ONTOLOGY_ADAPTER = FROZEN_GO_ADAPTER
-POSITIVE_ACTIONS = {"ACCEPT", "KEEP_AS_NON_CORE"}
-NEGATIVE_ACTIONS = {"REMOVE", "MARK_AS_OVER_ANNOTATED"}
 ONTOLOGY_NOTE_MARKER = "[ONTOLOGY_LABEL_AUDIT]"
 
 
@@ -118,20 +122,13 @@ def load_goa_terms(goa_file: Path) -> set[str]:
 
 def load_aigr_review(review_file: Path) -> tuple[dict[str, set[str]], set[str]]:
     """Load all exact AIGR actions and authored core-function GO terms."""
-    actions: dict[str, set[str]] = {}
+    actions = load_aigr_term_actions(review_file)
     core_terms: set[str] = set()
     if not review_file.exists():
         return actions, core_terms
 
     with review_file.open() as handle:
         doc = yaml.safe_load(handle) or {}
-
-    for ann in doc.get("existing_annotations", []):
-        go_id = ann.get("term", {}).get("id", "")
-        action = ann.get("review", {}).get("action", "")
-        if not go_id.startswith("GO:") or not action:
-            continue
-        actions.setdefault(go_id, set()).add(action)
 
     def add_term_values(value: Any) -> None:
         values = value if isinstance(value, list) else [value]
@@ -160,31 +157,44 @@ def assess_prediction(
     core_terms: set[str],
 ) -> dict[str, Any]:
     exact_actions = actions.get(go_id, set())
+    biological_actions = exact_actions - {PROVENANCE_LIMITED_NEGATIVE}
 
-    if exact_actions and exact_actions <= NEGATIVE_ACTIONS:
+    if biological_actions and biological_actions <= NEGATIVE_ACTIONS:
         return {
             "assessment": "NPI",
             "confidence_score": 0,
             "summary": (
                 "The exact AIGR actions are "
-                f"{', '.join(sorted(exact_actions))}. The SFT model is reproducing "
+                f"{', '.join(sorted(biological_actions))}. The SFT model is reproducing "
                 "an annotation that the current review rejects or flags as "
                 "over-annotated."
             ),
         }
 
-    if exact_actions & POSITIVE_ACTIONS:
+    if biological_actions & POSITIVE_ACTIONS:
         return {
             "assessment": "CNN",
             "confidence_score": 2,
             "summary": (
                 "The exact term is already present in AIGR with a positive action "
-                f"({', '.join(sorted(exact_actions & POSITIVE_ACTIONS))}). Correct "
+                f"({', '.join(sorted(biological_actions & POSITIVE_ACTIONS))}). Correct "
                 "but not novel."
             ),
         }
 
-    if go_id in goa_terms and exact_actions == {"MODIFY"}:
+    if not biological_actions and PROVENANCE_LIMITED_NEGATIVE in exact_actions:
+        return {
+            "assessment": "UNC",
+            "confidence_score": 1,
+            "summary": (
+                "The exact AIGR annotation has a negative action tied to a reference "
+                "adjudicated as miscited or wrongly identified. That decision rejects "
+                "the cited evidence but does not by itself validate or refute the "
+                "biological prediction."
+            ),
+        }
+
+    if go_id in goa_terms and biological_actions == {"MODIFY"}:
         return {
             "assessment": "LSP",
             "confidence_score": 2,

--- a/src/ai_gene_review/sft_prediction_evidence.py
+++ b/src/ai_gene_review/sft_prediction_evidence.py
@@ -1,0 +1,61 @@
+"""Shared exact-evidence loading for BioReason prediction review tools."""
+
+from collections import defaultdict
+import re
+from pathlib import Path
+
+import yaml
+
+
+POSITIVE_ACTIONS = {"ACCEPT", "KEEP_AS_NON_CORE"}
+NEGATIVE_ACTIONS = {"REMOVE", "MARK_AS_OVER_ANNOTATED"}
+NEGATED_ACTION_PREFIX = "NOT:"
+PROVENANCE_LIMITED_NEGATIVE = "PROVENANCE_LIMITED_NEGATIVE"
+INVALID_REFERENCE_CORRECTNESS = {"MISCITED", "WRONG_IDENTIFIER"}
+GO_ID_RE = re.compile(r"GO:\d{7}")
+
+
+def load_aigr_term_actions(
+    review_file: Path, *, preserve_negated: bool = False
+) -> dict[str, set[str]]:
+    """Return exact AIGR action evidence grouped by GO ID.
+
+    A negative action attached to an explicitly miscited or wrongly identified
+    reference may reject that source rather than the biological term. Preserve
+    that distinction with a sentinel instead of treating it as either a biological
+    refutation or no evidence. The sentinel lets initial assessors return UNC while
+    leaving manually adjudicated predictions intact.
+
+    Reference-level correctness is necessarily coarser than a finding review. It is
+    used here only for negative actions whose annotation cites that exact reference.
+    """
+    actions: dict[str, set[str]] = defaultdict(set)
+    if not review_file.exists():
+        return actions
+
+    with review_file.open() as handle:
+        document = yaml.safe_load(handle) or {}
+
+    invalid_source_references = {
+        reference_id
+        for reference in (document.get("references") or [])
+        if isinstance(reference, dict)
+        if (reference_id := reference.get("id"))
+        and (reference.get("reference_review") or {}).get("correctness")
+        in INVALID_REFERENCE_CORRECTNESS
+    }
+    for annotation in document.get("existing_annotations") or []:
+        go_id = (annotation.get("term") or {}).get("id", "")
+        action = (annotation.get("review") or {}).get("action", "")
+        if not GO_ID_RE.fullmatch(go_id) or not action:
+            continue
+        if (
+            action in NEGATIVE_ACTIONS
+            and annotation.get("original_reference_id") in invalid_source_references
+        ):
+            actions[go_id].add(PROVENANCE_LIMITED_NEGATIVE)
+            continue
+        if preserve_negated and annotation.get("negated"):
+            action = f"{NEGATED_ACTION_PREFIX}{action}"
+        actions[go_id].add(action)
+    return actions

--- a/tests/test_sft_prediction_review.py
+++ b/tests/test_sft_prediction_review.py
@@ -24,8 +24,11 @@ from scripts.auto_review_sft_predictions import (
 )
 from scripts.hf_to_sft_predictions import (
     assess_prediction,
+    load_aigr_review,
     ontology_label_note,
 )
+from scripts.gogpt_predict import deterministic_assessment, load_review_decisions
+from ai_gene_review.sft_prediction_evidence import PROVENANCE_LIMITED_NEGATIVE
 
 
 def test_load_aigr_actions_preserves_mixed_decisions(tmp_path):
@@ -43,6 +46,84 @@ existing_annotations:
     assert load_aigr_term_actions(review_file) == {
         "GO:0000001": {"ACCEPT", "REMOVE"}
     }
+
+
+def test_load_aigr_actions_marks_only_negative_miscitation_decisions(tmp_path):
+    review_file = tmp_path / "review.yaml"
+    review_file.write_text(
+        """
+references:
+  - id: PMID:1
+    reference_review: {correctness: MISCITED}
+  - id: PMID:2
+    reference_review: {correctness: WRONG_IDENTIFIER}
+  - id: PMID:3
+    reference_review: {correctness: VERIFIED}
+  - id: PMID:4
+    reference_review:
+  - reference_review: {correctness: MISCITED}
+existing_annotations:
+  - term: {id: "GO:0000001", label: miscited negative}
+    original_reference_id: PMID:1
+    review: {action: REMOVE}
+  - term: {id: "GO:0000002", label: wrong-identifier negative}
+    original_reference_id: PMID:2
+    review: {action: MARK_AS_OVER_ANNOTATED}
+  - term: {id: "GO:0000003", label: verified negative}
+    original_reference_id: PMID:3
+    review: {action: REMOVE}
+  - term: {id: "GO:0000004", label: unreviewed negative}
+    original_reference_id: PMID:4
+    review: {action: REMOVE}
+  - term: {id: "GO:0000005", label: positive despite miscitation}
+    original_reference_id: PMID:1
+    review: {action: ACCEPT}
+"""
+    )
+
+    expected = {
+        "GO:0000001": {PROVENANCE_LIMITED_NEGATIVE},
+        "GO:0000002": {PROVENANCE_LIMITED_NEGATIVE},
+        "GO:0000003": {"REMOVE"},
+        "GO:0000004": {"REMOVE"},
+        "GO:0000005": {"ACCEPT"},
+    }
+    assert load_aigr_term_actions(review_file) == expected
+    assert load_aigr_review(review_file)[0] == expected
+    assert load_review_decisions(review_file) == expected
+
+
+def test_provenance_limited_negative_defaults_to_uncertain():
+    actions = {"GO:0000001": {PROVENANCE_LIMITED_NEGATIVE}}
+    assert auto_assess("GO:0000001", {"GO:0000001"}, actions, set())[:2] == (
+        "UNC",
+        1,
+    )
+    result = assess_prediction("GO:0000001", {"GO:0000001"}, actions, set())
+    assert (result["assessment"], result["confidence_score"]) == ("UNC", 1)
+    assert deterministic_assessment("GO:0000001", actions)[0] == "UNC"
+
+
+def test_verified_negative_remains_decisive_alongside_provenance_limited_action():
+    exact_actions = {"REMOVE", PROVENANCE_LIMITED_NEGATIVE}
+    actions = {"GO:0000001": exact_actions}
+    assert auto_assess("GO:0000001", {"GO:0000001"}, actions, set())[:2] == (
+        "NPI",
+        0,
+    )
+    result = assess_prediction("GO:0000001", {"GO:0000001"}, actions, set())
+    assert (result["assessment"], result["confidence_score"]) == ("NPI", 0)
+    assert deterministic_assessment("GO:0000001", actions)[0] == "NPI"
+
+
+def test_modify_remains_less_precise_alongside_provenance_limited_action():
+    actions = {"GO:0000001": {"MODIFY", PROVENANCE_LIMITED_NEGATIVE}}
+    assert auto_assess("GO:0000001", {"GO:0000001"}, actions, set())[:2] == (
+        "LSP",
+        2,
+    )
+    result = assess_prediction("GO:0000001", {"GO:0000001"}, actions, set())
+    assert (result["assessment"], result["confidence_score"]) == ("LSP", 2)
 
 
 def test_deterministic_reclassification_uses_only_exact_contradictions():


### PR DESCRIPTION
## Summary

- centralize exact AIGR action loading for the SFT auditor, HF converter, and GO-GPT refresh path
- preserve negative actions tied to MISCITED or WRONG_IDENTIFIER references as explicit provenance-limited evidence
- classify fresh provenance-limited cases as UNC rather than NPI or an unjustified GOA-presence CNN
- retain verified/unreviewed biological negatives and positive actions
- add cross-path parity, null-safety, mixed-evidence, and committed-cohort regression coverage

## Why

A REMOVE or MARK_AS_OVER_ANNOTATED action can reject a specific citation rather than the GO term itself. That should not automatically refute an independently assessed prediction, but it also must not be discarded and converted into affirmative evidence.

## Validation

- just test (1802 tests, 154 doctests, mypy, Ruff)
- documented --help entrypoints for all three scripts
- direct DnaJ check: GO:0051087 and GO:0032991 retain manual CNN assessments without deterministic conflicts