### PR TITLE
Fix fallback deep-research filenames

### DIFF
--- a/scripts/deep_research_wrapper.py
+++ b/scripts/deep_research_wrapper.py
@@ -255,6 +255,13 @@ def _build_cmd(
     return cmd
 
 
+def _fallback_output_path(output_path: Path, provider: str) -> Path:
+    """Return the canonical gene research path for a fallback provider."""
+    return output_path.parent / (
+        f"{output_path.parent.name}-deep-research-{provider}{output_path.suffix}"
+    )
+
+
 def run_deep_research(
     organism: str,
     gene_id: str,
@@ -292,7 +299,7 @@ def run_deep_research(
 
         # Adjust output path for fallback providers
         if is_fallback:
-            prov_output = output_path.parent / f"{output_path.stem.rsplit('-', 1)[0]}-{prov}{output_path.suffix}"
+            prov_output = _fallback_output_path(output_path, prov)
         else:
             prov_output = output_path
 

--- a/tests/test_deep_research_provider_selection.py
+++ b/tests/test_deep_research_provider_selection.py
@@ -108,6 +108,40 @@ def test_build_command_maps_codex_to_cyberian_agent_type(tmp_path: Path) -> None
     assert "agent_type=codex" in cmd
 
 
+def test_fallback_after_hyphenated_provider_uses_canonical_output_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    wrapper = load_wrapper()
+    gene_dir = tmp_path / "TP53"
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, returncode=1 if len(calls) == 1 else 0)
+
+    monkeypatch.setattr(wrapper.subprocess, "run", fake_run)
+
+    result = wrapper.run_deep_research(
+        organism="human",
+        gene_id="TP53",
+        provider="perplexity-lite",
+        gene_symbol="TP53",
+        output_path=gene_dir / "TP53-deep-research-perplexity-lite.md",
+        use_template=False,
+        fallback_providers=["falcon"],
+    )
+
+    assert result == 0
+    assert len(calls) == 2
+    assert calls[0][calls[0].index("--output") + 1] == str(
+        gene_dir / "TP53-deep-research-perplexity-lite.md"
+    )
+    assert calls[1][calls[1].index("--output") + 1] == str(
+        gene_dir / "TP53-deep-research-falcon.md"
+    )
+
+
 @pytest.mark.parametrize(
     "provider_args",
     [


### PR DESCRIPTION
## Summary
- construct fallback research filenames from the canonical gene directory name
- preserve hyphenated primary provider names when switching providers
- add an end-to-end regression for perplexity-lite falling back to falcon

## Validation
- just test
- git diff --check