### PR TITLE
Clarify DnaJ lambda replication evidence

### DIFF
--- a/genes/ECOLI/DnaJ/DnaJ-ai-review.html
+++ b/genes/ECOLI/DnaJ/DnaJ-ai-review.html
@@ -1641,7 +1641,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA from UniProt keyword mapping (KW-0235 &#34;DNA replication&#34;). DnaJ participates in phage lambda and plasmid DNA replication as part of the DnaK/DnaJ/GrpE chaperone system, which disassembles the replication initiation complex (PMID:1361234, PMID:3889001). This is a well-established non-core function of DnaJ.
+                            <strong>Summary:</strong> IEA from UniProt keyword mapping (KW-0235 &#34;DNA replication&#34;). The attached literature establishes DnaJ participation in phage lambda genome replication as part of the DnaK/DnaJ/GrpE chaperone system, which remodels the replication initiation complex (PMID:1361234, PMID:3889001). This is a specialized non-core application of DnaJ&#39;s chaperone activity.
                         </div>
 
 
@@ -7223,10 +7223,11 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: IEA from UniProt keyword mapping (KW-0235 &#34;DNA replication&#34;). DnaJ participates
-      in phage lambda and plasmid DNA replication as part of the DnaK/DnaJ/GrpE chaperone
-      system, which disassembles the replication initiation complex (PMID:1361234,
-      PMID:3889001). This is a well-established non-core function of DnaJ.
+    summary: IEA from UniProt keyword mapping (KW-0235 &#34;DNA replication&#34;). The attached
+      literature establishes DnaJ participation in phage lambda genome replication
+      as part of the DnaK/DnaJ/GrpE chaperone system, which remodels the replication
+      initiation complex (PMID:1361234, PMID:3889001). This is a specialized non-core
+      application of DnaJ&#39;s chaperone activity.
     action: KEEP_AS_NON_CORE
     reason: DnaJ involvement in DNA replication is indirect -- it functions as a chaperone
       to disassemble replication initiation complexes (e.g., lambda P protein release

--- a/genes/ECOLI/DnaJ/DnaJ-ai-review.yaml
+++ b/genes/ECOLI/DnaJ/DnaJ-ai-review.yaml
@@ -271,10 +271,11 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: IEA from UniProt keyword mapping (KW-0235 "DNA replication"). DnaJ participates
-      in phage lambda and plasmid DNA replication as part of the DnaK/DnaJ/GrpE chaperone
-      system, which disassembles the replication initiation complex (PMID:1361234,
-      PMID:3889001). This is a well-established non-core function of DnaJ.
+    summary: IEA from UniProt keyword mapping (KW-0235 "DNA replication"). The attached
+      literature establishes DnaJ participation in phage lambda genome replication
+      as part of the DnaK/DnaJ/GrpE chaperone system, which remodels the replication
+      initiation complex (PMID:1361234, PMID:3889001). This is a specialized non-core
+      application of DnaJ's chaperone activity.
     action: KEEP_AS_NON_CORE
     reason: DnaJ involvement in DNA replication is indirect -- it functions as a chaperone
       to disassemble replication initiation complexes (e.g., lambda P protein release


### PR DESCRIPTION
## Summary

- remove an unsupported plasmid-replication clause from the DnaJ IEA review summary
- describe only the phage-lambda genome-replication evidence attached to the row
- regenerate the DnaJ review HTML through the public render wrapper

This is the non-blocking evidence-wording follow-up identified during the approved re-review of #2756. It does not change the review action, retained term set, or benchmark metrics.

## Validation

- just render ECOLI DnaJ
- just validate ECOLI DnaJ
- just validate-goa ECOLI DnaJ
