### PR TITLE
Make Skp pair-decision test data-driven

### DIFF
--- a/tests/test_sft_prediction_review.py
+++ b/tests/test_sft_prediction_review.py
@@ -162,7 +162,7 @@ def test_skp_folding_uses_ontology_pair_decision_not_dead_manual_override():
     manual_key = ("ECOLI", "Skp", "GO:0061077")
     pair_key = (*manual_key, "chaperone-mediated protein folding")
     assert manual_key not in MANUAL_OVERRIDES
-    assert ONTOLOGY_PAIR_DECISIONS[pair_key].assessment == "CNN"
+    expected_assessment = ONTOLOGY_PAIR_DECISIONS[pair_key].assessment
 
     doc = {
         "predictions": [
@@ -173,8 +173,8 @@ def test_skp_folding_uses_ontology_pair_decision_not_dead_manual_override():
                     "label": "chaperone-mediated protein folding",
                 },
                 "review": {
-                    "assessment": "NPI",
-                    "confidence_score": 0,
+                    "assessment": "UNC",
+                    "confidence_score": 1,
                     "summary": "Historical rationale.",
                 },
             }
@@ -195,8 +195,8 @@ def test_skp_folding_uses_ontology_pair_decision_not_dead_manual_override():
 
     review = doc["predictions"][0]["review"]
     assert changed is True
-    assert review["assessment"] == "CNN"
-    assert review["confidence_score"] == EXPECTED_CONFIDENCE["CNN"]
+    assert review["assessment"] == expected_assessment
+    assert review["confidence_score"] == EXPECTED_CONFIDENCE[expected_assessment]
     assert ONTOLOGY_ADJUDICATION_MARKER in review["summary"]
 
 


### PR DESCRIPTION
## Summary
- stop hard-coding the current CNN value in the Skp ontology-pair regression
- assert that `repair_document` applies whichever assessment the committed adjudication TSV declares
- continue checking that the shadowed manual override stays absent, confidence is normalized, and the frozen-adjudication marker is emitted

## Why
The prior regression correctly guarded the dead override but accidentally froze curation data. Updating the Skp adjudication TSV from CNN to NPI should not require changing support-test logic.

## Validation
- `just test` (1909 tests passed, 156 doctests passed, mypy and Ruff passed)
- `git diff --check`
