### PR TITLE
Remove shadowed Skp SFT override

### DIFF
--- a/scripts/auto_review_sft_predictions.py
+++ b/scripts/auto_review_sft_predictions.py
@@ -349,15 +349,15 @@ MANUAL_OVERRIDES: dict[tuple[str, str, str], ManualOverride] = {
         ),
     ),
     ("ECOLI", "Skp", "GO:0061077"): ManualOverride(
-        assessment="CNN",
+        assessment="NPI",
         error_type=None,
         set_error_type=True,
         summary=(
-            "Correct but not novel under the curated reference. The replacement protein "
-            "folding term (GO:0006457) has IBA, IDA, and IMP annotations in current GOA, "
-            "and the AIGR accepts it. Skp acts as a holdase/carrier before OMP folding, "
-            "but that mechanistic qualification does not justify overruling the positive "
-            "experimental curation."
+            "The predicted chaperone-mediated folding role is not supported for Skp. "
+            "Current curation modifies the broader GO:0006457 rows to outer-membrane "
+            "assembly because Skp holds OMP beta-barrels unfolded and delivers them "
+            "toward BAM rather than catalyzing their folding. The supplied GO:0061077 "
+            "ID is also obsolete; the raw source pair remains unchanged for provenance."
         ),
     ),
     ("ECOLI", "Spy", "GO:0014070"): ManualOverride(

--- a/scripts/auto_review_sft_predictions.py
+++ b/scripts/auto_review_sft_predictions.py
@@ -348,18 +348,6 @@ MANUAL_OVERRIDES: dict[tuple[str, str, str], ManualOverride] = {
             "refolding role."
         ),
     ),
-    ("ECOLI", "Skp", "GO:0061077"): ManualOverride(
-        assessment="NPI",
-        error_type=None,
-        set_error_type=True,
-        summary=(
-            "The predicted chaperone-mediated folding role is not supported for Skp. "
-            "Current curation modifies the broader GO:0006457 rows to outer-membrane "
-            "assembly because Skp holds OMP beta-barrels unfolded and delivers them "
-            "toward BAM rather than catalyzing their folding. The supplied GO:0061077 "
-            "ID is also obsolete; the raw source pair remains unchanged for provenance."
-        ),
-    ),
     ("ECOLI", "Spy", "GO:0014070"): ManualOverride(
         assessment="COR",
         error_type=None,

--- a/tests/test_sft_prediction_review.py
+++ b/tests/test_sft_prediction_review.py
@@ -9,6 +9,8 @@ import yaml
 from scripts.auto_review_sft_predictions import (
     EXPECTED_CONFIDENCE,
     MANUAL_OVERRIDES,
+    ONTOLOGY_ADJUDICATION_MARKER,
+    ONTOLOGY_PAIR_DECISIONS,
     LabelCheck,
     RepairStats,
     apply_label_note,
@@ -156,12 +158,46 @@ def test_drome_git_override_uses_canonical_symbol():
     assert ("DROME", "git", "GO:0005515") not in MANUAL_OVERRIDES
 
 
-def test_skp_folding_override_matches_holdase_curation():
-    override = MANUAL_OVERRIDES[("ECOLI", "Skp", "GO:0061077")]
+def test_skp_folding_uses_ontology_pair_decision_not_dead_manual_override():
+    manual_key = ("ECOLI", "Skp", "GO:0061077")
+    pair_key = (*manual_key, "chaperone-mediated protein folding")
+    assert manual_key not in MANUAL_OVERRIDES
+    assert ONTOLOGY_PAIR_DECISIONS[pair_key].assessment == "CNN"
 
-    assert override.assessment == "NPI"
-    assert "holds OMP beta-barrels unfolded" in override.summary
-    assert "AIGR accepts it" not in override.summary
+    doc = {
+        "predictions": [
+            {
+                "source_version": "wanglab/protein_catalogue",
+                "predicted_term": {
+                    "id": "GO:0061077",
+                    "label": "chaperone-mediated protein folding",
+                },
+                "review": {
+                    "assessment": "NPI",
+                    "confidence_score": 0,
+                    "summary": "Historical rationale.",
+                },
+            }
+        ]
+    }
+
+    changed = repair_document(
+        doc,
+        "ECOLI",
+        "Skp",
+        {"GO:0006457"},
+        {"GO:0006457": {"ACCEPT"}},
+        set(),
+        "wanglab/protein_catalogue",
+        None,
+        RepairStats(),
+    )
+
+    review = doc["predictions"][0]["review"]
+    assert changed is True
+    assert review["assessment"] == "CNN"
+    assert review["confidence_score"] == EXPECTED_CONFIDENCE["CNN"]
+    assert ONTOLOGY_ADJUDICATION_MARKER in review["summary"]
 
 
 def test_auto_assess_emits_only_schema_categories():

--- a/tests/test_sft_prediction_review.py
+++ b/tests/test_sft_prediction_review.py
@@ -156,6 +156,14 @@ def test_drome_git_override_uses_canonical_symbol():
     assert ("DROME", "git", "GO:0005515") not in MANUAL_OVERRIDES
 
 
+def test_skp_folding_override_matches_holdase_curation():
+    override = MANUAL_OVERRIDES[("ECOLI", "Skp", "GO:0061077")]
+
+    assert override.assessment == "NPI"
+    assert "holds OMP beta-barrels unfolded" in override.summary
+    assert "AIGR accepts it" not in override.summary
+
+
 def test_auto_assess_emits_only_schema_categories():
     negative = {"GO:0000001": {"REMOVE"}}
     assert auto_assess("GO:0000001", {"GO:0000001"}, negative, set())[:2] == (


### PR DESCRIPTION
## Summary
- remove the unreachable Skp GO:0061077 manual override that is shadowed by the ontology-pair adjudication table
- preserve the current CNN behavior from the committed pair decision
- add a behavioral regression through `repair_document`, confirming the pair decision is applied and the dead manual override does not return

## Validation
- `just test` (1909 tests passed, 156 doctests passed, mypy and Ruff passed)
- `git diff --check`

## Review follow-up
This supersedes the initial semantic reclassification. The reviewer correctly identified that the manual override was unreachable and conflicted with the committed adjudication table. The Skp curation change will update the adjudication row and generated sidecar together in the separate one-gene PR.
