### PR TITLE
Avoid blank source metadata in hypothesis reports

### DIFF
--- a/scripts/gene_hypothesis_deep_research.py
+++ b/scripts/gene_hypothesis_deep_research.py
@@ -19,6 +19,7 @@ import yaml
 DEFAULT_GENES_ROOT = Path("genes")
 DEFAULT_TEMPLATE = Path("templates/gene_hypothesis_deep_research.md")
 DEFAULT_FUNCTION_SUPPORT_TEMPLATE = Path("templates/function_support_deep_research.md")
+UNSPECIFIED_SOURCE = "Not supplied."
 LOCAL_EVIDENCE_MAX_CHARS_PER_FILE = 12000
 LOCAL_EVIDENCE_MAX_CHARS_TOTAL = 24000
 FOCUS_TYPES = {
@@ -1185,8 +1186,11 @@ def template_vars(record: GeneHypothesisRecord, *, genes_root: Path) -> dict[str
         "hypothesis_text": record.hypothesis_text,
         "term_context": record.term_context,
         "reference_context": format_reference_context(provider_reference_ids),
-        "source_file": str(record.source_file or ""),
-        "source_selector": record.source_selector,
+        # Empty substitutions leave trailing spaces in Markdown template lines such as
+        # ``- **Source file:** {source_file}``, which then propagate into every saved
+        # provider report. Use an explicit value for free-text hypotheses instead.
+        "source_file": str(record.source_file) if record.source_file else UNSPECIFIED_SOURCE,
+        "source_selector": record.source_selector or UNSPECIFIED_SOURCE,
         "source_context_yaml": dump_context_yaml(provider_source_context),
     }
 

--- a/tests/test_gene_hypothesis_deep_research.py
+++ b/tests/test_gene_hypothesis_deep_research.py
@@ -277,6 +277,27 @@ def test_function_support_free_text_hypothesis(tmp_path: Path) -> None:
     assert record.source_selector == "free-text"
 
 
+def test_template_vars_use_explicit_placeholders_for_missing_source(
+    tmp_path: Path,
+) -> None:
+    genes_root = make_iba_workspace(tmp_path)
+    record = ghr.make_record(
+        organism="human",
+        gene="IBAT",
+        gene_symbol="IBAT",
+        taxon_id="NCBITaxon:9606",
+        taxon_label="Homo sapiens",
+        focus_type="core_function",
+        slug="free-text-hypothesis",
+        hypothesis_text="IBAT has a test function",
+    )
+
+    variables = ghr.template_vars(record, genes_root=genes_root)
+
+    assert variables["source_file"] == ghr.UNSPECIFIED_SOURCE
+    assert variables["source_selector"] == ghr.UNSPECIFIED_SOURCE
+
+
 def test_function_support_from_term_id(tmp_path: Path) -> None:
     genes_root = make_iba_workspace(tmp_path)
     args = ghr.parse_args(


### PR DESCRIPTION
## Summary
- render explicit `Not supplied.` placeholders for free-text hypothesis source metadata
- prevent trailing whitespace from propagating into saved OpenScientist/deep-research reports
- add a regression test for records without source files or selectors

## Validation
- `just test`
  - 1,948 tests passed / 63 deselected
  - 156 doctests passed / 37 skipped
  - mypy clean
  - Ruff clean
- `git diff --check`