### PR TITLE
Restore generic deep-research wrapper

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -271,6 +271,11 @@ litscan-module-member *args="":
 #   just deep-research-openai METEA C5B1I4 --alias mllA  # gene_symbol=mllA, gene_id=C5B1I4
 #   just deep-research-openai human TP53 --fallback perplexity-lite  # fallback on failure/timeout
 #   just deep-research-openai human CFAP300 --extra-args --param "model=gpt-4o"
+# Generic provider-selecting entry point documented in AGENTS.md and automation prompts.
+# Example: just deep-research human TP53 --provider perplexity
+deep-research organism gene_id *args="":
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} {{args}}
+
 deep-research-openai organism gene_id *args="":
     uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} openai {{args}}
 

--- a/project.justfile
+++ b/project.justfile
@@ -262,6 +262,12 @@ descriptions-status organism *args="":
 litscan-module-member *args="":
     uv run ai-gene-review litscan module-member {{args}}
 
+# Generic provider-selecting entry point documented in AGENTS.md and automation prompts.
+# Supports --provider, --alias, --fallback, --timeout, and --extra-args (which must come last).
+# Example: just deep-research human TP53 --provider perplexity
+deep-research organism gene_id *args="":
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} {{args}}
+
 # Deep research using OpenAI (GPT models)
 # Gene symbol automatically looked up from UniProt file if --alias not provided
 # Supports --fallback PROVIDER [PROVIDER ...] and --timeout SECONDS
@@ -271,11 +277,6 @@ litscan-module-member *args="":
 #   just deep-research-openai METEA C5B1I4 --alias mllA  # gene_symbol=mllA, gene_id=C5B1I4
 #   just deep-research-openai human TP53 --fallback perplexity-lite  # fallback on failure/timeout
 #   just deep-research-openai human CFAP300 --extra-args --param "model=gpt-4o"
-# Generic provider-selecting entry point documented in AGENTS.md and automation prompts.
-# Example: just deep-research human TP53 --provider perplexity
-deep-research organism gene_id *args="":
-    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} {{args}}
-
 deep-research-openai organism gene_id *args="":
     uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} openai {{args}}
 

--- a/scripts/deep_research_wrapper.py
+++ b/scripts/deep_research_wrapper.py
@@ -24,6 +24,21 @@ DEFAULT_OPENSCIENTIST_TIMEOUT = 7200
 DEFAULT_DRC_PACKAGE = "deep-research-client[cyberian]==0.2.7rc1"
 
 
+def select_provider(positional: str | None, option: str | None) -> str:
+    """Resolve the provider accepted by old and generic wrapper interfaces."""
+    if positional and option and positional != option:
+        raise ValueError(
+            f"Conflicting providers: positional '{positional}' and --provider '{option}'"
+        )
+    provider = option or positional
+    if not provider:
+        raise ValueError(
+            "A provider is required; pass --provider PROVIDER or use a "
+            "provider-specific just recipe"
+        )
+    return provider
+
+
 def deep_research_client_command() -> list[str]:
     """Return the command prefix for invoking deep-research-client.
 
@@ -299,7 +314,13 @@ def main():
     parser.add_argument("organism", help="Organism name")
     parser.add_argument("gene_id", help="Gene identifier (UniProt ID, locus tag, or gene symbol)")
     parser.add_argument(
-        "provider",
+        "provider_positional",
+        nargs="?",
+        help="Provider used by the legacy provider-specific just recipes",
+    )
+    parser.add_argument(
+        "--provider",
+        dest="provider_option",
         help="Provider (for example: openai, perplexity, perplexity-lite, falcon, cyberian, openscientist)",
     )
     parser.add_argument("--alias", help="Gene symbol alias (if not provided, will lookup from UniProt)")
@@ -321,6 +342,10 @@ def main():
     parser.add_argument("--extra-args", nargs=argparse.REMAINDER, help="Extra args to pass to deep-research-client")
 
     args = parser.parse_args()
+    try:
+        provider = select_provider(args.provider_positional, args.provider_option)
+    except ValueError as error:
+        parser.error(str(error))
 
     # Determine gene symbol and parse UniProt context
     uniprot_context = None
@@ -365,11 +390,11 @@ def main():
         base_dir = Path(f"genes/{args.organism}/{args.gene_id}")
 
     # Construct output path
-    if args.provider == "perplexity-lite":
+    if provider == "perplexity-lite":
         output_file = base_dir / f"{base_dir.name}-deep-research-perplexity-lite.md"
         use_template = False
     else:
-        output_file = base_dir / f"{base_dir.name}-deep-research-{args.provider}.md"
+        output_file = base_dir / f"{base_dir.name}-deep-research-{provider}.md"
         use_template = True
 
     # Create directory if it doesn't exist
@@ -379,7 +404,7 @@ def main():
     if effective_timeout is None:
         effective_timeout = (
             DEFAULT_OPENSCIENTIST_TIMEOUT
-            if args.provider == "openscientist"
+            if provider == "openscientist"
             else DEFAULT_TIMEOUT
         )
 
@@ -387,7 +412,7 @@ def main():
     return run_deep_research(
         organism=args.organism,
         gene_id=args.gene_id,
-        provider=args.provider,
+        provider=provider,
         gene_symbol=gene_symbol,
         output_path=output_file,
         uniprot_context=uniprot_context,

--- a/tests/test_deep_research_provider_selection.py
+++ b/tests/test_deep_research_provider_selection.py
@@ -1,0 +1,124 @@
+"""End-to-end tests for the generic deep-research provider interface."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_wrapper():
+    scripts_dir = ROOT / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    path = scripts_dir / "deep_research_wrapper.py"
+    spec = importlib.util.spec_from_file_location("deep_research_wrapper", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("provider_args", "expected_provider"),
+    [
+        (["--provider", "perplexity"], "perplexity"),
+        (["openai"], "openai"),
+    ],
+)
+def test_main_accepts_option_and_legacy_positional_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    provider_args: list[str],
+    expected_provider: str,
+) -> None:
+    wrapper = load_wrapper()
+    captured: dict[str, object] = {}
+
+    def fake_run_deep_research(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(wrapper, "run_deep_research", fake_run_deep_research)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["deep_research_wrapper.py", "human", "TP53", *provider_args],
+    )
+
+    assert wrapper.main() == 0
+    assert captured["provider"] == expected_provider
+
+
+def test_select_provider_rejects_conflicting_values() -> None:
+    wrapper = load_wrapper()
+
+    with pytest.raises(ValueError, match="Conflicting providers"):
+        wrapper.select_provider("falcon", "perplexity")
+
+
+def test_generic_just_recipe_forwards_arguments(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["DEEP_RESEARCH_ARGV_LOG"], "w") as handle:
+    json.dump(sys.argv[1:], handle)
+"""
+    )
+    fake_uv.chmod(0o755)
+    log_path = tmp_path / "argv.json"
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["DEEP_RESEARCH_ARGV_LOG"] = str(log_path)
+
+    result = subprocess.run(
+        [
+            "just",
+            "deep-research",
+            "human",
+            "TP53",
+            "--provider",
+            "perplexity",
+            "--alias",
+            "TP53",
+            "--timeout",
+            "42",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(log_path.read_text()) == [
+        "run",
+        "python",
+        "scripts/deep_research_wrapper.py",
+        "human",
+        "TP53",
+        "--provider",
+        "perplexity",
+        "--alias",
+        "TP53",
+        "--timeout",
+        "42",
+    ]

--- a/tests/test_deep_research_timeout_propagation.py
+++ b/tests/test_deep_research_timeout_propagation.py
@@ -39,29 +39,6 @@ def test_gene_wrapper_propagates_openscientist_timeout(tmp_path):
     assert "timeout=7200" in cmd
 
 
-def test_gene_wrapper_accepts_generic_provider_option():
-    wrapper = load_script("deep_research_wrapper")
-
-    assert wrapper.select_provider(None, "perplexity") == "perplexity"
-
-
-def test_gene_wrapper_keeps_positional_provider_compatibility():
-    wrapper = load_script("deep_research_wrapper")
-
-    assert wrapper.select_provider("falcon", None) == "falcon"
-
-
-def test_gene_wrapper_rejects_conflicting_providers():
-    wrapper = load_script("deep_research_wrapper")
-
-    try:
-        wrapper.select_provider("falcon", "perplexity")
-    except ValueError as error:
-        assert "Conflicting providers" in str(error)
-    else:
-        raise AssertionError("Expected conflicting providers to fail")
-
-
 def test_module_pathway_wrapper_propagates_openscientist_timeout(tmp_path):
     wrapper = load_script("module_pathway_taxon_deep_research_wrapper")
 

--- a/tests/test_deep_research_timeout_propagation.py
+++ b/tests/test_deep_research_timeout_propagation.py
@@ -39,6 +39,29 @@ def test_gene_wrapper_propagates_openscientist_timeout(tmp_path):
     assert "timeout=7200" in cmd
 
 
+def test_gene_wrapper_accepts_generic_provider_option():
+    wrapper = load_script("deep_research_wrapper")
+
+    assert wrapper.select_provider(None, "perplexity") == "perplexity"
+
+
+def test_gene_wrapper_keeps_positional_provider_compatibility():
+    wrapper = load_script("deep_research_wrapper")
+
+    assert wrapper.select_provider("falcon", None) == "falcon"
+
+
+def test_gene_wrapper_rejects_conflicting_providers():
+    wrapper = load_script("deep_research_wrapper")
+
+    try:
+        wrapper.select_provider("falcon", "perplexity")
+    except ValueError as error:
+        assert "Conflicting providers" in str(error)
+    else:
+        raise AssertionError("Expected conflicting providers to fail")
+
+
 def test_module_pathway_wrapper_propagates_openscientist_timeout(tmp_path):
     wrapper = load_script("module_pathway_taxon_deep_research_wrapper")
 


### PR DESCRIPTION
Restores the documented public `just deep-research ORGANISM GENE --provider PROVIDER` entry point while preserving the legacy positional provider syntax and all provider-specific wrappers.

Adds validation for conflicting positional and option provider selections.

Verification:
- `just test`
- targeted wrapper tests
- `just --show deep-research`
- `git diff --check`