### PR TITLE
Refine pap1 interaction and family review

### DIFF
--- a/genes/SCHPO/pap1/pap1-ai-review.html
+++ b/genes/SCHPO/pap1/pap1-ai-review.html
@@ -2980,15 +2980,15 @@ activation was demonstrated by ChIP and expression analysis. Supports the core a
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Records the experimentally demonstrated interaction with the HMG protein Oxs1 (SPBC29A10.12) during
-diamide/cadmium disulfide stress. The bare &#34;protein binding&#34; term is uninformative; the biologically
-meaningful information (a stress-dependent transcriptional co-regulator interaction) is better
-captured by the transcription regulator complex annotation.
+                            <strong>Summary:</strong> Records the experimentally demonstrated interaction with Oxs1 (SPBC29A10.12), a
+nucleocytoplasmic HMG transcription coregulator, during diamide/cadmium disulfide stress.
+Oxs1 is not described as a sequence-specific DNA-binding transcription factor, so the
+generic interaction is best replaced by transcription coregulator binding.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Replace generic protein binding with DNA-binding transcription factor binding to capture the cooperative Pap1-Oxs1 promoter-regulator interaction.
+                            <strong>Reason:</strong> Replace generic protein binding with transcription coregulator binding to capture the cooperative Pap1-Oxs1 interaction without misclassifying Oxs1 as a DNA-binding transcription factor.
                         </div>
 
 
@@ -2997,8 +2997,8 @@ captured by the transcription regulator complex annotation.
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140297" target="_blank" class="term-link">
-                                    DNA-binding transcription factor binding
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001221" target="_blank" class="term-link">
+                                    transcription coregulator binding
                                 </a>
                             </span>
 
@@ -3575,9 +3575,9 @@ response to oxidative stress. Direct support for the activator function.
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Captures the Pap1-Prr1 physical interaction (SPAC8C9.14). The bare &#34;protein binding&#34; term is
-uninformative on its own; the meaningful biology (the Pap1-Prr1 heterodimeric transcription
-regulator complex) is captured by the GO:0090575 annotation from the same study.
+                            <strong>Summary:</strong> Captures the Pap1-Prr1 physical interaction (SPAC8C9.14). Prr1 is a DNA-binding
+transcription factor, so GO:0140297 directly and more informatively captures Pap1
+binding to this partner than the generic protein-binding term.
                         </div>
 
 
@@ -4335,10 +4335,11 @@ target DNA, providing direct evidence of sequence-specific DNA binding. Core mol
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> The IPI WITH/FROM field self-references pap1 (SPAC1783.07c), recording experimental
-self-association rather than circular propagation. The cached abstract for the crystallographic
-source does not expose oligomeric-state details, so the structural basis is not independently
-asserted here. Replace generic protein binding with the informative homodimerization activity.
+                            <strong>Summary:</strong> The GOA row records IPI evidence with pap1 itself (PomBase:SPAC1783.07c), supporting
+binding between identical Pap1 proteins rather than circular propagation. The cached abstract
+for the crystallographic source does not expose oligomeric-state details, so the structural
+basis is not independently asserted here. Replace generic protein binding with the informative
+homodimerization activity.
                         </div>
 
 
@@ -4359,6 +4360,22 @@ asserted here. Replace generic protein binding with the informative homodimeriza
 
                         </div>
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/pap1/pap1-goa.tsv
+
+                                </span>
+
+                                <div class="support-text">IPI	PMID:9757124	PomBase:SPAC1783.07c</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -5709,7 +5726,7 @@ for induction of oxidative-stress genes. Core biological process.
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Sequence-specific DNA-binding transcriptional activator (RNA Pol II) that binds AP-1/TRE-like sites
-(consensus TTACGTAA) as a bZIP homodimer and induces target-gene expression.</h3>
+(consensus TTACGTAA) through its bZIP DNA-binding domain and induces target-gene expression.</h3>
                 <span class="vote-buttons" data-g="Q01663" data-a="FUNCTION: Sequence-specific DNA-binding transcriptional acti..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -5923,6 +5940,19 @@ basal expression of these MDR transporters.</h3>
 
 
 
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045944" target="_blank" class="term-link">
+                                positive regulation of transcription by RNA polymerase II
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
 
 
                 <div class="function-term-group">
@@ -5987,6 +6017,29 @@ basal expression of these MDR transporters.</h3>
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:SCHPO/pap1/pap1-goa.tsv
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PomBase GO annotation export for pap1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The PMID:9757124 protein-binding row carries IPI evidence with pap1 itself (PomBase:SPAC1783.07c), supporting identical-protein interaction.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
 
             <div class="reference-item">
                 <div class="reference-header">
@@ -7711,11 +7764,12 @@ drug-efflux/MDR genes (bfr1/hba2, pmd1, caf5, obr1). At high H2O2 the Sty1/Atf1 
   units so the redox and MDR descriptions are represented consistently with the primary<br />
   transcription-activator activity.</li>
 <li>Verified current ontology records before replacing generic binding terms: GO:0042803 is<br />
-<code>protein homodimerization activity</code>, and GO:0140297 is <code>DNA-binding transcription factor
-  binding</code>. The Pap1 self-interaction row is therefore MODIFY to GO:0042803; the direct<br />
-  Oxs1 and Prr1 co-regulator interactions are MODIFY to GO:0140297. The Imp1/Cut15 importin<br />
-  interaction remains MARK_AS_OVER_ANNOTATED because no equally informative MF term was<br />
-  established.</li>
+<code>protein homodimerization activity</code>, GO:0140297 is <code>DNA-binding transcription factor
+  binding</code>, and GO:0001221 is <code>transcription coregulator binding</code>. The Pap1 self-interaction<br />
+  row is therefore MODIFY to GO:0042803 and is explicitly supported by the self-IPI GOA row;<br />
+  the Prr1 interaction is MODIFY to GO:0140297, while the interaction with the HMG<br />
+  coregulator Oxs1 is MODIFY to GO:0001221. The Imp1/Cut15 importin interaction remains<br />
+  MARK_AS_OVER_ANNOTATED because no equally informative MF term was established.</li>
 <li>Removed the unsupported claim that the abstract-only Pap1-DNA crystallography record<br />
   independently demonstrates homodimerization. The self-referential IPI WITH/FROM is retained<br />
   as the experimental self-association evidence, with curator deference.</li>
@@ -8229,15 +8283,15 @@ existing_annotations:
   qualifier: enables
   review:
     summary: |-
-      Records the experimentally demonstrated interaction with the HMG protein Oxs1 (SPBC29A10.12) during
-      diamide/cadmium disulfide stress. The bare &#34;protein binding&#34; term is uninformative; the biologically
-      meaningful information (a stress-dependent transcriptional co-regulator interaction) is better
-      captured by the transcription regulator complex annotation.
+      Records the experimentally demonstrated interaction with Oxs1 (SPBC29A10.12), a
+      nucleocytoplasmic HMG transcription coregulator, during diamide/cadmium disulfide stress.
+      Oxs1 is not described as a sequence-specific DNA-binding transcription factor, so the
+      generic interaction is best replaced by transcription coregulator binding.
     action: MODIFY
-    reason: Replace generic protein binding with DNA-binding transcription factor binding to capture the cooperative Pap1-Oxs1 promoter-regulator interaction.
+    reason: Replace generic protein binding with transcription coregulator binding to capture the cooperative Pap1-Oxs1 interaction without misclassifying Oxs1 as a DNA-binding transcription factor.
     proposed_replacement_terms:
-    - id: GO:0140297
-      label: DNA-binding transcription factor binding
+    - id: GO:0001221
+      label: transcription coregulator binding
     supported_by:
     - reference_id: PMID:27664222
       supporting_text: Oxs1 and Pap1 form a complex when cells are exposed to diamide or Cd that causes disulfide stress
@@ -8347,9 +8401,9 @@ existing_annotations:
   qualifier: enables
   review:
     summary: |-
-      Captures the Pap1-Prr1 physical interaction (SPAC8C9.14). The bare &#34;protein binding&#34; term is
-      uninformative on its own; the meaningful biology (the Pap1-Prr1 heterodimeric transcription
-      regulator complex) is captured by the GO:0090575 annotation from the same study.
+      Captures the Pap1-Prr1 physical interaction (SPAC8C9.14). Prr1 is a DNA-binding
+      transcription factor, so GO:0140297 directly and more informatively captures Pap1
+      binding to this partner than the generic protein-binding term.
     action: MODIFY
     reason: Replace generic protein binding with DNA-binding transcription factor binding for the stress-dependent Pap1-Prr1 interaction.
     proposed_replacement_terms:
@@ -8496,15 +8550,19 @@ existing_annotations:
   qualifier: enables
   review:
     summary: |-
-      The IPI WITH/FROM field self-references pap1 (SPAC1783.07c), recording experimental
-      self-association rather than circular propagation. The cached abstract for the crystallographic
-      source does not expose oligomeric-state details, so the structural basis is not independently
-      asserted here. Replace generic protein binding with the informative homodimerization activity.
+      The GOA row records IPI evidence with pap1 itself (PomBase:SPAC1783.07c), supporting
+      binding between identical Pap1 proteins rather than circular propagation. The cached abstract
+      for the crystallographic source does not expose oligomeric-state details, so the structural
+      basis is not independently asserted here. Replace generic protein binding with the informative
+      homodimerization activity.
     action: MODIFY
     reason: The self-interaction supports protein homodimerization activity, which is more informative than generic protein binding.
     proposed_replacement_terms:
     - id: GO:0042803
       label: protein homodimerization activity
+    supported_by:
+    - reference_id: file:SCHPO/pap1/pap1-goa.tsv
+      supporting_text: &#34;IPI\tPMID:9757124\tPomBase:SPAC1783.07c&#34;
 - term:
     id: GO:0005634
     label: nucleus
@@ -8768,7 +8826,7 @@ existing_annotations:
 core_functions:
 - description: |-
     Sequence-specific DNA-binding transcriptional activator (RNA Pol II) that binds AP-1/TRE-like sites
-    (consensus TTACGTAA) as a bZIP homodimer and induces target-gene expression.
+    (consensus TTACGTAA) through its bZIP DNA-binding domain and induces target-gene expression.
   supported_by:
   - reference_id: PMID:11017199
     supporting_text: PAP1, a fission yeast AP-1-like transcription factor that binds DNA containing the novel consensus sequence TTACGTAA
@@ -8820,6 +8878,9 @@ core_functions:
   molecular_function:
     id: GO:0001228
     label: DNA-binding transcription activator activity, RNA polymerase II-specific
+  directly_involved_in:
+  - id: GO:0045944
+    label: positive regulation of transcription by RNA polymerase II
   locations:
   - id: GO:0005634
     label: nucleus
@@ -8852,6 +8913,10 @@ suggested_experiments:
     chromatin-bridged association; retained binding in a reconstituted assay would establish
     a direct nucleosome interaction.
 references:
+- id: file:SCHPO/pap1/pap1-goa.tsv
+  title: PomBase GO annotation export for pap1
+  findings:
+  - statement: The PMID:9757124 protein-binding row carries IPI evidence with pap1 itself (PomBase:SPAC1783.07c), supporting identical-protein interaction.
 - id: file:interpro/panther/PTHR40621/PTHR40621-review.md
   title: &#39;PANTHER family review PTHR40621: IBA propagation assessment for pap1&#39;
   findings: []

--- a/genes/SCHPO/pap1/pap1-ai-review.html
+++ b/genes/SCHPO/pap1/pap1-ai-review.html
@@ -2969,10 +2969,10 @@ activation was demonstrated by ChIP and expression analysis. Supports the core a
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q01663" data-a="GO:0005515" data-r="PMID:27664222" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q01663" data-a="GO:0005515" data-r="PMID:27664222" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2988,10 +2988,21 @@ captured by the transcription regulator complex annotation.
 
 
                         <div>
-                            <strong>Reason:</strong> Specific interactor (Oxs1) is informative, but generic protein binding does not describe the cooperative transcription-regulator role.
+                            <strong>Reason:</strong> Replace generic protein binding with DNA-binding transcription factor binding to capture the cooperative Pap1-Oxs1 promoter-regulator interaction.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140297" target="_blank" class="term-link">
+                                    DNA-binding transcription factor binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -3553,10 +3564,10 @@ response to oxidative stress. Direct support for the activator function.
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q01663" data-a="GO:0005515" data-r="PMID:22344694" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q01663" data-a="GO:0005515" data-r="PMID:22344694" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3571,10 +3582,21 @@ regulator complex) is captured by the GO:0090575 annotation from the same study.
 
 
                         <div>
-                            <strong>Reason:</strong> Specific Prr1 interaction is informative, but generic protein binding is redundant with the transcription regulator complex annotation.
+                            <strong>Reason:</strong> Replace generic protein binding with DNA-binding transcription factor binding for the stress-dependent Pap1-Prr1 interaction.
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140297" target="_blank" class="term-link">
+                                    DNA-binding transcription factor binding
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -4302,10 +4324,10 @@ target DNA, providing direct evidence of sequence-specific DNA binding. Core mol
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q01663" data-a="GO:0005515" data-r="PMID:9757124" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q01663" data-a="GO:0005515" data-r="PMID:9757124" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -4313,37 +4335,30 @@ target DNA, providing direct evidence of sequence-specific DNA binding. Core mol
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> The WITH/FROM field self-references pap1 (SPAC1783.07c), consistent with Pap1 homodimerization as
-shown crystallographically. The generic &#34;protein binding&#34; term is uninformative; the meaningful
-biology (homodimerization of the bZIP factor) is captured by the homodimer/subunit data and DNA
-binding annotations.
+                            <strong>Summary:</strong> The IPI WITH/FROM field self-references pap1 (SPAC1783.07c), recording experimental
+self-association rather than circular propagation. The cached abstract for the crystallographic
+source does not expose oligomeric-state details, so the structural basis is not independently
+asserted here. Replace generic protein binding with the informative homodimerization activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Reflects Pap1 self-association, but generic protein binding does not capture bZIP homodimerization or DNA-binding function.
+                            <strong>Reason:</strong> The self-interaction supports protein homodimerization activity, which is more informative than generic protein binding.
                         </div>
 
 
 
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
 
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11017199" target="_blank" class="term-link">
-                                        PMID:11017199
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">PAP1, a fission yeast AP-1-like transcription factor</div>
-
-                            </div>
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
+                                    protein homodimerization activity
+                                </a>
+                            </span>
 
                         </div>
+
 
 
                     </td>
@@ -5801,6 +5816,15 @@ in part via heterodimerization with Prr1.</h3>
 
             <div class="core-function-terms">
 
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001228" target="_blank" class="term-link">
+                            DNA-binding transcription activator activity, RNA polymerase II-specific
+                        </a>
+                    </span>
+                </div>
+
 
 
                 <div class="function-term-group">
@@ -5888,9 +5912,31 @@ basal expression of these MDR transporters.</h3>
 
             <div class="core-function-terms">
 
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001228" target="_blank" class="term-link">
+                            DNA-binding transcription activator activity, RNA polymerase II-specific
+                        </a>
+                    </span>
+                </div>
 
 
 
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
 
 
 
@@ -7659,6 +7705,23 @@ drug-efflux/MDR genes (bfr1/hba2, pmd1, caf5, obr1). At high H2O2 the Sty1/Atf1 
   and dissertation material, it is used as corroborating context only; the cached primary<br />
   publications remain the evidence source for annotation decisions.</li>
 </ul>
+<h2 id="2026-09-01-post-merge-review-follow-up">2026-09-01 post-merge review follow-up</h2>
+<ul>
+<li>Added GO:0001228 and nuclear-location structure to the remaining core-function activity<br />
+  units so the redox and MDR descriptions are represented consistently with the primary<br />
+  transcription-activator activity.</li>
+<li>Verified current ontology records before replacing generic binding terms: GO:0042803 is<br />
+<code>protein homodimerization activity</code>, and GO:0140297 is <code>DNA-binding transcription factor
+  binding</code>. The Pap1 self-interaction row is therefore MODIFY to GO:0042803; the direct<br />
+  Oxs1 and Prr1 co-regulator interactions are MODIFY to GO:0140297. The Imp1/Cut15 importin<br />
+  interaction remains MARK_AS_OVER_ANNOTATED because no equally informative MF term was<br />
+  established.</li>
+<li>Removed the unsupported claim that the abstract-only Pap1-DNA crystallography record<br />
+  independently demonstrates homodimerization. The self-referential IPI WITH/FROM is retained<br />
+  as the experimental self-association evidence, with curator deference.</li>
+<li>Tightened the PTHR40621 paralog caveat to the reviewed fungal SF6 slice and labeled the<br />
+  six-subfamily value as a cached InterPro counter, avoiding another family-wide census claim.</li>
+</ul>
             </div>
         </details>
 
@@ -8170,8 +8233,11 @@ existing_annotations:
       diamide/cadmium disulfide stress. The bare &#34;protein binding&#34; term is uninformative; the biologically
       meaningful information (a stress-dependent transcriptional co-regulator interaction) is better
       captured by the transcription regulator complex annotation.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Specific interactor (Oxs1) is informative, but generic protein binding does not describe the cooperative transcription-regulator role.
+    action: MODIFY
+    reason: Replace generic protein binding with DNA-binding transcription factor binding to capture the cooperative Pap1-Oxs1 promoter-regulator interaction.
+    proposed_replacement_terms:
+    - id: GO:0140297
+      label: DNA-binding transcription factor binding
     supported_by:
     - reference_id: PMID:27664222
       supporting_text: Oxs1 and Pap1 form a complex when cells are exposed to diamide or Cd that causes disulfide stress
@@ -8284,8 +8350,11 @@ existing_annotations:
       Captures the Pap1-Prr1 physical interaction (SPAC8C9.14). The bare &#34;protein binding&#34; term is
       uninformative on its own; the meaningful biology (the Pap1-Prr1 heterodimeric transcription
       regulator complex) is captured by the GO:0090575 annotation from the same study.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Specific Prr1 interaction is informative, but generic protein binding is redundant with the transcription regulator complex annotation.
+    action: MODIFY
+    reason: Replace generic protein binding with DNA-binding transcription factor binding for the stress-dependent Pap1-Prr1 interaction.
+    proposed_replacement_terms:
+    - id: GO:0140297
+      label: DNA-binding transcription factor binding
     supported_by:
     - reference_id: PMID:22344694
       supporting_text: only oxidized/nuclear Pap1 was able to interact with Prr1
@@ -8427,16 +8496,15 @@ existing_annotations:
   qualifier: enables
   review:
     summary: |-
-      The WITH/FROM field self-references pap1 (SPAC1783.07c), consistent with Pap1 homodimerization as
-      shown crystallographically. The generic &#34;protein binding&#34; term is uninformative; the meaningful
-      biology (homodimerization of the bZIP factor) is captured by the homodimer/subunit data and DNA
-      binding annotations.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Reflects Pap1 self-association, but generic protein binding does not capture bZIP homodimerization or DNA-binding function.
-    supported_by:
-    - reference_id: PMID:11017199
-      supporting_text: PAP1, a fission yeast AP-1-like transcription factor
-      reference_section_type: ABSTRACT
+      The IPI WITH/FROM field self-references pap1 (SPAC1783.07c), recording experimental
+      self-association rather than circular propagation. The cached abstract for the crystallographic
+      source does not expose oligomeric-state details, so the structural basis is not independently
+      asserted here. Replace generic protein binding with the informative homodimerization activity.
+    action: MODIFY
+    reason: The self-interaction supports protein homodimerization activity, which is more informative than generic protein binding.
+    proposed_replacement_terms:
+    - id: GO:0042803
+      label: protein homodimerization activity
 - term:
     id: GO:0005634
     label: nucleus
@@ -8729,6 +8797,9 @@ core_functions:
   - reference_id: PMID:15824112
     supporting_text: the reduced thioredoxin peroxidase-active form of Tpx1 is required for the peroxide-induced oxidation and nuclear accumulation of Pap1
     reference_section_type: ABSTRACT
+  molecular_function:
+    id: GO:0001228
+    label: DNA-binding transcription activator activity, RNA polymerase II-specific
   directly_involved_in:
   - id: GO:0034599
     label: cellular response to oxidative stress
@@ -8746,6 +8817,12 @@ core_functions:
   - reference_id: PMID:22840777
     supporting_text: Pap1 controls the basal, but not the drug-induced expression, of the bfr1+ and pmd1+ genes
     reference_section_type: RESULTS
+  molecular_function:
+    id: GO:0001228
+    label: DNA-binding transcription activator activity, RNA polymerase II-specific
+  locations:
+  - id: GO:0005634
+    label: nucleus
 proposed_new_terms: []
 suggested_questions:
 - question: |-

--- a/genes/SCHPO/pap1/pap1-ai-review.yaml
+++ b/genes/SCHPO/pap1/pap1-ai-review.yaml
@@ -496,8 +496,11 @@ existing_annotations:
       diamide/cadmium disulfide stress. The bare "protein binding" term is uninformative; the biologically
       meaningful information (a stress-dependent transcriptional co-regulator interaction) is better
       captured by the transcription regulator complex annotation.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Specific interactor (Oxs1) is informative, but generic protein binding does not describe the cooperative transcription-regulator role.
+    action: MODIFY
+    reason: Replace generic protein binding with DNA-binding transcription factor binding to capture the cooperative Pap1-Oxs1 promoter-regulator interaction.
+    proposed_replacement_terms:
+    - id: GO:0140297
+      label: DNA-binding transcription factor binding
     supported_by:
     - reference_id: PMID:27664222
       supporting_text: Oxs1 and Pap1 form a complex when cells are exposed to diamide or Cd that causes disulfide stress
@@ -610,8 +613,11 @@ existing_annotations:
       Captures the Pap1-Prr1 physical interaction (SPAC8C9.14). The bare "protein binding" term is
       uninformative on its own; the meaningful biology (the Pap1-Prr1 heterodimeric transcription
       regulator complex) is captured by the GO:0090575 annotation from the same study.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Specific Prr1 interaction is informative, but generic protein binding is redundant with the transcription regulator complex annotation.
+    action: MODIFY
+    reason: Replace generic protein binding with DNA-binding transcription factor binding for the stress-dependent Pap1-Prr1 interaction.
+    proposed_replacement_terms:
+    - id: GO:0140297
+      label: DNA-binding transcription factor binding
     supported_by:
     - reference_id: PMID:22344694
       supporting_text: only oxidized/nuclear Pap1 was able to interact with Prr1
@@ -753,16 +759,15 @@ existing_annotations:
   qualifier: enables
   review:
     summary: |-
-      The WITH/FROM field self-references pap1 (SPAC1783.07c), consistent with Pap1 homodimerization as
-      shown crystallographically. The generic "protein binding" term is uninformative; the meaningful
-      biology (homodimerization of the bZIP factor) is captured by the homodimer/subunit data and DNA
-      binding annotations.
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Reflects Pap1 self-association, but generic protein binding does not capture bZIP homodimerization or DNA-binding function.
-    supported_by:
-    - reference_id: PMID:11017199
-      supporting_text: PAP1, a fission yeast AP-1-like transcription factor
-      reference_section_type: ABSTRACT
+      The IPI WITH/FROM field self-references pap1 (SPAC1783.07c), recording experimental
+      self-association rather than circular propagation. The cached abstract for the crystallographic
+      source does not expose oligomeric-state details, so the structural basis is not independently
+      asserted here. Replace generic protein binding with the informative homodimerization activity.
+    action: MODIFY
+    reason: The self-interaction supports protein homodimerization activity, which is more informative than generic protein binding.
+    proposed_replacement_terms:
+    - id: GO:0042803
+      label: protein homodimerization activity
 - term:
     id: GO:0005634
     label: nucleus
@@ -1055,6 +1060,9 @@ core_functions:
   - reference_id: PMID:15824112
     supporting_text: the reduced thioredoxin peroxidase-active form of Tpx1 is required for the peroxide-induced oxidation and nuclear accumulation of Pap1
     reference_section_type: ABSTRACT
+  molecular_function:
+    id: GO:0001228
+    label: DNA-binding transcription activator activity, RNA polymerase II-specific
   directly_involved_in:
   - id: GO:0034599
     label: cellular response to oxidative stress
@@ -1072,6 +1080,12 @@ core_functions:
   - reference_id: PMID:22840777
     supporting_text: Pap1 controls the basal, but not the drug-induced expression, of the bfr1+ and pmd1+ genes
     reference_section_type: RESULTS
+  molecular_function:
+    id: GO:0001228
+    label: DNA-binding transcription activator activity, RNA polymerase II-specific
+  locations:
+  - id: GO:0005634
+    label: nucleus
 proposed_new_terms: []
 suggested_questions:
 - question: |-

--- a/genes/SCHPO/pap1/pap1-ai-review.yaml
+++ b/genes/SCHPO/pap1/pap1-ai-review.yaml
@@ -492,15 +492,15 @@ existing_annotations:
   qualifier: enables
   review:
     summary: |-
-      Records the experimentally demonstrated interaction with the HMG protein Oxs1 (SPBC29A10.12) during
-      diamide/cadmium disulfide stress. The bare "protein binding" term is uninformative; the biologically
-      meaningful information (a stress-dependent transcriptional co-regulator interaction) is better
-      captured by the transcription regulator complex annotation.
+      Records the experimentally demonstrated interaction with Oxs1 (SPBC29A10.12), a
+      nucleocytoplasmic HMG transcription coregulator, during diamide/cadmium disulfide stress.
+      Oxs1 is not described as a sequence-specific DNA-binding transcription factor, so the
+      generic interaction is best replaced by transcription coregulator binding.
     action: MODIFY
-    reason: Replace generic protein binding with DNA-binding transcription factor binding to capture the cooperative Pap1-Oxs1 promoter-regulator interaction.
+    reason: Replace generic protein binding with transcription coregulator binding to capture the cooperative Pap1-Oxs1 interaction without misclassifying Oxs1 as a DNA-binding transcription factor.
     proposed_replacement_terms:
-    - id: GO:0140297
-      label: DNA-binding transcription factor binding
+    - id: GO:0001221
+      label: transcription coregulator binding
     supported_by:
     - reference_id: PMID:27664222
       supporting_text: Oxs1 and Pap1 form a complex when cells are exposed to diamide or Cd that causes disulfide stress
@@ -610,9 +610,9 @@ existing_annotations:
   qualifier: enables
   review:
     summary: |-
-      Captures the Pap1-Prr1 physical interaction (SPAC8C9.14). The bare "protein binding" term is
-      uninformative on its own; the meaningful biology (the Pap1-Prr1 heterodimeric transcription
-      regulator complex) is captured by the GO:0090575 annotation from the same study.
+      Captures the Pap1-Prr1 physical interaction (SPAC8C9.14). Prr1 is a DNA-binding
+      transcription factor, so GO:0140297 directly and more informatively captures Pap1
+      binding to this partner than the generic protein-binding term.
     action: MODIFY
     reason: Replace generic protein binding with DNA-binding transcription factor binding for the stress-dependent Pap1-Prr1 interaction.
     proposed_replacement_terms:
@@ -759,15 +759,19 @@ existing_annotations:
   qualifier: enables
   review:
     summary: |-
-      The IPI WITH/FROM field self-references pap1 (SPAC1783.07c), recording experimental
-      self-association rather than circular propagation. The cached abstract for the crystallographic
-      source does not expose oligomeric-state details, so the structural basis is not independently
-      asserted here. Replace generic protein binding with the informative homodimerization activity.
+      The GOA row records IPI evidence with pap1 itself (PomBase:SPAC1783.07c), supporting
+      binding between identical Pap1 proteins rather than circular propagation. The cached abstract
+      for the crystallographic source does not expose oligomeric-state details, so the structural
+      basis is not independently asserted here. Replace generic protein binding with the informative
+      homodimerization activity.
     action: MODIFY
     reason: The self-interaction supports protein homodimerization activity, which is more informative than generic protein binding.
     proposed_replacement_terms:
     - id: GO:0042803
       label: protein homodimerization activity
+    supported_by:
+    - reference_id: file:SCHPO/pap1/pap1-goa.tsv
+      supporting_text: "IPI\tPMID:9757124\tPomBase:SPAC1783.07c"
 - term:
     id: GO:0005634
     label: nucleus
@@ -1031,7 +1035,7 @@ existing_annotations:
 core_functions:
 - description: |-
     Sequence-specific DNA-binding transcriptional activator (RNA Pol II) that binds AP-1/TRE-like sites
-    (consensus TTACGTAA) as a bZIP homodimer and induces target-gene expression.
+    (consensus TTACGTAA) through its bZIP DNA-binding domain and induces target-gene expression.
   supported_by:
   - reference_id: PMID:11017199
     supporting_text: PAP1, a fission yeast AP-1-like transcription factor that binds DNA containing the novel consensus sequence TTACGTAA
@@ -1083,6 +1087,9 @@ core_functions:
   molecular_function:
     id: GO:0001228
     label: DNA-binding transcription activator activity, RNA polymerase II-specific
+  directly_involved_in:
+  - id: GO:0045944
+    label: positive regulation of transcription by RNA polymerase II
   locations:
   - id: GO:0005634
     label: nucleus
@@ -1115,6 +1122,10 @@ suggested_experiments:
     chromatin-bridged association; retained binding in a reconstituted assay would establish
     a direct nucleosome interaction.
 references:
+- id: file:SCHPO/pap1/pap1-goa.tsv
+  title: PomBase GO annotation export for pap1
+  findings:
+  - statement: The PMID:9757124 protein-binding row carries IPI evidence with pap1 itself (PomBase:SPAC1783.07c), supporting identical-protein interaction.
 - id: file:interpro/panther/PTHR40621/PTHR40621-review.md
   title: 'PANTHER family review PTHR40621: IBA propagation assessment for pap1'
   findings: []

--- a/genes/SCHPO/pap1/pap1-notes.md
+++ b/genes/SCHPO/pap1/pap1-notes.md
@@ -114,11 +114,12 @@ drug-efflux/MDR genes (bfr1/hba2, pmd1, caf5, obr1). At high H2O2 the Sty1/Atf1 
   units so the redox and MDR descriptions are represented consistently with the primary
   transcription-activator activity.
 - Verified current ontology records before replacing generic binding terms: GO:0042803 is
-  `protein homodimerization activity`, and GO:0140297 is `DNA-binding transcription factor
-  binding`. The Pap1 self-interaction row is therefore MODIFY to GO:0042803; the direct
-  Oxs1 and Prr1 co-regulator interactions are MODIFY to GO:0140297. The Imp1/Cut15 importin
-  interaction remains MARK_AS_OVER_ANNOTATED because no equally informative MF term was
-  established.
+  `protein homodimerization activity`, GO:0140297 is `DNA-binding transcription factor
+  binding`, and GO:0001221 is `transcription coregulator binding`. The Pap1 self-interaction
+  row is therefore MODIFY to GO:0042803 and is explicitly supported by the self-IPI GOA row;
+  the Prr1 interaction is MODIFY to GO:0140297, while the interaction with the HMG
+  coregulator Oxs1 is MODIFY to GO:0001221. The Imp1/Cut15 importin interaction remains
+  MARK_AS_OVER_ANNOTATED because no equally informative MF term was established.
 - Removed the unsupported claim that the abstract-only Pap1-DNA crystallography record
   independently demonstrates homodimerization. The self-referential IPI WITH/FROM is retained
   as the experimental self-association evidence, with curator deference.

--- a/genes/SCHPO/pap1/pap1-notes.md
+++ b/genes/SCHPO/pap1/pap1-notes.md
@@ -107,3 +107,20 @@ drug-efflux/MDR genes (bfr1/hba2, pmd1, caf5, obr1). At high H2O2 the Sty1/Atf1 
   Pap1-versus-Sty1/Atf1 response. Because parts of its mechanistic synthesis cite reviews
   and dissertation material, it is used as corroborating context only; the cached primary
   publications remain the evidence source for annotation decisions.
+
+## 2026-09-01 post-merge review follow-up
+
+- Added GO:0001228 and nuclear-location structure to the remaining core-function activity
+  units so the redox and MDR descriptions are represented consistently with the primary
+  transcription-activator activity.
+- Verified current ontology records before replacing generic binding terms: GO:0042803 is
+  `protein homodimerization activity`, and GO:0140297 is `DNA-binding transcription factor
+  binding`. The Pap1 self-interaction row is therefore MODIFY to GO:0042803; the direct
+  Oxs1 and Prr1 co-regulator interactions are MODIFY to GO:0140297. The Imp1/Cut15 importin
+  interaction remains MARK_AS_OVER_ANNOTATED because no equally informative MF term was
+  established.
+- Removed the unsupported claim that the abstract-only Pap1-DNA crystallography record
+  independently demonstrates homodimerization. The self-referential IPI WITH/FROM is retained
+  as the experimental self-association evidence, with curator deference.
+- Tightened the PTHR40621 paralog caveat to the reviewed fungal SF6 slice and labeled the
+  six-subfamily value as a cached InterPro counter, avoiding another family-wide census claim.

--- a/interpro/panther/PTHR40621/PTHR40621-review.md
+++ b/interpro/panther/PTHR40621/PTHR40621-review.md
@@ -8,7 +8,7 @@
 | **Official PANTHER Name** | TRANSCRIPTION FACTOR KAPC-RELATED |
 | **InterPro Entry** | IPR050936 |
 | **Cached InterPro counters** | 11,010 protein matches; 3,258 taxon records |
-| **Subfamilies** | 6 |
+| **Cached InterPro subfamily counter** | 6 |
 | **Representative Structure** | 1gd2 (Crystal structure of bZIP transcription factor Pap1 bound to DNA) |
 
 ## Executive Summary
@@ -88,7 +88,13 @@ descendant evidence is represented by PomBase/SGD/CGD identifiers (including pap
 not that the PAINT judgment lacks experimental grounding. The target's appearance among the
 IBD descendants is expected and is not circular.
 
-**Paralog caveat (curatorial note)**: The general dbTF / cis-regulatory-binding terms transfer well across the family because all members are AP-1-type transcription factors. What does **not** transfer cleanly are *paralog-specific biological processes* and *specific target/stress programs* — e.g. iron regulation (Yap5/Yap7), arsenic resistance (Arr1/Yap8), or pap1's particular oxidative-stress and multidrug-resistance regulons. IBA propagation of such process-specific or stress-specific terms across SF6 should be scrutinized, but the molecular-function and generic transcription terms reviewed above are correct for pap1.
+**Paralog caveat (curatorial note)**: Within the reviewed fungal SF6 slice, general dbTF /
+cis-regulatory-binding terms are shared, but *paralog-specific biological processes* and
+specific target/stress programs do not transfer cleanly — e.g. iron regulation (Yap5/Yap7),
+arsenic resistance (Arr1/Yap8), or pap1's particular oxidative-stress and
+multidrug-resistance regulons. IBA propagation of such process-specific terms beyond the
+actual PTN008082960 node should be scrutinized; no corresponding claim is made for all of
+PTHR40621.
 
 ## Review Status
 


### PR DESCRIPTION
## Summary
- structure all three pap1 core activity units consistently
- replace three generic protein-binding rows with verified informative GO terms
- remove an unsupported crystallographic homodimerization claim while retaining the IPI self-interaction evidence
- scope the PTHR40621 paralog caveat and subfamily counter correctly

## Validation
- `just validate SCHPO pap1`
- `just validate-families`
- `just render SCHPO pap1`
- `git diff --check`

Follow-up to the non-blocking review suggestions on #2838.