### PR TITLE
Update DnaJ unfolded-protein-binding tracker

### DIFF
--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -1442,9 +1442,9 @@ established:</p>
 <td><a href="../../genes/ECOLI/DnaJ/DnaJ-ai-review.html">DnaJ</a></td>
 <td><em>E. coli</em></td>
 <td>P08622</td>
-<td>48</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>J-domain co-chaperone</td>
+<td>49</td>
+<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a> (3 rows); MARK_AS_OVER_ANNOTATED (1 miscited CAFA row); NEW <a href="http://amigo.geneontology.org/amigo/term/GO:0001671">GO:0001671</a></td>
+<td>J-domain co-chaperone and <a href="../../genes/ECOLI/DnaK/DnaK-ai-review.html">DnaK</a> ATPase activator; comprehensive review complete</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/DnaK/DnaK-ai-review.html">DnaK</a></td>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -494,7 +494,7 @@ established:
 | Edem2 | *D. melanogaster* | Q9VK27 | 23 | OVER_ANNOTATED | ERAD sensor, not chaperone |
 | CnoX | *E. coli* | P77395 | 12 | MODIFY → GO:0044183 | Redox-activated holdase |
 | CpxP | *E. coli* | P0AE85 | 11 | MARK_AS_OVER_ANNOTATED; NEW GO:0140767, GO:0070298; MODIFY → GO:0030547, GO:0045862 | DegP substrate adaptor and CpxA inhibitor; weak in-vitro chaperone activity does not establish a general holdase function |
-| DnaJ | *E. coli* | P08622 | 48 | MODIFY → GO:0044183 | J-domain co-chaperone |
+| DnaJ | *E. coli* | P08622 | 49 | MODIFY → GO:0044183 (3 rows); MARK_AS_OVER_ANNOTATED (1 miscited CAFA row); NEW GO:0001671 | J-domain co-chaperone and DnaK ATPase activator; comprehensive review complete |
 | DnaK | *E. coli* | P0A6Y8 | 61 | MODIFY → GO:0044183 | HSP70 foldase/holdase |
 | GroEL | *E. coli* | P0A6F5 | 64 | MODIFY → GO:0044183 | Chaperonin |
 | HdeA | *E. coli* | P0AES9 | 14 | MODIFY → holdase NTR; retain GO:0051082 interim; NEW GO:0050821 | Acid-activated in-situ holdase; no defined acceptor or delivery destination; GO:0042026 for refolding process |


### PR DESCRIPTION
## Summary

- reconcile the DnaJ tracker row after the comprehensive review merged in #2756 and its evidence clarification in #2758
- update the reviewed GOA row count from 48 to 49
- record three GO:0051082 MODIFY decisions to GO:0044183, one miscited CAFA over-annotation, and the new GO:0001671 ATPase activator annotation
- regenerate the project page through the public wrapper

## Validation

- just render-project UNFOLDED_PROTEIN_BINDING
