### PR TITLE
Reuse existing review accession in fetch-gene

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -91,6 +91,7 @@ sync-codex-skills:
 # Fetch gene data from UniProt and GOA
 # Use --alias to specify a custom directory name and file prefix
 # Use --force to overwrite existing UniProt and GOA files
+# Accession precedence: --uniprot-id, existing review id, then symbol resolution
 # Example: just fetch-gene 9BACT F0JBF1 --alias HgcB
 # Example: just fetch-gene human TP53 --force
 [positional-arguments]

--- a/src/ai_gene_review/etl/gene.py
+++ b/src/ai_gene_review/etl/gene.py
@@ -22,6 +22,18 @@ import yaml
 import re
 
 
+# Official UniProtKB accession syntax (6 or 10 characters).
+# https://www.uniprot.org/help/accession_numbers
+_UNIPROT_ACCESSION_RE = re.compile(
+    r"^([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2})$"
+)
+
+
+def is_uniprot_accession(value: str) -> bool:
+    """Return whether ``value`` has the shape of a UniProtKB accession."""
+    return bool(_UNIPROT_ACCESSION_RE.fullmatch(value))
+
+
 def _extract_alternative_products(uniprot_data: str, uniprot_id: str) -> List[Dict[str, str]]:
     """Extract alternative products (isoforms) from UniProt data.
 
@@ -251,7 +263,8 @@ def fetch_gene_data(
 
     Args:
         gene_info: Tuple of (organism, gene_name) e.g. ("human", "CFAP300")
-        uniprot_id: Optional UniProt accession ID. If not provided, will attempt to resolve.
+        uniprot_id: Optional UniProt accession ID. Precedence is explicit ID, then the
+            accession in an existing review, then gene-symbol resolution.
         base_path: Base directory for output files. Defaults to current directory.
         seed_annotations: If True, creates/seeds ai-review.yaml with GOA annotations.
         fetch_titles: If True, fetch actual titles from PubMed when seeding (default: True).
@@ -300,10 +313,12 @@ def fetch_gene_data(
     # UniProt and GOA snapshots. Reuse it before querying by symbol: MOD-standard
     # symbols are not always present in UniProt's gene_exact index (for example,
     # S. pombe dca7 is stored under systematic locus SPBC17D11.08).
+    reused_review_accession: Optional[str] = None
     if uniprot_id is None:
         yaml_file = gene_dir / f"{file_prefix}-ai-review.yaml"
-        uniprot_id = _existing_review_uniprot_id(yaml_file)
-        if uniprot_id:
+        reused_review_accession = _existing_review_uniprot_id(yaml_file)
+        if reused_review_accession:
+            uniprot_id = reused_review_accession
             print(
                 f"  - Reusing UniProt ID {uniprot_id} from "
                 f"{file_prefix}-ai-review.yaml"
@@ -315,8 +330,29 @@ def fetch_gene_data(
     uniprot_file = gene_dir / f"{file_prefix}-uniprot.txt"
     goa_file = gene_dir / f"{file_prefix}-goa.tsv"
 
-    # Fetch UniProt and GOA data
+    # Fetch UniProt data first so a reused secondary/demerged accession cannot be
+    # sent to QuickGO, which returns a header-only response for such accessions.
     uniprot_data = fetch_uniprot_data(uniprot_id)
+    primary_accession = _primary_uniprot_accession(uniprot_data)
+    if reused_review_accession and primary_accession != reused_review_accession:
+        if primary_accession:
+            print(
+                f"  ⚠ Review accession {reused_review_accession} resolves to UniProt "
+                f"primary accession {primary_accession}; resolving {gene_name} again "
+                "before fetching GOA"
+            )
+        else:
+            print(
+                f"  ⚠ Could not confirm review accession {reused_review_accession} "
+                f"against the fetched UniProt entry; resolving {gene_name} again "
+                "before fetching GOA"
+            )
+        uniprot_id = resolve_gene_to_uniprot(gene_name, organism)
+        uniprot_data = fetch_uniprot_data(uniprot_id)
+        resolved_primary = _primary_uniprot_accession(uniprot_data)
+        if resolved_primary:
+            uniprot_id = resolved_primary
+
     goa_data = fetch_goa_data(uniprot_id)
 
     # Check for differences
@@ -520,7 +556,17 @@ def _existing_review_uniprot_id(review_file: Path) -> Optional[str]:
     accession = accession.strip()
     if accession.startswith("UniProtKB:"):
         accession = accession.split(":", 1)[1]
-    return accession or None
+    return accession if is_uniprot_accession(accession) else None
+
+
+def _primary_uniprot_accession(uniprot_data: str) -> Optional[str]:
+    """Extract the primary accession from a UniProt flat-file entry."""
+    for line in uniprot_data.splitlines():
+        if not line.startswith("AC   "):
+            continue
+        accession = line[5:].split(";", 1)[0].strip()
+        return accession if is_uniprot_accession(accession) else None
+    return None
 
 
 def expand_organism_name(organism: str) -> str:

--- a/src/ai_gene_review/etl/gene.py
+++ b/src/ai_gene_review/etl/gene.py
@@ -22,7 +22,9 @@ import yaml
 import re
 
 
-# Official UniProtKB accession syntax (6 or 10 characters).
+# Official UniProtKB accession syntax (6 or 10 characters). Used to decide
+# whether a value is an accession or a gene symbol, so that all-uppercase gene
+# symbols 6-10 chars long (e.g. ATP6AP1, ATP6V1H, CCDC47) are not misclassified.
 # https://www.uniprot.org/help/accession_numbers
 _UNIPROT_ACCESSION_RE = re.compile(
     r"^([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2})$"
@@ -30,7 +32,18 @@ _UNIPROT_ACCESSION_RE = re.compile(
 
 
 def is_uniprot_accession(value: str) -> bool:
-    """Return whether ``value`` has the shape of a UniProtKB accession."""
+    """Return whether ``value`` has the shape of a UniProtKB accession.
+
+    Examples:
+        >>> is_uniprot_accession("Q9H2V7")
+        True
+        >>> is_uniprot_accession("A0A024R161")
+        True
+        >>> is_uniprot_accession("ATP6AP1")
+        False
+        >>> is_uniprot_accession("SPNS1")
+        False
+    """
     return bool(_UNIPROT_ACCESSION_RE.fullmatch(value))
 
 
@@ -332,26 +345,38 @@ def fetch_gene_data(
 
     # Fetch UniProt data first so a reused secondary/demerged accession cannot be
     # sent to QuickGO, which returns a header-only response for such accessions.
-    uniprot_data = fetch_uniprot_data(uniprot_id)
+    try:
+        uniprot_data = fetch_uniprot_data(uniprot_id)
+    except ValueError:
+        if not reused_review_accession:
+            raise
+        print(
+            f"  ⚠ Review accession {reused_review_accession} no longer resolves; "
+            f"resolving {gene_name} again"
+        )
+        uniprot_id = resolve_gene_to_uniprot(gene_name, organism)
+        uniprot_data = fetch_uniprot_data(uniprot_id)
+
     primary_accession = _primary_uniprot_accession(uniprot_data)
     if reused_review_accession and primary_accession != reused_review_accession:
         if primary_accession:
             print(
                 f"  ⚠ Review accession {reused_review_accession} resolves to UniProt "
-                f"primary accession {primary_accession}; resolving {gene_name} again "
-                "before fetching GOA"
+                f"primary accession {primary_accession}; using the primary accession "
+                "for GOA"
             )
+            uniprot_id = primary_accession
         else:
             print(
                 f"  ⚠ Could not confirm review accession {reused_review_accession} "
                 f"against the fetched UniProt entry; resolving {gene_name} again "
                 "before fetching GOA"
             )
-        uniprot_id = resolve_gene_to_uniprot(gene_name, organism)
-        uniprot_data = fetch_uniprot_data(uniprot_id)
-        resolved_primary = _primary_uniprot_accession(uniprot_data)
-        if resolved_primary:
-            uniprot_id = resolved_primary
+            uniprot_id = resolve_gene_to_uniprot(gene_name, organism)
+            uniprot_data = fetch_uniprot_data(uniprot_id)
+            resolved_primary = _primary_uniprot_accession(uniprot_data)
+            if resolved_primary:
+                uniprot_id = resolved_primary
 
     goa_data = fetch_goa_data(uniprot_id)
 

--- a/src/ai_gene_review/etl/gene.py
+++ b/src/ai_gene_review/etl/gene.py
@@ -296,9 +296,20 @@ def fetch_gene_data(
     gene_dir = base_path / "genes" / organism / dir_name
     gene_dir.mkdir(parents=True, exist_ok=True)
 
-    # Resolve UniProt ID if not provided
+    # Existing reviews already record the accession that owns their machine-derived
+    # UniProt and GOA snapshots. Reuse it before querying by symbol: MOD-standard
+    # symbols are not always present in UniProt's gene_exact index (for example,
+    # S. pombe dca7 is stored under systematic locus SPBC17D11.08).
     if uniprot_id is None:
-        uniprot_id = resolve_gene_to_uniprot(gene_name, organism)
+        yaml_file = gene_dir / f"{file_prefix}-ai-review.yaml"
+        uniprot_id = _existing_review_uniprot_id(yaml_file)
+        if uniprot_id:
+            print(
+                f"  - Reusing UniProt ID {uniprot_id} from "
+                f"{file_prefix}-ai-review.yaml"
+            )
+        else:
+            uniprot_id = resolve_gene_to_uniprot(gene_name, organism)
 
     # Determine file paths
     uniprot_file = gene_dir / f"{file_prefix}-uniprot.txt"
@@ -484,6 +495,32 @@ def fetch_gene_data(
         result["panther_family_id"] = None
 
     return result
+
+
+def _existing_review_uniprot_id(review_file: Path) -> Optional[str]:
+    """Return the accession recorded by an existing gene review, if present.
+
+    The review ID is the repository's grounding for an already-seeded gene. It is
+    preferable to a fresh symbol lookup when a model-organism database symbol is
+    absent from UniProt's gene_exact index. The fetched UniProt request still
+    validates that the accession resolves.
+    """
+    if not review_file.exists():
+        return None
+
+    try:
+        review = yaml.safe_load(review_file.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+
+    accession = review.get("id")
+    if not isinstance(accession, str) or not accession.strip():
+        return None
+
+    accession = accession.strip()
+    if accession.startswith("UniProtKB:"):
+        accession = accession.split(":", 1)[1]
+    return accession or None
 
 
 def expand_organism_name(organism: str) -> str:

--- a/src/ai_gene_review/tools/deep_research_unified.py
+++ b/src/ai_gene_review/tools/deep_research_unified.py
@@ -2,7 +2,6 @@
 """Unified CLI wrapper for deep research using deep-research-client library."""
 
 import sys
-import re
 from pathlib import Path
 from typing import Optional
 
@@ -10,33 +9,12 @@ import click
 from deep_research_client import DeepResearchClient  # type: ignore[import-untyped]
 from deep_research_client.templates import TemplateManager  # type: ignore[import-untyped]
 
-from ai_gene_review.etl.gene import expand_organism_name, fetch_uniprot_data, resolve_gene_to_uniprot
-
-
-# Official UniProtKB accession syntax (6 or 10 characters). Used to decide
-# whether a positional argument is an accession or a gene symbol, so that
-# all-uppercase gene symbols 6-10 chars long (e.g. ATP6AP1, ATP6V1H, CCDC47)
-# are NOT misclassified as accessions.
-# https://www.uniprot.org/help/accession_numbers
-_UNIPROT_ACCESSION_RE = re.compile(
-    r'^([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2})$'
+from ai_gene_review.etl.gene import (
+    expand_organism_name,
+    fetch_uniprot_data,
+    is_uniprot_accession,
+    resolve_gene_to_uniprot,
 )
-
-
-def is_uniprot_accession(value: str) -> bool:
-    """Return True if ``value`` looks like a UniProtKB accession.
-
-    Examples:
-        >>> is_uniprot_accession("Q9H2V7")
-        True
-        >>> is_uniprot_accession("A0A024R161")
-        True
-        >>> is_uniprot_accession("ATP6AP1")
-        False
-        >>> is_uniprot_accession("SPNS1")
-        False
-    """
-    return bool(_UNIPROT_ACCESSION_RE.match(value))
 
 
 def extract_uniprot_fields(uniprot_text: str, uniprot_id: str) -> dict:

--- a/tests/test_deep_research_unified.py
+++ b/tests/test_deep_research_unified.py
@@ -43,6 +43,10 @@ def test_is_uniprot_accession_false_for_gene_symbols(value: str) -> None:
     assert not is_uniprot_accession(value)
 
 
+def test_is_uniprot_accession_rejects_trailing_newline() -> None:
+    assert not is_uniprot_accession("Q9H2V7\n")
+
+
 def test_extract_uniprot_fields_parses_family_and_domains() -> None:
     uniprot_text = (
         "ID   SPNS1_HUMAN             Reviewed;         528 AA.\n"

--- a/tests/test_gene_etl.py
+++ b/tests/test_gene_etl.py
@@ -189,3 +189,72 @@ def test_explicit_accession_overrides_existing_review_accession(
     mock_resolve.assert_not_called()
     mock_fetch_uniprot.assert_called_once_with("P12345")
     mock_fetch_goa.assert_called_once_with("P12345")
+
+
+@pytest.mark.parametrize(
+    "review_content",
+    [
+        None,
+        "gene_symbol: dca7\n",
+        "id: '  '\ngene_symbol: dca7\n",
+        "id: URS000075D95B_9606\ngene_symbol: XIST\n",
+        "id: [\n",
+    ],
+)
+@patch("ai_gene_review.etl.gene.fetch_goa_data")
+@patch("ai_gene_review.etl.gene.fetch_uniprot_data")
+@patch("ai_gene_review.etl.gene.resolve_gene_to_uniprot")
+def test_fetch_gene_data_falls_back_when_review_has_no_protein_accession(
+    mock_resolve, mock_fetch_uniprot, mock_fetch_goa, review_content, tmp_path
+):
+    """Missing, invalid, ncRNA, and malformed review IDs use symbol resolution."""
+    gene_dir = tmp_path / "genes" / "SCHPO" / "dca7"
+    gene_dir.mkdir(parents=True)
+    if review_content is not None:
+        (gene_dir / "dca7-ai-review.yaml").write_text(review_content)
+    mock_resolve.return_value = "P12345"
+    mock_fetch_uniprot.return_value = "AC   P12345;\n"
+    mock_fetch_goa.return_value = "GO TERM\tGO NAME\n"
+
+    fetch_gene_data(
+        ("SCHPO", "dca7"),
+        base_path=tmp_path,
+        seed_annotations=False,
+    )
+
+    mock_resolve.assert_called_once_with("dca7", "SCHPO")
+    mock_fetch_uniprot.assert_called_once_with("P12345")
+    mock_fetch_goa.assert_called_once_with("P12345")
+
+
+@patch("ai_gene_review.etl.gene.fetch_goa_data")
+@patch("ai_gene_review.etl.gene.fetch_uniprot_data")
+@patch("ai_gene_review.etl.gene.resolve_gene_to_uniprot")
+def test_stale_review_accession_is_resolved_before_fetching_goa(
+    mock_resolve, mock_fetch_uniprot, mock_fetch_goa, tmp_path
+):
+    """QuickGO must receive the current primary accession, not a stale review ID."""
+    gene_dir = tmp_path / "genes" / "SCHPO" / "dca7"
+    gene_dir.mkdir(parents=True)
+    (gene_dir / "dca7-ai-review.yaml").write_text(
+        "id: O74763\ngene_symbol: dca7\n"
+    )
+    mock_resolve.return_value = "P12345"
+    mock_fetch_uniprot.side_effect = [
+        "AC   P12345; O74763;\n",
+        "AC   P12345; O74763;\n",
+    ]
+    mock_fetch_goa.return_value = "GO TERM\tGO NAME\n"
+
+    fetch_gene_data(
+        ("SCHPO", "dca7"),
+        base_path=tmp_path,
+        seed_annotations=False,
+    )
+
+    mock_resolve.assert_called_once_with("dca7", "SCHPO")
+    assert [call.args[0] for call in mock_fetch_uniprot.call_args_list] == [
+        "O74763",
+        "P12345",
+    ]
+    mock_fetch_goa.assert_called_once_with("P12345")

--- a/tests/test_gene_etl.py
+++ b/tests/test_gene_etl.py
@@ -239,10 +239,36 @@ def test_stale_review_accession_is_resolved_before_fetching_goa(
     (gene_dir / "dca7-ai-review.yaml").write_text(
         "id: O74763\ngene_symbol: dca7\n"
     )
+    mock_fetch_uniprot.return_value = "AC   P12345; O74763;\n"
+    mock_fetch_goa.return_value = "GO TERM\tGO NAME\n"
+
+    fetch_gene_data(
+        ("SCHPO", "dca7"),
+        base_path=tmp_path,
+        seed_annotations=False,
+    )
+
+    mock_resolve.assert_not_called()
+    mock_fetch_uniprot.assert_called_once_with("O74763")
+    mock_fetch_goa.assert_called_once_with("P12345")
+
+
+@patch("ai_gene_review.etl.gene.fetch_goa_data")
+@patch("ai_gene_review.etl.gene.fetch_uniprot_data")
+@patch("ai_gene_review.etl.gene.resolve_gene_to_uniprot")
+def test_dead_review_accession_falls_back_to_symbol_resolution(
+    mock_resolve, mock_fetch_uniprot, mock_fetch_goa, tmp_path
+):
+    """A deleted review accession must not prevent a self-healing refresh."""
+    gene_dir = tmp_path / "genes" / "SCHPO" / "dca7"
+    gene_dir.mkdir(parents=True)
+    (gene_dir / "dca7-ai-review.yaml").write_text(
+        "id: O74763\ngene_symbol: dca7\n"
+    )
     mock_resolve.return_value = "P12345"
     mock_fetch_uniprot.side_effect = [
-        "AC   P12345; O74763;\n",
-        "AC   P12345; O74763;\n",
+        ValueError("deleted accession"),
+        "AC   P12345;\n",
     ]
     mock_fetch_goa.return_value = "GO TERM\tGO NAME\n"
 

--- a/tests/test_gene_etl.py
+++ b/tests/test_gene_etl.py
@@ -2,6 +2,8 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 from ai_gene_review.etl.gene import fetch_gene_data
 
@@ -127,3 +129,63 @@ def test_fetch_gene_data_different_organisms(organism, gene):
         uniprot_file = gene_dir / f"{gene}-uniprot.txt"
         assert uniprot_file.exists()
         assert uniprot_file.read_text()  # Should have content
+
+
+@patch("ai_gene_review.etl.gene.resolve_gene_to_uniprot")
+@patch("ai_gene_review.etl.gene.fetch_goa_data")
+@patch("ai_gene_review.etl.gene.fetch_uniprot_data")
+def test_fetch_gene_data_reuses_existing_review_accession(
+    mock_fetch_uniprot, mock_fetch_goa, mock_resolve, tmp_path
+):
+    """Existing reviews must not depend on a fresh UniProt symbol lookup."""
+    gene_dir = tmp_path / "genes" / "SCHPO" / "dca7"
+    gene_dir.mkdir(parents=True)
+    (gene_dir / "dca7-ai-review.yaml").write_text(
+        "id: O74763\ngene_symbol: dca7\n"
+    )
+    mock_fetch_uniprot.return_value = (
+        "ID   DCA7_SCHPO Reviewed; 500 AA.\n"
+        "AC   O74763;\n"
+        "OS   Schizosaccharomyces pombe.\n"
+    )
+    mock_fetch_goa.return_value = "GO TERM\tGO NAME\n"
+
+    fetch_gene_data(
+        ("SCHPO", "dca7"),
+        base_path=tmp_path,
+        seed_annotations=False,
+    )
+
+    mock_resolve.assert_not_called()
+    mock_fetch_uniprot.assert_called_once_with("O74763")
+    mock_fetch_goa.assert_called_once_with("O74763")
+
+
+@patch("ai_gene_review.etl.gene.resolve_gene_to_uniprot")
+@patch("ai_gene_review.etl.gene.fetch_goa_data")
+@patch("ai_gene_review.etl.gene.fetch_uniprot_data")
+def test_explicit_accession_overrides_existing_review_accession(
+    mock_fetch_uniprot, mock_fetch_goa, mock_resolve, tmp_path
+):
+    """An explicit --uniprot-id remains authoritative over the local review."""
+    gene_dir = tmp_path / "genes" / "SCHPO" / "dca7"
+    gene_dir.mkdir(parents=True)
+    (gene_dir / "dca7-ai-review.yaml").write_text(
+        "id: O74763\ngene_symbol: dca7\n"
+    )
+    mock_fetch_uniprot.return_value = (
+        "ID   EXPLICIT Reviewed; 100 AA.\n"
+        "AC   P12345;\n"
+    )
+    mock_fetch_goa.return_value = "GO TERM\tGO NAME\n"
+
+    fetch_gene_data(
+        ("SCHPO", "dca7"),
+        uniprot_id="P12345",
+        base_path=tmp_path,
+        seed_annotations=False,
+    )
+
+    mock_resolve.assert_not_called()
+    mock_fetch_uniprot.assert_called_once_with("P12345")
+    mock_fetch_goa.assert_called_once_with("P12345")


### PR DESCRIPTION
## Summary
- reuse the UniProt accession recorded in an existing gene review before attempting a symbol lookup
- preserve explicit `--uniprot-id` precedence and fall back to normal resolution for new reviews
- add hermetic regression coverage for both paths

This fixes refreshes for MOD-standard symbols absent from UniProt gene_exact indexing, including `SCHPO/dca7`, without bypassing the `just fetch-gene` wrapper.

## Validation
- `uv run pytest -q tests/test_gene_etl.py tests/test_fetch_gene_wrapper.py`
- `just fetch-gene SCHPO dca7` (resolved local `O74763`; no tracked gene files changed)
- `just test` (1939 passed, 63 deselected; 156 doctests passed, 37 skipped; mypy and ruff passed)