### PR TITLE
Map concept Codex research correctly

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -754,7 +754,7 @@ term-deep-research-cyberian concept *args="":
     uv run python scripts/concept_deep_research_wrapper.py "{{concept}}" cyberian {{args}}
 
 term-deep-research-codex concept *args="":
-    uv run python scripts/concept_deep_research_wrapper.py "{{concept}}" cyberian --extra-args --param agent_type=codex {{args}}
+    uv run python scripts/concept_deep_research_wrapper.py "{{concept}}" codex {{args}}
 
 # Module deep research (targets module YAMLs and writes beside the YAML by default)
 # Examples:

--- a/scripts/concept_deep_research_wrapper.py
+++ b/scripts/concept_deep_research_wrapper.py
@@ -14,6 +14,15 @@ import subprocess
 import sys
 from pathlib import Path
 
+PROVIDERS = (
+    "openai",
+    "perplexity",
+    "perplexity-lite",
+    "falcon",
+    "cyberian",
+    "codex",
+)
+
 
 def slugify(text: str) -> str:
     """Convert text to a unix-friendly slug.
@@ -38,7 +47,12 @@ def run_deep_research(
 ) -> int:
     """Run deep-research-client with proper arguments."""
     # Map internal provider names to deep-research-client provider names
-    actual_provider = "perplexity" if provider == "perplexity-lite" else provider
+    if provider == "perplexity-lite":
+        actual_provider = "perplexity"
+    elif provider == "codex":
+        actual_provider = "cyberian"
+    else:
+        actual_provider = provider
 
     if use_template:
         cmd = [
@@ -81,6 +95,9 @@ def run_deep_research(
             str(output_path),
         ]
 
+    if provider == "codex":
+        cmd.extend(["--param", "agent_type=codex"])
+
     if extra_args:
         cmd.extend(extra_args)
 
@@ -96,7 +113,7 @@ def main() -> int:
     parser.add_argument("concept", help="Concept or pathway name (quote if it has spaces)")
     parser.add_argument(
         "provider",
-        choices=["openai", "perplexity", "perplexity-lite", "falcon", "cyberian"],
+        choices=PROVIDERS,
         help="Deep research provider",
     )
     parser.add_argument(

--- a/tests/test_concept_deep_research_wrapper.py
+++ b/tests/test_concept_deep_research_wrapper.py
@@ -1,0 +1,90 @@
+"""Tests for concept deep-research provider handling."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_wrapper():
+    path = ROOT / "scripts" / "concept_deep_research_wrapper.py"
+    spec = importlib.util.spec_from_file_location("concept_deep_research_wrapper", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_codex_maps_to_cyberian_agent_type(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    wrapper = load_wrapper()
+    captured: list[str] = []
+
+    def fake_run(cmd):
+        captured.extend(cmd)
+        return subprocess.CompletedProcess(cmd, returncode=0)
+
+    monkeypatch.setattr(wrapper.subprocess, "run", fake_run)
+
+    result = wrapper.run_deep_research(
+        concept="spliceosome",
+        concept_slug="spliceosome",
+        provider="codex",
+        output_path=tmp_path / "spliceosome-deep-research-codex.md",
+        template_path=Path("templates/concept_research.md.j2"),
+    )
+
+    assert result == 0
+    assert captured[captured.index("--provider") + 1] == "cyberian"
+    assert "agent_type=codex" in captured
+
+
+def test_main_preserves_codex_in_output_filename(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    wrapper = load_wrapper()
+    captured: dict[str, object] = {}
+
+    def fake_run_deep_research(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(wrapper, "run_deep_research", fake_run_deep_research)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "concept_deep_research_wrapper.py",
+            "RNA splicing",
+            "codex",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert wrapper.main() == 0
+    assert captured["provider"] == "codex"
+    assert captured["output_path"] == (
+        tmp_path / "rna_splicing" / "rna_splicing-deep-research-codex.md"
+    )
+
+
+def test_public_codex_recipe_passes_canonical_provider() -> None:
+    recipe_text = (ROOT / "project.justfile").read_text()
+
+    assert (
+        'term-deep-research-codex concept *args="":\n'
+        '    uv run python scripts/concept_deep_research_wrapper.py "{{concept}}" codex {{args}}'
+        in recipe_text
+    )


### PR DESCRIPTION
## Summary
- accept codex as a first-class concept research provider
- map codex to the Cyberian client with agent_type=codex
- preserve codex in concept artifact filenames
- simplify the public term-deep-research-codex recipe

## Validation
- just test
- just --show term-deep-research-codex
- git diff --check