### PR TITLE
Normalize prediction evaluation HTML whitespace

### DIFF
--- a/pages/projects/BIOREASON_COMPARISON/deepectf-eval.html
+++ b/pages/projects/BIOREASON_COMPARISON/deepectf-eval.html
@@ -218,41 +218,41 @@
         <div class="value">7</div>
         <div class="label">Predictions</div>
     </div>
-    
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
+
     <div class="summary-stat">
         <div class="value" style="color: var(--color-unc);">2</div>
         <div class="label">UNC</div>
     </div>
-    
-    
-    
+
+
+
     <div class="summary-stat">
         <div class="value" style="color: var(--color-pli);">1</div>
         <div class="label">PLI</div>
     </div>
-    
-    
-    
+
+
+
     <div class="summary-stat">
         <div class="value" style="color: var(--color-npi);">3</div>
         <div class="label">NPI</div>
     </div>
-    
-    
-    
+
+
+
     <div class="summary-stat">
         <div class="value" style="color: var(--color-rep);">1</div>
         <div class="label">REP</div>
     </div>
-    
-    
+
+
     <div class="summary-stat">
         <div class="value">0.3</div>
         <div class="label">Mean CS</div>
@@ -261,37 +261,37 @@
 
 
 <div class="assessment-dist">
-    
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
+
     <div class="seg seg-UNC" style="flex: 2;" title="UNC: 2">
         UNC (2)
     </div>
-    
-    
-    
+
+
+
     <div class="seg seg-PLI" style="flex: 1;" title="PLI: 1">
         PLI (1)
     </div>
-    
-    
-    
+
+
+
     <div class="seg seg-NPI" style="flex: 3;" title="NPI: 3">
         NPI (3)
     </div>
-    
-    
-    
+
+
+
     <div class="seg seg-REP" style="flex: 1;" title="REP: 1">
         REP (1)
     </div>
-    
-    
+
+
 </div>
 
 
@@ -309,27 +309,27 @@
     <input type="text" id="search" placeholder="Filter by protein, term, or text…" oninput="filterTable()">
     <select id="assessmentFilter" onchange="filterTable()">
         <option value="">All assessments</option>
-        
+
         <option value="COR">COR</option>
-        
+
         <option value="CNN">CNN</option>
-        
+
         <option value="LSP">LSP</option>
-        
+
         <option value="UNC">UNC</option>
-        
+
         <option value="PLI">PLI</option>
-        
+
         <option value="NPI">NPI</option>
-        
+
         <option value="REP">REP</option>
-        
+
     </select>
     <select id="typeFilter" onchange="filterTable()">
         <option value="">All term types</option>
-        
+
         <option value="EC">EC</option>
-        
+
     </select>
     <label style="font-size:0.85rem;">
         <input type="checkbox" id="hideNoPred" onchange="filterTable()"> Hide no-prediction rows

--- a/pages/projects/BIOREASON_COMPARISON/gogpt-eval.html
+++ b/pages/projects/BIOREASON_COMPARISON/gogpt-eval.html
@@ -7971,6 +7971,401 @@
 
 
 
+<tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0060090</strong><br>
+        molecular adaptor activity
+    </td>
+    <td><span class="term-type">GO_MF</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0005515</strong><br>
+        protein binding
+    </td>
+    <td><span class="term-type">GO_MF</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0051641</strong><br>
+        cellular localization
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0007275</strong><br>
+        multicellular organism development
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0060322</strong><br>
+        head development
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0046621</strong><br>
+        negative regulation of organ growth
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0070727</strong><br>
+        obsolete cellular macromolecule localization
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment. [ONTOLOGY_LABEL_AUDIT] Raw BioReason label &#39;cellular macromolecule localization&#39; did not match the current GO label &#39;obsolete cellular macromolecule localization&#39;; the structured label was normalized from GO and the raw source was retained.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0016319</strong><br>
+        mushroom body development
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0007420</strong><br>
+        brain development
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0099504</strong><br>
+        synaptic vesicle cycle
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0036465</strong><br>
+        synaptic vesicle recycling
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0007399</strong><br>
+        nervous system development
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0007417</strong><br>
+        central nervous system development
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0007525</strong><br>
+        somatic muscle development
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0035332</strong><br>
+        positive regulation of hippo signaling
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0035418</strong><br>
+        protein localization to synapse
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0031252</strong><br>
+        cell leading edge
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0048786</strong><br>
+        presynaptic active zone
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0098793</strong><br>
+        presynapse
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0071944</strong><br>
+        cell periphery
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0098831</strong><br>
+        presynaptic active zone cytoplasmic component
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0045202</strong><br>
+        synapse
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0048788</strong><br>
+        cytoskeleton of presynaptic active zone
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
+</tr>
+
+
+
+
+
 <tr data-assessment="UNC" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/DROME/Hsp83/Hsp83-ai-review.html">P02828</a>
@@ -9127,401 +9522,6 @@
     <td>
         <strong>GO:0031594</strong><br>
         neuromuscular junction
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-
-
-
-
-<tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0060090</strong><br>
-        molecular adaptor activity
-    </td>
-    <td><span class="term-type">GO_MF</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0005515</strong><br>
-        protein binding
-    </td>
-    <td><span class="term-type">GO_MF</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0051641</strong><br>
-        cellular localization
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0007275</strong><br>
-        multicellular organism development
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0060322</strong><br>
-        head development
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0046621</strong><br>
-        negative regulation of organ growth
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0070727</strong><br>
-        obsolete cellular macromolecule localization
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment. [ONTOLOGY_LABEL_AUDIT] Raw BioReason label &#39;cellular macromolecule localization&#39; did not match the current GO label &#39;obsolete cellular macromolecule localization&#39;; the structured label was normalized from GO and the raw source was retained.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0016319</strong><br>
-        mushroom body development
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0007420</strong><br>
-        brain development
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0099504</strong><br>
-        synaptic vesicle cycle
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0036465</strong><br>
-        synaptic vesicle recycling
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0007399</strong><br>
-        nervous system development
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0007417</strong><br>
-        central nervous system development
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0007525</strong><br>
-        somatic muscle development
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0035332</strong><br>
-        positive regulation of hippo signaling
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0035418</strong><br>
-        protein localization to synapse
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0031252</strong><br>
-        cell leading edge
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0048786</strong><br>
-        presynaptic active zone
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0098793</strong><br>
-        presynapse
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0071944</strong><br>
-        cell periphery
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0098831</strong><br>
-        presynaptic active zone cytoplasmic component
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0045202</strong><br>
-        synapse
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Deterministic exact-match comparison: current AIGR action(s) ACCEPT retain this GO term, so it is correct but not novel.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0048788</strong><br>
-        cytoskeleton of presynaptic active zone
     </td>
     <td><span class="term-type">GO_CC</span></td>
     <td><span class="badge badge-CNN">CNN</span></td>
@@ -13969,95 +13969,6 @@
 
 
 
-<tr data-assessment="UNC" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
-        <br><small style="color:var(--text-muted)">Tim10</small>
-    </td>
-    <td><small>SCHPO</small></td>
-    <td>
-        <strong>GO:0005515</strong><br>
-        protein binding
-    </td>
-    <td><span class="term-type">GO_MF</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
-        <br><small style="color:var(--text-muted)">Tim10</small>
-    </td>
-    <td><small>SCHPO</small></td>
-    <td>
-        <strong>GO:0007005</strong><br>
-        mitochondrion organization
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment. [ONTOLOGY_LABEL_AUDIT] Raw BioReason label &#39;mitochondrial organization&#39; did not match the current GO label &#39;mitochondrion organization&#39;; the structured label was normalized from GO and the raw source was retained.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
-        <br><small style="color:var(--text-muted)">Tim10</small>
-    </td>
-    <td><small>SCHPO</small></td>
-    <td>
-        <strong>GO:0006825</strong><br>
-        copper ion transport
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
-        <br><small style="color:var(--text-muted)">Tim10</small>
-    </td>
-    <td><small>SCHPO</small></td>
-    <td>
-        <strong>GO:0005737</strong><br>
-        cytoplasm
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment. [ONTOLOGY_LABEL_AUDIT] Raw BioReason label &#39;mitochondrion&#39; did not match the current GO label &#39;cytoplasm&#39;; the structured label was normalized from GO and the raw source was retained.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
-        <br><small style="color:var(--text-muted)">Tim10</small>
-    </td>
-    <td><small>SCHPO</small></td>
-    <td>
-        <strong>GO:0005739</strong><br>
-        mitochondrion
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
-</tr>
-
-
-
-
-
 <tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/SCHPO/alo1/alo1-ai-review.html">Q9HDX8</a>
@@ -17187,6 +17098,95 @@
     <td>
         <strong>GO:0005634</strong><br>
         nucleus
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+
+
+
+
+<tr data-assessment="UNC" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
+        <br><small style="color:var(--text-muted)">tim10</small>
+    </td>
+    <td><small>SCHPO</small></td>
+    <td>
+        <strong>GO:0005515</strong><br>
+        protein binding
+    </td>
+    <td><span class="term-type">GO_MF</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
+        <br><small style="color:var(--text-muted)">tim10</small>
+    </td>
+    <td><small>SCHPO</small></td>
+    <td>
+        <strong>GO:0007005</strong><br>
+        mitochondrion organization
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment. [ONTOLOGY_LABEL_AUDIT] Raw BioReason label &#39;mitochondrial organization&#39; did not match the current GO label &#39;mitochondrion organization&#39;; the structured label was normalized from GO and the raw source was retained.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
+        <br><small style="color:var(--text-muted)">tim10</small>
+    </td>
+    <td><small>SCHPO</small></td>
+    <td>
+        <strong>GO:0006825</strong><br>
+        copper ion transport
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
+        <br><small style="color:var(--text-muted)">tim10</small>
+    </td>
+    <td><small>SCHPO</small></td>
+    <td>
+        <strong>GO:0005737</strong><br>
+        cytoplasm
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">No deterministic exact-action match resolves this prediction in the current AIGR review. Requires manual assessment. [ONTOLOGY_LABEL_AUDIT] Raw BioReason label &#39;mitochondrion&#39; did not match the current GO label &#39;cytoplasm&#39;; the structured label was normalized from GO and the raw source was retained.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
+        <br><small style="color:var(--text-muted)">tim10</small>
+    </td>
+    <td><small>SCHPO</small></td>
+    <td>
+        <strong>GO:0005739</strong><br>
+        mitochondrion
     </td>
     <td><span class="term-type">GO_CC</span></td>
     <td><span class="badge badge-UNC">UNC</span></td>

--- a/pages/projects/BIOREASON_COMPARISON/sft-eval.html
+++ b/pages/projects/BIOREASON_COMPARISON/sft-eval.html
@@ -221,28 +221,28 @@
 
 
     <div class="summary-stat">
-        <div class="value" style="color: var(--color-cor);">37</div>
+        <div class="value" style="color: var(--color-cor);">38</div>
         <div class="label">COR</div>
     </div>
 
 
 
     <div class="summary-stat">
-        <div class="value" style="color: var(--color-cnn);">3218</div>
+        <div class="value" style="color: var(--color-cnn);">3238</div>
         <div class="label">CNN</div>
     </div>
 
 
 
     <div class="summary-stat">
-        <div class="value" style="color: var(--color-lsp);">462</div>
+        <div class="value" style="color: var(--color-lsp);">445</div>
         <div class="label">LSP</div>
     </div>
 
 
 
     <div class="summary-stat">
-        <div class="value" style="color: var(--color-unc);">7123</div>
+        <div class="value" style="color: var(--color-unc);">7126</div>
         <div class="label">UNC</div>
     </div>
 
@@ -256,7 +256,7 @@
 
 
     <div class="summary-stat">
-        <div class="value" style="color: var(--color-npi);">221</div>
+        <div class="value" style="color: var(--color-npi);">214</div>
         <div class="label">NPI</div>
     </div>
 
@@ -278,26 +278,26 @@
 <div class="assessment-dist">
 
 
-    <div class="seg seg-COR" style="flex: 37;" title="COR: 37">
+    <div class="seg seg-COR" style="flex: 38;" title="COR: 38">
 
     </div>
 
 
 
-    <div class="seg seg-CNN" style="flex: 3218;" title="CNN: 3218">
-        CNN (3218)
+    <div class="seg seg-CNN" style="flex: 3238;" title="CNN: 3238">
+        CNN (3238)
     </div>
 
 
 
-    <div class="seg seg-LSP" style="flex: 462;" title="LSP: 462">
+    <div class="seg seg-LSP" style="flex: 445;" title="LSP: 445">
 
     </div>
 
 
 
-    <div class="seg seg-UNC" style="flex: 7123;" title="UNC: 7123">
-        UNC (7123)
+    <div class="seg seg-UNC" style="flex: 7126;" title="UNC: 7126">
+        UNC (7126)
     </div>
 
 
@@ -308,7 +308,7 @@
 
 
 
-    <div class="seg seg-NPI" style="flex: 221;" title="NPI: 221">
+    <div class="seg seg-NPI" style="flex: 214;" title="NPI: 214">
 
     </div>
 
@@ -5536,7 +5536,7 @@
     <td class="summary-cell"><div class="summary-text">Incorrect prediction. Subtilisin E is a bacterial secreted protease from B. subtilis with no physiological role in blood coagulation. While subtilisins can cleave some coagulation factors in vitro (due to broad serine protease specificity), there is no evidence that AprE functions in blood coagulation in vivo. This is a clear nonparalog incorrect prediction, likely confusing AprE with mammalian serine proteases like thrombin or plasmin that have roles in coagulation. AprE functions in nutrient acquisition and quorum sensing pheromone processing in B. subtilis.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/BACSU/aprE/aprE-ai-review.html">P04189</a>
         <br><small style="color:var(--text-muted)">aprE</small>
@@ -5547,10 +5547,10 @@
         extracellular space
     </td>
     <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0005615 is &#39;obsolete extracellular space&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct cellular component prediction. AprE is a secreted enzyme exported via the Sec pathway; UniProt states &#39;Secreted&#39;. Already present in curated annotations (extracellular region accepted in ai-review.yaml). In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0005615 resolves to &#39;obsolete extracellular space&#39;, not &#39;extracellular space&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0005615 is &#39;obsolete extracellular space&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct cellular component prediction. AprE is a secreted enzyme exported via the Sec pathway; UniProt states &#39;Secreted&#39;. Already present in curated annotations (extracellular region accepted in ai-review.yaml). In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0005615 resolves to &#39;obsolete extracellular space&#39;, not &#39;extracellular space&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 
@@ -15520,6 +15520,180 @@
 
 <tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0060090</strong><br>
+        molecular adaptor activity
+    </td>
+    <td><span class="term-type">GO_MF</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Core function of git; ACCEPT in curated review. GIT is a multidomain scaffold/adaptor protein forming the dPix-Git-PAK complex. Already in GOA training data.</div></td>
+</tr>
+
+<tr data-assessment="REP" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0005515</strong><br>
+        protein binding
+    </td>
+    <td><span class="term-type">GO_MF</span></td>
+    <td><span class="badge badge-REP">REP</span></td>
+    <td>0</td>
+    <td><span class="badge-error">FREQUENCY_BIAS</span></td>
+    <td class="summary-cell"><div class="summary-text">Annotated MODIFY in curated review (replace with more specific terms like signaling adaptor activity). GIT interacts with multiple proteins. Present in GOA training data but too generic.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0046621</strong><br>
+        negative regulation of organ growth
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT promotes Hippo signaling, thereby negatively regulating organ growth. Already in GOA training data.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0016319</strong><br>
+        mushroom body development
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT is required for proper mushroom body development in the brain. Already in GOA training data.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0036465</strong><br>
+        synaptic vesicle recycling
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT regulates synaptic vesicle recycling at the NMJ through its role in endocytic pathways. Already in GOA training data.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0007525</strong><br>
+        somatic muscle development
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT is required for somatic muscle development and organization. Already in GOA training data.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0035332</strong><br>
+        positive regulation of hippo signaling
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT activates Hippo signaling through its scaffold function, promoting Warts/LATS activity. Already in GOA training data.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0035418</strong><br>
+        protein localization to synapse
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review (as GO:1905383 protein localization to presynapse). GIT mediates localization of PAK and PIX to the presynaptic compartment. Already in GOA training data.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0031252</strong><br>
+        cell leading edge
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT localizes to lamellipodia and the cell leading edge where it regulates actin dynamics. Already in GOA training data.</div></td>
+</tr>
+
+<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
+        <br><small style="color:var(--text-muted)">Git</small>
+    </td>
+    <td><small>DROME</small></td>
+    <td>
+        <strong>GO:0048788</strong><br>
+        cytoskeleton of presynaptic active zone
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT localizes to the presynaptic cytoskeleton at the active zone. Already in GOA training data.</div></td>
+</tr>
+
+
+
+
+
+<tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
         <a class="gene-link" href="../../../genes/DROME/Hsp83/Hsp83-ai-review.html">P02828</a>
         <br><small style="color:var(--text-muted)">Hsp83</small>
     </td>
@@ -15777,7 +15951,7 @@
     <td class="summary-cell"><div class="summary-text">LysB functions as a digestive enzyme in the gut/salivary glands, not as an immune defense response protein. The curated review notes MODIFY for the existing defense response annotations, indicating the model over-annotated immune function. LysB expressed in the midgut degrades dietary bacteria as part of digestion, not as an innate immune defense response. Immune defensive lysozymes in Drosophila are in the hemolymph; LysB is not expressed there. An independent OpenScientist investigation (see file reference) upholds the PLI but adds nuance -- this term is weakly supported at best, existing only as a single ISS by-similarity annotation and in tension with the digestive expression pattern, so it should be treated as low-confidence / non-core rather than asserted. (A minority of insect C-type lysozymes are dual-function digestive + mild immune effectors, so low-level bactericidal activity cannot be fully excluded -- but that would still not justify this term from the prediction alone.)</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/DROME/LysB/LysB-ai-review.html">Q08694</a>
         <br><small style="color:var(--text-muted)">LysB</small>
@@ -15788,10 +15962,10 @@
         extracellular space
     </td>
     <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0005615 is &#39;obsolete extracellular space&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: LysB is secreted into the extracellular space (gut lumen, salivary duct). ACCEPT in curated review. Already in GOA training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0005615 resolves to &#39;obsolete extracellular space&#39;, not &#39;extracellular space&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0005615 is &#39;obsolete extracellular space&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: LysB is secreted into the extracellular space (gut lumen, salivary duct). ACCEPT in curated review. Already in GOA training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0005615 resolves to &#39;obsolete extracellular space&#39;, not &#39;extracellular space&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 
@@ -16140,180 +16314,6 @@
     <td>2</td>
     <td></td>
     <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GCL is a substrate adaptor for the CRL3 (Cullin3-RING) E3 ubiquitin ligase complex. Already in GOA training data.</div></td>
-</tr>
-
-
-
-
-
-<tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0060090</strong><br>
-        molecular adaptor activity
-    </td>
-    <td><span class="term-type">GO_MF</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Core function of git; ACCEPT in curated review. GIT is a multidomain scaffold/adaptor protein forming the dPix-Git-PAK complex. Already in GOA training data.</div></td>
-</tr>
-
-<tr data-assessment="REP" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0005515</strong><br>
-        protein binding
-    </td>
-    <td><span class="term-type">GO_MF</span></td>
-    <td><span class="badge badge-REP">REP</span></td>
-    <td>0</td>
-    <td><span class="badge-error">FREQUENCY_BIAS</span></td>
-    <td class="summary-cell"><div class="summary-text">Annotated MODIFY in curated review (replace with more specific terms like signaling adaptor activity). GIT interacts with multiple proteins. Present in GOA training data but too generic.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0046621</strong><br>
-        negative regulation of organ growth
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT promotes Hippo signaling, thereby negatively regulating organ growth. Already in GOA training data.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0016319</strong><br>
-        mushroom body development
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT is required for proper mushroom body development in the brain. Already in GOA training data.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0036465</strong><br>
-        synaptic vesicle recycling
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT regulates synaptic vesicle recycling at the NMJ through its role in endocytic pathways. Already in GOA training data.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0007525</strong><br>
-        somatic muscle development
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT is required for somatic muscle development and organization. Already in GOA training data.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0035332</strong><br>
-        positive regulation of hippo signaling
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT activates Hippo signaling through its scaffold function, promoting Warts/LATS activity. Already in GOA training data.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0035418</strong><br>
-        protein localization to synapse
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review (as GO:1905383 protein localization to presynapse). GIT mediates localization of PAK and PIX to the presynaptic compartment. Already in GOA training data.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0031252</strong><br>
-        cell leading edge
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT localizes to lamellipodia and the cell leading edge where it regulates actin dynamics. Already in GOA training data.</div></td>
-</tr>
-
-<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/DROME/Git/Git-ai-review.html">Q95RG8</a>
-        <br><small style="color:var(--text-muted)">git</small>
-    </td>
-    <td><small>DROME</small></td>
-    <td>
-        <strong>GO:0048788</strong><br>
-        cytoskeleton of presynaptic active zone
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-CNN">CNN</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">ACCEPT in curated review. GIT localizes to the presynaptic cytoskeleton at the active zone. Already in GOA training data.</div></td>
 </tr>
 
 
@@ -16702,7 +16702,7 @@
     <td class="summary-cell"><div class="summary-text">CnoX does bind unfolded proteins (IDA, PMID:29754824). This is already in the curated GOA. However, the curated review recommends replacing GO:0051082 with a carrier chaperone term (GO:0140597 protein carrier chaperone or GO:0140309 unfolded protein carrier activity) because CnoX not only binds but escorts substrates to GroEL/DnaK. CNN because the binding aspect is real and annotated, but the term is less specific than the curated replacement. The prediction is not novel.</div></td>
 </tr>
 
-<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/CnoX/CnoX-ai-review.html">P77395</a>
         <br><small style="color:var(--text-muted)">CnoX</small>
@@ -16713,10 +16713,10 @@
         chaperone-mediated protein folding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-NPI">NPI</span></td>
-    <td>0</td>
-    <td><span class="badge-error">MULTIPLE_FUNCTIONS</span></td>
-    <td class="summary-cell"><div class="summary-text">CnoX is an ATP-independent holdase chaperedoxin that does NOT directly fold proteins. It maintains substrates in an unfolded but non-aggregated state and transfers them to GroEL/GroES and DnaK/DnaJ/GrpE for folding (PMID:29754824). The curated review annotates CnoX with GO:0036506 (maintenance of unfolded protein) as its core BP, not chaperone-mediated protein folding. Predicting CnoX as mediating chaperone-dependent folding conflates the holdase function with the downstream ATP-dependent foldase function of GroEL/DnaK. This is an NPI because the evidence specifically refutes CnoX as a foldase. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td><span class="badge badge-LSP">LSP</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0061077 is &#39;obsolete chaperone-mediated protein folding&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Less precise, not refuted. GOA and the AIGR directly support CnoX in protein refolding (GO:0042026): CnoX preserves substrates and hands them to the GroEL/DnaK foldases. The supplied historical chaperone-mediated protein-folding concept is broader and misses that specific handoff and refolding role. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -16791,7 +16791,7 @@
 
 
 
-<tr data-assessment="NPI" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="UNC" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/CpxP/CpxP-ai-review.html">P0AE85</a>
         <br><small style="color:var(--text-muted)">CpxP</small>
@@ -16802,10 +16802,10 @@
         protein folding chaperone
     </td>
     <td><span class="term-type">GO_MF</span></td>
-    <td><span class="badge badge-NPI">NPI</span></td>
-    <td>0</td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">CpxP is not a general protein folding chaperone. UniProt explicitly describes it as having only &#34;mild protein chaperone activity&#34; (PMID:21317898), and the curated review marks the existing unfolded protein binding (GO:0051082) annotations as MARK_AS_OVER_ANNOTATED. CpxP&#39;s primary evolved functions are inhibition of CpxA sensor kinase autophosphorylation (signaling receptor inhibitor activity, GO:0030547) and serving as a periplasmic adaptor that delivers misfolded substrates to DegP protease. The chaperone prediction likely reflects frequency bias in the training data toward canonical chaperone terms for proteins that interact with misfolded proteins. Not present in GOA.</div></td>
+    <td class="summary-cell"><div class="summary-text">Uncertain rather than refuted. CpxP has reported mild protein-chaperone activity, but its established core roles are CpxA inhibition and delivery of misfolded substrates to DegP. The available evidence does not establish a general protein-folding chaperone function, yet it also does not support a confident NPI call.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -16825,7 +16825,7 @@
     <td class="summary-cell"><div class="summary-text">GO:0005515 (protein binding) is present in GOA with IDA evidence from two publications (PMID:17259177, PMID:25207645), both demonstrating direct physical interaction between CpxP and the sensor kinase CpxA. The term is therefore correct and not novel (CNN). However, the curated review recommends replacing it with the more informative GO:0030547 (signaling receptor inhibitor activity), since CpxP binds CpxA specifically to inhibit its autophosphorylation activity. The prediction is accurate but uninformative — a less precise characterization than what the biology warrants.</div></td>
 </tr>
 
-<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/CpxP/CpxP-ai-review.html">P0AE85</a>
         <br><small style="color:var(--text-muted)">CpxP</small>
@@ -16836,13 +16836,13 @@
         chaperone-mediated protein folding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-NPI">NPI</span></td>
-    <td>0</td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">CpxP does not mediate protein folding. The protein binds misfolded periplasmic substrates (e.g., PapE pilus subunits) not to refold them, but to deliver them to the DegP protease for degradation (PMID:16303867) and to modulate CpxA signaling. The curated review marks the unfolded protein binding annotations (GO:0051082) as MARK_AS_OVER_ANNOTATED because CpxP has only mild chaperone activity and its primary role is adaptor/inhibitor. This prediction reflects frequency bias: proteins annotated with stress-response and misfolded-protein interactions tend to be over-predicted as chaperones. Not present in GOA. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0061077 is &#39;obsolete chaperone-mediated protein folding&#39;. The canonical GO term is not resolved by the current reference evidence. The pair is classified UNC; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Uncertain rather than refuted. CpxP binds misfolded periplasmic proteins and has mild chaperone activity, but direct participation in productive protein folding is not established. Its adaptor role in DegP degradation does not by itself prove or disprove this broader process prediction. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
-<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/CpxP/CpxP-ai-review.html">P0AE85</a>
         <br><small style="color:var(--text-muted)">CpxP</small>
@@ -16853,10 +16853,10 @@
         response to organic cyclic compound
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-NPI">NPI</span></td>
-    <td>0</td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">No experimental evidence supports a role for CpxP in responding to organic cyclic compounds. CpxP responds to envelope stress signals including alkaline pH, high salt, and misfolded periplasmic proteins (PMID:9473036, PMID:25207645). The curated GOA includes GO:0006950 (response to stress) with IDA evidence, but nothing related to organic cyclic compounds. This appears to be a spurious prediction with no mechanistic basis. Not present in GOA. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0014070 resolves to &#39;obsolete response to organic cyclic compound&#39;, not &#39;response to organic cyclic compound&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0014070 is &#39;obsolete response to organic cyclic compound&#39;. The canonical GO term is not resolved by the current reference evidence. The pair is classified UNC; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Uncertain. CpxP is experimentally involved in envelope-stress responses, but the current evidence does not isolate an organic cyclic compound as the causal stimulus. Absence of an exact GOA annotation is not biological refutation, so NPI was too strong. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0014070 resolves to &#39;obsolete response to organic cyclic compound&#39;, not &#39;response to organic cyclic compound&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -17016,7 +17016,7 @@
     <td class="summary-cell"><div class="summary-text">DnaJ is a heat shock protein (Hsp40) induced during heat stress. Response to heat (GO:0009408) is already annotated (IEA, GO_REF:0000002; IMP, PMID:2144273; IEP, PMID:8349564). The curated review accepts this annotation. The prediction is correct but not novel.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/DnaJ/DnaJ-ai-review.html">P08622</a>
         <br><small style="color:var(--text-muted)">DnaJ</small>
@@ -17027,10 +17027,10 @@
         chaperone cofactor-dependent protein refolding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0051085 is &#39;obsolete chaperone cofactor-dependent protein refolding&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: DnaJ functions as a co-chaperone (cofactor) for DnaK in the ATP-dependent refolding cycle. GO:0051085 (chaperone cofactor-dependent protein refolding) is already annotated (IBA, GO_REF:0000033) and accepted in the curated review as a core function. The prediction is correct but not novel. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0051085 resolves to &#39;obsolete chaperone cofactor-dependent protein refolding&#39;, not &#39;chaperone cofactor-dependent protein refolding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0051085 is &#39;obsolete chaperone cofactor-dependent protein refolding&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: DnaJ functions as a co-chaperone (cofactor) for DnaK in the ATP-dependent refolding cycle. GO:0051085 (chaperone cofactor-dependent protein refolding) is already annotated (IBA, GO_REF:0000033) and accepted in the curated review as a core function. The prediction is correct but not novel. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0051085 resolves to &#39;obsolete chaperone cofactor-dependent protein refolding&#39;, not &#39;chaperone cofactor-dependent protein refolding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -17241,7 +17241,7 @@
     <td class="summary-cell"><div class="summary-text">DnaK is a major heat shock protein induced under heat stress. Response to heat (GO:0009408) is already annotated (IEA, GO_REF:0000002; IMP, PMID:2144273) and accepted in the curated review. The prediction is correct but not novel.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/DnaK/DnaK-ai-review.html">P0A6Y8</a>
         <br><small style="color:var(--text-muted)">DnaK</small>
@@ -17252,10 +17252,10 @@
         chaperone cofactor-dependent protein refolding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0051085 is &#39;obsolete chaperone cofactor-dependent protein refolding&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: DnaK refolds substrates in a cofactor-dependent manner, requiring DnaJ as co-chaperone and GrpE as nucleotide exchange factor. GO:0051085 (chaperone cofactor-dependent protein refolding) is already annotated (IBA, GO_REF:0000033) and accepted in the curated review. The prediction is correct but not novel. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0051085 resolves to &#39;obsolete chaperone cofactor-dependent protein refolding&#39;, not &#39;chaperone cofactor-dependent protein refolding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0051085 is &#39;obsolete chaperone cofactor-dependent protein refolding&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: DnaK refolds substrates in a cofactor-dependent manner, requiring DnaJ as co-chaperone and GrpE as nucleotide exchange factor. GO:0051085 (chaperone cofactor-dependent protein refolding) is already annotated (IBA, GO_REF:0000033) and accepted in the curated review. The prediction is correct but not novel. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0051085 resolves to &#39;obsolete chaperone cofactor-dependent protein refolding&#39;, not &#39;chaperone cofactor-dependent protein refolding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -17860,7 +17860,7 @@
     <td class="summary-cell"><div class="summary-text">Skp forms a stable homotrimer (jellyfish-like architecture with alpha-helical tentacles from a beta-barrel body, PMID:15304217). Identical protein binding (homotrimerization) is already annotated in the curated GOA (IPI, PMID:16858726) and accepted in the curated review. The prediction is correct but not novel.</div></td>
 </tr>
 
-<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/Skp/Skp-ai-review.html">P0AEU7</a>
         <br><small style="color:var(--text-muted)">Skp</small>
@@ -17871,10 +17871,10 @@
         chaperone-mediated protein folding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-NPI">NPI</span></td>
-    <td>0</td>
-    <td><span class="badge-error">MULTIPLE_FUNCTIONS</span></td>
-    <td class="summary-cell"><div class="summary-text">Skp is an ATP-independent holdase/carrier chaperone that maintains OMPs in an unfolded state during periplasmic transit (PMID:19181847). Folding of the OMP beta-barrel does NOT occur while the OMP is bound to Skp; it only folds after release at the BAM complex, assisted by LPS (PMID:12509434). The curated review annotates Skp&#39;s core BP as protein stabilization (GO:0050821) and outer membrane assembly (GO:0043165). GO:0061077 (chaperone-mediated protein folding) is specifically not annotated for Skp because Skp is a holdase, not a foldase. The OmpA beta-barrel is maintained in an unfolded state while bound to Skp (PMID:19181847). This prediction incorrectly classifies Skp as a foldase. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0061077 is &#39;obsolete chaperone-mediated protein folding&#39;. The raw and canonical labels denote the same biological concept, and the replacement concept is already supported by GOA and the AIGR. The prediction is correct but not novel; ontology status is flagged separately. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct but not novel under the curated reference. The replacement protein folding term (GO:0006457) has IBA, IDA, and IMP annotations in current GOA, and the AIGR accepts it. Skp acts as a holdase/carrier before OMP folding, but that mechanistic qualification does not justify overruling the positive experimental curation. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -18085,7 +18085,7 @@
     <td class="summary-cell"><div class="summary-text">SlyD is upregulated under heat stress (PMID:17971396) and participates in the proteostasis response. Response to heat (GO:0009408) is already annotated in the curated GOA (IEA) and accepted. The prediction is correct but not novel.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/SlyD/SlyD-ai-review.html">P0A9K9</a>
         <br><small style="color:var(--text-muted)">SlyD</small>
@@ -18096,10 +18096,10 @@
         protein maturation by protein folding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">SlyD participates in protein maturation through both PPIase-catalyzed proline isomerization (accelerating refolding, PMID:16388577) and chaperone holdase activity. However, GO:0022417 (protein maturation by protein folding) is more generic than the curated annotations. The curated review annotates SlyD with protein refolding (GO:0042026, IBA and IDA) and protein peptidyl- prolyl isomerization (GO:0000413, IDA). Additionally, SlyD&#39;s most distinctive maturation function is hydrogenase maturation (GO:0006086 or related terms) via nickel delivery. GO:0022417 is correct at a high level but less precise than existing annotations. LSP. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0022417 resolves to &#39;obsolete protein maturation by protein folding&#39;, not &#39;protein maturation by protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0022417 is &#39;obsolete protein maturation by protein folding&#39;. The raw and canonical labels denote the same biological concept, and the replacement concept is already supported by GOA and the AIGR. The prediction is correct but not novel; ontology status is flagged separately. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: SlyD participates in protein maturation through both PPIase-catalyzed proline isomerization (accelerating refolding, PMID:16388577) and chaperone holdase activity. However, GO:0022417 (protein maturation by protein folding) is more generic than the curated annotations. The curated review annotates SlyD with protein refolding (GO:0042026, IBA and IDA) and protein peptidyl- prolyl isomerization (GO:0000413, IDA). Additionally, SlyD&#39;s most distinctive maturation function is hydrogenase maturation (GO:0006086 or related terms) via nickel delivery. GO:0022417 is correct at a high level but less precise than existing annotations. LSP. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0022417 resolves to &#39;obsolete protein maturation by protein folding&#39;, not &#39;protein maturation by protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -18225,7 +18225,7 @@
     <td class="summary-cell"><div class="summary-text">Correct and present in the curated annotations (multiple IDA entries with PMID:26619265 and PMID:27239796). Spy binds unfolded, intermediate, and native Im7 with micromolar affinities. However this prediction is CNN (Correct but Not Novel) because GO:0051082 is already in the curated GOA and is a standard annotation for chaperones; predicting it from sequence features is unsurprising. Note: GO:0051082 is also proposed for obsoletion and may be replaced by a holdase NTR.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/Spy/Spy-ai-review.html">P77754</a>
         <br><small style="color:var(--text-muted)">Spy</small>
@@ -18236,13 +18236,13 @@
         chaperone-mediated protein folding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">Less Precise. GO:0061077 (chaperone-mediated protein folding) is technically correct but the curated review annotates the more specific GO:0006457 (protein folding, IDA from PMID:21317898) for this gene. GO:0061077 implies involvement of a classical ATP-dependent chaperone system; Spy is an ATP-independent holdase/foldase in the periplasm. The biological process annotation GO:0006457 is more appropriate and more specific for this periplasmic holdase. LSP rather than NPI because Spy does assist protein folding in a chaperone-mediated fashion. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0061077 is &#39;obsolete chaperone-mediated protein folding&#39;. The raw and canonical labels denote the same biological concept, and the replacement concept is already supported by GOA and the AIGR. The prediction is correct but not novel; ontology status is flagged separately. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Less Precise. GO:0061077 (chaperone-mediated protein folding) is technically correct but the curated review annotates the more specific GO:0006457 (protein folding, IDA from PMID:21317898) for this gene. GO:0061077 implies involvement of a classical ATP-dependent chaperone system; Spy is an ATP-independent holdase/foldase in the periplasm. The biological process annotation GO:0006457 is more appropriate and more specific for this periplasmic holdase. LSP rather than NPI because Spy does assist protein folding in a chaperone-mediated fashion. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
-<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="COR" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/Spy/Spy-ai-review.html">P77754</a>
         <br><small style="color:var(--text-muted)">Spy</small>
@@ -18253,10 +18253,10 @@
         response to organic cyclic compound
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-NPI">NPI</span></td>
-    <td>0</td>
+    <td><span class="badge badge-COR">COR</span></td>
+    <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">Incorrect. GO:0014070 (response to organic cyclic compound) has no support in the literature or annotations for Spy. Spy is strongly induced by tannin (a polyphenol) and butanol stress via the Bae and Cpx two-component systems, but this is captured by envelope stress response annotations -- Spy is the effector chaperone, not a signaling component responding to organic cyclic compounds. This term is not present in the curated GOA and represents a spurious prediction, likely arising from frequency bias in training data associating stress-response proteins with this broad process term. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0014070 resolves to &#39;obsolete response to organic cyclic compound&#39;, not &#39;response to organic cyclic compound&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0014070 is &#39;obsolete response to organic cyclic compound&#39;. The canonical GO term is supported and absent as an exact ID from the frozen GOA. The pair is classified COR; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct novel biological response. Tannin, an organic cyclic polyphenol, strongly induces spy; Spy protects proteins during tannin stress, and spy-null cells are tannin-sensitive (PMID:21317898). The concept is supported but is absent as an exact term from current GOA. Its obsolete ontology status is reported separately from the COR assessment. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0014070 resolves to &#39;obsolete response to organic cyclic compound&#39;, not &#39;response to organic cyclic compound&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -19310,7 +19310,7 @@
     <td class="summary-cell"><div class="summary-text">Correct and already in the curated GOA (IBA from GO_REF:0000033 and IEA from GO_REF:0000120). SurA has confirmed PPIase activity (EC 5.2.1.8) residing in its second parvulin domain (PMID:8985185). CNN because the parvulin PPIase domain (IPR000297) is detectable by InterPro and directly predicts this activity. Note: the PPIase activity is dispensable for SurA&#39;s primary in vivo chaperone function (PMID:11226178), which the SFT model does not capture in this term prediction.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ECOLI/surA/surA-ai-review.html">P0ABZ6</a>
         <br><small style="color:var(--text-muted)">surA</small>
@@ -19321,10 +19321,10 @@
         chaperone-mediated protein folding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">Less Precise. GO:0061077 (chaperone-mediated protein folding) is technically correct but is less specific than the curated annotation. The curated review accepts GO:0006457 (protein folding, IBA) and also includes GO:0043165 (Gram-negative-bacterium-type cell outer membrane assembly, IBA) for SurA, with the latter being more informative about SurA&#39;s specific biological role in OMP biogenesis. GO:0061077 implies general chaperone-assisted folding without capturing SurA&#39;s specific role in OMP delivery to the BAM complex. LSP rather than NPI because SurA does participate in chaperone-mediated protein folding. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0061077 is &#39;obsolete chaperone-mediated protein folding&#39;. The raw and canonical labels denote the same biological concept, and the replacement concept is already supported by GOA and the AIGR. The prediction is correct but not novel; ontology status is flagged separately. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Less Precise. GO:0061077 (chaperone-mediated protein folding) is technically correct but is less specific than the curated annotation. The curated review accepts GO:0006457 (protein folding, IBA) and also includes GO:0043165 (Gram-negative-bacterium-type cell outer membrane assembly, IBA) for SurA, with the latter being more informative about SurA&#39;s specific biological role in OMP biogenesis. GO:0061077 implies general chaperone-assisted folding without capturing SurA&#39;s specific role in OMP delivery to the BAM complex. LSP rather than NPI because SurA does participate in chaperone-mediated protein folding. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -24692,78 +24692,6 @@
 
 
 
-<tr data-assessment="REP" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
-        <br><small style="color:var(--text-muted)">Tim10</small>
-    </td>
-    <td><small>SCHPO</small></td>
-    <td>
-        <strong>GO:0005515</strong><br>
-        protein binding
-    </td>
-    <td><span class="term-type">GO_MF</span></td>
-    <td><span class="badge badge-REP">REP</span></td>
-    <td>0</td>
-    <td><span class="badge-error">FREQUENCY_BIAS</span></td>
-    <td class="summary-cell"><div class="summary-text">Uninformative generic term. Not in GOA. Tim10 has well-characterized molecular function as unfolded protein carrier activity (GO:0140309, ACCEPT in AIGR) and membrane insertase activity (IBA in GOA). Protein binding adds no functional information and is a frequency-biased default.</div></td>
-</tr>
-
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
-        <br><small style="color:var(--text-muted)">Tim10</small>
-    </td>
-    <td><small>SCHPO</small></td>
-    <td>
-        <strong>GO:0006810</strong><br>
-        transport
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Correct biology but too general. GOA contains the more specific GO:0015031 (protein transport, IEA) and GO:0045039 (protein insertion into mitochondrial inner membrane, IBA -- ACCEPT in AIGR). Transport is a parent term of protein transport which is in GOA. LSP relative to the specific mitochondrial carrier protein import function.</div></td>
-</tr>
-
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
-        <br><small style="color:var(--text-muted)">Tim10</small>
-    </td>
-    <td><small>SCHPO</small></td>
-    <td>
-        <strong>GO:0007005</strong><br>
-        mitochondrion organization
-    </td>
-    <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Not in GOA. Tim10 functions in protein import into the mitochondrial inner membrane (GO:0045039, ACCEPT in AIGR) which is a subset of mitochondrion organization. The AIGR review does not explicitly accept mitochondrion organization but the function is consistent with it. This is an uncertain intermediate-precision prediction -- not wrong but not confirmed by GOA or AIGR.</div></td>
-</tr>
-
-<tr data-assessment="LSP" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
-    <td>
-        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
-        <br><small style="color:var(--text-muted)">Tim10</small>
-    </td>
-    <td><small>SCHPO</small></td>
-    <td>
-        <strong>GO:0005739</strong><br>
-        mitochondrion
-    </td>
-    <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
-    <td>2</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">Correct broad localization but less precise than GOA. GOA contains GO:0005743 (mitochondrial inner membrane, IEA from UniProt subcellular) and the AIGR review identifies the true location as mitochondrial intermembrane space (GO:0005758) based on structural studies. Mitochondrion is a parent term and is LSP relative to mitochondrial inner membrane and intermembrane space.</div></td>
-</tr>
-
-
-
-
-
 <tr data-assessment="PLI" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/SCHPO/alo1/alo1-ai-review.html">Q9HDX8</a>
@@ -25527,7 +25455,7 @@
     <td class="summary-cell"><div class="summary-text">In GOA with two IDA/IMP evidence lines. cps1 (SPAC24C9.08) is an M20A family metallopeptidase with carboxypeptidase activity confirmed in GOA (both GO:0004180 and GO:0004181 metallocarboxypeptidase activity are present). The AIGR review accepts this annotation, noting uncertainty about exact substrate specificity but confirming carboxypeptidase function. Correct and not novel.</div></td>
 </tr>
 
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/SCHPO/cps1/cps1-ai-review.html">O13968</a>
         <br><small style="color:var(--text-muted)">cps1</small>
@@ -25538,10 +25466,10 @@
         proteolysis involved in protein catabolic process
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0051603 is &#39;obsolete proteolysis involved in protein catabolic process&#39;. The canonical GO term is not resolved by the current reference evidence. The pair is classified UNC; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: In GOA (IDA evidence). cps1 is a vacuolar carboxypeptidase involved in proteolytic degradation in the vacuole (GO:0007039 protein catabolic process in the vacuole is also in GOA). Correct and not novel. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0051603 resolves to &#39;obsolete proteolysis involved in protein catabolic process&#39;, not &#39;proteolysis involved in protein catabolic process&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0051603 is &#39;obsolete proteolysis involved in protein catabolic process&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: In GOA (IDA evidence). cps1 is a vacuolar carboxypeptidase involved in proteolytic degradation in the vacuole (GO:0007039 protein catabolic process in the vacuole is also in GOA). Correct and not novel. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0051603 resolves to &#39;obsolete proteolysis involved in protein catabolic process&#39;, not &#39;proteolysis involved in protein catabolic process&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -26581,6 +26509,78 @@
     <td>0</td>
     <td></td>
     <td class="summary-cell"><div class="summary-text">Current-snapshot audit reclassified UNC to NPI because all exact AIGR actions are negative (REMOVE). This exact-join decision supersedes conflicting conclusions in the earlier rationale. Retained biological rationale. In GOA as is_active_in with ISS evidence (GO_REF:0000024 ortholog inference). However, the AIGR review recommends REMOVE for this annotation because the sequence similarity to human KNOP1 is too low (16.7% identity) to justify orthology-based transfer, and tam10 is described as a &#34;sequence orphan.&#34; The ISS annotation is technically CNN, but the AIGR review flags it as likely incorrect. UNC at confidence 1 given AIGR recommendation to remove.</div></td>
+</tr>
+
+
+
+
+
+<tr data-assessment="REP" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
+        <br><small style="color:var(--text-muted)">tim10</small>
+    </td>
+    <td><small>SCHPO</small></td>
+    <td>
+        <strong>GO:0005515</strong><br>
+        protein binding
+    </td>
+    <td><span class="term-type">GO_MF</span></td>
+    <td><span class="badge badge-REP">REP</span></td>
+    <td>0</td>
+    <td><span class="badge-error">FREQUENCY_BIAS</span></td>
+    <td class="summary-cell"><div class="summary-text">Uninformative generic term. Not in GOA. Tim10 has well-characterized molecular function as unfolded protein carrier activity (GO:0140309, ACCEPT in AIGR) and membrane insertase activity (IBA in GOA). Protein binding adds no functional information and is a frequency-biased default.</div></td>
+</tr>
+
+<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
+        <br><small style="color:var(--text-muted)">tim10</small>
+    </td>
+    <td><small>SCHPO</small></td>
+    <td>
+        <strong>GO:0006810</strong><br>
+        transport
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-LSP">LSP</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Correct biology but too general. GOA contains the more specific GO:0015031 (protein transport, IEA) and GO:0045039 (protein insertion into mitochondrial inner membrane, IBA -- ACCEPT in AIGR). Transport is a parent term of protein transport which is in GOA. LSP relative to the specific mitochondrial carrier protein import function.</div></td>
+</tr>
+
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
+        <br><small style="color:var(--text-muted)">tim10</small>
+    </td>
+    <td><small>SCHPO</small></td>
+    <td>
+        <strong>GO:0007005</strong><br>
+        mitochondrion organization
+    </td>
+    <td><span class="term-type">GO_BP</span></td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Not in GOA. Tim10 functions in protein import into the mitochondrial inner membrane (GO:0045039, ACCEPT in AIGR) which is a subset of mitochondrion organization. The AIGR review does not explicitly accept mitochondrion organization but the function is consistent with it. This is an uncertain intermediate-precision prediction -- not wrong but not confirmed by GOA or AIGR.</div></td>
+</tr>
+
+<tr data-assessment="LSP" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+    <td>
+        <a class="gene-link" href="../../../genes/SCHPO/tim10/tim10-ai-review.html">Q9UTE9</a>
+        <br><small style="color:var(--text-muted)">tim10</small>
+    </td>
+    <td><small>SCHPO</small></td>
+    <td>
+        <strong>GO:0005739</strong><br>
+        mitochondrion
+    </td>
+    <td><span class="term-type">GO_CC</span></td>
+    <td><span class="badge badge-LSP">LSP</span></td>
+    <td>2</td>
+    <td></td>
+    <td class="summary-cell"><div class="summary-text">Correct broad localization but less precise than GOA. GOA contains GO:0005743 (mitochondrial inner membrane, IEA from UniProt subcellular) and the AIGR review identifies the true location as mitochondrial intermembrane space (GO:0005758) based on structural studies. Mitochondrion is a parent term and is LSP relative to mitochondrial inner membrane and intermembrane space.</div></td>
 </tr>
 
 
@@ -43322,7 +43322,7 @@
     <td class="summary-cell"><div class="summary-text">GO:0045333 (cellular respiration) is present in GOA with TAS evidence (PMID:10383829). The curated review accepts this annotation. While the more specific terms (GO:0006122, GO:0006123) are also annotated, cellular respiration is a valid higher-level process. Prediction is correct but not novel.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/human/CYCS/CYCS-ai-review.html">P99999</a>
         <br><small style="color:var(--text-muted)">CYCS</small>
@@ -43333,10 +43333,10 @@
         activation of cysteine-type endopeptidase activity involved in apoptotic process
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0008635 is &#39;obsolete activation of cysteine-type endopeptidase activity involved in apoptotic process by cytochrome c&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: GO:0008635 is NOT present in the GOA TSV for CYCS. However, this is biologically correct: cytochrome c released from mitochondria binds APAF-1 to form the apoptosome, which activates procaspase-9 (a cysteine-type endopeptidase), thereby triggering downstream caspase cascades. The curated review explicitly supports the intrinsic apoptotic signaling pathway (GO:0097193) and the execution phase (GO:0097194). GO:0008635 captures the caspase-activation mechanism accurately. This is a biologically sound novel prediction not currently in the GOA. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0008635 resolves to &#39;obsolete activation of cysteine-type endopeptidase activity involved in apoptotic process by cytochrome c&#39;, not &#39;activation of cysteine-type endopeptidase activity involved in apoptotic process&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0008635 is &#39;obsolete activation of cysteine-type endopeptidase activity involved in apoptotic process by cytochrome c&#39;. The canonical GO concept is supported and already established in GOA, the AIGR, or UniProt, so it is correct but not novel. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: GO:0008635 is NOT present in the GOA TSV for CYCS. However, this is biologically correct: cytochrome c released from mitochondria binds APAF-1 to form the apoptosome, which activates procaspase-9 (a cysteine-type endopeptidase), thereby triggering downstream caspase cascades. The curated review explicitly supports the intrinsic apoptotic signaling pathway (GO:0097193) and the execution phase (GO:0097194). GO:0008635 captures the caspase-activation mechanism accurately. This is a biologically sound novel prediction not currently in the GOA. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0008635 resolves to &#39;obsolete activation of cysteine-type endopeptidase activity involved in apoptotic process by cytochrome c&#39;, not &#39;activation of cysteine-type endopeptidase activity involved in apoptotic process&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -53767,7 +53767,7 @@
     <td class="summary-cell"><div class="summary-text">GO:0010506 (regulation of autophagy) is present in GOA for KEAP1. The curated review accepts this annotation: KEAP1 is regulated by SQSTM1/p62 through autophagy-mediated sequestration in inclusion bodies, which releases KEAP1&#39;s grip on NRF2. Prediction is correct but not novel.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/human/KEAP1/KEAP1-ai-review.html">Q14145</a>
         <br><small style="color:var(--text-muted)">KEAP1</small>
@@ -53778,10 +53778,10 @@
         negative regulation of DNA-binding transcription factor activity
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0043433 is &#39;obsolete negative regulation of DNA-binding transcription factor activity&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: GO:0043433 (negative regulation of DNA-binding transcription factor activity) is NOT present in GOA for KEAP1. However, this is biologically very plausible: KEAP1 targets NRF2 for degradation, thereby negatively regulating NRF2&#39;s transcription factor activity. The GOA instead has GO:0000122 (negative regulation of transcription by RNA polymerase II) which captures a related downstream effect. The curated review would likely support this annotation as it directly captures KEAP1&#39;s core regulatory mechanism (ubiquitin-mediated degradation of NRF2 to suppress its TF activity). Classified UNC because it is not in GOA despite being biologically sound. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0043433 resolves to &#39;obsolete negative regulation of DNA-binding transcription factor activity&#39;, not &#39;negative regulation of DNA-binding transcription factor activity&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0043433 is &#39;obsolete negative regulation of DNA-binding transcription factor activity&#39;. The raw and canonical labels denote the same biological concept, and the replacement concept is already supported by GOA and the AIGR. The prediction is correct but not novel; ontology status is flagged separately. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: GO:0043433 (negative regulation of DNA-binding transcription factor activity) is NOT present in GOA for KEAP1. However, this is biologically very plausible: KEAP1 targets NRF2 for degradation, thereby negatively regulating NRF2&#39;s transcription factor activity. The GOA instead has GO:0000122 (negative regulation of transcription by RNA polymerase II) which captures a related downstream effect. The curated review would likely support this annotation as it directly captures KEAP1&#39;s core regulatory mechanism (ubiquitin-mediated degradation of NRF2 to suppress its TF activity). Classified UNC because it is not in GOA despite being biologically sound. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0043433 resolves to &#39;obsolete negative regulation of DNA-binding transcription factor activity&#39;, not &#39;negative regulation of DNA-binding transcription factor activity&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -60630,7 +60630,7 @@
     <td class="summary-cell"><div class="summary-text">GO:0071630 (ER-associated, ubiquitin-dependent protein catabolic process) is NOT present in GOA for NFE2L2. The curated review describes NRF2 as a substrate of KEAP1-mediated ubiquitination and proteasomal degradation but this is not an ER-associated process—it occurs in the cytoplasm. NRF2 is not known to be specifically degraded via ER-associated degradation (ERAD). This prediction appears to be a hallucination, possibly confusing NRF2&#39;s role in regulating ERAD pathway genes (GO:1904294 positive regulation of ERAD pathway in GOA) with NRF2 itself being an ERAD substrate. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0071630 resolves to &#39;nuclear protein quality control by the ubiquitin-proteasome system&#39;, not &#39;ER-associated, ubiquitin-dependent protein catabolic process&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/human/NFE2L2/NFE2L2-ai-review.html">Q16236</a>
         <br><small style="color:var(--text-muted)">NFE2L2</small>
@@ -60641,10 +60641,10 @@
         negative regulation of hydrogen peroxide-induced cell death
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:1903206 is &#39;obsolete negative regulation of hydrogen peroxide-induced cell death&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: GO:1903206 (negative regulation of hydrogen peroxide-induced cell death) is NOT present in GOA for NFE2L2. The curated review accepts GO:0070301 (cellular response to hydrogen peroxide) and GO:1902176 (negative regulation of oxidative stress-induced intrinsic apoptotic signaling pathway) as GOA annotations. GO:1903206 is plausible—NRF2 activates antioxidant genes that protect against H2O2-induced cell death—but is not in GOA. The prediction is biologically reasonable but not confirmed in the curated ground truth. Uncertain. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:1903206 resolves to &#39;obsolete negative regulation of hydrogen peroxide-induced cell death&#39;, not &#39;negative regulation of hydrogen peroxide-induced cell death&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:1903206 is &#39;obsolete negative regulation of hydrogen peroxide-induced cell death&#39;. The raw and canonical labels denote the same biological concept, and the replacement concept is already supported by GOA and the AIGR. The prediction is correct but not novel; ontology status is flagged separately. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: GO:1903206 (negative regulation of hydrogen peroxide-induced cell death) is NOT present in GOA for NFE2L2. The curated review accepts GO:0070301 (cellular response to hydrogen peroxide) and GO:1902176 (negative regulation of oxidative stress-induced intrinsic apoptotic signaling pathway) as GOA annotations. GO:1903206 is plausible—NRF2 activates antioxidant genes that protect against H2O2-induced cell death—but is not in GOA. The prediction is biologically reasonable but not confirmed in the curated ground truth. Uncertain. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:1903206 resolves to &#39;obsolete negative regulation of hydrogen peroxide-induced cell death&#39;, not &#39;negative regulation of hydrogen peroxide-induced cell death&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -93068,7 +93068,7 @@
     <td class="summary-cell"><div class="summary-text">Correct and already in GOA (GO:1903589 present; also GO:0043117 positive regulation of vascular permeability). VEGFA was originally identified as vascular permeability factor (VPF). This is one of its defining functions. CNN. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:1903589 resolves to &#39;positive regulation of blood vessel endothelial cell proliferation involved in sprouting angiogenesis&#39;, not &#39;positive regulation of vascular permeability&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
-<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/human/VEGFA/VEGFA-ai-review.html">P15692</a>
         <br><small style="color:var(--text-muted)">VEGFA</small>
@@ -93079,10 +93079,10 @@
         positive regulation of transcription from RNA polymerase II promoter in response to hypoxia
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-NPI">NPI</span></td>
-    <td>0</td>
+    <td><span class="badge badge-UNC">UNC</span></td>
+    <td>1</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">Incorrect direction of causal relationship. VEGFA expression is INDUCED by hypoxia (it is the target of HIF-1alpha transcriptional activation, not the activator of Pol II transcription in hypoxia). This term implies VEGFA activates transcription from PolII promoters in response to hypoxia, which reverses the well-established regulatory logic. VEGFA is the output of hypoxia-responsive transcription, not a transcriptional regulator during hypoxia. NPI. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061419 resolves to &#39;obsolete positive regulation of transcription from RNA polymerase II promoter in response to hypoxia&#39;, not &#39;positive regulation of transcription from RNA polymerase II promoter in response to hypoxia&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0061419 is &#39;obsolete positive regulation of transcription from RNA polymerase II promoter in response to hypoxia&#39;. The canonical GO term is not resolved by the current reference evidence. The pair is classified UNC; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Uncertain rather than refuted. Current GOA and the AIGR support VEGFA in positive regulation of RNA polymerase II transcription, but they do not resolve whether that role is specifically executed in response to hypoxia. The prior causal-reversal rationale was too strong because VEGFA signaling can activate downstream transcription; the narrower hypoxia context still requires expert confirmation. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061419 resolves to &#39;obsolete positive regulation of transcription from RNA polymerase II promoter in response to hypoxia&#39;, not &#39;positive regulation of transcription from RNA polymerase II promoter in response to hypoxia&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -93153,7 +93153,7 @@
     <td class="summary-cell"><div class="summary-text">Correct and already in GOA (IEA or IDA). VEGFA activates the Ras-Raf-MEK-ERK cascade downstream of VEGFR2, essential for endothelial cell proliferation. CNN.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/human/VEGFA/VEGFA-ai-review.html">P15692</a>
         <br><small style="color:var(--text-muted)">VEGFA</small>
@@ -93164,10 +93164,10 @@
         positive regulation of phosphatidylinositol 3-kinase signaling
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0014068 is &#39;obsolete positive regulation of phosphatidylinositol 3-kinase signaling&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct and already in GOA (IEA/IDA). VEGFA activates PI3K via VEGFR2, leading to Akt activation and endothelial cell survival. CNN. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0014068 resolves to &#39;obsolete positive regulation of phosphatidylinositol 3-kinase signaling&#39;, not &#39;positive regulation of phosphatidylinositol 3-kinase signaling&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0014068 is &#39;obsolete positive regulation of phosphatidylinositol 3-kinase signaling&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct and already in GOA (IEA/IDA). VEGFA activates PI3K via VEGFR2, leading to Akt activation and endothelial cell survival. CNN. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0014068 resolves to &#39;obsolete positive regulation of phosphatidylinositol 3-kinase signaling&#39;, not &#39;positive regulation of phosphatidylinositol 3-kinase signaling&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -178924,7 +178924,7 @@
     <td class="summary-cell"><div class="summary-text">Generic or ancestor term not confirmed or refuted by GOA or AI gene review.</div></td>
 </tr>
 
-<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/rat/St13/St13-ai-review.html">P50503</a>
         <br><small style="color:var(--text-muted)">St13</small>
@@ -178935,10 +178935,10 @@
         chaperone cofactor-dependent protein refolding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-NPI">NPI</span></td>
-    <td>0</td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0051085 is &#39;obsolete chaperone cofactor-dependent protein refolding&#39;. The function denoted by the supplied GO ID is contradicted by the current reference. The pair is classified NPI; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Generic or ancestor term not confirmed or refuted by GOA or AI gene review. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0051085 resolves to &#39;obsolete chaperone cofactor-dependent protein refolding&#39;, not &#39;chaperone cofactor-dependent protein refolding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0051085 is &#39;obsolete chaperone cofactor-dependent protein refolding&#39;. The raw and canonical labels denote the same biological concept, and the replacement concept is already supported by GOA and the AIGR. The prediction is correct but not novel; ontology status is flagged separately. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Generic or ancestor term not confirmed or refuted by GOA or AI gene review. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0051085 resolves to &#39;obsolete chaperone cofactor-dependent protein refolding&#39;, not &#39;chaperone cofactor-dependent protein refolding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="NPI" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -185351,7 +185351,7 @@
     <td class="summary-cell"><div class="summary-text">Correct but already annotated. HSP-90/DAF-21 is required for chemosensory behavior in C. elegans. The curated review notes essential roles for chemosensory behavior. Already in GOA. Not novel.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/worm/hsp-90/hsp-90-ai-review.html">Q18688</a>
         <br><small style="color:var(--text-muted)">hsp-90</small>
@@ -185362,10 +185362,10 @@
         chaperone-mediated protein folding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0061077 is &#39;obsolete chaperone-mediated protein folding&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct but already annotated. Chaperone-mediated protein folding is the core function of HSP-90, including folding of kinases, myosin, and signaling receptors. Already in GOA. Not novel. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0061077 is &#39;obsolete chaperone-mediated protein folding&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct but already annotated. Chaperone-mediated protein folding is the core function of HSP-90, including folding of kinases, myosin, and signaling receptors. Already in GOA. Not novel. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0061077 resolves to &#39;obsolete chaperone-mediated protein folding&#39;, not &#39;chaperone-mediated protein folding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -187265,7 +187265,7 @@
     <td class="summary-cell"><div class="summary-text">Current-snapshot audit reclassified NPI to CNN because the current AIGR contains a positive exact action (KEEP_AS_NON_CORE). This exact-join decision supersedes conflicting conclusions in the earlier rationale. Retained biological rationale. Incorrect prediction. HSP104 is a cytoplasmic/nuclear disaggregase that does not localize to the ER and has no known role in ER protein folding. ER protein folding is mediated by ER-resident chaperones (KAR2/BiP, PDI1, CNE1). This prediction likely arises from frequency bias toward chaperone-related processes in training data, confusing cytoplasmic disaggregation with ER protein quality control.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/yeast/HSP104/HSP104-ai-review.html">P31539</a>
         <br><small style="color:var(--text-muted)">HSP104</small>
@@ -187276,10 +187276,10 @@
         chaperone cofactor-dependent protein refolding
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0051085 is &#39;obsolete chaperone cofactor-dependent protein refolding&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct biological process. HSP104 works with Hsp70/Hsp40 co-chaperones in an obligate collaborative mechanism for protein disaggregation and refolding. This co-chaperone-dependent activity is a defining feature of the Hsp100 disaggregase mechanism. Already in GOA. In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0051085 resolves to &#39;obsolete chaperone cofactor-dependent protein refolding&#39;, not &#39;chaperone cofactor-dependent protein refolding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0051085 is &#39;obsolete chaperone cofactor-dependent protein refolding&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct biological process. HSP104 works with Hsp70/Hsp40 co-chaperones in an obligate collaborative mechanism for protein disaggregation and refolding. This co-chaperone-dependent activity is a defining feature of the Hsp100 disaggregase mechanism. Already in GOA. In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0051085 resolves to &#39;obsolete chaperone cofactor-dependent protein refolding&#39;, not &#39;chaperone cofactor-dependent protein refolding&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -187817,7 +187817,7 @@
     <td class="summary-cell"><div class="summary-text">Correct biological process. IRE1 undergoes trans-autophosphorylation upon ER stress activation, which is required for full activation of the RNase domain. Autophosphorylation is a documented regulatory mechanism. Already in curated GOA. In training data.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/yeast/IRE1/IRE1-ai-review.html">P32361</a>
         <br><small style="color:var(--text-muted)">IRE1</small>
@@ -187828,10 +187828,10 @@
         mRNA cleavage involved in mRNA processing
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0098787 is &#39;obsolete mRNA cleavage involved in mRNA processing&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct biological process. IRE1&#39;s endoribonuclease domain cleaves HAC1 pre-mRNA at two specific sites as part of unconventional cytoplasmic mRNA splicing/processing. This is a core function. Already in curated GOA. In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0098787 resolves to &#39;obsolete mRNA cleavage involved in mRNA processing&#39;, not &#39;mRNA cleavage involved in mRNA processing&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0098787 is &#39;obsolete mRNA cleavage involved in mRNA processing&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct biological process. IRE1&#39;s endoribonuclease domain cleaves HAC1 pre-mRNA at two specific sites as part of unconventional cytoplasmic mRNA splicing/processing. This is a core function. Already in curated GOA. In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0098787 resolves to &#39;obsolete mRNA cleavage involved in mRNA processing&#39;, not &#39;mRNA cleavage involved in mRNA processing&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="COR" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -187991,7 +187991,7 @@
     <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0034976 is &#39;response to endoplasmic reticulum stress&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct biological process. KAR2/BiP is a key effector of the UPR and is itself induced by ER stress. It participates in the cellular response to unfolded proteins both as a chaperone and as a negative regulator of IRE1 (BiP binding to IRE1 keeps it inactive under non-stress conditions). Already in curated GOA. In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0034976 resolves to &#39;response to endoplasmic reticulum stress&#39;, not &#39;response to unfolded protein&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/yeast/KAR2/KAR2-ai-review.html">P16474</a>
         <br><small style="color:var(--text-muted)">KAR2</small>
@@ -188002,10 +188002,10 @@
         ubiquitin-dependent ERAD pathway
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0030433 is &#39;obsolete ubiquitin-dependent ERAD pathway&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct biological process. KAR2/BiP participates in ERAD by maintaining misfolded glycoprotein substrates in a soluble, retrotranslocation-competent state and facilitating their recognition by E3 ubiquitin ligase complexes. Already in curated GOA. In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0030433 resolves to &#39;obsolete ubiquitin-dependent ERAD pathway&#39;, not &#39;ubiquitin-dependent ERAD pathway&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0030433 is &#39;obsolete ubiquitin-dependent ERAD pathway&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct biological process. KAR2/BiP participates in ERAD by maintaining misfolded glycoprotein substrates in a soluble, retrotranslocation-competent state and facilitating their recognition by E3 ubiquitin ligase complexes. Already in curated GOA. In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0030433 resolves to &#39;obsolete ubiquitin-dependent ERAD pathway&#39;, not &#39;ubiquitin-dependent ERAD pathway&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -188666,7 +188666,7 @@
     <td class="summary-cell"><div class="summary-text">In GOA (IMP, PMID:2558958). Curated review KEEP_AS_NON_CORE. RAS2 plays a permissive role in sporulation via nutrient starvation response but is not a primary regulator of meiosis. Correct but not novel, and non-core.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/yeast/RAS2/RAS2-ai-review.html">P01120</a>
         <br><small style="color:var(--text-muted)">RAS2</small>
@@ -188677,10 +188677,10 @@
         cytoplasm to vacuole transport by the Cvt pathway
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
-    <td>2</td>
+    <td><span class="badge badge-NPI">NPI</span></td>
+    <td>0</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0032258 is &#39;cytoplasm to vacuole targeting by the Cvt pathway&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: In GOA (IMP, PMID:15016820). The curated review recommends MODIFY to GO:2001159 (regulation of protein localization by the Cvt pathway), the closest current GO term; the evidence indicates inhibitory regulation, but GO has no current negative-regulation child. The prediction reproduces the direct-process annotation and misses that regulatory relationship. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0032258 resolves to &#39;cytoplasm to vacuole targeting by the Cvt pathway&#39;, not &#39;cytoplasm to vacuole transport by the Cvt pathway&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0032258 is &#39;cytoplasm to vacuole targeting by the Cvt pathway&#39;. The function denoted by the supplied GO ID is contradicted by the current reference. The pair is classified NPI; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: In GOA (IMP, PMID:15016820). The curated review recommends MODIFY to GO:2001159 (regulation of protein localization by the Cvt pathway), the closest current GO term; the evidence indicates inhibitory regulation, but GO has no current negative-regulation child. The prediction reproduces the direct-process annotation and misses that regulatory relationship. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0032258 resolves to &#39;cytoplasm to vacuole targeting by the Cvt pathway&#39;, not &#39;cytoplasm to vacuole transport by the Cvt pathway&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -189218,7 +189218,7 @@
     <td class="summary-cell"><div class="summary-text">Current-snapshot audit reclassified UNC to CNN because the current AIGR contains a positive exact action (KEEP_AS_NON_CORE). This exact-join decision supersedes conflicting conclusions in the earlier rationale. Retained biological rationale. Uncertain prediction. SSA1 has been associated with polysomes (predicted below) and has roles in translation-related processes, but direct evidence for SSA1 in cytoplasmic translation per se is limited. SSA1&#39;s chaperone function may support cotranslational folding on ribosomes. Cannot confidently assess without reviewing the specific experimental support.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/yeast/SSA1/SSA1-ai-review.html">P10591</a>
         <br><small style="color:var(--text-muted)">SSA1</small>
@@ -189229,10 +189229,10 @@
         protein targeting to mitochondrion
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0006626 is &#39;obsolete protein targeting to mitochondrion&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct biological process. SSA1 functions in targeting and import of precursor proteins into mitochondria, keeping them in an import-competent unfolded state. Already in curated GOA (accepted). In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0006626 resolves to &#39;obsolete protein targeting to mitochondrion&#39;, not &#39;protein targeting to mitochondrion&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0006626 is &#39;obsolete protein targeting to mitochondrion&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct biological process. SSA1 functions in targeting and import of precursor proteins into mitochondria, keeping them in an import-competent unfolded state. Already in curated GOA (accepted). In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0006626 resolves to &#39;obsolete protein targeting to mitochondrion&#39;, not &#39;protein targeting to mitochondrion&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -189354,7 +189354,7 @@
     <td class="summary-cell"><div class="summary-text">Correct cellular component. SSA1 is the major constitutively expressed cytoplasmic/cytosolic Hsp70. Confirmed by IDA (PMID:8755907) and HDA. Already in curated GOA (accepted). In training data.</div></td>
 </tr>
 
-<tr data-assessment="LSP" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/yeast/SSA1/SSA1-ai-review.html">P10591</a>
         <br><small style="color:var(--text-muted)">SSA1</small>
@@ -189365,10 +189365,10 @@
         polysome
     </td>
     <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-LSP">LSP</span></td>
+    <td><span class="badge badge-CNN">CNN</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0005844 is &#39;obsolete polysome&#39;. The intended concept is supported, but the supplied ID is obsolete or requires a current or more precise term. The pair is classified LSP; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct cellular component. SSA1 has been found associated with polysomes, consistent with its role in cotranslational folding assistance. Already in curated GOA. In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0005844 resolves to &#39;obsolete polysome&#39;, not &#39;polysome&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
+    <td class="summary-cell"><div class="summary-text">[FROZEN_ONTOLOGY_ADJUDICATION] Assessed the supplied GO ID rather than the intended raw label: GO:0005844 is &#39;obsolete polysome&#39;. The raw and canonical labels denote the same biological concept. Ontology status is flagged separately, so the biological novelty and precision assessment is retained. The pair is classified CNN; the raw source pair remains unchanged. Historical rationale about the intended raw label is retained below for provenance, not as support for the canonical GO ID: Correct cellular component. SSA1 has been found associated with polysomes, consistent with its role in cotranslational folding assistance. Already in curated GOA. In training data. [ONTOLOGY_LABEL_AUDIT] Raw model pair mismatch: GO:0005844 resolves to &#39;obsolete polysome&#39;, not &#39;polysome&#39;. The raw ID and label are retained for provenance; the assessment applies to the GO ID and explicitly flags the label error.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">

--- a/pages/projects/PROTNLM_EVALUATION/protnlm-eval.html
+++ b/pages/projects/PROTNLM_EVALUATION/protnlm-eval.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ARGO-ProtNLM-50 Prediction Evaluation</title>
+    <title>ProtNLM-50 Prediction Evaluation</title>
     <style>
         :root {
             --color-cor: #16a34a;
@@ -206,7 +206,7 @@
 </head>
 <body>
 
-<h1>ARGO-ProtNLM-50 Prediction Evaluation</h1>
+<h1>ProtNLM-50 Prediction Evaluation</h1>
 <p class="subtitle"></p>
 
 <div class="summary-bar">
@@ -218,98 +218,98 @@
         <div class="value">77</div>
         <div class="label">Predictions</div>
     </div>
-    
-    
+
+
     <div class="summary-stat">
-        <div class="value" style="color: var(--color-cor);">17</div>
+        <div class="value" style="color: var(--color-cor);">20</div>
         <div class="label">COR</div>
     </div>
-    
-    
-    
+
+
+
     <div class="summary-stat">
-        <div class="value" style="color: var(--color-cnn);">11</div>
+        <div class="value" style="color: var(--color-cnn);">12</div>
         <div class="label">CNN</div>
     </div>
-    
-    
-    
+
+
+
     <div class="summary-stat">
         <div class="value" style="color: var(--color-lsp);">18</div>
         <div class="label">LSP</div>
     </div>
-    
-    
-    
+
+
+
     <div class="summary-stat">
-        <div class="value" style="color: var(--color-unc);">15</div>
+        <div class="value" style="color: var(--color-unc);">3</div>
         <div class="label">UNC</div>
     </div>
-    
-    
-    
+
+
+
     <div class="summary-stat">
         <div class="value" style="color: var(--color-pli);">2</div>
         <div class="label">PLI</div>
     </div>
-    
-    
-    
+
+
+
     <div class="summary-stat">
-        <div class="value" style="color: var(--color-npi);">14</div>
+        <div class="value" style="color: var(--color-npi);">22</div>
         <div class="label">NPI</div>
     </div>
-    
-    
-    
-    
+
+
+
+
     <div class="summary-stat">
-        <div class="value">1.4</div>
+        <div class="value">1.3</div>
         <div class="label">Mean CS</div>
     </div>
 </div>
 
 
 <div class="assessment-dist">
-    
-    
-    <div class="seg seg-COR" style="flex: 17;" title="COR: 17">
-        COR (17)
+
+
+    <div class="seg seg-COR" style="flex: 20;" title="COR: 20">
+        COR (20)
     </div>
-    
-    
-    
-    <div class="seg seg-CNN" style="flex: 11;" title="CNN: 11">
-        CNN (11)
+
+
+
+    <div class="seg seg-CNN" style="flex: 12;" title="CNN: 12">
+        CNN (12)
     </div>
-    
-    
-    
+
+
+
     <div class="seg seg-LSP" style="flex: 18;" title="LSP: 18">
         LSP (18)
     </div>
-    
-    
-    
-    <div class="seg seg-UNC" style="flex: 15;" title="UNC: 15">
-        UNC (15)
+
+
+
+    <div class="seg seg-UNC" style="flex: 3;" title="UNC: 3">
+
     </div>
-    
-    
-    
+
+
+
     <div class="seg seg-PLI" style="flex: 2;" title="PLI: 2">
-        
+
     </div>
-    
-    
-    
-    <div class="seg seg-NPI" style="flex: 14;" title="NPI: 14">
-        NPI (14)
+
+
+
+    <div class="seg seg-NPI" style="flex: 22;" title="NPI: 22">
+        NPI (22)
     </div>
-    
-    
-    
-    
+
+
+
+
 </div>
 
 
@@ -327,31 +327,31 @@
     <input type="text" id="search" placeholder="Filter by protein, term, or text…" oninput="filterTable()">
     <select id="assessmentFilter" onchange="filterTable()">
         <option value="">All assessments</option>
-        
+
         <option value="COR">COR</option>
-        
+
         <option value="CNN">CNN</option>
-        
+
         <option value="LSP">LSP</option>
-        
+
         <option value="UNC">UNC</option>
-        
+
         <option value="PLI">PLI</option>
-        
+
         <option value="NPI">NPI</option>
-        
+
         <option value="REP">REP</option>
-        
+
     </select>
     <select id="typeFilter" onchange="filterTable()">
         <option value="">All term types</option>
-        
+
         <option value="GO_BP">GO_BP</option>
-        
+
         <option value="GO_CC">GO_CC</option>
-        
+
         <option value="GO_MF">GO_MF</option>
-        
+
     </select>
     <label style="font-size:0.85rem;">
         <input type="checkbox" id="hideNoPred" onchange="filterTable()"> Hide no-prediction rows
@@ -416,7 +416,7 @@
 <tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ABRPR/A0A8B8L1Z3/A0A8B8L1Z3-ai-review.html">A0A8B8L1Z3</a>
-        
+
     </td>
     <td><small>Abrus precatorius</small></td>
     <td>
@@ -437,7 +437,7 @@
 <tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/AEDAE/A0A6I8TLE4/A0A6I8TLE4-ai-review.html">A0A6I8TLE4</a>
-        
+
     </td>
     <td><small>Aedes aegypti</small></td>
     <td>
@@ -455,10 +455,10 @@
 
 
 
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/AQUCT/A0A2G9RZF1/A0A2G9RZF1-ai-review.html">A0A2G9RZF1</a>
-        
+
     </td>
     <td><small>Aquarana catesbeiana</small></td>
     <td>
@@ -466,16 +466,16 @@
         single fertilization
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted GO:0007338 (single fertilization) for this CUB domain-containing protein. The prediction is biologically plausible: PANTHER classifies this protein in the OVOCHYMASE-RELATED family (PTHR24251), and ovochymases are serine proteases involved in egg envelope hardening during fertilization in amphibians. CUB domains are also found in amphibian egg envelope glycoproteins that mediate sperm-egg recognition (Hedrick 2008). However, A0A2G9RZF1 is only 156 aa (likely a protein fragment), contains a single CUB domain without any identifiable protease or catalytic domain, and UniProt notes it lacks conserved residues required for feature propagation. There are no GOA annotations, no expression data, and no direct experimental evidence linking this specific protein to fertilization. While the family context makes reproductive biology a reasonable hypothesis, the prediction cannot be validated or refuted with available evidence.</div></td>
+    <td><span class="badge badge-NPI">NPI</span></td>
+    <td>0</td>
+    <td><span class="badge-error">PARALOG_OVERANNOTATION</span></td>
+    <td class="summary-cell"><div class="summary-text">Downgraded from UNC to NPI. An independent OpenScientist investigation (see file reference) refutes the ovochymase/fertilization prediction. A0A2G9RZF1 is a short, 156-amino-acid, CUB-domain-only protein with no serine protease domain whatsoever and no catalytic triad -- a direct motif scan found none of the diagnostic S1-protease signatures (TAAHC His-loop, GDSGGP nucleophile), so the His-Asp-Ser catalytic triad that defines a competent serine protease is not present, and a ~220-260-residue protease domain cannot fit in a 156-aa protein that is already almost entirely CUB (PF00431). Every characterized ovochymase is a large (564-1575 aa) multidomain S1-protease + CUB protein. This is best explained as paralog/family over-annotation: the single CUB module places the protein in a broad ovochymase-related/CUB family, and ProtNLM2 propagated the family&#39;s protease/fertilization function to a protein lacking the catalytic domain. Caveat: the entry is a genome-derived predicted ORF (TrEMBL, proteinExistence &#34;Predicted&#34;); a partial gene model cannot be fully excluded from sequence alone, though it is not flagged as a fragment and the AlphaFold model spans the full 1-156 as one compact CUB domain.</div></td>
 </tr>
 
 <tr data-assessment="COR" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/AQUCT/A0A2G9RZF1/A0A2G9RZF1-ai-review.html">A0A2G9RZF1</a>
-        
+
     </td>
     <td><small>Aquarana catesbeiana</small></td>
     <td>
@@ -495,7 +495,7 @@
 <tr data-assessment="" data-type="" data-nopred="1" class="no-pred-row">
     <td>
         <a class="gene-link" href="../../../genes/ARAHY/A0A444Z7V7/A0A444Z7V7-ai-review.html">A0A444Z7V7</a>
-        
+
     </td>
     <td><small>Arachis hypogaea</small></td>
     <td colspan="6" class="no-predictions">No predictions</td>
@@ -507,7 +507,7 @@
 <tr data-assessment="PLI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ARATH/F4JLB7/F4JLB7-ai-review.html">F4JLB7</a>
-        
+
     </td>
     <td><small>Arabidopsis thaliana</small></td>
     <td>
@@ -518,13 +518,13 @@
     <td><span class="badge badge-PLI">PLI</span></td>
     <td>0</td>
     <td><span class="badge-error">PARALOG_OVERANNOTATION</span></td>
-    <td class="summary-cell"><div class="summary-text">GO:0016310 (phosphorylation) predicts that RIC7 is involved in a phosphorylation process, implying it acts as or with a kinase. This is incorrect. RIC7 is a ROP GTPase effector protein whose characterized biological roles are negative regulation of stomatal opening (GO:1902457) and regulation of stomatal movement (GO:0010119), mediated by binding activated ROP2 via its CRIB domain and inhibiting Exo70B1. RIC7 belongs to the receptor-like protein (RLP) family, which by definition lacks the intracellular kinase domain present in the related receptor-like kinase (RLK) family. The UniProt entry for F4JLB7 lists no kinase-related domains, keywords, or functions. InterPro annotations show only LRR domains (IPR001611, IPR032675) and a stomatal development/plant interaction regulator domain (IPR052941), with no protein kinase domain. The FunFam classification with the ERECTA kinase superfamily (3.80.10.10:FF:000041) reflects shared LRR structural domains, not shared kinase function -- ERECTA is an RLK with a kinase domain, while RIC7 is an RLP without one. No experimental evidence from Wu et al. 2001 (PMID:11752391) or subsequent functional studies supports any role for RIC7 in phosphorylation. This prediction is a paralog overannotation error arising from failure to distinguish kinase-containing from kinase-lacking members of the LRR superfamily.</div></td>
+    <td class="summary-cell"><div class="summary-text">GO:0016310 (phosphorylation) predicts that RIC7 is involved in a phosphorylation process, implying it acts as or with a kinase. This is incorrect. RIC7 is a ROP GTPase effector protein whose characterized biological roles are negative regulation of stomatal opening (GO:1902457) and regulation of stomatal movement (GO:0010119), mediated by binding activated ROP2 via its CRIB domain and inhibiting Exo70B1. RIC7 belongs to the receptor-like protein (RLP) family, which by definition lacks the intracellular kinase domain present in the related receptor-like kinase (RLK) family. The UniProt entry for F4JLB7 lists no kinase-related domains, keywords, or functions. InterPro annotations show only LRR domains (IPR001611, IPR032675) and a stomatal development/plant interaction regulator domain (IPR052941), with no protein kinase domain. The FunFam classification with the ERECTA kinase superfamily (3.80.10.10:FF:000041) reflects shared LRR structural domains, not shared kinase function -- ERECTA is an RLK with a kinase domain, while RIC7 is an RLP without one. No experimental evidence from Wu et al. 2001 (PMID:11752391) or subsequent functional studies supports any role for RIC7 in phosphorylation. This prediction is a paralog overannotation error arising from failure to distinguish kinase-containing from kinase-lacking members of the LRR superfamily. An independent OpenScientist investigation (see file reference) confirms the dispute: F4JLB7 has no protein-kinase catalytic domain of any kind (no VAIK/HRD/DFG active-site machinery; the HRD catalytic aspartate is absent), so it is mechanistically incapable of catalyzing phosphotransfer. It also flags a gene-symbol collision -- the characterized RIC7 (ROP2/CRIB effector) is the adjacent locus At4g28556 (Q1G3K8), while F4JLB7 itself appears to be an LRR receptor-like protein; under either identity the kinase/phosphorylation terms are unsupported. PLI confirmed.</div></td>
 </tr>
 
 <tr data-assessment="PLI" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ARATH/F4JLB7/F4JLB7-ai-review.html">F4JLB7</a>
-        
+
     </td>
     <td><small>Arabidopsis thaliana</small></td>
     <td>
@@ -535,17 +535,17 @@
     <td><span class="badge badge-PLI">PLI</span></td>
     <td>0</td>
     <td><span class="badge-error">PARALOG_OVERANNOTATION</span></td>
-    <td class="summary-cell"><div class="summary-text">GO:0016301 (kinase activity) predicts that RIC7 catalyzes the transfer of a phosphate group to a substrate. This is incorrect. RIC7&#39;s characterized molecular function is small GTPase binding (GO:0031267), not kinase activity. The protein functions as a signaling adaptor downstream of ROP2, not as a catalytic enzyme. Structurally, RIC7 contains a CRIB (Cdc42/Rac-interactive binding) motif for GTPase interaction and LRR domains for protein-protein interactions, but no kinase domain of any type. The Pfam annotations for F4JLB7 are exclusively LRR_1 (PF00560, 3 copies) and LRR_8 (PF13855, 1 copy), with no Pkinase (PF00069) or Pkinase_Tyr (PF07714) domains. This distinguishes RIC7 from LRR-RLK proteins like ERECTA (AT2G26330), which share the LRR extracellular domain but additionally possess a cytoplasmic kinase domain. The curated ai-review explicitly notes that RIC7 &#34;lacks a kinase domain and functions as a cytoplasmic effector rather than a receptor.&#34; ProtNLM2 likely propagated kinase activity from LRR-RLK superfamily members in its training data to this kinase-lacking RLP family member, a classic Type 6 paralog overannotation error where the model fails to distinguish nonisofunctional members of a protein superfamily.</div></td>
+    <td class="summary-cell"><div class="summary-text">GO:0016301 (kinase activity) predicts that RIC7 catalyzes the transfer of a phosphate group to a substrate. This is incorrect. RIC7&#39;s characterized molecular function is small GTPase binding (GO:0031267), not kinase activity. The protein functions as a signaling adaptor downstream of ROP2, not as a catalytic enzyme. Structurally, RIC7 contains a CRIB (Cdc42/Rac-interactive binding) motif for GTPase interaction and LRR domains for protein-protein interactions, but no kinase domain of any type. The Pfam annotations for F4JLB7 are exclusively LRR_1 (PF00560, 3 copies) and LRR_8 (PF13855, 1 copy), with no Pkinase (PF00069) or Pkinase_Tyr (PF07714) domains. This distinguishes RIC7 from LRR-RLK proteins like ERECTA (AT2G26330), which share the LRR extracellular domain but additionally possess a cytoplasmic kinase domain. The curated ai-review explicitly notes that RIC7 &#34;lacks a kinase domain and functions as a cytoplasmic effector rather than a receptor.&#34; ProtNLM2 likely propagated kinase activity from LRR-RLK superfamily members in its training data to this kinase-lacking RLP family member, a classic Type 6 paralog overannotation error where the model fails to distinguish nonisofunctional members of a protein superfamily. An independent OpenScientist investigation (see file reference) confirms the dispute: F4JLB7 has no protein-kinase catalytic domain of any kind (no VAIK/HRD/DFG; HRD catalytic aspartate absent), so it is mechanistically incapable of catalyzing phosphotransfer. Caveat on identity: OpenScientist found F4JLB7 to be an LRR receptor-like protein and places the characterized CRIB-motif RIC7 (ROP2 effector) at the adjacent locus At4g28556 (Q1G3K8) -- so the CRIB-domain attribution above may belong to that paralog. Either way the kinase-activity term is refuted. PLI confirmed.</div></td>
 </tr>
 
 
 
 
 
-<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="COR" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ARTAN/A0A2U1PS28/A0A2U1PS28-ai-review.html">A0A2U1PS28</a>
-        
+
     </td>
     <td><small>Artemisia annua</small></td>
     <td>
@@ -553,10 +553,10 @@
         chloroplast
     </td>
     <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-COR">COR</span></td>
+    <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted chloroplast localization for this plant GUF1 homolog. All existing GOA annotations place this protein in the mitochondrion (GO:0005743 mitochondrial inner membrane, GO:0005759 mitochondrial matrix), based on HAMAP-Rule MF_03137 and UniProtKB-UniRule. However, the PANTHER subfamily classification (PTHR43512:SF4) explicitly labels this protein as &#34;TRANSLATION FACTOR GUF1 HOMOLOG, CHLOROPLASTIC,&#34; providing independent support for chloroplast targeting. In plants, the LepA/EF-4 family includes paralogs targeted to different organelles: chloroplastic cpLepA functions in plastid translation while mitochondrial GUF1 operates in mitochondrial translation. Both organelles maintain their own translation machinery and require elongation factor 4 for translational quality control. The N-terminal sequence of A0A2U1PS28 contains features (disordered polar-rich region, residues 1-25) that could constitute either a mitochondrial or chloroplast transit peptide, and distinguishing these computationally is notoriously difficult in plants. The existing AI review explicitly flags the question of whether this protein localizes to mitochondria, chloroplasts, or both as an unresolved issue requiring fluorescent tagging and confocal microscopy with organelle markers. Without such experimental data, this prediction remains genuinely uncertain -- it is biologically plausible given the PANTHER classification and the known diversity of organellar EF-4 targeting in plants, but it contradicts the HAMAP-based annotations that form the basis of the current GOA record.</div></td>
+    <td class="summary-cell"><div class="summary-text">Upgraded from UNC to COR. An independent OpenScientist investigation (see file reference) supports the ProtNLM2 chloroplast prediction and identifies the existing GOA/HAMAP mitochondrial annotation (GO:0005743, GO:0005759 via HAMAP-Rule MF_03137) as an automated misapplication. Two convergent lines of evidence: (1) orthology -- A0A2U1PS28 is ~78% identical to the Arabidopsis chloroplastic paralog Q9FNM5 (cpLEPA/EF4, experimentally plastid-localized) but only ~47% to the mitochondrial paralog Q9FLE4, placing it in the chloroplast cpLEPA clade rather than the mitochondrial GUF1 clade; (2) its N-terminal region has the Ser/Thr-rich, acidic-residue-devoid chloroplast transit-peptide signature rather than an amphipathic Arg-rich mitochondrial presequence. COR because chloroplast localization is correct and novel relative to GOA. The existing mitochondrial CC annotations are a curation lead for correction. Caveat: dedicated targeting predictors (TargetP-2.0 / DeepLoc) were unavailable in the run environment, so the conclusion rests on orthology plus composition -- both strong and mutually consistent -- rather than experimental localization of the Artemisia protein.</div></td>
 </tr>
 
 
@@ -566,7 +566,7 @@
 <tr data-assessment="COR" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ASPOR/Q2U1U6/Q2U1U6-ai-review.html">Q2U1U6</a>
-        
+
     </td>
     <td><small>Aspergillus oryzae</small></td>
     <td>
@@ -577,13 +577,13 @@
     <td><span class="badge badge-COR">COR</span></td>
     <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">GO:0000272 (polysaccharide catabolic process) is a correct novel prediction for Q2U1U6. The protein contains a Chondroitin_lyas domain (IPR008929) and matches the Chondroitin AC/alginate lyase SUPFAM fold (SSF48230), both of which are diagnostic for polysaccharide lyases that depolymerize glycosaminoglycan chains. The deep research report confirms that the protein is predicted to function as a polysaccharide lyase degrading GAG substrates (chondroitin sulfate, dermatan sulfate, and possibly hyaluronic acid) through a beta-elimination mechanism. This activity falls squarely within polysaccharide catabolic process. The term is somewhat broad -- a more precise annotation might be glycosaminoglycan catabolic process (GO:0006027) -- but GO:0000272 is not wrong and represents a biologically meaningful novel prediction for a protein with no existing GOA annotations. Aspergillus species encode extensive CAZyme repertoires including polysaccharide lyases, and the comparative genomics of section Flavi Aspergilli supports the plausibility of such activity in A. oryzae.</div></td>
+    <td class="summary-cell"><div class="summary-text">GO:0000272 (polysaccharide catabolic process) is a correct novel prediction for Q2U1U6. The protein contains a Chondroitin_lyas domain (IPR008929) and matches the Chondroitin AC/alginate lyase SUPFAM fold (SSF48230), both of which are diagnostic for polysaccharide lyases that depolymerize glycosaminoglycan chains. The deep research report confirms that the protein is predicted to function as a polysaccharide lyase degrading GAG substrates (chondroitin sulfate, dermatan sulfate, and possibly hyaluronic acid) through a beta-elimination mechanism. This activity falls squarely within polysaccharide catabolic process. The term is somewhat broad -- a more precise annotation might be glycosaminoglycan catabolic process (GO:0006027) -- but GO:0000272 is not wrong and represents a biologically meaningful novel prediction for a protein with no existing GOA annotations. Aspergillus species encode extensive CAZyme repertoires including polysaccharide lyases, and the comparative genomics of section Flavi Aspergilli supports the plausibility of such activity in A. oryzae. Curator flag: the independent OpenScientist run (see the GO:0004553 review below) notes the protein is only 134 aa with a partial SSF48230 match and is far smaller than any reviewed family member, so even this positive lyase-based process call may be over-confident and should be curator-rechecked; the conservative alternative is to leave it uncharacterized pending experimental evidence.</div></td>
 </tr>
 
 <tr data-assessment="NPI" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ASPOR/Q2U1U6/Q2U1U6-ai-review.html">Q2U1U6</a>
-        
+
     </td>
     <td><small>Aspergillus oryzae</small></td>
     <td>
@@ -594,7 +594,7 @@
     <td><span class="badge badge-NPI">NPI</span></td>
     <td>0</td>
     <td><span class="badge-error">FREQUENCY_BIAS</span></td>
-    <td class="summary-cell"><div class="summary-text">GO:0004553 (hydrolase activity, hydrolyzing O-glycosyl compounds) is mechanistically incorrect for Q2U1U6. The protein&#39;s only domain annotation is Chondroitin_lyas (IPR008929) with a structural match to Chondroitin AC/alginate lyase (SSF48230), placing it firmly in the polysaccharide lyase (PL) superfamily, not the glycoside hydrolase (GH) superfamily. These are fundamentally different enzyme classes in the CAZy classification system. Polysaccharide lyases cleave glycosidic bonds via a beta-elimination mechanism, abstracting a proton from C5 of a hexuronic acid residue and eliminating across C4-O4 to generate products with a characteristic delta-4,5-unsaturated bond. Glycoside hydrolases, by contrast, cleave glycosidic bonds through hydrolysis, adding water across the bond. The reaction mechanisms, active site architectures, and products are categorically different. ProtNLM2 appears to have conflated the general concept of polysaccharide-degrading activity with glycoside hydrolase activity, likely because glycoside hydrolases are the most frequently annotated polysaccharide-degrading enzymes in training data. The correct molecular function term would be in the polysaccharide lyase activity branch, not the hydrolase branch.</div></td>
+    <td class="summary-cell"><div class="summary-text">GO:0004553 (hydrolase activity, hydrolyzing O-glycosyl compounds) is mechanistically incorrect for Q2U1U6. The protein&#39;s only domain annotation is Chondroitin_lyas (IPR008929) with a structural match to Chondroitin AC/alginate lyase (SSF48230), placing it firmly in the polysaccharide lyase (PL) superfamily, not the glycoside hydrolase (GH) superfamily. These are fundamentally different enzyme classes in the CAZy classification system. Polysaccharide lyases cleave glycosidic bonds via a beta-elimination mechanism, abstracting a proton from C5 of a hexuronic acid residue and eliminating across C4-O4 to generate products with a characteristic delta-4,5-unsaturated bond. Glycoside hydrolases, by contrast, cleave glycosidic bonds through hydrolysis, adding water across the bond. The reaction mechanisms, active site architectures, and products are categorically different. ProtNLM2 appears to have conflated the general concept of polysaccharide-degrading activity with glycoside hydrolase activity, likely because glycoside hydrolases are the most frequently annotated polysaccharide-degrading enzymes in training data. The correct molecular function term would be in the polysaccharide lyase activity branch, not the hydrolase branch. An independent OpenScientist investigation (see file reference) confirms the dispute as a CAZy class misassignment (lyase fold, beta-elimination -- not a hydrolase), and adds an important caveat: at 134 aa the protein is ~2.5x smaller than the smallest of 53 reviewed IPR008929 members (331-1372 aa) and the SSF48230 match is partial (res 6-97), so it cannot reconstitute the (alpha/alpha) toroid or catalytic constellation -- meaning the data do not license a positive lyase annotation either. NPI confirmed; the honest state is an uncharacterized protein with a weak fold resemblance, warranting no MF enzyme term without experimental evidence.</div></td>
 </tr>
 
 
@@ -603,7 +603,7 @@
 <tr data-assessment="" data-type="" data-nopred="1" class="no-pred-row">
     <td>
         <a class="gene-link" href="../../../genes/BALMU/A0A8B8WEG2/A0A8B8WEG2-ai-review.html">A0A8B8WEG2</a>
-        
+
     </td>
     <td><small>Balaenoptera musculus</small></td>
     <td colspan="6" class="no-predictions">No predictions</td>
@@ -614,7 +614,7 @@
 <tr data-assessment="" data-type="" data-nopred="1" class="no-pred-row">
     <td>
         <a class="gene-link" href="../../../genes/BORPE/Q7VZI5/Q7VZI5-ai-review.html">Q7VZI5</a>
-        
+
     </td>
     <td><small>Bordetella pertussis</small></td>
     <td colspan="6" class="no-predictions">No predictions</td>
@@ -626,7 +626,7 @@
 <tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/BOVIN/E1BL04/E1BL04-ai-review.html">E1BL04</a>
-        
+
     </td>
     <td><small>Bos taurus</small></td>
     <td>
@@ -643,7 +643,7 @@
 <tr data-assessment="LSP" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/BOVIN/E1BL04/E1BL04-ai-review.html">E1BL04</a>
-        
+
     </td>
     <td><small>Bos taurus</small></td>
     <td>
@@ -660,7 +660,7 @@
 <tr data-assessment="LSP" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/BOVIN/E1BL04/E1BL04-ai-review.html">E1BL04</a>
-        
+
     </td>
     <td><small>Bos taurus</small></td>
     <td>
@@ -692,7 +692,7 @@
     <td><span class="badge badge-NPI">NPI</span></td>
     <td>0</td>
     <td><span class="badge-error">FREQUENCY_BIAS</span></td>
-    <td class="summary-cell"><div class="summary-text">MCM-4 is a subunit of the MCM2-7 replicative DNA helicase complex and has no known role in transcription initiation at RNA polymerase II promoters. The protein&#39;s sole domain in this 74 AA fragment is the winged-helix domain WHD_MCM4 (PF21128), which is structurally related to winged-helix domains found in some transcription factors. This structural similarity likely caused ProtNLM2 to predict a transcription-related function. However, the MCM4 WHD is specifically involved in DNA binding during replication origin licensing and replication fork progression, not in transcription. All established functions of MCM-4 -- DNA helicase activity, DNA replication initiation, and participation in the MCM complex -- are in the DNA replication pathway, not the transcription pathway. No literature or ortholog evidence supports a direct role for any MCM4 subunit in RNA polymerase II transcription initiation.</div></td>
+    <td class="summary-cell"><div class="summary-text">MCM-4 is a subunit of the MCM2-7 replicative DNA helicase complex and has no known role in transcription initiation at RNA polymerase II promoters. The protein&#39;s sole domain in this 74 AA fragment is the winged-helix domain WHD_MCM4 (PF21128), which is structurally related to winged-helix domains found in some transcription factors. This structural similarity likely caused ProtNLM2 to predict a transcription-related function. However, the MCM4 WHD is specifically involved in DNA binding during replication origin licensing and replication fork progression, not in transcription. All established functions of MCM-4 -- DNA helicase activity, DNA replication initiation, and participation in the MCM complex -- are in the DNA replication pathway, not the transcription pathway. No literature or ortholog evidence supports a direct role for any MCM4 subunit in RNA polymerase II transcription initiation. An independent OpenScientist investigation (see file reference) confirms the dispute: A0A061AL94 is unambiguously a 74-aa fragment of the MCM2-7 replicative DNA helicase subunit MCM4 (WormBase Y39G10AR.14b, sole domain PF21128 WHD_MCM4), not an RNA polymerase II transcription-initiation factor; the WHD is a DNA-replication feature and the prediction is a winged-helix/frequency-bias conflation. NPI confirmed.</div></td>
 </tr>
 
 <tr data-assessment="COR" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
@@ -716,10 +716,10 @@
 
 
 
-<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="COR" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/CALMI/A0A4W3GVU1/A0A4W3GVU1-ai-review.html">A0A4W3GVU1</a>
-        
+
     </td>
     <td><small>Callorhinchus milii</small></td>
     <td>
@@ -727,10 +727,10 @@
         nucleus
     </td>
     <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-COR">COR</span></td>
+    <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted subcellular location &#39;Nucleus&#39;, mapped to GO:0005634 (nucleus). This is a subcellular location prediction rather than a direct GO term prediction.</div></td>
+    <td class="summary-cell"><div class="summary-text">Upgraded from UNC to COR. An independent OpenScientist investigation (see file reference) identifies A0A4W3GVU1 as ESRP1 (epithelial splicing regulatory protein 1; paralog ESRP2 ruled out quantitatively) -- a soluble, three-RRM RNA-binding protein with no transmembrane segments. Its experimentally studied human ortholog ESRP1 has direct IDA nucleus/nucleoplasm/nuclear-body annotations, giving a robust ISS basis, so the nucleus prediction is correct and well-supported (primary/dominant localization), and novel relative to GOA. The prediction is correct but low in added information relative to existing orthology-based knowledge; a fuller annotation would capture the ESRP1 identity and its mRNA-splicing-regulator molecular function. Caveat: the ISS assignment rests on orthology to human ESRP1 rather than direct experimental data for the elephant-shark protein.</div></td>
 </tr>
 
 
@@ -794,7 +794,7 @@
 <tr data-assessment="" data-type="" data-nopred="1" class="no-pred-row">
     <td>
         <a class="gene-link" href="../../../genes/CHRVO/Q7NUH2/Q7NUH2-ai-review.html">Q7NUH2</a>
-        
+
     </td>
     <td><small>Chromobacterium violaceum</small></td>
     <td colspan="6" class="no-predictions">No predictions</td>
@@ -806,7 +806,7 @@
 <tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/COLLI/A0A2I0M3K7/A0A2I0M3K7-ai-review.html">A0A2I0M3K7</a>
-        
+
     </td>
     <td><small>Columba livia</small></td>
     <td>
@@ -864,7 +864,7 @@
 <tr data-assessment="" data-type="" data-nopred="1" class="no-pred-row">
     <td>
         <a class="gene-link" href="../../../genes/CUCME/A0A1S3BTE3/A0A1S3BTE3-ai-review.html">A0A1S3BTE3</a>
-        
+
     </td>
     <td><small>Cucumis melo</small></td>
     <td colspan="6" class="no-predictions">No predictions</td>
@@ -887,7 +887,7 @@
     <td><span class="badge badge-NPI">NPI</span></td>
     <td>0</td>
     <td><span class="badge-error">FREQUENCY_BIAS</span></td>
-    <td class="summary-cell"><div class="summary-text">Auxilin/DNAJC6 contains a PTEN-like phosphatase domain (residues 109-276), which ProtNLM2 likely used to predict involvement in dephosphorylation. However, the phosphatase domain of auxilin has only &#34;probable&#34; phosphatase activity per UniProt characterization. Its experimentally established role is phosphoinositide binding for membrane targeting during clathrin-mediated endocytosis, not catalytic dephosphorylation of substrates. The curated ai-review independently marked the related GOA annotation for phosphoprotein phosphatase activity (GO:0004721) as MARK_AS_OVER_ANNOTATED and hydrolase activity (GO:0016787) as REMOVE, noting that these sequence- feature-based annotations overstate the functional evidence. The core molecular function of auxilin is as a J-domain co-chaperone that recruits and stimulates HSC70 ATPase activity to disassemble clathrin coats from newly formed vesicles. Loss-of-function phenotypes in human (PARK19 Parkinson&#39;s disease) and zebrafish (impaired Notch signaling) are attributable to defective clathrin uncoating, not loss of phosphatase activity. This prediction reflects the model&#39;s reliance on the PTEN-like domain fold without accounting for the divergent functional role of this domain in the auxilin protein context.</div></td>
+    <td class="summary-cell"><div class="summary-text">Auxilin/DNAJC6 contains a PTEN-like phosphatase domain (residues 109-276), which ProtNLM2 likely used to predict involvement in dephosphorylation. However, the phosphatase domain of auxilin has only &#34;probable&#34; phosphatase activity per UniProt characterization. Its experimentally established role is phosphoinositide binding for membrane targeting during clathrin-mediated endocytosis, not catalytic dephosphorylation of substrates. The curated ai-review independently marked the related GOA annotation for phosphoprotein phosphatase activity (GO:0004721) as MARK_AS_OVER_ANNOTATED and hydrolase activity (GO:0016787) as REMOVE, noting that these sequence- feature-based annotations overstate the functional evidence. The core molecular function of auxilin is as a J-domain co-chaperone that recruits and stimulates HSC70 ATPase activity to disassemble clathrin coats from newly formed vesicles. Loss-of-function phenotypes in human (PARK19 Parkinson&#39;s disease) and zebrafish (impaired Notch signaling) are attributable to defective clathrin uncoating, not loss of phosphatase activity. This prediction reflects the model&#39;s reliance on the PTEN-like domain fold without accounting for the divergent functional role of this domain in the auxilin protein context. An independent OpenScientist investigation (see file reference) confirms this NPI: the dephosphorylation prediction is a misassignment driven by homology to the PTEN/tensin phosphatase fold, not by an intact catalytic site -- the domain is a pseudophosphatase. NPI confirmed.</div></td>
 </tr>
 
 
@@ -897,7 +897,7 @@
 <tr data-assessment="LSP" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/DEIRA/Q9RSY6/Q9RSY6-ai-review.html">Q9RSY6</a>
-        
+
     </td>
     <td><small>Deinococcus radiodurans</small></td>
     <td>
@@ -914,7 +914,7 @@
 <tr data-assessment="LSP" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/DEIRA/Q9RSY6/Q9RSY6-ai-review.html">Q9RSY6</a>
-        
+
     </td>
     <td><small>Deinococcus radiodurans</small></td>
     <td>
@@ -935,7 +935,7 @@
 <tr data-assessment="NPI" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/DROPS/A0A6I8W8A2/A0A6I8W8A2-ai-review.html">A0A6I8W8A2</a>
-        
+
     </td>
     <td><small>Drosophila pseudoobscura pseudoobscura</small></td>
     <td>
@@ -946,17 +946,17 @@
     <td><span class="badge badge-NPI">NPI</span></td>
     <td>0</td>
     <td><span class="badge-error">FREQUENCY_BIAS</span></td>
-    <td class="summary-cell"><div class="summary-text">GO:0016874 (ligase activity) is incorrect for this protein. The prediction appears driven by the automated RefSeq protein name &#34;Probable E3 ubiquitin-protein ligase HERC3 isoform X3&#34; rather than the actual domain content. HERC family E3 ligases require a C-terminal HECT (Homologous to E6-AP Carboxyl Terminus) domain to catalyze the transfer of ubiquitin from an E2 conjugating enzyme to substrate proteins. This 169 AA protein is far too short to contain a HECT domain (typically 350+ AA) and its entire domain architecture consists exclusively of two RCC1 repeats (positions 32-87 and 88-142), as confirmed by PROSITE, Pfam (PF00415 RCC1, PF13540 RCC1_2), InterPro (IPR000408), and Gene3D (2.130.10.30). The RCC1 repeat region in HERC proteins functions in substrate recognition and protein-protein interactions, not in catalytic ubiquitin ligation. This isoform X3 likely represents a truncated splice variant retaining only the N-terminal substrate-binding region of the full-length HERC3 ortholog. An appropriate molecular function annotation for this fragment would be in the protein binding domain (e.g., contributing to substrate recognition in a complex), not ligase activity. The protein has no curated GOA annotations and is unreviewed in UniProt (PE 4, predicted), further indicating that no experimental or curated evidence supports ligase activity for this specific gene product.</div></td>
+    <td class="summary-cell"><div class="summary-text">GO:0016874 (ligase activity) is incorrect for this protein. The prediction appears driven by the automated RefSeq protein name &#34;Probable E3 ubiquitin-protein ligase HERC3 isoform X3&#34; rather than the actual domain content. HERC family E3 ligases require a C-terminal HECT (Homologous to E6-AP Carboxyl Terminus) domain to catalyze the transfer of ubiquitin from an E2 conjugating enzyme to substrate proteins. This 169 AA protein is far too short to contain a HECT domain (typically 350+ AA) and its entire domain architecture consists exclusively of two RCC1 repeats (positions 32-87 and 88-142), as confirmed by PROSITE, Pfam (PF00415 RCC1, PF13540 RCC1_2), InterPro (IPR000408), and Gene3D (2.130.10.30). The RCC1 repeat region in HERC proteins functions in substrate recognition and protein-protein interactions, not in catalytic ubiquitin ligation. This isoform X3 likely represents a truncated splice variant retaining only the N-terminal substrate-binding region of the full-length HERC3 ortholog. An appropriate molecular function annotation for this fragment would be in the protein binding domain (e.g., contributing to substrate recognition in a complex), not ligase activity. The protein has no curated GOA annotations and is unreviewed in UniProt (PE 4, predicted), further indicating that no experimental or curated evidence supports ligase activity for this specific gene product. An independent OpenScientist investigation (see file reference) confirms this NPI: the 169-aa protein consists exclusively of an RCC1/RLD beta-propeller (IPR000408 / PF00415) with no HECT, RING, or U-box catalytic domain, and at 169 aa is structurally incapable of hosting a functional ligase active site -- the call is a name-transfer artifact from the &#34;HERC3&#34; RefSeq name. NPI confirmed.</div></td>
 </tr>
 
 
 
 
 
-<tr data-assessment="UNC" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="COR" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/DROVI/B4MAQ2/B4MAQ2-ai-review.html">B4MAQ2</a>
-        
+
     </td>
     <td><small>Drosophila virilis</small></td>
     <td>
@@ -964,17 +964,17 @@
         cytoplasm
     </td>
     <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-COR">COR</span></td>
+    <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted subcellular location &#39;Cytoplasm&#39;, mapped to GO:0005737 (cytoplasm). This is a subcellular location prediction rather than a direct GO term prediction.</div></td>
+    <td class="summary-cell"><div class="summary-text">Upgraded from UNC to COR. An independent OpenScientist investigation (see file reference) identifies B4MAQ2 as Exportin-5, an importin-beta-family nucleocytoplasmic transport receptor (85.5% identity to the experimentally characterized D. melanogaster ortholog). Cytoplasmic localization is correct -- Exportin-5 has an obligatory cytoplasmic phase in its transport cycle, so GO:0005737 is factually valid and novel relative to GOA -- but under-informative: it collapses a Ran-GTP-binding shuttle (carrying pre-miRNAs, tRNAs and certain proteins) to a single generic CC term. Curation lead: a fuller annotation would add the nucleus/nuclear envelope, nucleocytoplasmic transport, and exportin / Ran-GTPase-binding molecular function. Caveat: no direct experimental data exist for B4MAQ2 itself; the attribution rests on strong orthology, and exportin-5 cargo preferences diverge across species, so specifics should be annotated conservatively.</div></td>
 </tr>
 
 
 
 
 
-<tr data-assessment="NPI" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/GADMO/A0A8C5FPT8/A0A8C5FPT8-ai-review.html">A0A8C5FPT8</a>
         <br><small style="color:var(--text-muted)">tbc1d14</small>
@@ -985,10 +985,10 @@
         autophagosome
     </td>
     <td><span class="term-type">GO_CC</span></td>
-    <td><span class="badge badge-NPI">NPI</span></td>
-    <td>0</td>
+    <td><span class="badge badge-CNN">CNN</span></td>
+    <td>2</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted GO:0005776 (autophagosome) as a more specific replacement for the existing GOA annotation GO:0005773 (vacuole). This prediction is incorrect. TBC1D14 is a negative regulator of macroautophagy that acts by controlling ATG9 vesicle trafficking from recycling endosomes, but it does not localize to autophagosomes themselves. Detailed studies of mammalian TBC1D14 (Lamb et al. 2016) demonstrate localization to RAB11-positive recycling endosomes, the Golgi complex, and tubulo-vesicular transport intermediates between these compartments. When TBC1D14 is overexpressed, it causes tubulation of recycling endosomes and sequesters ULK1 and ATG9 away from autophagosome formation sites, thereby inhibiting autophagy -- but TBC1D14 itself remains on the endosomal compartment, not on the autophagosome. The existing vacuole annotation (GO:0005773) was already flagged as MARK_AS_OVER_ANNOTATED in the curated review because no evidence supports vacuolar or lysosomal localization. The ProtNLM2 prediction of autophagosome appears to conflate functional involvement in autophagy regulation (a biological process) with physical residence at the autophagosome (a cellular component), a category error. The correct cellular component annotations for TBC1D14 would be recycling endosome (GO:0055037) and Golgi apparatus (GO:0005794), neither of which was predicted.</div></td>
+    <td class="summary-cell"><div class="summary-text">Reassessed from NPI to CNN on independent review. The original call rejected autophagosome localization outright, but that was too harsh: an independent OpenScientist investigation (see file reference), corroborated by a direct QuickGO check, shows the human ortholog TBC1D14 (Q9P2M4) carries a curated IDA autophagosome annotation (GO:0005776, located_in) from Longatti et al. 2012 (PMID:22613832), plus a phylogenetic IBA (GO_REF:0000033). Autophagosome localization is therefore experimentally established for the ortholog and defensible for this fish protein by orthology, so the prediction is correct (and not novel, as it reflects known ortholog biology). The valid caveat preserved from the original review is one of precision, not correctness: autophagosome is a secondary, condition-dependent localization -- TBC1D14&#39;s primary compartment is the RAB11-positive recycling endosome (GO:0055037; relocalizing to the Golgi on starvation), and its core role is regulatory (negative regulation of autophagy initiation via ULK1 and ATG9 trafficking). Curation guidance: retain GO:0005776, but alongside recycling endosome and regulation-of-autophagy terms, never as the sole or primary cellular component. (The pre-existing vacuole annotation GO:0005773 remains flagged MARK_AS_OVER_ANNOTATED in the curated review.)</div></td>
 </tr>
 
 
@@ -998,7 +998,7 @@
 <tr data-assessment="COR" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/GIBF5/S0EDH7/S0EDH7-ai-review.html">S0EDH7</a>
-        
+
     </td>
     <td><small>Gibberella fujikuroi</small></td>
     <td>
@@ -1015,7 +1015,7 @@
 <tr data-assessment="COR" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/GIBF5/S0EDH7/S0EDH7-ai-review.html">S0EDH7</a>
-        
+
     </td>
     <td><small>Gibberella fujikuroi</small></td>
     <td>
@@ -1035,7 +1035,7 @@
 <tr data-assessment="" data-type="" data-nopred="1" class="no-pred-row">
     <td>
         <a class="gene-link" href="../../../genes/JUGRE/A0A2I4G8T1/A0A2I4G8T1-ai-review.html">A0A2I4G8T1</a>
-        
+
     </td>
     <td><small>Juglans regia</small></td>
     <td colspan="6" class="no-predictions">No predictions</td>
@@ -1047,7 +1047,7 @@
 <tr data-assessment="COR" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/MACFA/A0A2K5UJ34/A0A2K5UJ34-ai-review.html">A0A2K5UJ34</a>
-        
+
     </td>
     <td><small>Macaca fascicularis</small></td>
     <td>
@@ -1067,7 +1067,7 @@
 <tr data-assessment="" data-type="" data-nopred="1" class="no-pred-row">
     <td>
         <a class="gene-link" href="../../../genes/MAIZE/A0A804UIX9/A0A804UIX9-ai-review.html">A0A804UIX9</a>
-        
+
     </td>
     <td><small>Zea mays</small></td>
     <td colspan="6" class="no-predictions">No predictions</td>
@@ -1079,7 +1079,7 @@
 <tr data-assessment="LSP" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/MYTGA/A0A8B6BFL6/A0A8B6BFL6-ai-review.html">A0A8B6BFL6</a>
-        
+
     </td>
     <td><small>Mytilus galloprovincialis</small></td>
     <td>
@@ -1096,7 +1096,7 @@
 <tr data-assessment="COR" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/MYTGA/A0A8B6BFL6/A0A8B6BFL6-ai-review.html">A0A8B6BFL6</a>
-        
+
     </td>
     <td><small>Mytilus galloprovincialis</small></td>
     <td>
@@ -1113,7 +1113,7 @@
 <tr data-assessment="COR" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/MYTGA/A0A8B6BFL6/A0A8B6BFL6-ai-review.html">A0A8B6BFL6</a>
-        
+
     </td>
     <td><small>Mytilus galloprovincialis</small></td>
     <td>
@@ -1134,7 +1134,7 @@
 <tr data-assessment="NPI" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/MYTGA/A0A8B6GS20/A0A8B6GS20-ai-review.html">A0A8B6GS20</a>
-        
+
     </td>
     <td><small>Mytilus galloprovincialis</small></td>
     <td>
@@ -1145,17 +1145,17 @@
     <td><span class="badge badge-NPI">NPI</span></td>
     <td>0</td>
     <td><span class="badge-error">PARALOG_OVERANNOTATION</span></td>
-    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted GO:0004438 (phosphatidylinositol-3-phosphate phosphatase activity) for MTMR9, but this is a catalytic activity that MTMR9 cannot perform. MTMR9 is a well-characterized catalytically inactive pseudophosphatase within the myotubularin subfamily. It retains the overall myotubularin phosphatase domain fold (Pfam PF06602, Myotub-related; PROSITE PS51339, PPASE_MYOTUBULARIN) but lacks the critical catalytic cysteine in the conserved CX5R motif required for phosphoinositide dephosphorylation. The existing GOA annotations reflect this biology correctly: MTMR9 is annotated with protein phosphatase binding (GO:0019903), capturing its role as a scaffold that heterodimerizes with catalytically active family members (MTMR6, MTMR7, MTMR8), and its involvement in phosphatidylinositol dephosphorylation (GO:0046856) was flagged in the ai-review as requiring modification to the regulatory term GO:0060304 (regulation of phosphatidylinositol dephosphorylation). The ProtNLM2 error is a classic paralog overannotation (Type 6): the sequence-based model recognized the conserved myotubularin domain architecture and predicted the catalytic activity of the active subfamily members (MTMR1-4, MTMR6-8) without detecting the degenerate active site that distinguishes the pseudophosphatase branch (MTMR5, MTMR9, MTMR10-13). This is precisely the kind of subfamily-level functional divergence that sequence similarity methods struggle to capture, as the overall domain architecture is preserved despite loss of catalytic competence. PI(3)P phosphatase activity is the canonical substrate specificity of the active myotubularins, making it a plausible but biologically incorrect prediction for this catalytically dead family member.</div></td>
+    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted GO:0004438 (phosphatidylinositol-3-phosphate phosphatase activity) for MTMR9, but this is a catalytic activity that MTMR9 cannot perform. MTMR9 is a well-characterized catalytically inactive pseudophosphatase within the myotubularin subfamily. It retains the overall myotubularin phosphatase domain fold (Pfam PF06602, Myotub-related; PROSITE PS51339, PPASE_MYOTUBULARIN) but lacks the critical catalytic cysteine in the conserved CX5R motif required for phosphoinositide dephosphorylation. The existing GOA annotations reflect this biology correctly: MTMR9 is annotated with protein phosphatase binding (GO:0019903), capturing its role as a scaffold that heterodimerizes with catalytically active family members (MTMR6, MTMR7, MTMR8), and its involvement in phosphatidylinositol dephosphorylation (GO:0046856) was flagged in the ai-review as requiring modification to the regulatory term GO:0060304 (regulation of phosphatidylinositol dephosphorylation). The ProtNLM2 error is a classic paralog overannotation (Type 6): the sequence-based model recognized the conserved myotubularin domain architecture and predicted the catalytic activity of the active subfamily members (MTMR1-4, MTMR6-8) without detecting the degenerate active site that distinguishes the pseudophosphatase branch (MTMR5, MTMR9, MTMR10-13). This is precisely the kind of subfamily-level functional divergence that sequence similarity methods struggle to capture, as the overall domain architecture is preserved despite loss of catalytic competence. PI(3)P phosphatase activity is the canonical substrate specificity of the active myotubularins, making it a plausible but biologically incorrect prediction for this catalytically dead family member. An independent OpenScientist investigation (see file reference) confirms the dispute: the protein is a catalytically dead pseudophosphatase (MTMR9-like) that acts as a non-catalytic adaptor for active myotubularin partners, so GO:0004438 should not be a direct molecular function. Caveats it raises (neither rescuing the missing catalytic residues): the exact human paralog assignment is provisional (weak k-mer similarity), and the mollusc protein has an atypical N-terminal zona-pellucida/D8C_UMOD-like region (IPR057774) absent from vertebrate MTMR9, raising gene-model questions. NPI confirmed.</div></td>
 </tr>
 
 
 
 
 
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ORYSI/B8BAB0/B8BAB0-ai-review.html">B8BAB0</a>
-        
+
     </td>
     <td><small>Oryza sativa subsp. indica</small></td>
     <td>
@@ -1163,10 +1163,10 @@
         pollen maturation
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
-    <td></td>
-    <td class="summary-cell"><div class="summary-text">GO:0010152 (pollen maturation) is a biological process prediction for a BURP domain-containing protein with no existing GOA annotations and no direct experimental characterization (UniProt PE level 4). The prediction has some biological plausibility because the BURP protein family includes members with roles in reproductive development: BNM2 (the founding BNM2-like subfamily member) is linked to pollen grain embryogenesis, and OsRAFTIN1, a rice BURP protein, is specifically expressed in anthers during microspore development and is required for male fertility. However, B8BAB0 is classified by PANTHER (PTHR31458:SF2) as a PG1beta-like BURP protein, not a BNM2-like protein. The PG1beta-like subfamily has well-characterized members in rice (OsBURP14, OsBURP16) that function as non-catalytic beta subunits of polygalacturonase isozyme 1, participating in cell wall pectin degradation under ethylene/ABA stress signaling rather than pollen-specific processes. Furthermore, B8BAB0 contains an N-terminal signal peptide (aa 1-21) and a C-terminal BURP domain (aa 384-595) consistent with a secreted protein involved in extracellular matrix or cell wall modification, but its variable internal region and overall domain architecture align with PG-associated function (IPR051897, PG-associated_BURP) rather than reproductive-specific roles. The prediction may reflect ProtNLM2 conflating BURP family-level associations with reproductive biology (driven by BNM2-like and RAFTIN members in the training data) and applying them indiscriminately across the family. Without expression data, mutant phenotypes, or protein interaction studies for B8BAB0, the prediction cannot be confirmed or refuted. Pollen maturation does involve cell wall remodeling processes that could theoretically engage PG-associated proteins, but this indirect reasoning is insufficient for a confident assignment.</div></td>
+    <td><span class="badge badge-NPI">NPI</span></td>
+    <td>0</td>
+    <td><span class="badge-error">PARALOG_OVERANNOTATION</span></td>
+    <td class="summary-cell"><div class="summary-text">GO:0010152 (pollen maturation) is a biological process prediction for a BURP domain-containing protein with no existing GOA annotations and no direct experimental characterization (UniProt PE level 4). The prediction has some biological plausibility because the BURP protein family includes members with roles in reproductive development: BNM2 (the founding BNM2-like subfamily member) is linked to pollen grain embryogenesis, and OsRAFTIN1, a rice BURP protein, is specifically expressed in anthers during microspore development and is required for male fertility. However, B8BAB0 is classified by PANTHER (PTHR31458:SF2) as a PG1beta-like BURP protein, not a BNM2-like protein. The PG1beta-like subfamily has well-characterized members in rice (OsBURP14, OsBURP16) that function as non-catalytic beta subunits of polygalacturonase isozyme 1, participating in cell wall pectin degradation under ethylene/ABA stress signaling rather than pollen-specific processes. Furthermore, B8BAB0 contains an N-terminal signal peptide (aa 1-21) and a C-terminal BURP domain (aa 384-595) consistent with a secreted protein involved in extracellular matrix or cell wall modification, but its variable internal region and overall domain architecture align with PG-associated function (IPR051897, PG-associated_BURP) rather than reproductive-specific roles. The prediction may reflect ProtNLM2 conflating BURP family-level associations with reproductive biology (driven by BNM2-like and RAFTIN members in the training data) and applying them indiscriminately across the family. Without expression data, mutant phenotypes, or protein interaction studies for B8BAB0, the prediction cannot be confirmed or refuted. Pollen maturation does involve cell wall remodeling processes that could theoretically engage PG-associated proteins, but this indirect reasoning is insufficient for a confident assignment. An independent OpenScientist investigation (see file reference) resolves this to a refutation: B8BAB0 belongs to the PG1beta-like (polygalacturonase non-catalytic beta-subunit-like) cell-wall/pectin BURP clade, not the cereal anther-specific RAFTIN/BURP-VII clade that provides the only well-documented reproductive-development precedent among BURP proteins. The prediction is a frequency/superfamily over-generalization -- borrowing the &#34;some BURP proteins act in reproduction&#34; association and applying it to a protein that actually belongs to the cell-wall clade. Downgraded from UNC to NPI.</div></td>
 </tr>
 
 
@@ -1176,7 +1176,7 @@
 <tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ORYSJ/Q6YYC5/Q6YYC5-ai-review.html">Q6YYC5</a>
-        
+
     </td>
     <td><small>Oryza sativa subsp. japonica</small></td>
     <td>
@@ -1187,13 +1187,13 @@
     <td><span class="badge badge-UNC">UNC</span></td>
     <td>1</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted GO:0070534 (protein K63-linked ubiquitination) as a more specific refinement of the existing GOA annotation GO:0016567 (protein ubiquitination). The prediction is biologically plausible but uncertain. The Arabidopsis ortholog RGLG2 (AT3G01650/Q9LY87), one of the source genes for the IBA transfer to Q6YYC5, has been experimentally shown to catalyze K63-linked polyubiquitin chain formation. However, ubiquitin chain-type linkage specificity is primarily determined by the E2 conjugating enzyme partner, not the E3 ligase itself. RGLG2 catalyzes K63-linked chains when paired with UBC35 (a group-III E2), but may produce different linkage types with other E2s. No experimental data exist for Q6YYC5, and the specific E2 partner(s) of this uncharacterized rice RGLG protein are unknown. Furthermore, while Q6YYC5 is classified in the RGLG family (PTHR45751:SF16, RGLG4), not all RGLG family members necessarily share K63 linkage specificity -- the rice RGLG family includes members (OsRGLG5, OsRGLG6) that target substrates for 26S proteasomal degradation, which typically involves K48-linked chains. The prediction cannot be confirmed or refuted without biochemical characterization of Q6YYC5 with its cognate E2 enzyme(s).</div></td>
+    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted GO:0070534 (protein K63-linked ubiquitination) as a more specific refinement of the existing GOA annotation GO:0016567 (protein ubiquitination). The prediction is biologically plausible but uncertain. The Arabidopsis ortholog RGLG2 (AT3G01650/Q9LY87), one of the source genes for the IBA transfer to Q6YYC5, has been experimentally shown to catalyze K63-linked polyubiquitin chain formation. However, ubiquitin chain-type linkage specificity is primarily determined by the E2 conjugating enzyme partner, not the E3 ligase itself. RGLG2 catalyzes K63-linked chains when paired with UBC35 (a group-III E2), but may produce different linkage types with other E2s. No experimental data exist for Q6YYC5, and the specific E2 partner(s) of this uncharacterized rice RGLG protein are unknown. Furthermore, while Q6YYC5 is classified in the RGLG family (PTHR45751:SF16, RGLG4), not all RGLG family members necessarily share K63 linkage specificity -- the rice RGLG family includes members (OsRGLG5, OsRGLG6) that target substrates for 26S proteasomal degradation, which typically involves K48-linked chains. The prediction cannot be confirmed or refuted without biochemical characterization of Q6YYC5 with its cognate E2 enzyme(s). An independent OpenScientist investigation (see file reference) corroborates this: it confirms Q6YYC5 is a functional RGLG-family RING E3 ligase (generic ubiquitination/E3-ligase terms well supported by structure and family membership) but concludes the K63 linkage specialization is not decidable from sequence or orthology and would require a direct in vitro chain-linkage assay with the rice cognate E2. Kept UNC as a lead; the recommendation is to retain the generic ubiquitination terms and not add GO:0070534 without that assay.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/ORYSJ/Q6YYC5/Q6YYC5-ai-review.html">Q6YYC5</a>
-        
+
     </td>
     <td><small>Oryza sativa subsp. japonica</small></td>
     <td>
@@ -1214,7 +1214,7 @@
 <tr data-assessment="LSP" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/PANPA/A0A2R9CAF4/A0A2R9CAF4-ai-review.html">A0A2R9CAF4</a>
-        
+
     </td>
     <td><small>Pan paniscus</small></td>
     <td>
@@ -1231,7 +1231,7 @@
 <tr data-assessment="LSP" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/PANPA/A0A2R9CAF4/A0A2R9CAF4-ai-review.html">A0A2R9CAF4</a>
-        
+
     </td>
     <td><small>Pan paniscus</small></td>
     <td>
@@ -1252,7 +1252,7 @@
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/PARTE/A0BFB4/A0BFB4-ai-review.html">A0BFB4</a>
-        
+
     </td>
     <td><small>Paramecium tetraurelia</small></td>
     <td>
@@ -1270,10 +1270,10 @@
 
 
 
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/PHATC/B7FXQ8/B7FXQ8-ai-review.html">B7FXQ8</a>
-        
+
     </td>
     <td><small>Phaeodactylum tricornutum</small></td>
     <td>
@@ -1281,16 +1281,16 @@
         response to salt stress
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-NPI">NPI</span></td>
+    <td>0</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">While sHSPs can be induced by multiple abiotic stresses beyond heat, there is no direct evidence that HSP20A in P. tricornutum is specifically involved in the response to salt stress. The deep research report focuses exclusively on thermal stress roles for this protein family in diatoms, with no mention of salinity-induced expression. P. tricornutum is a marine diatom and does experience osmotic stress, but the expanded HSF regulatory network described in this organism (Huang et al. 2025, Lin et al. 2024) is characterized in the context of thermal tolerance, not salt acclimation. Some plant sHSPs are salt-inducible, but extrapolating this to a diatom HSP20 without organism-specific evidence is speculative. ProtNLM2 may have learned a general association between stress-response proteins and salt stress from plant training data, but this remains unvalidated for HSP20A. Cannot be confirmed or refuted without transcriptomic or genetic evidence under salinity stress conditions.</div></td>
+    <td class="summary-cell"><div class="summary-text">While sHSPs can be induced by multiple abiotic stresses beyond heat, there is no direct evidence that HSP20A in P. tricornutum is specifically involved in the response to salt stress. The deep research report focuses exclusively on thermal stress roles for this protein family in diatoms, with no mention of salinity-induced expression. P. tricornutum is a marine diatom and does experience osmotic stress, but the expanded HSF regulatory network described in this organism (Huang et al. 2025, Lin et al. 2024) is characterized in the context of thermal tolerance, not salt acclimation. Some plant sHSPs are salt-inducible, but extrapolating this to a diatom HSP20 without organism-specific evidence is speculative. ProtNLM2 may have learned a general association between stress-response proteins and salt stress from plant training data, but this remains unvalidated for HSP20A. An independent OpenScientist investigation (see file reference) confirms B7FXQ8 is a bona fide cytosolic small heat-shock protein (alpha-crystallin/ACD holdase chaperone) whose only defensible process across the P. tricornutum HSP20 family is response to heat (GO:0009408); the salt term is weakly plausible only by cross-kingdom analogy with a moss sHSP and has no diatom-specific evidence. Downgraded from UNC to NPI as a generic-abiotic-stress over-extension; do not add from the prediction alone.</div></td>
 </tr>
 
 <tr data-assessment="COR" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/PHATC/B7FXQ8/B7FXQ8-ai-review.html">B7FXQ8</a>
-        
+
     </td>
     <td><small>Phaeodactylum tricornutum</small></td>
     <td>
@@ -1307,7 +1307,7 @@
 <tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/PHATC/B7FXQ8/B7FXQ8-ai-review.html">B7FXQ8</a>
-        
+
     </td>
     <td><small>Phaeodactylum tricornutum</small></td>
     <td>
@@ -1324,7 +1324,7 @@
 <tr data-assessment="COR" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/PHATC/B7FXQ8/B7FXQ8-ai-review.html">B7FXQ8</a>
-        
+
     </td>
     <td><small>Phaeodactylum tricornutum</small></td>
     <td>
@@ -1338,10 +1338,10 @@
     <td class="summary-cell"><div class="summary-text">This is a correct novel prediction and arguably the most biologically well-supported of all six predictions. HSP20A is named as a heat shock protein and belongs to the sHSP/HSP20 family, whose defining biological role is the cellular response to heat stress. In P. tricornutum specifically, recent research has established that the organism possesses an exceptionally expanded heat shock transcription factor (HSF) repertoire (69 HSF genes, 44.2% of all transcription factors) that controls thermal tolerance programs, with HSP proteins as downstream effectors (Huang et al. 2025, Lin et al. 2024). In the related marine dinoflagellate Scrippsiella trochoidea, HSP20 transcripts are strongly upregulated under heat stress (Deng et al. 2020). The UniProt entry for B7FXQ8 carries a keyword annotation for stress response, and the ARBA automated rule (ARBA00023016) supports this assignment. Since P. tricornutum thrives across temperatures from 5 to 28 degrees C in diverse marine environments, heat shock proteins are critical for its thermal adaptability. This is a high-confidence correct prediction.</div></td>
 </tr>
 
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/PHATC/B7FXQ8/B7FXQ8-ai-review.html">B7FXQ8</a>
-        
+
     </td>
     <td><small>Phaeodactylum tricornutum</small></td>
     <td>
@@ -1349,16 +1349,16 @@
         response to hydrogen peroxide
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-NPI">NPI</span></td>
+    <td>0</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">There is no direct evidence that HSP20A in P. tricornutum is involved in the response to hydrogen peroxide. While some sHSPs in other organisms (particularly plant and mammalian systems) have been shown to confer protection against oxidative stress, and oxidative stress and heat stress response pathways can overlap, the deep research report for this protein does not mention any oxidative stress role. The alpha-crystallin domain in vertebrate lens crystallins does protect against oxidative damage, but this function has not been demonstrated for diatom HSP20 proteins. ProtNLM2 may have learned an association between sHSPs and oxidative stress responses from well-characterized plant or mammalian training examples, but without P. tricornutum-specific evidence (e.g., transcriptomic upregulation under H2O2 treatment or genetic perturbation data), this prediction cannot be validated or refuted.</div></td>
+    <td class="summary-cell"><div class="summary-text">There is no direct evidence that HSP20A in P. tricornutum is involved in the response to hydrogen peroxide. While some sHSPs in other organisms (particularly plant and mammalian systems) have been shown to confer protection against oxidative stress, and oxidative stress and heat stress response pathways can overlap, the deep research report for this protein does not mention any oxidative stress role. The alpha-crystallin domain in vertebrate lens crystallins does protect against oxidative damage, but this function has not been demonstrated for diatom HSP20 proteins. ProtNLM2 may have learned an association between sHSPs and oxidative stress responses from well-characterized plant or mammalian training examples, but without P. tricornutum-specific evidence (e.g., transcriptomic upregulation under H2O2 treatment or genetic perturbation data), this prediction is unsupported. An independent OpenScientist investigation (see file reference) rates this the weaker of the two stress predictions: it is speculative and partly contradicted by sHSP precedent (a well-characterized moss sHSP was explicitly NOT induced by oxidative-stress compounds), so H2O2 responsiveness is not a general sHSP property. Downgraded from UNC to NPI; do not add from the prediction alone.</div></td>
 </tr>
 
 <tr data-assessment="COR" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/PHATC/B7FXQ8/B7FXQ8-ai-review.html">B7FXQ8</a>
-        
+
     </td>
     <td><small>Phaeodactylum tricornutum</small></td>
     <td>
@@ -1400,7 +1400,7 @@
 <tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/SOYBN/C6T1A2/C6T1A2-ai-review.html">C6T1A2</a>
-        
+
     </td>
     <td><small>Glycine max</small></td>
     <td>
@@ -1411,13 +1411,13 @@
     <td><span class="badge badge-UNC">UNC</span></td>
     <td>1</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted GO:0009788 (negative regulation of abscisic acid-activated signaling pathway) for C6T1A2, a soybean C2H2-type zinc finger protein with no curated GO annotations in GOA. This prediction is biologically plausible but uncertain. The most likely basis for this prediction is sequence similarity to Arabidopsis ZFP7 (Q39266), which shares the same IPR053266 (Zinc_finger_protein_7) family membership and single-C2H2 domain architecture, and has been experimentally shown to negatively regulate ABA-activated signaling during seed germination. However, several factors limit confidence in this functional transfer: (1) the C2H2 zinc finger superfamily is one of the largest transcription factor families in plants, with members participating in diverse biological processes including cold stress, flower development, trichome initiation, and photomorphogenesis -- sharing a C2H2 domain does not predict specific pathway involvement; (2) no gene-specific experimental studies exist for C6T1A2 / Glyma17g18110.1, and the protein was only identified as part of a soybean transcription factor ORFeome cloning effort (PMID:26268547) without individual functional characterization; (3) while soybean does possess ABA signaling pathways involved in drought responses, the specific negative regulatory role of ZFP7-family members may not be conserved across the ~90 million year divergence between Arabidopsis and Glycine max, given extensive C2H2 gene family expansion and subfunctionalization in legumes. The prediction cannot be confirmed or refuted without experimental evidence such as ABA-responsive expression profiling or overexpression/knockout phenotyping in soybean.</div></td>
+    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted GO:0009788 (negative regulation of abscisic acid-activated signaling pathway) for C6T1A2, a soybean C2H2-type zinc finger protein with no curated GO annotations in GOA. This prediction is biologically plausible but uncertain. The most likely basis for this prediction is sequence similarity to Arabidopsis ZFP7 (Q39266), which shares the same IPR053266 (Zinc_finger_protein_7) family membership and single-C2H2 domain architecture, and has been experimentally shown to negatively regulate ABA-activated signaling during seed germination. However, several factors limit confidence in this functional transfer: (1) the C2H2 zinc finger superfamily is one of the largest transcription factor families in plants, with members participating in diverse biological processes including cold stress, flower development, trichome initiation, and photomorphogenesis -- sharing a C2H2 domain does not predict specific pathway involvement; (2) no gene-specific experimental studies exist for C6T1A2 / Glyma17g18110.1, and the protein was only identified as part of a soybean transcription factor ORFeome cloning effort (PMID:26268547) without individual functional characterization; (3) while soybean does possess ABA signaling pathways involved in drought responses, the specific negative regulatory role of ZFP7-family members may not be conserved across the ~90 million year divergence between Arabidopsis and Glycine max, given extensive C2H2 gene family expansion and subfunctionalization in legumes. The prediction cannot be confirmed or refuted without experimental evidence such as ABA-responsive expression profiling or overexpression/knockout phenotyping in soybean. An independent OpenScientist investigation (see file reference) corroborates this: it confirms C6T1A2 is a plant Q-type (QALGGH motif) single C2H2 zinc-finger transcription factor -- so DNA-binding transcription factor activity, zinc ion binding, and nucleus are all defensible from sequence -- but concludes the specific process term GO:0009788 should not be entered as a direct/experimental annotation, at most retained as an ISS/ISO lead with an overexpression-only caveat. Kept UNC as a lead.</div></td>
 </tr>
 
 <tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/SOYBN/C6T1A2/C6T1A2-ai-review.html">C6T1A2</a>
-        
+
     </td>
     <td><small>Glycine max</small></td>
     <td>
@@ -1438,7 +1438,7 @@
 <tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/STRCO/Q9KZ33/Q9KZ33-ai-review.html">Q9KZ33</a>
-        
+
     </td>
     <td><small>Streptomyces coelicolor (strain ATCC BAA-471 / A3(2) / M145)</small></td>
     <td>
@@ -1473,7 +1473,7 @@
     <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted GO:0008253 (5&#39;-nucleotidase activity), the hydrolysis of a 5&#39;-ribonucleotide or 5&#39;-deoxyribonucleotide to a ribonucleoside or deoxyribonucleoside and orthophosphate. This prediction is well-supported by multiple independent lines of evidence. SCO2678 contains a HAD_SAK_2 domain (PF18143), placing it in the haloacid dehalogenase (HAD) superfamily, which catalyzes phosphate ester hydrolysis via a conserved nucleophilic aspartate mechanism. The protein is classified in eggNOG COG1877 (5&#39;-nucleotidase/2&#39;,3&#39;-cyclic phosphodiesterase and related esterases), which directly supports assignment of 5&#39;-nucleotidase activity within the broader HAD phosphatase family. A characterized S. coelicolor homolog, SCO4152, is a PhoP-regulated extracellular 5&#39;-nucleotidase involved in phosphate scavenging, providing direct functional precedent in this organism. S. coelicolor lacks organic phosphate transporters (uhp-type systems), necessitating extracellular dephosphorylation of nucleotides before phosphate uptake via PstSCAB or PitH transporters, which provides strong biological rationale for secreted nucleotidase activity. The UniProt entry designates SCO2678 as a secreted protein, consistent with an extracellular phosphatase role. GOA contains no curated annotations for this protein, so this prediction is genuinely novel. The independent AI review of this gene also proposed GO:0008253 as a new annotation based on the same convergent evidence. While the exact substrate specificity of SCO2678 has not been experimentally determined and HAD superfamily members can exhibit substrate promiscuity across nucleotides, sugar phosphates, and other phosphomonoesters, the COG1877 classification specifically favors 5&#39;-nucleotidase over other HAD activities.</div></td>
 </tr>
 
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/STRCO/Q9L243/Q9L243-ai-review.html">Q9L243</a>
         <br><small style="color:var(--text-muted)">SCO2678</small>
@@ -1484,10 +1484,10 @@
         deoxyribonucleotide catabolic process
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-NPI">NPI</span></td>
+    <td>0</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">ProtNLM2 predicted GO:0009264 (deoxyribonucleotide catabolic process), the chemical reactions resulting in the breakdown of deoxyribonucleotides. This prediction is plausible but insufficiently supported. If SCO2678 indeed possesses 5&#39;-nucleotidase activity (as predicted above), hydrolysis of deoxyribonucleotides would fall within the scope of that activity, and participation in deoxyribonucleotide catabolism would logically follow. However, the prediction is problematic for two reasons. First, it is overly specific: no available evidence distinguishes deoxyribonucleotide substrates from ribonucleotide substrates for this enzyme. HAD superfamily members, including characterized 5&#39;-nucleotidases, typically hydrolyze both ribo- and deoxyribonucleotides, and the deep research on SCO2678 consistently references broad substrate classes (nucleotides, sugar phosphates, glycerophosphodiesters) without singling out deoxyribonucleotides. Second, the biological context of S. coelicolor phosphate scavenging does not specifically implicate deoxyribonucleotide catabolism over general nucleotide catabolism -- the organism&#39;s need is for inorganic phosphate release from whatever organophosphates are available in the soil environment. A more appropriate biological process annotation would be GO:0006796 (phosphate-containing compound metabolic process) or GO:0009166 (nucleotide catabolic process), which are agnostic to the deoxy/ribo distinction. Without experimental substrate profiling demonstrating a preference for deoxyribonucleotides, this prediction cannot be confirmed or refuted.</div></td>
+    <td class="summary-cell"><div class="summary-text">Downgraded from UNC to NPI. An independent OpenScientist investigation (see file reference) walked the nested claim chain and refuted GO:0009264 as a core function. SCO2678 is a HAD-superfamily phosphohydrolase (motifs intact, AlphaFold pLDDT 85.5, PF18143), but PF18143 is the RNA-repair &#34;Swiss Army Knife&#34; HAD family, not a characterized 5&#39;-nucleotidase subfamily -- so even the sibling 5&#39;-nucleotidase call (assessed COR above) is over-specific and worth a curator re-check. It shares no Pfam with dNMP-acting HAD nucleotidases (YjjG/NagD), and even bona fide HAD 5&#39;-nucleotidases prefer non-deoxyribonucleotide substrates, so a deoxyribonucleotide-specific role is unsupported. GO:0009264 is a physiological process term that requires a defensible pathway role, and there is no experimental, pathway, or genomic-context evidence for one; the defensible annotation is a low-specificity phosphatase molecular function, not this process term. Caveat: HAD enzymes are promiscuous, so weak in-vitro dNMP hydrolysis cannot be excluded -- but that would not justify the specific catabolic-process annotation.</div></td>
 </tr>
 
 
@@ -1518,7 +1518,7 @@
 <tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/TOBAC/A0A1S3Y076/A0A1S3Y076-ai-review.html">A0A1S3Y076</a>
-        
+
     </td>
     <td><small>Nicotiana tabacum</small></td>
     <td>
@@ -1539,7 +1539,7 @@
 <tr data-assessment="COR" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/TRIV3/A2FPI7/A2FPI7-ai-review.html">A2FPI7</a>
-        
+
     </td>
     <td><small>Trichomonas vaginalis</small></td>
     <td>
@@ -1560,7 +1560,7 @@
 <tr data-assessment="LSP" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/A0A3B6GK97/A0A3B6GK97-ai-review.html">A0A3B6GK97</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1577,7 +1577,7 @@
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/A0A3B6GK97/A0A3B6GK97-ai-review.html">A0A3B6GK97</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1598,7 +1598,7 @@
 <tr data-assessment="LSP" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/A0A3B6NKR6/A0A3B6NKR6-ai-review.html">A0A3B6NKR6</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1616,10 +1616,10 @@
 
 
 
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/A0A3B6RKV1/A0A3B6RKV1-ai-review.html">A0A3B6RKV1</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1627,16 +1627,16 @@
         regulation of photomorphogenesis
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-NPI">NPI</span></td>
+    <td>0</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">The closest characterized ortholog in Arabidopsis (AT5G06550, JMJ22/PKDM7D) participates in photomorphogenesis through histone demethylation at target gene loci, making this prediction biologically plausible at the ortholog level. However, no experimental evidence exists for photomorphogenesis regulation by any wheat JmjC family member. Photomorphogenesis regulatory networks differ between monocots and dicots, and wheat KDM5/JARID1 members show dynamic expression under drought stress rather than light-responsive regulation in published studies (Wang et al. 2022). The protein has PE level 3 (inferred from homology) with no direct functional characterization. This prediction likely reflects training data from the well-characterized Arabidopsis JMJ22 ortholog rather than wheat-specific evidence.</div></td>
+    <td class="summary-cell"><div class="summary-text">The closest characterized ortholog in Arabidopsis (AT5G06550, JMJ22/PKDM7D) participates in photomorphogenesis through histone demethylation at target gene loci, making this prediction biologically plausible at the ortholog level. However, no experimental evidence exists for photomorphogenesis regulation by any wheat JmjC family member. Photomorphogenesis regulatory networks differ between monocots and dicots, and wheat KDM5/JARID1 members show dynamic expression under drought stress rather than light-responsive regulation in published studies (Wang et al. 2022). The protein has PE level 3 (inferred from homology) with no direct functional characterization. This prediction likely reflects training data from the well-characterized Arabidopsis JMJ22 ortholog rather than wheat-specific evidence. An independent OpenScientist investigation (see file reference) confirms A0A3B6RKV1 is a catalytically competent JMJ22 co-ortholog (a JMJD6-type histone arginine demethylase -- correcting the KDM5/JARID lysine-demethylase framing above -- with an intact JmjC Fe(II)/2-oxoglutarate active site), but concludes the four Arabidopsis-specific developmental BP terms are IMP-derived redundant-pair (JMJ20/JMJ22) seed-biology phenotypes not transferable to wheat by orthology alone. Downgraded from UNC to NPI; retain only the histone-demethylase molecular function at ISS/IBA strength.</div></td>
 </tr>
 
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/A0A3B6RKV1/A0A3B6RKV1-ai-review.html">A0A3B6RKV1</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1644,16 +1644,16 @@
         gibberellin mediated signaling pathway
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-NPI">NPI</span></td>
+    <td>0</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">Arabidopsis JMJ22/PKDM7D demethylates histones at GA biosynthesis gene loci, linking it to gibberellin-mediated signaling. Wheat JmjC gene promoters contain GA-responsive cis-elements (Wang et al. 2022; Ma et al. 2022), providing indirect support for GA pathway involvement. However, the presence of hormone-responsive promoter elements is common across many gene families and does not establish direct involvement in GA signaling. No experimental evidence demonstrates that this specific wheat protein regulates GA biosynthesis or signaling. The prediction is plausible through orthology to JMJ22 but remains unverifiable without wheat-specific functional data.</div></td>
+    <td class="summary-cell"><div class="summary-text">Arabidopsis JMJ22/PKDM7D demethylates histones at GA biosynthesis gene loci, linking it to gibberellin-mediated signaling. Wheat JmjC gene promoters contain GA-responsive cis-elements (Wang et al. 2022; Ma et al. 2022), providing indirect support for GA pathway involvement. However, the presence of hormone-responsive promoter elements is common across many gene families and does not establish direct involvement in GA signaling. No experimental evidence demonstrates that this specific wheat protein regulates GA biosynthesis or signaling. The prediction is plausible through orthology to JMJ22 but remains unverifiable without wheat-specific functional data. An independent OpenScientist investigation (see file reference) confirms A0A3B6RKV1 is a catalytically competent JMJ22 co-ortholog (a JMJD6-type histone arginine demethylase with an intact JmjC Fe(II)/2-oxoglutarate active site), but concludes the four Arabidopsis-specific developmental BP terms are IMP-derived redundant-pair (JMJ20/JMJ22) seed-biology phenotypes not transferable to wheat by orthology alone. Downgraded from UNC to NPI; retain only the histone-demethylase molecular function at ISS/IBA strength.</div></td>
 </tr>
 
 <tr data-assessment="COR" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/A0A3B6RKV1/A0A3B6RKV1-ai-review.html">A0A3B6RKV1</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1667,10 +1667,10 @@
     <td class="summary-cell"><div class="summary-text">This is a correct novel prediction. A0A3B6RKV1 contains a JmjC catalytic domain (residues 285-445) and belongs to the KDM5/JARID1 histone demethylase subfamily, which catalyzes Fe(II)- and 2-oxoglutarate-dependent oxidative removal of methyl groups from histone H3K4me1/2/3 marks. Histone demethylation is by definition a mechanism of epigenetic gene expression regulation. Phylogenetic analysis across 21 plant species confirms that KDM5/JARID subfamily members function as H3K4 demethylases (Ma et al. 2022), and 18 of 24 wheat JmjC family members localize to the nucleus consistent with chromatin-associated function (Wang et al. 2022). The ai-review independently lists this term as a core function. This GO term was not present in the existing GOA annotations, making it a genuinely novel and correct prediction that follows directly from the established enzymatic activity of the protein family.</div></td>
 </tr>
 
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/A0A3B6RKV1/A0A3B6RKV1-ai-review.html">A0A3B6RKV1</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1678,16 +1678,16 @@
         response to red light
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-NPI">NPI</span></td>
+    <td>0</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">Red light response is mechanistically linked to photomorphogenesis and phytochrome signaling, and some Arabidopsis JmjC proteins participate in light-mediated developmental pathways. However, this is a more specific prediction than regulation of photomorphogenesis, and the evidence supporting it is weaker. No published study demonstrates response to red light for any wheat KDM5/JARID1 member, nor has the Arabidopsis ortholog JMJ22 been specifically characterized as red-light responsive (its photomorphogenesis role involves broader light signaling). The deep research report for A0A3B6RKV1 does not mention red light or phytochrome signaling among the biological processes of wheat JmjC proteins. This prediction may reflect frequency bias from ProtNLM2 associating photomorphogenesis-related terms as a cluster for JmjC-like sequences in the training data.</div></td>
+    <td class="summary-cell"><div class="summary-text">Red light response is mechanistically linked to photomorphogenesis and phytochrome signaling, and some Arabidopsis JmjC proteins participate in light-mediated developmental pathways. However, this is a more specific prediction than regulation of photomorphogenesis, and the evidence supporting it is weaker. No published study demonstrates response to red light for any wheat KDM5/JARID1 member, nor has the Arabidopsis ortholog JMJ22 been specifically characterized as red-light responsive (its photomorphogenesis role involves broader light signaling). The deep research report for A0A3B6RKV1 does not mention red light or phytochrome signaling among the biological processes of wheat JmjC proteins. This prediction may reflect frequency bias from ProtNLM2 associating photomorphogenesis-related terms as a cluster for JmjC-like sequences in the training data. An independent OpenScientist investigation (see file reference) confirms A0A3B6RKV1 is a catalytically competent JMJ22 co-ortholog (a JMJD6-type histone arginine demethylase with an intact JmjC Fe(II)/2-oxoglutarate active site), but concludes the four Arabidopsis-specific developmental BP terms are IMP-derived redundant-pair (JMJ20/JMJ22) seed-biology phenotypes not transferable to wheat by orthology alone. Downgraded from UNC to NPI; retain only the histone-demethylase molecular function at ISS/IBA strength.</div></td>
 </tr>
 
-<tr data-assessment="UNC" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
+<tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/A0A3B6RKV1/A0A3B6RKV1-ai-review.html">A0A3B6RKV1</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1695,10 +1695,10 @@
         positive regulation of seed germination
     </td>
     <td><span class="term-type">GO_BP</span></td>
-    <td><span class="badge badge-UNC">UNC</span></td>
-    <td>1</td>
+    <td><span class="badge badge-NPI">NPI</span></td>
+    <td>0</td>
     <td></td>
-    <td class="summary-cell"><div class="summary-text">Arabidopsis JMJ22/PKDM7D participates in seed germination through histone arginine demethylation at GA biosynthesis gene loci, providing ortholog-based support for this prediction. GA signaling is a key regulator of seed germination across angiosperms, and the mechanistic link between histone demethylation and GA-dependent germination is well-established in Arabidopsis. However, the specific polarity of regulation (positive vs. negative) has not been established for this wheat protein. KDM5/JARID1 demethylases remove activating H3K4 marks, which typically represses transcription, so the prediction of positive regulation of germination requires that the demethylase targets negative regulators of germination (an indirect mechanism). Without wheat-specific experimental data, both the involvement in germination and the direction of regulation remain unverified.</div></td>
+    <td class="summary-cell"><div class="summary-text">Arabidopsis JMJ22/PKDM7D participates in seed germination through histone arginine demethylation at GA biosynthesis gene loci, providing ortholog-based support for this prediction. GA signaling is a key regulator of seed germination across angiosperms, and the mechanistic link between histone demethylation and GA-dependent germination is well-established in Arabidopsis. However, the specific polarity of regulation (positive vs. negative) has not been established for this wheat protein. Note the OpenScientist analysis reassigns the enzyme as a JMJD6-type histone arginine demethylase (H4R3me2 at GA3ox loci), not a KDM5/JARID1 H3K4 lysine demethylase, so the H3K4-based directionality argument below does not apply. Without wheat-specific experimental data, both the involvement in germination and the direction of regulation remain unverified. An independent OpenScientist investigation (see file reference) confirms A0A3B6RKV1 is a catalytically competent JMJ22 co-ortholog with an intact JmjC Fe(II)/2-oxoglutarate active site, but concludes the four Arabidopsis-specific developmental BP terms are IMP-derived redundant-pair (JMJ20/JMJ22) seed-biology phenotypes not transferable to wheat by orthology alone. Downgraded from UNC to NPI; retain only the histone-demethylase molecular function at ISS/IBA strength.</div></td>
 </tr>
 
 
@@ -1708,7 +1708,7 @@
 <tr data-assessment="NPI" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/F6LAX4/F6LAX4-ai-review.html">F6LAX4</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1719,13 +1719,13 @@
     <td><span class="badge badge-NPI">NPI</span></td>
     <td>0</td>
     <td><span class="badge-error">FREQUENCY_BIAS</span></td>
-    <td class="summary-cell"><div class="summary-text">GO:0046982 (protein heterodimerization activity) is a generic protein-protein interaction term that technically applies to any protein forming a heterodimer. While the PP2A A subunit does form an A-C heterodimer with the catalytic C subunit, this term is uninformative and misleading: the A subunit&#39;s molecular function is not generic heterodimerization but rather a highly specific scaffolding/regulatory role captured by GO:0019888 (protein phosphatase regulator activity), which is already annotated with IBA evidence. The A subunit&#39;s HEAT-repeat solenoid architecture provides a platform for both the catalytic C subunit and a regulatory B subunit, forming a heterotrimer rather than a simple heterodimer. Annotating this protein with GO:0046982 would obscure its specific phosphatase-regulatory scaffold function and replace it with a term that applies to thousands of unrelated proteins. This prediction likely reflects frequency bias, as protein heterodimerization activity is among the most commonly assigned MF terms in GO training data and is frequently predicted for any protein with protein-protein interaction domains such as HEAT repeats.</div></td>
+    <td class="summary-cell"><div class="summary-text">GO:0046982 (protein heterodimerization activity) is a generic protein-protein interaction term that technically applies to any protein forming a heterodimer. While the PP2A A subunit does form an A-C heterodimer with the catalytic C subunit, this term is uninformative and misleading: the A subunit&#39;s molecular function is not generic heterodimerization but rather a highly specific scaffolding/regulatory role captured by GO:0019888 (protein phosphatase regulator activity), which is already annotated with IBA evidence. The A subunit&#39;s HEAT-repeat solenoid architecture provides a platform for both the catalytic C subunit and a regulatory B subunit, forming a heterotrimer rather than a simple heterodimer. Annotating this protein with GO:0046982 would obscure its specific phosphatase-regulatory scaffold function and replace it with a term that applies to thousands of unrelated proteins. This prediction likely reflects frequency bias, as protein heterodimerization activity is among the most commonly assigned MF terms in GO training data and is frequently predicted for any protein with protein-protein interaction domains such as HEAT repeats. An independent OpenScientist investigation (see file reference) confirms all six disputed animal-context predictions on F6LAX4 (this term plus GO:0043005, GO:0043025, GO:1990405, GO:0000775, GO:0007059): it identifies F6LAX4 as the wheat PP2A A/PR65 scaffold subunit (85-90% identity to the Arabidopsis PP2A A subunits; local fold RMSD ~0.29 Angstrom), rules the neuronal and antigen terms taxon-inappropriate for a plant (no neurons, no adaptive immune system), and finds the centromere/segregation terms are a Shugoshin-PP2A function mediated by the B56 regulatory subunit -- not by the A scaffold intrinsically -- so not assertable on this subunit. All six NPI calls upheld.</div></td>
 </tr>
 
 <tr data-assessment="NPI" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/F6LAX4/F6LAX4-ai-review.html">F6LAX4</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1742,7 +1742,7 @@
 <tr data-assessment="NPI" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/F6LAX4/F6LAX4-ai-review.html">F6LAX4</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1759,7 +1759,7 @@
 <tr data-assessment="NPI" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/F6LAX4/F6LAX4-ai-review.html">F6LAX4</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1776,7 +1776,7 @@
 <tr data-assessment="NPI" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/F6LAX4/F6LAX4-ai-review.html">F6LAX4</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1793,7 +1793,7 @@
 <tr data-assessment="NPI" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/WHEAT/F6LAX4/F6LAX4-ai-review.html">F6LAX4</a>
-        
+
     </td>
     <td><small>Triticum aestivum</small></td>
     <td>
@@ -1835,7 +1835,7 @@
 <tr data-assessment="NPI" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/XENNA/D3VIU4/D3VIU4-ai-review.html">D3VIU4</a>
-        
+
     </td>
     <td><small>Xenorhabdus nematophila</small></td>
     <td>
@@ -1846,7 +1846,7 @@
     <td><span class="badge badge-NPI">NPI</span></td>
     <td>0</td>
     <td><span class="badge-error">FREQUENCY_BIAS</span></td>
-    <td class="summary-cell"><div class="summary-text">GO:0015276 (ligand-gated monoatomic ion channel activity) is unequivocally wrong for D3VIU4. This protein is FliY, the periplasmic substrate-binding component of the FliY-YecSC (TcyJLN) ABC transporter for L-cystine import. It belongs to bacterial solute-binding protein family 3 (PF00497, IPR001638, CDD cd13711 PBP2_Ngo0372_TcyA), a well-characterized family of soluble periplasmic proteins that bind amino acids or compatible solutes and deliver them to cognate ABC transporter permeases. The protein has a cleavable signal peptide (residues 1-28) for periplasmic secretion and no transmembrane helices whatsoever. Ligand-gated ion channels, by contrast, are integral membrane proteins with multiple transmembrane segments that form a selective ion- conducting pore opened by ligand binding -- a completely different protein architecture and mechanism. No domain hit (InterPro, Pfam, CDD, PANTHER, PROSITE), no eggNOG orthologous group (COG0834, which covers extracellular solute-binding proteins), and no literature on FliY orthologs in E. coli or other Enterobacterales supports any ion channel activity. The known molecular function of FliY is amino acid binding (GO:0016597) in the context of L-cystine transport (GO:0015811). This prediction appears to be a frequency- biased misassignment, possibly driven by superficial sequence features that the model incorrectly associates with channel activity rather than substrate binding.</div></td>
+    <td class="summary-cell"><div class="summary-text">GO:0015276 (ligand-gated monoatomic ion channel activity) is unequivocally wrong for D3VIU4. This protein is FliY, the periplasmic substrate-binding component of the FliY-YecSC (TcyJLN) ABC transporter for L-cystine import. It belongs to bacterial solute-binding protein family 3 (PF00497, IPR001638, CDD cd13711 PBP2_Ngo0372_TcyA), a well-characterized family of soluble periplasmic proteins that bind amino acids or compatible solutes and deliver them to cognate ABC transporter permeases. The protein has a cleavable signal peptide (residues 1-28) for periplasmic secretion and no transmembrane helices whatsoever. Ligand-gated ion channels, by contrast, are integral membrane proteins with multiple transmembrane segments that form a selective ion- conducting pore opened by ligand binding -- a completely different protein architecture and mechanism. No domain hit (InterPro, Pfam, CDD, PANTHER, PROSITE), no eggNOG orthologous group (COG0834, which covers extracellular solute-binding proteins), and no literature on FliY orthologs in E. coli or other Enterobacterales supports any ion channel activity. The known molecular function of FliY is amino acid binding (GO:0016597) in the context of L-cystine transport (GO:0015811). This prediction appears to be a frequency- biased misassignment, possibly driven by superficial sequence features that the model incorrectly associates with channel activity rather than substrate binding. An independent OpenScientist investigation (see file reference) confirms this NPI: D3VIU4 is a periplasmic substrate-binding protein (SBP family 3, SUPFAM SSF53850) whose ligand-binding clamshell is evolutionarily homologous to the extracellular ligand-binding domain of ionotropic glutamate receptors -- a fold-homology misassignment -- but it has no transmembrane pore-forming segment, which is decisive against ion-channel activity. NPI confirmed.</div></td>
 </tr>
 
 
@@ -1856,7 +1856,7 @@
 <tr data-assessment="CNN" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/XENTR/A0A8J0SCI2/A0A8J0SCI2-ai-review.html">A0A8J0SCI2</a>
-        
+
     </td>
     <td><small>Xenopus tropicalis</small></td>
     <td>
@@ -1873,7 +1873,7 @@
 <tr data-assessment="CNN" data-type="GO_BP" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/XENTR/A0A8J0SCI2/A0A8J0SCI2-ai-review.html">A0A8J0SCI2</a>
-        
+
     </td>
     <td><small>Xenopus tropicalis</small></td>
     <td>
@@ -1890,7 +1890,7 @@
 <tr data-assessment="CNN" data-type="GO_CC" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/XENTR/A0A8J0SCI2/A0A8J0SCI2-ai-review.html">A0A8J0SCI2</a>
-        
+
     </td>
     <td><small>Xenopus tropicalis</small></td>
     <td>
@@ -1907,7 +1907,7 @@
 <tr data-assessment="NPI" data-type="GO_MF" data-nopred="0" onclick="this.classList.toggle('expanded')">
     <td>
         <a class="gene-link" href="../../../genes/XENTR/A0A8J0SCI2/A0A8J0SCI2-ai-review.html">A0A8J0SCI2</a>
-        
+
     </td>
     <td><small>Xenopus tropicalis</small></td>
     <td>
@@ -1918,7 +1918,7 @@
     <td><span class="badge badge-NPI">NPI</span></td>
     <td>0</td>
     <td><span class="badge-error">PARALOG_OVERANNOTATION</span></td>
-    <td class="summary-cell"><div class="summary-text">This prediction incorrectly specifies transcription activator activity for a protein where no evidence supports activator versus repressor function. A0A8J0SCI2 is a pure zinc finger array protein with 8 tandem C2H2 zinc finger domains spanning nearly its entire length (residues 37-260) and a short N-terminal disordered region (residues 1-27). Critically, it lacks any known effector domains -- no KRAB repressor domain, no SCAN dimerization domain, no BTB/POZ domain, and no identifiable activation domain. Without an effector domain, the directionality of transcriptional regulation (activation vs. repression) cannot be inferred from sequence alone. The existing IBA annotation appropriately uses the parent term GO:0000981 (DNA-binding transcription factor activity, RNA polymerase II-specific), which is agnostic to activator/repressor function. As noted in the gene review, ProtNLM2 likely derived this prediction from sequence similarity to KRAB-ZNF proteins (CATH FunFam assignments include ZNF1184 and ZNF527/577, which are KRAB-containing repressors), but this protein lacks the KRAB domain entirely, making the activator/repressor specificity prediction unreliable. The error is classified as PARALOG_OVERANNOTATION because the prediction inappropriately transfers a specific functional characteristic (activator activity) from distantly related zinc finger proteins with different domain architectures.</div></td>
+    <td class="summary-cell"><div class="summary-text">This prediction incorrectly specifies transcription activator activity for a protein where no evidence supports activator versus repressor function. A0A8J0SCI2 is a pure zinc finger array protein with 8 tandem C2H2 zinc finger domains spanning nearly its entire length (residues 37-260) and a short N-terminal disordered region (residues 1-27). Critically, it lacks any known effector domains -- no KRAB repressor domain, no SCAN dimerization domain, no BTB/POZ domain, and no identifiable activation domain. Without an effector domain, the directionality of transcriptional regulation (activation vs. repression) cannot be inferred from sequence alone. The existing IBA annotation appropriately uses the parent term GO:0000981 (DNA-binding transcription factor activity, RNA polymerase II-specific), which is agnostic to activator/repressor function. As noted in the gene review, ProtNLM2 likely derived this prediction from sequence similarity to KRAB-ZNF proteins (CATH FunFam assignments include ZNF1184 and ZNF527/577, which are KRAB-containing repressors), but this protein lacks the KRAB domain entirely, making the activator/repressor specificity prediction unreliable. The error is classified as PARALOG_OVERANNOTATION because the prediction inappropriately transfers a specific functional characteristic (activator activity) from distantly related zinc finger proteins with different domain architectures. An independent OpenScientist investigation (see file reference) confirms this NPI: A0A8J0SCI2 is a naked tandem 8x C2H2 array with no accessory effector domain of any kind, and because a zinc-finger array encodes DNA sequence specificity rather than regulatory direction, activator-versus-repressor cannot be inferred from sequence -- so the safest curation is to retain the neutral GO:0000981 and withhold GO:0001228. NPI confirmed (an over-specific directional child term); the protein remains a legitimate candidate sequence-specific TF, just not demonstrably an activator.</div></td>
 </tr>
 
 
@@ -1927,7 +1927,7 @@
 <tr data-assessment="" data-type="" data-nopred="1" class="no-pred-row">
     <td>
         <a class="gene-link" href="../../../genes/XENTR/A0A8J1IYX6/A0A8J1IYX6-ai-review.html">A0A8J1IYX6</a>
-        
+
     </td>
     <td><small>Xenopus tropicalis</small></td>
     <td colspan="6" class="no-predictions">No predictions</td>
@@ -1938,7 +1938,7 @@
 <tr data-assessment="" data-type="" data-nopred="1" class="no-pred-row">
     <td>
         <a class="gene-link" href="../../../genes/XENTR/F6WPT1/F6WPT1-ai-review.html">F6WPT1</a>
-        
+
     </td>
     <td><small>Xenopus tropicalis</small></td>
     <td colspan="6" class="no-predictions">No predictions</td>

--- a/src/ai_gene_review/render_prediction_eval.py
+++ b/src/ai_gene_review/render_prediction_eval.py
@@ -31,6 +31,8 @@ from typing import Any
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
+from ai_gene_review.render_modules import clean_rendered_html
+
 CS_MAP = {"COR": 2, "CNN": 2, "LSP": 2, "UNC": 1, "PLI": 0, "NPI": 0, "REP": 0}
 ASSESSMENT_ORDER = ["COR", "CNN", "LSP", "UNC", "PLI", "NPI", "REP"]
 
@@ -155,12 +157,13 @@ def render_prediction_eval(
         autoescape=True,
     )
     template = env.get_template(template_path.name)
-    return template.render(
+    rendered = template.render(
         title=title,
         subtitle=subtitle,
         proteins=proteins,
         **stats,
     )
+    return clean_rendered_html(rendered)
 
 
 def main() -> None:

--- a/tests/test_render_prediction_eval.py
+++ b/tests/test_render_prediction_eval.py
@@ -1,0 +1,17 @@
+from ai_gene_review.render_prediction_eval import render_prediction_eval
+
+
+def test_render_prediction_eval_has_no_trailing_whitespace():
+    html = render_prediction_eval(
+        [
+            {
+                "id": "P0A6Y8",
+                "gene_symbol": "DnaK",
+                "taxon": {"label": "Escherichia coli"},
+                "predictions": [],
+            }
+        ]
+    )
+
+    assert html.endswith("\n")
+    assert all(line == line.rstrip() for line in html.splitlines())


### PR DESCRIPTION
## Summary
- strip trailing whitespace from prediction evaluation HTML generated by Jinja control-flow blocks
- ensure generated output ends with a newline
- add a regression test for whitespace-clean output

## Validation
- `just render-bioreason-eval`
- `git diff --check`
- `just test` (1804 passed, 51 deselected)