### PR TITLE
Update GroEL unfolded-protein-binding tracker

### DIFF
--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -1458,9 +1458,9 @@ established:</p>
 <td><a href="../../genes/ECOLI/GroEL/GroEL-ai-review.html">GroEL</a></td>
 <td><em>E. coli</em></td>
 <td>P0A6F5</td>
-<td>64</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a></td>
-<td>Chaperonin</td>
+<td>62</td>
+<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140662">GO:0140662</a> (4 obsolete <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> rows); MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0051087">GO:0051087</a> (GroES-only protein-binding rows); MARK_AS_OVER_ANNOTATED (1 scaffold artifact)</td>
+<td>ATP-dependent GroEL-<a href="../../genes/PSEPK/groES/groES-ai-review.html">GroES</a> chaperonin foldase; comprehensive review complete</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/HdeA/HdeA-ai-review.html">HdeA</a></td>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -496,7 +496,7 @@ established:
 | CpxP | *E. coli* | P0AE85 | 11 | MARK_AS_OVER_ANNOTATED; NEW GO:0140767, GO:0070298; MODIFY → GO:0030547, GO:0045862 | DegP substrate adaptor and CpxA inhibitor; weak in-vitro chaperone activity does not establish a general holdase function |
 | DnaJ | *E. coli* | P08622 | 49 | MODIFY → GO:0044183 (3 rows); MARK_AS_OVER_ANNOTATED (1 miscited CAFA row); NEW GO:0001671 | J-domain co-chaperone and DnaK ATPase activator; comprehensive review complete |
 | DnaK | *E. coli* | P0A6Y8 | 61 | MODIFY → GO:0044183/GO:0140662; NEW holdase chaperone activity NTR | ATP-dependent HSP70 foldase with directly demonstrated ATP-independent holdase activity; comprehensive review complete |
-| GroEL | *E. coli* | P0A6F5 | 64 | MODIFY → GO:0044183 | Chaperonin |
+| GroEL | *E. coli* | P0A6F5 | 62 | MODIFY → GO:0140662 (4 obsolete GO:0051082 rows); MODIFY → GO:0051087 (GroES-only protein-binding rows); MARK_AS_OVER_ANNOTATED (1 scaffold artifact) | ATP-dependent GroEL-GroES chaperonin foldase; comprehensive review complete |
 | HdeA | *E. coli* | P0AES9 | 14 | MODIFY → holdase NTR; retain GO:0051082 interim; NEW GO:0050821 | Acid-activated in-situ holdase; no defined acceptor or delivery destination; GO:0042026 for refolding process |
 | HdeB | *E. coli* | P0AET2 | 8 | MODIFY → holdase NTR; retain GO:0051082 interim; NEW GO:0050821 | Acid-activated in-situ holdase; no defined acceptor or delivery destination |
 | RidA | *E. coli* | P0AF93 | 22 | OVER_ANNOTATED | Reactive intermediate deaminase |


### PR DESCRIPTION
## Summary
- update the GroEL tracker row after the comprehensive 62-signature annotation review
- record four obsolete `GO:0051082` rows modified to `GO:0140662`, GroES-only binding rows modified to `GO:0051087`, and the scaffold artifact marked over-annotated
- correct the grouped-signature count from 64 to 62 and regenerate the project HTML through the public wrapper

## Validation
- `just render-project UNFOLDED_PROTEIN_BINDING`
- `just test` (1,905 tests; 156 doctests; mypy across 169 source files; Ruff)
