### PR TITLE
Reject malformed remote fitness values

### DIFF
--- a/scripts/fetch_fitness_data.py
+++ b/scripts/fetch_fitness_data.py
@@ -255,10 +255,15 @@ def try_bulk_download(org_id: str, locus_tag: str) -> dict | None:
                 return None
             fitness = []
             for row in reader:
+                try:
+                    fit_value = float(row["fit"])
+                    t_value = float(row["t"])
+                except (KeyError, TypeError, ValueError):
+                    return None
                 fitness.append({
                     "expName": row.get("name", ""),
-                    "fit": float(row.get("fit", 0)),
-                    "t": float(row.get("t", 0)),
+                    "fit": fit_value,
+                    "t": t_value,
                     "expDesc": row.get("short", row.get("desc", "")),
                     "expGroup": row.get("Group", ""),
                     "condition_1": row.get("Condition_1", ""),

--- a/tests/test_fetch_fitness_data.py
+++ b/tests/test_fetch_fitness_data.py
@@ -142,3 +142,30 @@ def test_bulk_download_rejects_html_and_invalid_headers(
     monkeypatch.setattr("urllib.request.urlopen", lambda *_args, **_kwargs: Response())
 
     assert fitness.try_bulk_download("keio", "b3349") is None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "name\tfit\tt\nset1\t\t2.0\n",
+        "name\tfit\tt\nset1\tnot-a-number\t2.0\n",
+        "name\tfit\tt\nset1\t1.0\t\n",
+    ],
+)
+def test_bulk_download_rejects_invalid_numeric_cells(
+    content: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def read(self) -> bytes:
+            return content.encode()
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *_args, **_kwargs: Response())
+
+    assert fitness.try_bulk_download("keio", "b3349") is None


### PR DESCRIPTION
## Summary

- treat blank, missing, or non-numeric remote `fit` and `t` cells as an unusable response
- prevent malformed endpoint output from raising an uncaught conversion exception
- add regression coverage for invalid numeric cells

## Verification

- `just format`
- `just pytest` (1932 passed, 63 deselected)
- `git diff --check`
