### PR TITLE
Update RidA unfolded-protein tracker status

### DIFF
--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -1007,17 +1007,23 @@ because it has that second term as well; this is not an additional human gene.</
 <tr>
 <td>13</td>
 <td><strong>Peroxiredoxin/redox chaperones</strong></td>
-<td><a href="../../genes/yeast/TSA1/TSA1-ai-review.html">TSA1</a> (yeast); <a href="../../genes/SCHPO/pmp20/pmp20-ai-review.html">pmp20</a>, <a href="../../genes/SCHPO/tpx1/tpx1-ai-review.html">tpx1</a> (S. pombe); <a href="../../genes/ECOLI/CnoX/CnoX-ai-review.html">CnoX</a>, <a href="../../genes/ECOLI/RidA/RidA-ai-review.html">RidA</a> (E. coli); <a href="../../genes/PSEPK/PP_1084/PP_1084-ai-review.html">PP_1084</a>/PpPrx (<em>P. putida</em>, direct literature gap case)</td>
+<td><a href="../../genes/yeast/TSA1/TSA1-ai-review.html">TSA1</a> (yeast); <a href="../../genes/SCHPO/pmp20/pmp20-ai-review.html">pmp20</a>, <a href="../../genes/SCHPO/tpx1/tpx1-ai-review.html">tpx1</a> (S. pombe); <a href="../../genes/ECOLI/CnoX/CnoX-ai-review.html">CnoX</a> (E. coli); <a href="../../genes/PSEPK/PP_1084/PP_1084-ai-review.html">PP_1084</a>/PpPrx (<em>P. putida</em>, direct literature gap case)</td>
 <td>MODIFY → holdase NTR when evidence shows in-situ aggregation prevention without refolding; older <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a> sibling decisions require re-review</td>
 </tr>
 <tr>
 <td>14</td>
+<td><strong>Conditional moonlighting holdase</strong></td>
+<td><a href="../../genes/ECOLI/RidA/RidA-ai-review.html">RidA</a> (E. coli)</td>
+<td>MODIFY <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> → holdase NTR for reversible N-chlorination-dependent ATP-independent holdase activity; primary function is 2-iminoacid deaminase activity</td>
+</tr>
+<tr>
+<td>15</td>
 <td><strong>Membrane protein chaperones</strong></td>
 <td><a href="../../genes/yeast/SHR3/SHR3-ai-review.html">SHR3</a>, <a href="../../genes/yeast/PHO86/PHO86-ai-review.html">PHO86</a>, <a href="../../genes/yeast/GSF2/GSF2-ai-review.html">GSF2</a>, <a href="../../genes/yeast/CHS7/CHS7-ai-review.html">CHS7</a>, <a href="../../genes/yeast/NSG1/NSG1-ai-review.html">NSG1</a>, <a href="../../genes/yeast/NSG2/NSG2-ai-review.html">NSG2</a>, <a href="../../genes/yeast/VMA22/VMA22-ai-review.html">VMA22</a>, <a href="../../genes/yeast/VPS45/VPS45-ai-review.html">VPS45</a> (yeast)</td>
 <td>MODIFY or OVER_ANNOTATED</td>
 </tr>
 <tr>
-<td>15</td>
+<td>16</td>
 <td><strong>Other</strong></td>
 <td><a href="../../genes/human/NPM1/NPM1-ai-review.html">NPM1</a>, <a href="../../genes/human/TMEM67/TMEM67-ai-review.html">TMEM67</a> (human); <a href="../../genes/yeast/NAP1/NAP1-ai-review.html">NAP1</a>, <a href="../../genes/human/GET3/GET3-ai-review.html">GET3</a> (yeast); <a href="../../genes/rat/St13/St13-ai-review.html">St13</a>, <a href="../../genes/mouse/Serpinh1/Serpinh1-ai-review.html">Serpinh1</a> (mouse/rat); <a href="../../genes/DROME/Nmnat/Nmnat-ai-review.html">Nmnat</a> (fly); <a href="../../genes/worm/nud-1/nud-1-ai-review.html">nud-1</a>, <a href="../../genes/worm/hsp-12.3/hsp-12.3-ai-review.html">hsp-12.3</a>, <a href="../../genes/worm/hsp-12.6/hsp-12.6-ai-review.html">hsp-12.6</a> (worm); <a href="../../genes/ASPNG/tigA/tigA-ai-review.html">tigA</a> (A. niger); <a href="../../genes/ARATH/GIP1/GIP1-ai-review.html">GIP1</a> (Arabidopsis)</td>
 <td>Gene-specific decisions</td>
@@ -1076,12 +1082,12 @@ apply consistently across species.</p>
 <tbody>
 <tr>
 <td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0044183">GO:0044183</a> or holdase NTR</td>
-<td>88</td>
+<td>89</td>
 <td>Genuine chaperones reclassified to mechanism-specific terms</td>
 </tr>
 <tr>
 <td>MARK_AS_OVER_ANNOTATED</td>
-<td>22</td>
+<td>21</td>
 <td>Assembly factors, sensors, co-chaperones where UPB overstates activity</td>
 </tr>
 <tr>
@@ -1226,6 +1232,12 @@ established:</p>
 <p><strong><a href="../../genes/ECOLI/CnoX/CnoX-ai-review.html">CnoX</a> (E. coli)</strong> — Redox-activated holdase with thioredoxin domain. Interesting<br />
    mechanistic variant: becomes an active holdase specifically under oxidative stress when<br />
    its Cys residues are oxidized. Supports the holdase NTR need.</p>
+</li>
+<li>
+<p><strong><a href="../../genes/ECOLI/RidA/RidA-ai-review.html">RidA</a> (E. coli)</strong> — Modification-dependent moonlighting holdase whose primary function<br />
+   is 2-iminoacid deaminase activity. Reversible N-chlorination of Lys/Arg residues activates<br />
+   ATP-independent aggregation prevention, supporting the holdase NTR while keeping the<br />
+   chaperone activity distinct from <a href="../../genes/ECOLI/RidA/RidA-ai-review.html">RidA</a>'s core metabolic function.</p>
 </li>
 <li>
 <p><strong>Assembly factors (<a href="../../genes/yeast/ATP10/ATP10-ai-review.html">ATP10</a>, <a href="../../genes/human/PET100/PET100-ai-review.html">PET100</a>, <a href="../../genes/human/COX20/COX20-ai-review.html">COX20</a>, <a href="../../genes/yeast/SHY1/SHY1-ai-review.html">SHY1</a>, <a href="../../genes/NEUCR/cia30/cia30-ai-review.html">cia30</a>)</strong> — Single-client assembly<br />
@@ -1483,8 +1495,8 @@ established:</p>
 <td><em>E. coli</em></td>
 <td>P0AF93</td>
 <td>22</td>
-<td>OVER_ANNOTATED</td>
-<td>Reactive intermediate deaminase</td>
+<td>MODIFY <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> → holdase chaperone activity NTR; MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0120241">GO:0120241</a>/<a href="http://amigo.geneontology.org/amigo/term/GO:0009082">GO:0009082</a>/<a href="http://amigo.geneontology.org/amigo/term/GO:1901705">GO:1901705</a>/<a href="http://amigo.geneontology.org/amigo/term/GO:0005829">GO:0005829</a>; membrane HDA KEEP_AS_NON_CORE</td>
+<td>2-iminoacid deaminase with reversible N-chlorination-dependent ATP-independent holdase activity; comprehensive review complete</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/SecB/SecB-ai-review.html">SecB</a></td>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -368,9 +368,10 @@ All 148 genes organized by mechanism class (human + non-human combined):
 | 10 | **Ubiquitin/QC sensor** | SYVN1 (human); SAN1 (yeast); Fbxo2 (mouse); slrP (Salmonella) | REMOVE or MODIFY to GO:0051787 |
 | 11 | **Periplasmic/envelope chaperones** | SurA, Skp, Spy, SecB, HdeA, HdeB, SlyD, CpxP (E. coli) | Carrier-holdases SurA, SecB, and Skp: MODIFY → GO:0140309; HdeA/HdeB/Spy/SlyD await the general holdase NTR; CpxP is over-annotated and instead has NEW GO:0140767/GO:0070298 plus MODIFY → GO:0030547/GO:0045862. HdeA, HdeB, and Spy re-reviews found no defined acceptor or delivery destination and added GO:0050821 protein stabilization |
 | 12 | **Ribosome assembly** | SQT1, SYO1, YAR1, RRB1, TSR4, PNO1, ACL4, SHQ1, BTT1 (yeast) | MODIFY → GO:0044183 or OVER_ANNOTATED |
-| 13 | **Peroxiredoxin/redox chaperones** | TSA1 (yeast); pmp20, tpx1 (S. pombe); CnoX, RidA (E. coli); PP_1084/PpPrx (*P. putida*, direct literature gap case) | MODIFY → holdase NTR when evidence shows in-situ aggregation prevention without refolding; older GO:0044183 sibling decisions require re-review |
-| 14 | **Membrane protein chaperones** | SHR3, PHO86, GSF2, CHS7, NSG1, NSG2, VMA22, VPS45 (yeast) | MODIFY or OVER_ANNOTATED |
-| 15 | **Other** | NPM1, TMEM67 (human); NAP1, GET3 (yeast); St13, Serpinh1 (mouse/rat); Nmnat (fly); nud-1, hsp-12.3, hsp-12.6 (worm); tigA (A. niger); GIP1 (Arabidopsis) | Gene-specific decisions |
+| 13 | **Peroxiredoxin/redox chaperones** | TSA1 (yeast); pmp20, tpx1 (S. pombe); CnoX (E. coli); PP_1084/PpPrx (*P. putida*, direct literature gap case) | MODIFY → holdase NTR when evidence shows in-situ aggregation prevention without refolding; older GO:0044183 sibling decisions require re-review |
+| 14 | **Conditional moonlighting holdase** | RidA (E. coli) | MODIFY GO:0051082 → holdase NTR for reversible N-chlorination-dependent ATP-independent holdase activity; primary function is 2-iminoacid deaminase activity |
+| 15 | **Membrane protein chaperones** | SHR3, PHO86, GSF2, CHS7, NSG1, NSG2, VMA22, VPS45 (yeast) | MODIFY or OVER_ANNOTATED |
+| 16 | **Other** | NPM1, TMEM67 (human); NAP1, GET3 (yeast); St13, Serpinh1 (mouse/rat); Nmnat (fly); nud-1, hsp-12.3, hsp-12.6 (worm); tigA (A. niger); GIP1 (Arabidopsis) | Gene-specific decisions |
 
 ## Cross-Species Completeness Audit
 
@@ -394,8 +395,8 @@ apply consistently across species.
 
 | Decision | Count | Description |
 |----------|-------|-------------|
-| MODIFY → GO:0044183 or holdase NTR | 88 | Genuine chaperones reclassified to mechanism-specific terms |
-| MARK_AS_OVER_ANNOTATED | 22 | Assembly factors, sensors, co-chaperones where UPB overstates activity |
+| MODIFY → GO:0044183 or holdase NTR | 89 | Genuine chaperones reclassified to mechanism-specific terms |
+| MARK_AS_OVER_ANNOTATED | 21 | Assembly factors, sensors, co-chaperones where UPB overstates activity |
 | UNDECIDED | 1 | Full-text evidence is unavailable to resolve the direct binding assay (EUG1) |
 | ACCEPT (retain GO:0051082) | 3 | Genes where GO:0051082 remains best available term |
 | KEEP_AS_NON_CORE | 2 | UPB is secondary to primary function (ATP11, VMA22) |
@@ -449,17 +450,22 @@ established:
    mechanistic variant: becomes an active holdase specifically under oxidative stress when
    its Cys residues are oxidized. Supports the holdase NTR need.
 
-4. **Assembly factors (ATP10, PET100, COX20, SHY1, cia30)** — Single-client assembly
+4. **RidA (E. coli)** — Modification-dependent moonlighting holdase whose primary function
+   is 2-iminoacid deaminase activity. Reversible N-chlorination of Lys/Arg residues activates
+   ATP-independent aggregation prevention, supporting the holdase NTR while keeping the
+   chaperone activity distinct from RidA's core metabolic function.
+
+5. **Assembly factors (ATP10, PET100, COX20, SHY1, cia30)** — Single-client assembly
    chaperones for respiratory chain complexes. These bind specific subunits during complex
    assembly, not unfolded proteins generally. All MARK_AS_OVER_ANNOTATED. GO:0140777
    (protein-containing complex stabilizing activity) proposed as replacement for some.
 
-5. **IRE1 (yeast + T. reesei)** — UPR sensor kinase/endoribonuclease. Detects unfolded
+6. **IRE1 (yeast + T. reesei)** — UPR sensor kinase/endoribonuclease. Detects unfolded
    proteins in the ER lumen as a signaling sensor, not a chaperone. Cross-kingdom confirmation
    of OVER_ANNOTATED. The T. reesei review also flagged metazoan-specific GO terms
    (IRE1-TRAF2-ASK1 complex) that are biologically impossible in fungi.
 
-6. **Peroxiredoxins (TSA1, pmp20, tpx1; PP_1084/PpPrx as a literature-only gap case)** —
+7. **Peroxiredoxins (TSA1, pmp20, tpx1; PP_1084/PpPrx as a literature-only gap case)** —
    Dual-function peroxidase/holdases whose oligomeric state controls aggregation-prevention
    activity. PP_1084 provides the clearest discriminator: its full text explicitly reports
    suppression of model-substrate aggregation and failure to detect foldase activity
@@ -499,7 +505,7 @@ established:
 | GroEL | *E. coli* | P0A6F5 | 62 | MODIFY → GO:0140662 (4 obsolete GO:0051082 rows); MODIFY → GO:0051087 (GroES-only protein-binding rows); MARK_AS_OVER_ANNOTATED (1 scaffold artifact) | ATP-dependent GroEL-GroES chaperonin foldase; comprehensive review complete |
 | HdeA | *E. coli* | P0AES9 | 14 | MODIFY → holdase NTR; retain GO:0051082 interim; NEW GO:0050821 | Acid-activated in-situ holdase; no defined acceptor or delivery destination; GO:0042026 for refolding process |
 | HdeB | *E. coli* | P0AET2 | 8 | MODIFY → holdase NTR; retain GO:0051082 interim; NEW GO:0050821 | Acid-activated in-situ holdase; no defined acceptor or delivery destination |
-| RidA | *E. coli* | P0AF93 | 22 | OVER_ANNOTATED | Reactive intermediate deaminase |
+| RidA | *E. coli* | P0AF93 | 22 | MODIFY GO:0051082 → holdase chaperone activity NTR; MODIFY → GO:0120241/GO:0009082/GO:1901705/GO:0005829; membrane HDA KEEP_AS_NON_CORE | 2-iminoacid deaminase with reversible N-chlorination-dependent ATP-independent holdase activity; comprehensive review complete |
 | SecB | *E. coli* | P0AG86 | 27 | MODIFY → GO:0140309 | Secretion carrier-holdase |
 | Skp | *E. coli* | P0AEU7 | 34 | MODIFY → GO:0140309 | Periplasmic OMP carrier-holdase |
 | SlyD | *E. coli* | P0A9K9 | 35 | MODIFY → holdase NTR; retain GO:0051082 interim | FKBP-type PPIase/holdase; GO:0170061 for nickel chaperoning |


### PR DESCRIPTION
## Summary
- replace RidA's provisional tracker classification with the completed review decisions
- record the holdase NTR, term replacements, and curator-deferred membrane annotation
- regenerate the rendered project page through the public wrapper

## Validation
- `just render-project UNFOLDED_PROTEIN_BINDING`
- `just test` (1905 tests, 156 doctests, mypy, Ruff)

Follows the merged RidA review in #2771.
