### PR TITLE
Report GOA qualifier seed updates

### DIFF
--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -182,12 +182,17 @@ def fetch_gene(
                 if (
                     result["annotations_added"] > 0
                     or result.get("references_added", 0) > 0
+                    or result.get("qualifiers_backfilled", 0) > 0
                 ):
                     parts = []
                     if result["annotations_added"] > 0:
                         parts.append(f"{result['annotations_added']} annotations")
                     if result.get("references_added", 0) > 0:
                         parts.append(f"{result.get('references_added', 0)} references")
+                    if result.get("qualifiers_backfilled", 0) > 0:
+                        parts.append(
+                            f"qualifiers on {result.get('qualifiers_backfilled', 0)} annotations"
+                        )
                     typer.echo(
                         f"  - {file_prefix}-ai-review.yaml (added {' and '.join(parts)})"
                     )
@@ -1309,16 +1314,20 @@ def seed_goa(
 
     # Perform the seeding
     try:
-        added_count, output_path, refs_added = validator.seed_missing_annotations(
+        added_count, output_path, refs_added, qualifiers_backfilled = (
+            validator.seed_missing_annotations(
             yaml_file, goa_file, output, fetch_titles=fetch_titles
+            )
         )
 
-        if added_count > 0 or refs_added > 0:
+        if added_count > 0 or refs_added > 0 or qualifiers_backfilled > 0:
             parts = []
             if added_count > 0:
                 parts.append(f"{added_count} annotations")
             if refs_added > 0:
                 parts.append(f"{refs_added} references")
+            if qualifiers_backfilled > 0:
+                parts.append(f"qualifiers on {qualifiers_backfilled} annotations")
             typer.echo(f"\n✓ Successfully added {' and '.join(parts)} to {output_path}")
             typer.echo("\nNote: Review sections left empty for AI to complete")
         else:

--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -1316,7 +1316,7 @@ def seed_goa(
     try:
         added_count, output_path, refs_added, qualifiers_backfilled = (
             validator.seed_missing_annotations(
-            yaml_file, goa_file, output, fetch_titles=fetch_titles
+                yaml_file, goa_file, output, fetch_titles=fetch_titles
             )
         )
 

--- a/src/ai_gene_review/etl/gene.py
+++ b/src/ai_gene_review/etl/gene.py
@@ -206,6 +206,35 @@ def _compare_file_content(file_path: Path, new_content: str) -> bool:
         return True
 
 
+def _report_seed_updates(
+    file_prefix: str,
+    added_count: int,
+    refs_added: int,
+    qualifiers_backfilled: int,
+    yaml_existed: bool,
+) -> None:
+    """Report every mutation performed while seeding a gene review."""
+    if added_count > 0:
+        print(
+            f"  ✓ Seeded {added_count} GOA annotations in "
+            f"{file_prefix}-ai-review.yaml"
+        )
+    if qualifiers_backfilled > 0:
+        print(
+            f"  ✓ Backfilled qualifiers on {qualifiers_backfilled} annotations "
+            f"in {file_prefix}-ai-review.yaml"
+        )
+    if (
+        added_count == 0
+        and refs_added == 0
+        and qualifiers_backfilled == 0
+        and yaml_existed
+    ):
+        print(
+            f"  - {file_prefix}-ai-review.yaml already contains all GOA annotations"
+        )
+
+
 def fetch_gene_data(
     gene_info: Tuple[str, str],
     uniprot_id: Optional[str] = None,
@@ -289,6 +318,7 @@ def fetch_gene_data(
         "yaml_existed": False,
         "annotations_added": 0,
         "references_added": 0,
+        "qualifiers_backfilled": 0,
         "uniprot_updated": False,
         "goa_updated": False,
         "uniprot_differences": uniprot_differs,
@@ -394,26 +424,22 @@ def fetch_gene_data(
 
         # Now seed missing GOA annotations
         validator = GOAValidator()
-        added_count, _, refs_added, qualifiers_backfilled = validator.seed_missing_annotations(
-            yaml_file, goa_file, fetch_titles=fetch_titles
+        added_count, _, refs_added, qualifiers_backfilled = (
+            validator.seed_missing_annotations(
+                yaml_file, goa_file, fetch_titles=fetch_titles
+            )
         )
         result["annotations_added"] = added_count
         result["references_added"] = refs_added
         result["qualifiers_backfilled"] = qualifiers_backfilled
 
-        if added_count > 0:
-            print(
-                f"  ✓ Seeded {added_count} GOA annotations in {file_prefix}-ai-review.yaml"
-            )
-        if qualifiers_backfilled > 0:
-            print(
-                f"  ✓ Backfilled qualifiers on {qualifiers_backfilled} annotations "
-                f"in {file_prefix}-ai-review.yaml"
-            )
-        if added_count == 0 and qualifiers_backfilled == 0 and yaml_existed:
-            print(
-                f"  - {file_prefix}-ai-review.yaml already contains all GOA annotations"
-            )
+        _report_seed_updates(
+            file_prefix,
+            added_count,
+            refs_added,
+            qualifiers_backfilled,
+            yaml_existed,
+        )
 
         # Add alternative_products to existing files if missing
         if yaml_existed:
@@ -1381,6 +1407,7 @@ def fetch_gene_data_ncRNA(
         "yaml_existed": False,
         "annotations_added": 0,
         "references_added": 0,
+        "qualifiers_backfilled": 0,
         "rnacentral_updated": False,
         "goa_updated": False,
         "rnacentral_differences": rnacentral_differs,
@@ -1477,25 +1504,21 @@ def fetch_gene_data_ncRNA(
         # Now seed missing GOA annotations (same as for protein-coding genes)
         from ai_gene_review.validation.goa_validator import GOAValidator
         validator = GOAValidator()
-        added_count, _, refs_added, qualifiers_backfilled = validator.seed_missing_annotations(
-            yaml_file, goa_file, fetch_titles=True
+        added_count, _, refs_added, qualifiers_backfilled = (
+            validator.seed_missing_annotations(
+                yaml_file, goa_file, fetch_titles=True
+            )
         )
         result["annotations_added"] = added_count
         result["references_added"] = refs_added
         result["qualifiers_backfilled"] = qualifiers_backfilled
 
-        if added_count > 0:
-            print(
-                f"  ✓ Seeded {added_count} GOA annotations in {file_prefix}-ai-review.yaml"
-            )
-        if qualifiers_backfilled > 0:
-            print(
-                f"  ✓ Backfilled qualifiers on {qualifiers_backfilled} annotations "
-                f"in {file_prefix}-ai-review.yaml"
-            )
-        if added_count == 0 and qualifiers_backfilled == 0 and yaml_existed:
-            print(
-                f"  - {file_prefix}-ai-review.yaml already contains all GOA annotations"
-            )
+        _report_seed_updates(
+            file_prefix,
+            added_count,
+            refs_added,
+            qualifiers_backfilled,
+            yaml_existed,
+        )
 
     return result

--- a/src/ai_gene_review/etl/gene.py
+++ b/src/ai_gene_review/etl/gene.py
@@ -235,6 +235,7 @@ def fetch_gene_data(
             - yaml_existed: bool - True if ai-review.yaml already existed
             - annotations_added: int - Number of annotations added
             - references_added: int - Number of references added
+            - qualifiers_backfilled: int - Number of existing annotations enriched
             - uniprot_updated: bool - True if UniProt file was updated
             - goa_updated: bool - True if GOA file was updated
             - uniprot_differences: bool - True if UniProt content differs from existing
@@ -393,21 +394,26 @@ def fetch_gene_data(
 
         # Now seed missing GOA annotations
         validator = GOAValidator()
-        added_count, _, refs_added = validator.seed_missing_annotations(
+        added_count, _, refs_added, qualifiers_backfilled = validator.seed_missing_annotations(
             yaml_file, goa_file, fetch_titles=fetch_titles
         )
         result["annotations_added"] = added_count
         result["references_added"] = refs_added
+        result["qualifiers_backfilled"] = qualifiers_backfilled
 
         if added_count > 0:
             print(
                 f"  ✓ Seeded {added_count} GOA annotations in {file_prefix}-ai-review.yaml"
             )
-        else:
-            if yaml_existed:
-                print(
-                    f"  - {file_prefix}-ai-review.yaml already contains all GOA annotations"
-                )
+        if qualifiers_backfilled > 0:
+            print(
+                f"  ✓ Backfilled qualifiers on {qualifiers_backfilled} annotations "
+                f"in {file_prefix}-ai-review.yaml"
+            )
+        if added_count == 0 and qualifiers_backfilled == 0 and yaml_existed:
+            print(
+                f"  - {file_prefix}-ai-review.yaml already contains all GOA annotations"
+            )
 
         # Add alternative_products to existing files if missing
         if yaml_existed:
@@ -1471,20 +1477,25 @@ def fetch_gene_data_ncRNA(
         # Now seed missing GOA annotations (same as for protein-coding genes)
         from ai_gene_review.validation.goa_validator import GOAValidator
         validator = GOAValidator()
-        added_count, _, refs_added = validator.seed_missing_annotations(
+        added_count, _, refs_added, qualifiers_backfilled = validator.seed_missing_annotations(
             yaml_file, goa_file, fetch_titles=True
         )
         result["annotations_added"] = added_count
         result["references_added"] = refs_added
+        result["qualifiers_backfilled"] = qualifiers_backfilled
 
         if added_count > 0:
             print(
                 f"  ✓ Seeded {added_count} GOA annotations in {file_prefix}-ai-review.yaml"
             )
-        else:
-            if yaml_existed:
-                print(
-                    f"  - {file_prefix}-ai-review.yaml already contains all GOA annotations"
-                )
+        if qualifiers_backfilled > 0:
+            print(
+                f"  ✓ Backfilled qualifiers on {qualifiers_backfilled} annotations "
+                f"in {file_prefix}-ai-review.yaml"
+            )
+        if added_count == 0 and qualifiers_backfilled == 0 and yaml_existed:
+            print(
+                f"  - {file_prefix}-ai-review.yaml already contains all GOA annotations"
+            )
 
     return result

--- a/src/ai_gene_review/validation/goa_validator.py
+++ b/src/ai_gene_review/validation/goa_validator.py
@@ -615,7 +615,7 @@ class GOAValidator:
         goa_file: Optional[Path] = None,
         output_file: Optional[Path] = None,
         fetch_titles: bool = False,
-    ) -> Tuple[int, Path, int]:
+    ) -> Tuple[int, Path, int, int]:
         """Seed missing annotations from GOA file into YAML.
 
         This function adds any annotations present in the GOA file but missing
@@ -629,7 +629,8 @@ class GOAValidator:
             fetch_titles: If True, fetch actual titles from PubMed (may be slow)
 
         Returns:
-            Tuple of (number of annotations added, output file path, number of references added)
+            Tuple of (annotations added, output file path, references added,
+            qualifiers backfilled)
         """
         # Derive GOA file path if not provided
         if goa_file is None:
@@ -648,7 +649,8 @@ class GOAValidator:
         goa_annotations = self.parse_goa_file(goa_file)
 
         # Load the full YAML data (not just annotations)
-        if yaml_file.exists():
+        yaml_existed = yaml_file.exists()
+        if yaml_existed:
             with open(yaml_file, "r") as f:
                 yaml_data = yaml.safe_load(f) or {}
         else:
@@ -686,6 +688,7 @@ class GOAValidator:
 
         # Add missing annotations from GOA
         added_count = 0
+        qualifiers_backfilled = 0
         seen_tuples = set()  # Track which tuples we've already added
         pmids_to_add = set()  # Collect PMIDs and GO_REFs to add to references
 
@@ -728,6 +731,7 @@ class GOAValidator:
                     existing_ann = existing_without_qualifier.pop(0)
                     existing_ann["qualifier"] = parsed_qualifier
                     existing_tuples.add(tuple_key)
+                    qualifiers_backfilled += 1
                     continue
 
             # Create new annotation entry (stub for review)
@@ -845,17 +849,27 @@ class GOAValidator:
         if output_file is None:
             output_file = yaml_file
 
-        # Write the updated YAML
-        with open(output_file, "w") as f:
-            yaml.dump(
-                yaml_data,
-                f,
-                default_flow_style=False,
-                sort_keys=False,
-                allow_unicode=True,
-            )
+        # Preserve curated comments and formatting on a true no-op. PyYAML cannot
+        # round-trip those details, so only serialize when the document changed or
+        # the caller explicitly requested a separate output file.
+        should_write = (
+            not yaml_existed
+            or output_file != yaml_file
+            or added_count > 0
+            or refs_added > 0
+            or qualifiers_backfilled > 0
+        )
+        if should_write:
+            with open(output_file, "w") as f:
+                yaml.dump(
+                    yaml_data,
+                    f,
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True,
+                )
 
-        return added_count, output_file, refs_added
+        return added_count, output_file, refs_added, qualifiers_backfilled
 
     def _get_go_ref_title(self, go_ref_id: str, cache: Dict[str, str]) -> str:
         """Fetch GO_REF title from GO site YAML file.

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -546,7 +546,7 @@ UniProtKB	Q12345	TEST		GO:0009999	test location	CC	ECO:0007322	IEA	PMID:99999		N
 
     try:
         # Seed missing annotations
-        added_count, output_path, refs_added = validator.seed_missing_annotations(
+        added_count, output_path, refs_added, _ = validator.seed_missing_annotations(
             yaml_path, goa_path
         )
 
@@ -613,7 +613,7 @@ UniProtKB	Q12345	TEST	part_of	GO:0008888	test complex	CC	ECO:0000314	IDA	PMID:88
         yaml_path = Path(yaml_file.name)
 
     try:
-        added_count, _, _ = validator.seed_missing_annotations(yaml_path, goa_path)
+        added_count, _, _, _ = validator.seed_missing_annotations(yaml_path, goa_path)
 
         assert added_count == 4
 
@@ -633,6 +633,82 @@ UniProtKB	Q12345	TEST	part_of	GO:0008888	test complex	CC	ECO:0000314	IDA	PMID:88
     finally:
         goa_path.unlink()
         yaml_path.unlink()
+
+
+def test_seed_missing_annotations_reports_backfilled_qualifiers(tmp_path):
+    """Report qualifier enrichments separately from newly seeded annotations."""
+    validator = GOAValidator()
+    goa_path = tmp_path / "TEST-goa.tsv"
+    goa_path.write_text(
+        "GENE PRODUCT DB\tGENE PRODUCT ID\tSYMBOL\tQUALIFIER\tGO TERM\tGO NAME\t"
+        "GO ASPECT\tECO ID\tGO EVIDENCE CODE\tREFERENCE\tWITH/FROM\tTAXON ID\t"
+        "TAXON NAME\tASSIGNED BY\tGENE NAME\tDATE\n"
+        "UniProtKB\tQ12345\tTEST\tenables\tGO:0001234\ttest function\tMF\t"
+        "ECO:0000353\tIPI\tPMID:12345\t\tNCBITaxon:9606\tHomo sapiens\t"
+        "UniProt\tTest protein\t20180515\n"
+    )
+    yaml_path = tmp_path / "TEST-ai-review.yaml"
+    yaml_path.write_text(
+        "id: Q12345\n"
+        "gene_symbol: TEST\n"
+        "taxon:\n"
+        "  id: NCBITaxon:9606\n"
+        "  label: Homo sapiens\n"
+        "description: Test gene\n"
+        "existing_annotations:\n"
+        "- term:\n"
+        "    id: GO:0001234\n"
+        "    label: test function\n"
+        "  evidence_type: IPI\n"
+        "  original_reference_id: PMID:12345\n"
+    )
+
+    added, _, references_added, qualifiers_backfilled = (
+        validator.seed_missing_annotations(yaml_path, goa_path)
+    )
+
+    assert (added, references_added, qualifiers_backfilled) == (0, 1, 1)
+    document = yaml.safe_load(yaml_path.read_text())
+    assert document["existing_annotations"][0]["qualifier"] == "enables"
+
+
+def test_seed_missing_annotations_true_noop_preserves_yaml_bytes(tmp_path):
+    """A no-op seed must not reserialize a curated review file."""
+    validator = GOAValidator()
+    goa_path = tmp_path / "TEST-goa.tsv"
+    goa_path.write_text(
+        "GENE PRODUCT DB\tGENE PRODUCT ID\tSYMBOL\tQUALIFIER\tGO TERM\tGO NAME\t"
+        "GO ASPECT\tECO ID\tGO EVIDENCE CODE\tREFERENCE\tWITH/FROM\tTAXON ID\t"
+        "TAXON NAME\tASSIGNED BY\tGENE NAME\tDATE\n"
+        "UniProtKB\tQ12345\tTEST\tenables\tGO:0001234\ttest function\tMF\t"
+        "ECO:0000353\tIPI\tPMID:12345\t\tNCBITaxon:9606\tHomo sapiens\t"
+        "UniProt\tTest protein\t20180515\n"
+    )
+    yaml_path = tmp_path / "TEST-ai-review.yaml"
+    original = (
+        "# preserve this curator comment and formatting\n"
+        "id: Q12345\n"
+        "gene_symbol: TEST\n"
+        "taxon: {id: 'NCBITaxon:9606', label: Homo sapiens}\n"
+        "description: Test gene\n"
+        "existing_annotations:\n"
+        "- term: {id: 'GO:0001234', label: test function}\n"
+        "  evidence_type: IPI\n"
+        "  original_reference_id: PMID:12345\n"
+        "  qualifier: enables\n"
+        "references:\n"
+        "- id: PMID:12345\n"
+        "  title: Existing title\n"
+        "  findings: []\n"
+    )
+    yaml_path.write_text(original)
+
+    added, _, references_added, qualifiers_backfilled = (
+        validator.seed_missing_annotations(yaml_path, goa_path)
+    )
+
+    assert (added, references_added, qualifiers_backfilled) == (0, 0, 0)
+    assert yaml_path.read_text() == original
 
 
 def test_backfill_qualifiers_preserves_all_goa_qualifiers():
@@ -1117,7 +1193,7 @@ UniProtKB	P19544-1	WT1		GO:0045892	negative regulation of DNA-templated transcri
 
     try:
         # Seed annotations
-        added_count, output_path, refs_added = validator.seed_missing_annotations(
+        added_count, output_path, refs_added, _ = validator.seed_missing_annotations(
             yaml_path, goa_path
         )
 
@@ -1181,7 +1257,7 @@ UniProtKB	P19544-1	WT1	NOT|involved_in	GO:0045893	positive regulation of DNA-tem
 
     try:
         # Seed annotations
-        added_count, output_path, refs_added = validator.seed_missing_annotations(
+        added_count, output_path, refs_added, _ = validator.seed_missing_annotations(
             yaml_path, goa_path
         )
 
@@ -1233,7 +1309,7 @@ UniProtKB	Q12345	TEST	enables	GO:0001234	test function	MF	ECO:0000353	IPI	PMID:1
 
     try:
         # Seed should create the file
-        added_count, output_path, refs_added = validator.seed_missing_annotations(
+        added_count, output_path, refs_added, _ = validator.seed_missing_annotations(
             yaml_path, goa_path
         )
 

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -711,6 +711,49 @@ def test_seed_missing_annotations_true_noop_preserves_yaml_bytes(tmp_path):
     assert yaml_path.read_text() == original
 
 
+def test_seed_missing_annotations_noop_writes_requested_output(tmp_path):
+    """A no-op seed still writes a separately requested output file."""
+    validator = GOAValidator()
+    goa_path = tmp_path / "TEST-goa.tsv"
+    goa_path.write_text(
+        "GENE PRODUCT DB\tGENE PRODUCT ID\tSYMBOL\tQUALIFIER\tGO TERM\tGO NAME\t"
+        "GO ASPECT\tECO ID\tGO EVIDENCE CODE\tREFERENCE\tWITH/FROM\tTAXON ID\t"
+        "TAXON NAME\tASSIGNED BY\tGENE NAME\tDATE\n"
+        "UniProtKB\tQ12345\tTEST\tenables\tGO:0001234\ttest function\tMF\t"
+        "ECO:0000353\tIPI\tPMID:12345\t\tNCBITaxon:9606\tHomo sapiens\t"
+        "UniProt\tTest protein\t20180515\n"
+    )
+    yaml_path = tmp_path / "TEST-ai-review.yaml"
+    yaml_path.write_text(
+        "id: Q12345\n"
+        "gene_symbol: TEST\n"
+        "taxon: {id: 'NCBITaxon:9606', label: Homo sapiens}\n"
+        "description: Test gene\n"
+        "existing_annotations:\n"
+        "- term: {id: 'GO:0001234', label: test function}\n"
+        "  evidence_type: IPI\n"
+        "  original_reference_id: PMID:12345\n"
+        "  qualifier: enables\n"
+        "references:\n"
+        "- id: PMID:12345\n"
+        "  title: Existing title\n"
+        "  findings: []\n"
+    )
+    output_path = tmp_path / "copy.yaml"
+
+    added, returned_path, references_added, qualifiers_backfilled = (
+        validator.seed_missing_annotations(
+            yaml_path, goa_path, output_file=output_path
+        )
+    )
+
+    assert (added, references_added, qualifiers_backfilled) == (0, 0, 0)
+    assert returned_path == output_path
+    assert yaml.safe_load(output_path.read_text()) == yaml.safe_load(
+        yaml_path.read_text()
+    )
+
+
 def test_backfill_qualifiers_preserves_all_goa_qualifiers():
     """Test backfilling qualifiers beyond contributes_to."""
     validator = GOAValidator()


### PR DESCRIPTION
## Summary

- count qualifier backfills performed while seeding existing GOA annotations
- surface those qualifier-only changes in `fetch-gene` and `seed-goa` output instead of claiming the review was unmodified
- avoid reserializing curated YAML on a true no-op seed, preserving comments and formatting
- add regressions for qualifier-only updates and byte-for-byte no-op preservation

## Validation

- `uv run pytest tests/test_goa_validator.py -q` (38 passed)
- `uv run pytest tests/test_fetch_gene_wrapper.py -q` (3 passed)
- `just test` (1907 tests, 156 doctests, mypy, Ruff)
