### PR TITLE
Update SecB unfolded protein tracker

### DIFF
--- a/pages/projects/UNFOLDED_PROTEIN_BINDING.html
+++ b/pages/projects/UNFOLDED_PROTEIN_BINDING.html
@@ -1503,8 +1503,8 @@ established:</p>
 <td><em>E. coli</em></td>
 <td>P0AG86</td>
 <td>27</td>
-<td>MODIFY → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a></td>
-<td>Secretion carrier-holdase</td>
+<td>MODIFY <a href="http://amigo.geneontology.org/amigo/term/GO:0051082">GO:0051082</a> → <a href="http://amigo.geneontology.org/amigo/term/GO:0140309">GO:0140309</a> (4 rows); MODIFY broad cytoplasm/transport/localization → <a href="http://amigo.geneontology.org/amigo/term/GO:0005829">GO:0005829</a>/<a href="http://amigo.geneontology.org/amigo/term/GO:0043952">GO:0043952</a>/<a href="http://amigo.geneontology.org/amigo/term/GO:0006605">GO:0006605</a>; REMOVE protein-folding IEA</td>
+<td>ATP-independent SecA-directed carrier-holdase; comprehensive review complete</td>
 </tr>
 <tr>
 <td><a href="../../genes/ECOLI/Skp/Skp-ai-review.html">Skp</a></td>

--- a/projects/UNFOLDED_PROTEIN_BINDING.md
+++ b/projects/UNFOLDED_PROTEIN_BINDING.md
@@ -506,7 +506,7 @@ established:
 | HdeA | *E. coli* | P0AES9 | 14 | MODIFY → holdase NTR; retain GO:0051082 interim; NEW GO:0050821 | Acid-activated in-situ holdase; no defined acceptor or delivery destination; GO:0042026 for refolding process |
 | HdeB | *E. coli* | P0AET2 | 8 | MODIFY → holdase NTR; retain GO:0051082 interim; NEW GO:0050821 | Acid-activated in-situ holdase; no defined acceptor or delivery destination |
 | RidA | *E. coli* | P0AF93 | 22 | MODIFY GO:0051082 → holdase chaperone activity NTR; MODIFY → GO:0120241/GO:0009082/GO:1901705/GO:0005829; membrane HDA KEEP_AS_NON_CORE | 2-iminoacid deaminase with reversible N-chlorination-dependent ATP-independent holdase activity; comprehensive review complete |
-| SecB | *E. coli* | P0AG86 | 27 | MODIFY → GO:0140309 | Secretion carrier-holdase |
+| SecB | *E. coli* | P0AG86 | 27 | MODIFY GO:0051082 → GO:0140309 (4 rows); MODIFY broad cytoplasm/transport/localization → GO:0005829/GO:0043952/GO:0006605; REMOVE protein-folding IEA | ATP-independent SecA-directed carrier-holdase; comprehensive review complete |
 | Skp | *E. coli* | P0AEU7 | 34 | MODIFY → GO:0140309 | Periplasmic OMP carrier-holdase |
 | SlyD | *E. coli* | P0A9K9 | 35 | MODIFY → holdase NTR; retain GO:0051082 interim | FKBP-type PPIase/holdase; GO:0170061 for nickel chaperoning |
 | Spy | *E. coli* | P77754 | 11 | MODIFY → holdase NTR; retain GO:0051082 interim; NEW GO:0050821 | Periplasmic in-situ holdase; no defined acceptor or delivery destination; GO:0042026 for refolding process |


### PR DESCRIPTION
## Summary

- update the SecB project row after the comprehensive 27-signature review merged in #2773
- record the four obsolete `GO:0051082` replacements, the broader term refinements, and the protein-folding IEA removal
- mark the ATP-independent SecA-directed carrier-holdase review complete
- regenerate the project HTML through `just render-project UNFOLDED_PROTEIN_BINDING`

## Validation

- `just render-project UNFOLDED_PROTEIN_BINDING`
- `just test` (1905 tests, 156 doctests, mypy, Ruff)
