### PR TITLE
Fix GO-GPT wrapper package imports

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -2625,7 +2625,7 @@ ui-legacy port="5123":
 #   just gogpt-predict human TP53
 #   just gogpt-predict PSEPK rpoS
 gogpt-predict organism gene:
-    ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --output-dir .
+    PYTHONPATH=src ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --output-dir .
 
 # Run GO-GPT prediction and compare with curated review
 # Outputs GENE-gogpt-predictions.yaml in PredictionReview schema format
@@ -2633,11 +2633,11 @@ gogpt-predict organism gene:
 #   just gogpt-compare human TP53
 #   just gogpt-compare PSEPK rpoS
 gogpt-compare organism gene:
-    ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
+    PYTHONPATH=src ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
 
 # Alias for gogpt-compare
 gogpt-review organism gene:
-    ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
+    PYTHONPATH=src ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
 
 # Run GO-GPT predictions for all genes in an organism
 gogpt-predict-organism organism:
@@ -2650,7 +2650,7 @@ gogpt-predict-organism organism:
             uniprot="$gene_dir/${gene}-uniprot.txt"
             if [ -f "$uniprot" ]; then
                 echo "Processing $gene..."
-                ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $gene"
+                PYTHONPATH=src ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $gene"
                 count=$((count + 1))
             fi
         fi
@@ -2671,7 +2671,7 @@ gogpt-compare-all:
                 uniprot="$gene_dir/${gene}-uniprot.txt"
                 if [ -f "$review" ] && [ -f "$uniprot" ]; then
                     echo "Comparing $organism/$gene..."
-                    ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py "$organism" "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $organism/$gene"
+                    PYTHONPATH=src ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py "$organism" "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $organism/$gene"
                     total=$((total + 1))
                 fi
             fi

--- a/project.justfile
+++ b/project.justfile
@@ -2625,7 +2625,7 @@ ui-legacy port="5123":
 #   just gogpt-predict human TP53
 #   just gogpt-predict PSEPK rpoS
 gogpt-predict organism gene:
-    PYTHONPATH=src ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --output-dir .
+    PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --output-dir .
 
 # Run GO-GPT prediction and compare with curated review
 # Outputs GENE-gogpt-predictions.yaml in PredictionReview schema format
@@ -2633,11 +2633,11 @@ gogpt-predict organism gene:
 #   just gogpt-compare human TP53
 #   just gogpt-compare PSEPK rpoS
 gogpt-compare organism gene:
-    PYTHONPATH=src ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
+    PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
 
 # Alias for gogpt-compare
 gogpt-review organism gene:
-    PYTHONPATH=src ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
+    PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
 
 # Run GO-GPT predictions for all genes in an organism
 gogpt-predict-organism organism:
@@ -2650,7 +2650,7 @@ gogpt-predict-organism organism:
             uniprot="$gene_dir/${gene}-uniprot.txt"
             if [ -f "$uniprot" ]; then
                 echo "Processing $gene..."
-                PYTHONPATH=src ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $gene"
+                PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $gene"
                 count=$((count + 1))
             fi
         fi
@@ -2671,7 +2671,7 @@ gogpt-compare-all:
                 uniprot="$gene_dir/${gene}-uniprot.txt"
                 if [ -f "$review" ] && [ -f "$uniprot" ]; then
                     echo "Comparing $organism/$gene..."
-                    PYTHONPATH=src ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py "$organism" "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $organism/$gene"
+                    PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py "$organism" "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $organism/$gene"
                     total=$((total + 1))
                 fi
             fi

--- a/tests/test_gogpt_wrapper.py
+++ b/tests/test_gogpt_wrapper.py
@@ -1,0 +1,19 @@
+"""Regression tests for the repository GO-GPT just wrappers."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_JUSTFILE = REPO_ROOT / "project.justfile"
+
+
+def test_gogpt_wrappers_expose_repository_package_to_bioreason_python() -> None:
+    """Every external BioReason Python call must be able to import ai_gene_review."""
+    command_lines = [
+        line.strip()
+        for line in PROJECT_JUSTFILE.read_text().splitlines()
+        if "scripts/gogpt_predict.py" in line and not line.lstrip().startswith("#")
+    ]
+
+    assert len(command_lines) == 5
+    assert all(line.startswith("PYTHONPATH=src ") for line in command_lines)

--- a/tests/test_gogpt_wrapper.py
+++ b/tests/test_gogpt_wrapper.py
@@ -12,8 +12,15 @@ def test_gogpt_wrappers_expose_repository_package_to_bioreason_python() -> None:
     command_lines = [
         line.strip()
         for line in PROJECT_JUSTFILE.read_text().splitlines()
-        if "scripts/gogpt_predict.py" in line and not line.lstrip().startswith("#")
+        if "BioReason-Pro" in line
+        and "scripts/gogpt_predict.py" in line
+        and not line.lstrip().startswith("#")
     ]
 
-    assert len(command_lines) == 5
-    assert all(line.startswith("PYTHONPATH=src ") for line in command_lines)
+    assert command_lines, "expected at least one external BioReason GO-GPT invocation"
+    missing = [
+        line
+        for line in command_lines
+        if not line.startswith("PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ")
+    ]
+    assert not missing, f"BioReason invocations without repository PYTHONPATH: {missing}"


### PR DESCRIPTION
## Summary

- expose the repository `src` package to the external BioReason-Pro Python interpreter in every GO-GPT wrapper
- cover all five wrapper invocations with a regression test

## Bug

`just gogpt-compare-all` invoked `scripts/gogpt_predict.py` with the BioReason-Pro virtualenv but without the repository package on `PYTHONPATH`, so every gene failed immediately with `ModuleNotFoundError: No module named 'ai_gene_review'`.

## Validation

- red regression run before the fix: 1 failed, 1,804 passed
- `just test`: 1,805 tests passed; 154 doctests passed; mypy passed for 162 source files; Ruff passed
- `git diff --check`
