### PR TITLE
Add public wrappers for PANTHER IBA refresh

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -189,6 +189,23 @@ fetch-panther-paint family *args="":
 fetch-panther-paint-all *args="":
     uv run ai-gene-review fetch-panther-paint --all --output-dir . {{args}}
 
+# Regenerate the PANTHER IBA project tables through public wrapper recipes.
+# These may download cached PAINT source data on the first run.
+[group('QC')]
+refresh-panther-iba-propagation:
+    uv run python projects/PANTHER_IBA_REVIEW/extract_iba_propagation.py
+
+[group('QC')]
+refresh-panther-iba-node-annotations:
+    uv run python projects/PANTHER_IBA_REVIEW/extract_node_annotations.py
+
+[group('QC')]
+refresh-panther-iba-function-losses:
+    uv run python projects/PANTHER_IBA_REVIEW/extract_function_losses.py
+
+[group('QC')]
+refresh-panther-iba-project: refresh-panther-iba-propagation refresh-panther-iba-node-annotations refresh-panther-iba-function-losses
+
 # Rebuild interpro/panther/panther.obo from PANTHER's HMM classifications.
 # This is the authority behind PANTHER family/subfamily id + label validation
 # (conf/oak_config.yaml routes the PANTHER prefix at it). Re-run after a PANTHER

--- a/projects/PANTHER_IBA_REVIEW/README.md
+++ b/projects/PANTHER_IBA_REVIEW/README.md
@@ -62,10 +62,13 @@ propagation — rather than re-judging gene by gene.
 Regenerate:
 
 ```bash
-uv run python projects/PANTHER_IBA_REVIEW/extract_iba_propagation.py
-uv run python projects/PANTHER_IBA_REVIEW/extract_node_annotations.py
-uv run python projects/PANTHER_IBA_REVIEW/extract_function_losses.py
+just refresh-panther-iba-project
 ```
+
+The three tables can also be refreshed independently with
+`just refresh-panther-iba-propagation`,
+`just refresh-panther-iba-node-annotations`, and
+`just refresh-panther-iba-function-losses`.
 
 The node-level source files (`IBD.gaf`, leaf GAF) are downloaded on demand into
 a gitignored `.cache/panther/` and are not committed. Per-family node slices can


### PR DESCRIPTION
## Summary
- add public just recipes for regenerating each PANTHER IBA project table
- add an aggregate refresh recipe
- update project documentation to use the wrapper layer

## Validation
- just --list
- just --dry-run refresh-panther-iba-project
- git diff --check