### PR TITLE
Validate deep-research provider names

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -336,7 +336,7 @@ deep-research-asta organism gene_id *args="":
 #   just deep-research-codex human TP53
 #   just deep-research-codex METEA C5B1I4 --alias mllA
 deep-research-codex organism gene_id *args="":
-    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} cyberian --extra-args --param agent_type=codex {{args}}
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} codex {{args}}
 
 # Deep research on an InterPro entry (family/domain) behind InterPro2GO annotations.
 # Metadata is auto-fetched and cached under interpro/<database>/<ID>/ if absent.

--- a/scripts/deep_research_wrapper.py
+++ b/scripts/deep_research_wrapper.py
@@ -96,7 +96,7 @@ def parse_uniprot_gene_name(uniprot_file: Path) -> str:
     raise ValueError(f"Could not find gene name in {uniprot_file}")
 
 
-def parse_uniprot_context(uniprot_file: Path) -> dict:
+def parse_uniprot_context(uniprot_file: Path) -> dict[str, Any]:
     """Extract comprehensive context from UniProt file for gene identification.
 
     Args:
@@ -194,7 +194,12 @@ def _build_cmd(
     provider_timeout: int | None = None,
 ) -> list[str]:
     """Build the deep-research-client command list."""
-    actual_provider = "perplexity" if provider == "perplexity-lite" else provider
+    if provider == "perplexity-lite":
+        actual_provider = "perplexity"
+    elif provider == "codex":
+        actual_provider = "cyberian"
+    else:
+        actual_provider = provider
 
     if use_template:
         cmd = [
@@ -240,6 +245,9 @@ def _build_cmd(
 
     if actual_provider == "openscientist" and provider_timeout is not None:
         cmd.extend(["--param", f"timeout={provider_timeout}"])
+
+    if provider == "codex":
+        cmd.extend(["--param", "agent_type=codex"])
 
     if extra_args:
         cmd.extend(extra_args)

--- a/scripts/deep_research_wrapper.py
+++ b/scripts/deep_research_wrapper.py
@@ -17,11 +17,22 @@ import subprocess
 import sys
 from pathlib import Path
 import re
+from typing import Any
 
 # Default timeout for deep research subprocess (seconds)
 DEFAULT_TIMEOUT = 600
 DEFAULT_OPENSCIENTIST_TIMEOUT = 7200
 DEFAULT_DRC_PACKAGE = "deep-research-client[cyberian]==0.2.7rc1"
+PROVIDERS = (
+    "openai",
+    "perplexity",
+    "perplexity-lite",
+    "falcon",
+    "cyberian",
+    "codex",
+    "asta",
+    "openscientist",
+)
 
 
 def select_provider(positional: str | None, option: str | None) -> str:
@@ -35,6 +46,10 @@ def select_provider(positional: str | None, option: str | None) -> str:
         raise ValueError(
             "A provider is required; pass --provider PROVIDER or use a "
             "provider-specific just recipe"
+        )
+    if provider not in PROVIDERS:
+        raise ValueError(
+            f"Unsupported provider '{provider}'; choose from: {', '.join(PROVIDERS)}"
         )
     return provider
 
@@ -94,7 +109,7 @@ def parse_uniprot_context(uniprot_file: Path) -> dict:
     if not uniprot_file.exists():
         return {}
 
-    context = {
+    context: dict[str, Any] = {
         'accession': '',
         'protein_description': '',
         'gene_info': '',
@@ -249,7 +264,7 @@ def run_deep_research(
     Args:
         organism: Organism name
         gene_id: Gene identifier (UniProt ID, locus tag, or gene symbol)
-        provider: Provider name (openai, perplexity, perplexity-lite, falcon, cyberian, openscientist)
+        provider: Provider name from ``PROVIDERS``
         gene_symbol: Gene symbol/name to use in template
         output_path: Where to write output
         uniprot_context: Dictionary with UniProt context fields
@@ -316,17 +331,20 @@ def main():
     parser.add_argument(
         "provider_positional",
         nargs="?",
+        choices=PROVIDERS,
         help="Provider used by the legacy provider-specific just recipes",
     )
     parser.add_argument(
         "--provider",
         dest="provider_option",
-        help="Provider (for example: openai, perplexity, perplexity-lite, falcon, cyberian, openscientist)",
+        choices=PROVIDERS,
+        help="Provider (equivalent to the legacy positional provider argument)",
     )
     parser.add_argument("--alias", help="Gene symbol alias (if not provided, will lookup from UniProt)")
     parser.add_argument(
         "--fallback",
         nargs="+",
+        choices=PROVIDERS,
         metavar="PROVIDER",
         help="Ordered list of fallback providers to try if the primary provider fails or times out "
              "(e.g. --fallback perplexity-lite falcon)"

--- a/tests/test_deep_research_provider_selection.py
+++ b/tests/test_deep_research_provider_selection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -69,17 +70,20 @@ def test_select_provider_rejects_conflicting_values() -> None:
 
 def test_supported_providers_cover_public_gene_recipes() -> None:
     wrapper = load_wrapper()
+    recipe_text = (ROOT / "project.justfile").read_text()
+    recipe_providers = dict(
+        re.findall(
+            r"^deep-research-([a-z-]+)[^\n]*:\n"
+            r"\s+uv run python scripts/deep_research_wrapper\.py "
+            r"\{\{organism\}\} \{\{gene_id\}\} ([a-z-]+)",
+            recipe_text,
+            flags=re.MULTILINE,
+        )
+    )
 
-    assert set(wrapper.PROVIDERS) == {
-        "openai",
-        "perplexity",
-        "perplexity-lite",
-        "falcon",
-        "cyberian",
-        "codex",
-        "asta",
-        "openscientist",
-    }
+    assert recipe_providers
+    assert set(recipe_providers.values()) <= set(wrapper.PROVIDERS)
+    assert all(recipe == provider for recipe, provider in recipe_providers.items())
 
 
 def test_select_provider_rejects_unknown_value() -> None:
@@ -87,6 +91,21 @@ def test_select_provider_rejects_unknown_value() -> None:
 
     with pytest.raises(ValueError, match="Unsupported provider 'perplexty'"):
         wrapper.select_provider(None, "perplexty")
+
+
+def test_build_command_maps_codex_to_cyberian_agent_type(tmp_path: Path) -> None:
+    wrapper = load_wrapper()
+
+    cmd = wrapper._build_cmd(
+        organism="human",
+        gene_id="TP53",
+        provider="codex",
+        gene_symbol="TP53",
+        output_path=tmp_path / "TP53-deep-research-codex.md",
+    )
+
+    assert cmd[cmd.index("--provider") + 1] == "cyberian"
+    assert "agent_type=codex" in cmd
 
 
 @pytest.mark.parametrize(

--- a/tests/test_deep_research_provider_selection.py
+++ b/tests/test_deep_research_provider_selection.py
@@ -67,6 +67,53 @@ def test_select_provider_rejects_conflicting_values() -> None:
         wrapper.select_provider("falcon", "perplexity")
 
 
+def test_supported_providers_cover_public_gene_recipes() -> None:
+    wrapper = load_wrapper()
+
+    assert set(wrapper.PROVIDERS) == {
+        "openai",
+        "perplexity",
+        "perplexity-lite",
+        "falcon",
+        "cyberian",
+        "codex",
+        "asta",
+        "openscientist",
+    }
+
+
+def test_select_provider_rejects_unknown_value() -> None:
+    wrapper = load_wrapper()
+
+    with pytest.raises(ValueError, match="Unsupported provider 'perplexty'"):
+        wrapper.select_provider(None, "perplexty")
+
+
+@pytest.mark.parametrize(
+    "provider_args",
+    [
+        ["--provider", "perplexty"],
+        ["perplexty"],
+        ["--provider", "openai", "--fallback", "perplexty"],
+    ],
+)
+def test_main_rejects_unknown_primary_and_fallback_providers(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_args: list[str],
+) -> None:
+    wrapper = load_wrapper()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["deep_research_wrapper.py", "human", "TP53", *provider_args],
+    )
+
+    with pytest.raises(SystemExit) as error:
+        wrapper.main()
+
+    assert error.value.code == 2
+
+
 def test_generic_just_recipe_forwards_arguments(tmp_path: Path) -> None:
     fake_bin = tmp_path / "fake bin"
     fake_bin.mkdir()


### PR DESCRIPTION
Prevents misspelled generic or fallback provider names from reaching output-path construction and creating misleading `-deep-research-{provider}.md` artifacts.

The allow-list is derived from the repository’s supported wrappers and includes openai, perplexity, perplexity-lite, falcon, cyberian, codex, asta, and openscientist. Validation covers `--provider`, the legacy positional form, and `--fallback`.

Also makes the parsed UniProt context type explicit after targeted type checking exposed an existing heterogeneous-dictionary inference mismatch.

Verification:
- focused provider/wrapper suite: 28 passed
- full `just test`: 1,958 unit tests; 156 doctests; mypy; Ruff
- `git diff --check`