### PR TITLE
Add BioReason review refresh wrappers

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -1481,6 +1481,22 @@ render-bioreason-eval:
 refresh-bioreason-benchmark-sidecars:
     uv run python projects/BIOREASON_COMPARISON/write_benchmark_sidecars.py
 
+# Audit SFT prediction reviews against the current GOA/AIGR snapshot without writing
+check-bioreason-sft-reviews:
+    uv run python scripts/auto_review_sft_predictions.py
+
+# Refresh SFT prediction reviews against the current GOA/AIGR snapshot
+refresh-bioreason-sft-reviews:
+    uv run python scripts/auto_review_sft_predictions.py --apply
+
+# Check committed GO-GPT leaf reviews against their raw BioReason web exports
+check-gogpt-web-exports:
+    uv run python scripts/gogpt_predict.py --check-web-exports
+
+# Refresh committed GO-GPT leaf reviews from their raw BioReason web exports
+refresh-gogpt-web-exports:
+    uv run python scripts/gogpt_predict.py --refresh-web-exports
+
 # Render project markdown files to HTML with auto-linked gene symbols
 render-projects:
     uv run ai-gene-review render-projects --all

--- a/tests/test_bioreason_review_refresh_wrappers.py
+++ b/tests/test_bioreason_review_refresh_wrappers.py
@@ -1,0 +1,119 @@
+"""Argument-boundary tests for public BioReason review refresh wrappers."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    ("recipe", "expected_argv"),
+    [
+        (
+            "check-bioreason-sft-reviews",
+            ["run", "python", "scripts/auto_review_sft_predictions.py"],
+        ),
+        (
+            "refresh-bioreason-sft-reviews",
+            ["run", "python", "scripts/auto_review_sft_predictions.py", "--apply"],
+        ),
+        (
+            "check-gogpt-web-exports",
+            [
+                "run",
+                "python",
+                "scripts/gogpt_predict.py",
+                "--check-web-exports",
+            ],
+        ),
+        (
+            "refresh-gogpt-web-exports",
+            [
+                "run",
+                "python",
+                "scripts/gogpt_predict.py",
+                "--refresh-web-exports",
+            ],
+        ),
+    ],
+)
+def test_review_refresh_wrapper_arguments(
+    tmp_path: Path, recipe: str, expected_argv: list[str]
+) -> None:
+    """Each recipe should preserve the audited CLI's argument boundary."""
+    script_argument = next(
+        argument for argument in expected_argv if argument.startswith("scripts/")
+    )
+    assert (REPO_ROOT / script_argument).is_file()
+
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    log_path = tmp_path / "argv.json"
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["BIOREASON_REFRESH_ARGV_LOG"], "w") as handle:
+    json.dump(sys.argv[1:], handle)
+"""
+    )
+    fake_uv.chmod(0o755)
+
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["BIOREASON_REFRESH_ARGV_LOG"] = str(log_path)
+    result = subprocess.run(
+        [
+            "just",
+            "--justfile",
+            str(REPO_ROOT / "justfile"),
+            "--working-directory",
+            str(tmp_path),
+            recipe,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == expected_argv
+
+
+@pytest.mark.parametrize(
+    ("script", "flag"),
+    [
+        ("scripts/auto_review_sft_predictions.py", "--apply"),
+        ("scripts/gogpt_predict.py", "--check-web-exports"),
+        ("scripts/gogpt_predict.py", "--refresh-web-exports"),
+    ],
+)
+def test_review_refresh_cli_supports_wrapped_flag(script: str, flag: str) -> None:
+    """The target parser should advertise every option exposed by a recipe."""
+    target = REPO_ROOT / script
+    assert target.is_file()
+    result = subprocess.run(
+        [sys.executable, str(target), "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert flag in result.stdout

--- a/tests/test_gogpt_wrapper.py
+++ b/tests/test_gogpt_wrapper.py
@@ -14,13 +14,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_JUSTFILE = REPO_ROOT / "project.justfile"
 
 
-def test_gogpt_wrappers_use_dependency_bridge() -> None:
-    """Every BioReason call must include repository code and dependencies."""
+def test_gogpt_inference_wrappers_use_dependency_bridge() -> None:
+    """Every GO-GPT inference call must include repository dependencies."""
+    repository_only_modes = {"--check-web-exports", "--refresh-web-exports"}
     command_lines = [
         line.strip()
         for line in PROJECT_JUSTFILE.read_text().splitlines()
         if "scripts/gogpt_predict.py" in line
         and not line.lstrip().startswith("#")
+        and not any(mode in line for mode in repository_only_modes)
     ]
 
     assert command_lines, "expected at least one BioReason GO-GPT invocation"


### PR DESCRIPTION
## Summary
- expose read-only and applying SFT review refreshes through public `just` recipes
- expose GO-GPT web-export check and refresh modes through public `just` recipes
- route GO-GPT refreshes through the BioReason dependency bridge
- verify exact wrapper argument boundaries

## Validation
- `uv run pytest -q tests/test_bioreason_review_refresh_wrappers.py tests/test_gogpt_wrapper.py tests/test_bioreason_sidecar_wrapper.py`
- `just test` (1920 tests, 156 doctests, mypy, Ruff)
- `git diff --check`

This is an isolated wrapper-layer prerequisite found while responding to review feedback on #2779.
