### PR TITLE
Bridge repository dependencies into GO-GPT wrappers

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -2621,11 +2621,12 @@ ui-legacy port="5123":
 
 # Run GO-GPT prediction for a gene (outputs PredictionReview YAML)
 # Requires: GO-GPT model at ~/repos/BioReason-Pro/models/gogpt
+# Set BIOREASON_PYTHON to override the default ~/repos/BioReason-Pro/.venv interpreter.
 # Examples:
 #   just gogpt-predict human TP53
 #   just gogpt-predict PSEPK rpoS
 gogpt-predict organism gene:
-    PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --output-dir .
+    uv run python -m ai_gene_review.run_bioreason_python scripts/gogpt_predict.py {{organism}} {{gene}} --output-dir .
 
 # Run GO-GPT prediction and compare with curated review
 # Outputs GENE-gogpt-predictions.yaml in PredictionReview schema format
@@ -2633,11 +2634,11 @@ gogpt-predict organism gene:
 #   just gogpt-compare human TP53
 #   just gogpt-compare PSEPK rpoS
 gogpt-compare organism gene:
-    PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
+    uv run python -m ai_gene_review.run_bioreason_python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
 
 # Alias for gogpt-compare
 gogpt-review organism gene:
-    PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
+    uv run python -m ai_gene_review.run_bioreason_python scripts/gogpt_predict.py {{organism}} {{gene}} --compare --output-dir .
 
 # Run GO-GPT predictions for all genes in an organism
 gogpt-predict-organism organism:
@@ -2650,7 +2651,7 @@ gogpt-predict-organism organism:
             uniprot="$gene_dir/${gene}-uniprot.txt"
             if [ -f "$uniprot" ]; then
                 echo "Processing $gene..."
-                PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py {{organism}} "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $gene"
+                uv run python -m ai_gene_review.run_bioreason_python scripts/gogpt_predict.py {{organism}} "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $gene"
                 count=$((count + 1))
             fi
         fi
@@ -2671,7 +2672,7 @@ gogpt-compare-all:
                 uniprot="$gene_dir/${gene}-uniprot.txt"
                 if [ -f "$review" ] && [ -f "$uniprot" ]; then
                     echo "Comparing $organism/$gene..."
-                    PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ~/repos/BioReason-Pro/.venv/bin/python scripts/gogpt_predict.py "$organism" "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $organism/$gene"
+                    uv run python -m ai_gene_review.run_bioreason_python scripts/gogpt_predict.py "$organism" "$gene" --compare --output-dir . 2>&1 || echo "  Failed: $organism/$gene"
                     total=$((total + 1))
                 fi
             fi

--- a/src/ai_gene_review/_bioreason_sitecustomize/sitecustomize.py
+++ b/src/ai_gene_review/_bioreason_sitecustomize/sitecustomize.py
@@ -1,0 +1,33 @@
+"""Append repository dependencies and then run BioReason's own site customizer."""
+
+import os
+from pathlib import Path
+import runpy
+import site
+import sys
+
+# Keep this literal synchronized with run_bioreason_python.REPOSITORY_SITE_ENV.
+repository_site = os.environ.get("AIGR_REPOSITORY_SITE_PACKAGES")
+if repository_site:
+    site.addsitedir(repository_site)
+
+# This shim is first on PYTHONPATH, so explicitly chain the first different
+# sitecustomize that BioReason's normal sys.path would otherwise have imported.
+current_file = Path(__file__).resolve()
+for path_entry in sys.path:
+    entry = Path(path_entry or os.curdir)
+    candidates = (
+        entry / "sitecustomize.py",
+        entry / "sitecustomize" / "__init__.py",
+    )
+    chained = next(
+        (
+            candidate
+            for candidate in candidates
+            if candidate.is_file() and candidate.resolve() != current_file
+        ),
+        None,
+    )
+    if chained:
+        runpy.run_path(str(chained), run_name="_bioreason_original_sitecustomize")
+        break

--- a/src/ai_gene_review/run_bioreason_python.py
+++ b/src/ai_gene_review/run_bioreason_python.py
@@ -1,0 +1,105 @@
+"""Launch BioReason's Python with ai-gene-review code and dependencies available."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+import sysconfig
+from typing import NoReturn
+
+
+REPOSITORY_SITE_ENV = "AIGR_REPOSITORY_SITE_PACKAGES"
+
+
+def _python_version(python: Path) -> tuple[int, int]:
+    try:
+        result = subprocess.run(
+            [
+                str(python),
+                "-S",
+                "-c",
+                "import sys; print('%d.%d' % sys.version_info[:2])",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or str(error)
+        raise SystemExit(f"Could not inspect BioReason Python: {detail}") from error
+    version = result.stdout.strip()
+    major, minor = (int(part) for part in version.split("."))
+    return major, minor
+
+
+def _pythonpath_entries(
+    repo_root: Path,
+    inherited: str | None,
+) -> list[str]:
+    candidates = [
+        str(repo_root / "src"),
+        str(repo_root / "src" / "ai_gene_review" / "_bioreason_sitecustomize"),
+        *(inherited.split(os.pathsep) if inherited else []),
+    ]
+    return list(dict.fromkeys(entry for entry in candidates if entry))
+
+
+def main(argv: list[str] | None = None) -> NoReturn:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        raise SystemExit("usage: run_bioreason_python PYTHON_ARGS...")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    source_root = repo_root / "src"
+    shim_root = source_root / "ai_gene_review" / "_bioreason_sitecustomize"
+    if not source_root.is_dir() or not shim_root.is_dir():
+        raise SystemExit(
+            "BioReason dependency bridge requires an ai-gene-review source checkout"
+        )
+    configured = os.environ.get("BIOREASON_PYTHON")
+    bioreason_python = Path(configured).expanduser() if configured else (
+        Path.home() / "repos" / "BioReason-Pro" / ".venv" / "bin" / "python"
+    )
+    if not bioreason_python.is_file():
+        raise SystemExit(
+            f"BioReason Python not found at {bioreason_python}; "
+            "set BIOREASON_PYTHON to its virtual-environment interpreter"
+        )
+
+    bioreason_version = _python_version(bioreason_python)
+    repository_version = sys.version_info[:2]
+    if bioreason_version != repository_version:
+        raise SystemExit(
+            "BioReason and repository Python minor versions must match before "
+            "sharing compiled dependencies: "
+            f"BioReason is {bioreason_version[0]}.{bioreason_version[1]}, "
+            f"repository is {repository_version[0]}.{repository_version[1]}"
+        )
+    repository_site = Path(sysconfig.get_paths()["purelib"])
+    oaklib_spec = importlib.util.find_spec("oaklib")
+    oaklib_origin = oaklib_spec.origin if oaklib_spec else None
+    if not oaklib_origin or not Path(oaklib_origin).is_relative_to(repository_site):
+        raise SystemExit(
+            f"oaklib is not installed in repository environment {repository_site}; "
+            "launch through the public just wrapper or run `uv sync` first"
+        )
+
+    environment = os.environ.copy()
+    environment[REPOSITORY_SITE_ENV] = str(repository_site)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        _pythonpath_entries(repo_root, environment.get("PYTHONPATH"))
+    )
+    os.execve(
+        bioreason_python,
+        [str(bioreason_python), *args],
+        environment,
+    )
+    # Only reachable when tests replace os.execve with a recording stub.
+    raise RuntimeError("os.execve returned without replacing the process")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gogpt_wrapper.py
+++ b/tests/test_gogpt_wrapper.py
@@ -1,26 +1,174 @@
 """Regression tests for the repository GO-GPT just wrappers."""
 
 from pathlib import Path
+import json
+import os
+import subprocess
+import sys
+import sysconfig
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_JUSTFILE = REPO_ROOT / "project.justfile"
 
 
-def test_gogpt_wrappers_expose_repository_package_to_bioreason_python() -> None:
-    """Every external BioReason Python call must be able to import ai_gene_review."""
+def test_gogpt_wrappers_use_dependency_bridge() -> None:
+    """Every BioReason call must include repository code and dependencies."""
     command_lines = [
         line.strip()
         for line in PROJECT_JUSTFILE.read_text().splitlines()
-        if "BioReason-Pro" in line
-        and "scripts/gogpt_predict.py" in line
+        if "scripts/gogpt_predict.py" in line
         and not line.lstrip().startswith("#")
     ]
 
-    assert command_lines, "expected at least one external BioReason GO-GPT invocation"
+    assert command_lines, "expected at least one BioReason GO-GPT invocation"
     missing = [
         line
         for line in command_lines
-        if not line.startswith("PYTHONPATH=src${PYTHONPATH:+:$PYTHONPATH} ")
+        if not line.startswith(
+            "uv run python -m ai_gene_review.run_bioreason_python "
+        )
     ]
-    assert not missing, f"BioReason invocations without repository PYTHONPATH: {missing}"
+    assert not missing, f"BioReason invocations without dependency bridge: {missing}"
+
+
+def test_dependency_bridge_builds_minimal_pythonpath() -> None:
+    """Only source and the site shim are injected ahead of standard paths."""
+    from ai_gene_review.run_bioreason_python import _pythonpath_entries
+
+    entries = _pythonpath_entries(
+        REPO_ROOT,
+        "/inherited",
+    )
+
+    assert entries == [
+        str(REPO_ROOT / "src"),
+        str(REPO_ROOT / "src" / "ai_gene_review" / "_bioreason_sitecustomize"),
+        "/inherited",
+    ]
+
+
+def test_dependency_bridge_honors_expanded_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from ai_gene_review import run_bioreason_python as launcher
+
+    interpreter = tmp_path / "bio" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.touch()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BIOREASON_PYTHON", "~/bio/bin/python")
+    monkeypatch.setattr(
+        launcher,
+        "_python_version",
+        lambda path: launcher.sys.version_info[:2],
+    )
+    call: dict[str, object] = {}
+
+    def fake_execve(path: Path, args: list[str], env: dict[str, str]) -> None:
+        call.update(path=path, args=args, env=env)
+
+    monkeypatch.setattr(launcher.os, "execve", fake_execve)
+
+    with pytest.raises(RuntimeError, match="execve returned"):
+        launcher.main(["-c", "pass"])
+
+    assert call["path"] == interpreter
+    assert call["args"] == [str(interpreter), "-c", "pass"]
+    assert isinstance(call["env"], dict)
+    assert launcher.REPOSITORY_SITE_ENV in call["env"]
+
+
+def test_dependency_bridge_rejects_missing_interpreter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from ai_gene_review import run_bioreason_python as launcher
+
+    missing = tmp_path / "missing-python"
+    monkeypatch.setenv("BIOREASON_PYTHON", str(missing))
+
+    with pytest.raises(SystemExit, match="set BIOREASON_PYTHON"):
+        launcher.main(["-c", "pass"])
+
+
+def test_dependency_bridge_rejects_python_version_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from ai_gene_review import run_bioreason_python as launcher
+
+    interpreter = tmp_path / "python"
+    interpreter.touch()
+    monkeypatch.setenv("BIOREASON_PYTHON", str(interpreter))
+    monkeypatch.setattr(
+        launcher,
+        "_python_version",
+        lambda path: (3, 11),
+    )
+
+    with pytest.raises(SystemExit, match="minor versions must match"):
+        launcher.main(["-c", "pass"])
+
+
+def test_dependency_bridge_requires_python_args() -> None:
+    from ai_gene_review.run_bioreason_python import main
+
+    with pytest.raises(SystemExit, match="usage:"):
+        main([])
+
+
+def test_sitecustomize_appends_repository_site_and_processes_pth(
+    tmp_path: Path,
+) -> None:
+    repository_site = tmp_path / "repository-site"
+    pth_target = tmp_path / "pth-target"
+    repository_site.mkdir()
+    pth_target.mkdir()
+    (repository_site / "bridge-test.pth").write_text(f"{pth_target}\n")
+    shim = REPO_ROOT / "src" / "ai_gene_review" / "_bioreason_sitecustomize"
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(shim)
+    environment["AIGR_REPOSITORY_SITE_PACKAGES"] = str(repository_site)
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import json, sys; print(json.dumps(sys.path))"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    child_path = json.loads(result.stdout)
+
+    assert child_path.index(str(repository_site)) > child_path.index(
+        sysconfig.get_paths()["purelib"]
+    )
+    assert str(pth_target) in child_path
+
+
+def test_sitecustomize_is_stdlib_only_and_chains_existing_customizer(
+    tmp_path: Path,
+) -> None:
+    repository_site = tmp_path / "repository-site"
+    existing_site = tmp_path / "existing-site"
+    marker = tmp_path / "chained.txt"
+    repository_site.mkdir()
+    existing_site.mkdir()
+    (existing_site / "sitecustomize.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('ran')\n"
+    )
+    shim = REPO_ROOT / "src" / "ai_gene_review" / "_bioreason_sitecustomize"
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join((str(shim), str(existing_site)))
+    environment["AIGR_REPOSITORY_SITE_PACKAGES"] = str(repository_site)
+
+    subprocess.run(
+        [sys.executable, "-c", "pass"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert marker.read_text() == "ran"


### PR DESCRIPTION
## Problem

The public `just gogpt-compare` wrapper launches BioReason-Pro's external Python environment. That environment provides the large ML stack, but it does not contain this repository's `oaklib` dependency. The command therefore fails in `ai_gene_review.bioreason_ontology.get_go_adapter()` with `ModuleNotFoundError: No module named 'oaklib'`.

## Fix

- add a small launcher that executes BioReason's interpreter with:
  1. repository `src/`
  2. BioReason site-packages
  3. repository site-packages as a fallback
- route all public GO-GPT just recipes through that launcher
- preserve BioReason package precedence so repository packages cannot unexpectedly replace its ML stack
- add regression coverage for every wrapper invocation and the path ordering

`BIOREASON_PYTHON` can override the default interpreter location.

## Validation

- dependency smoke test imports `ai_gene_review`, `oaklib`, and `torch` in the bridged BioReason interpreter (`torch 2.10.0`)
- `just test`
  - 1910 unit tests passed, 63 deselected
  - 156 doctests passed, 37 skipped
  - mypy passed
  - Ruff passed
