### PR TITLE
Fix missing fetch-fitness Just wrapper

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -819,6 +819,12 @@ fetch-gene-pmids organism gene *args:
     fi
     uv run ai-gene-review fetch-gene-pmids "$organism" "$gene" --output-dir "$output_dir" "$@"
 
+# Fetch FEBA/RB-TnSeq fitness evidence for a bacterial gene.
+# Writes genes/ORGANISM/GENE/GENE-fitness.md.
+# Example: just fetch-fitness ECOLI SlyD
+fetch-fitness organism gene:
+    uv run python scripts/fetch_fitness_data.py {{organism}} {{gene}}
+
 # Fetch PMIDs from a file
 [positional-arguments]
 fetch-pmids-from-file file *args:


### PR DESCRIPTION
## Summary

- expose the existing bacterial FEBA/RB-TnSeq fetcher through the public Just wrapper layer
- document the generated fitness artifact and invocation

## Verification

- `just --list | rg '^    fetch-fitness '`
- `just --dry-run fetch-fitness ECOLI SlyD`
- `git diff --check`
