### PR TITLE
Track review provenance for free-text hypothesis reports

### DIFF
--- a/scripts/gene_hypothesis_deep_research.py
+++ b/scripts/gene_hypothesis_deep_research.py
@@ -1469,6 +1469,7 @@ def direct_record_from_args(args: argparse.Namespace) -> GeneHypothesisRecord:
     elif predictions_path.exists():
         metadata = load_yaml(predictions_path)
     gene_symbol, taxon_id, taxon_label = gene_metadata(metadata, args.gene)
+    source_file = review_path if review_path.exists() else None
 
     term_context_lines = []
     if args.term_id or args.term_label:
@@ -1488,6 +1489,8 @@ def direct_record_from_args(args: argparse.Namespace) -> GeneHypothesisRecord:
         hypothesis_text=args.hypothesis,
         term_context="\n".join(term_context_lines),
         reference_ids=args.reference_id,
+        source_file=source_file,
+        source_selector="free-text",
         source_context={
             "hypothesis": args.hypothesis,
             "focus_type": normalize_focus_type(args.focus_type),

--- a/tests/test_gene_hypothesis_deep_research.py
+++ b/tests/test_gene_hypothesis_deep_research.py
@@ -296,6 +296,30 @@ def test_template_vars_use_explicit_placeholders_for_missing_source(
 
     assert variables["source_file"] == ghr.UNSPECIFIED_SOURCE
     assert variables["source_selector"] == ghr.UNSPECIFIED_SOURCE
+    assert all(variables.values())
+
+
+def test_direct_free_text_record_tracks_review_source(tmp_path: Path) -> None:
+    genes_root = make_iba_workspace(tmp_path)
+    args = ghr.parse_args(
+        [
+            "run",
+            "human",
+            "IBAT",
+            "asta",
+            "--genes-root",
+            str(genes_root),
+            "--focus-type",
+            "core_function",
+            "--hypothesis",
+            "IBAT has a test function",
+        ]
+    )
+
+    record = ghr.direct_record_from_args(args)
+
+    assert record.source_file == genes_root / "human" / "IBAT" / "IBAT-ai-review.yaml"
+    assert record.source_selector == "free-text"
 
 
 def test_function_support_from_term_id(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary:

- thread the known gene-review path into direct free-text hypothesis records
- label the selector as free-text instead of falling back to an unspecified source
- exercise the real CLI record-construction path and retain the non-empty template-variable invariant

This follow-up was approved as part of #2809 but missed that PR squash merge because auto-merge raced the final push. A new mmf2 report reproduced the missing provenance on current main.

Validation:

- just test: 1,949 tests passed (63 deselected), 156 doctests passed (37 skipped), mypy clean, Ruff clean
- git diff --check