### PR TITLE
Complete pmp20 propagation evidence

### DIFF
--- a/genes/SCHPO/pmp20/pmp20-ai-review.html
+++ b/genes/SCHPO/pmp20/pmp20-ai-review.html
@@ -975,7 +975,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PAINT placed peroxisomal localization at an ancestral node supported by experimentally localized descendants. No target-specific localization evidence was found, so the inference is retained without treating it as an established core location or inferring membrane association from the protein name. The positive support includes peroxisomal Pmp20 homologs in methylotrophic fungi, unlike the lineage-specific transit-peptide logic behind the mitochondrial transfer. Pmp20 nevertheless lacks an obvious canonical C-terminal PTS1 motif.
+                            <strong>Reason:</strong> PAINT placed peroxisomal localization at an ancestral node supported by experimentally localized descendants. No target-specific localization evidence was found, so the inference is retained without treating it as an established core location or inferring membrane association from the protein name. The node has independent biological grounding from peroxisomal Pmp20 homologs in methylotrophic fungi, but their localization also depends on targeting signals. Because Pmp20 lacks an obvious canonical C-terminal PTS1 motif, transfer to the S. pombe target remains unverified and is retained only as non-core.
                         </div>
 
 
@@ -998,7 +998,7 @@
                                     <span class="badge">SUPPORTS TRANSFER</span>
 
 
-                                    <div class="propagation-comment">Peroxisomal Pmp20 biology is conserved in fungal homologs, so the ancestral assertion is defensible as non-core; direct S. pombe localization and precise topology remain unverified.</div>
+                                    <div class="propagation-comment">The PAINT node is supported by mammalian Prx5 donors; supplementary fungal literature independently establishes peroxisomal Pmp20 biology. Target transfer and precise topology remain unverified because S. pombe Pmp20 lacks an obvious canonical PTS1.</div>
 
                                 </div>
 
@@ -1031,7 +1031,7 @@
 
                                 </span>
 
-                                <div class="support-text">The His(6)-tagged CbPmp20 fusion protein was found to have glutathione peroxidase activity in vitro toward alkyl hydroperoxides and H(2)O(2).</div>
+                                <div class="support-text">Candida boidinii Pmp20 (CbPmp20), a protein associated with the inner side of peroxisomal membrane</div>
 
                             </div>
 
@@ -1482,6 +1482,17 @@
 
 
                                     <div class="propagation-comment">The fly descendant supports mitochondrial localization within its lineage, but supplies no target-specific targeting feature or evidence for mitochondrial localization of S. pombe Pmp20.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">RGD:71007</span>
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Rat Prdx5 supports mitochondrial localization in a mammalian isoform with an N-terminal targeting extension; that feature is absent from Pmp20.</div>
 
                                 </div>
 
@@ -4777,9 +4788,13 @@ this with annotations you find in gene/protein databases, but these can be outda
 <li>Replaced the partial homolog-panel quote with the exact contiguous RESULTS.md block<br />
   showing 27 proteins, 23 with resolving-cysteine architecture, and Pmp20 in the<br />
   four-member peroxidatic-only class.</li>
-<li>Made the peroxisome/mitochondrion distinction explicit: peroxisomal Pmp20 biology<br />
-  has support in fungal homologs, whereas the mitochondrial transfer depends on<br />
-  targeting features in animal descendants that are absent from Pmp20.</li>
+<li>Clarified the peroxisome/mitochondrion comparison after review: fungal homologs<br />
+  independently ground peroxisomal Pmp20 biology, but they too require targeting<br />
+  signals. Because S. pombe Pmp20 lacks an obvious canonical PTS1, the peroxisome<br />
+  transfer remains unverified and is retained only as non-core rather than accepted.</li>
+<li>Replaced an enzymatic-activity quote attached to the peroxisome annotation with the<br />
+  direct CbPmp20 peroxisomal-membrane localization sentence, and accounted for the<br />
+  rat mitochondrial donor alongside the human and fly sources.</li>
 </ul>
             </div>
         </details>
@@ -5045,16 +5060,17 @@ existing_annotations:
       experimentally localized descendants. No target-specific localization evidence
       was found, so the inference is retained without treating it as an established
       core location or inferring membrane association from the protein name. The
-      positive support includes peroxisomal Pmp20 homologs in methylotrophic fungi,
-      unlike the lineage-specific transit-peptide logic behind the mitochondrial
-      transfer. Pmp20 nevertheless lacks an obvious canonical C-terminal PTS1 motif.
+      node has independent biological grounding from peroxisomal Pmp20 homologs in
+      methylotrophic fungi, but their localization also depends on targeting signals.
+      Because Pmp20 lacks an obvious canonical C-terminal PTS1 motif, transfer to the
+      S. pombe target remains unverified and is retained only as non-core.
     supported_by:
     - reference_id: file:SCHPO/pmp20/pmp20-deep-research-falcon.md
       supporting_text: In the accessible literature, *S. pombe* Pmp20p is treated
         as **peroxisomal** in multiple yeast-focused reviews and models
     - reference_id: PMID:11278957
-      supporting_text: The His(6)-tagged CbPmp20 fusion protein was found to have glutathione
-        peroxidase activity in vitro toward alkyl hydroperoxides and H(2)O(2).
+      supporting_text: Candida boidinii Pmp20 (CbPmp20), a protein associated with
+        the inner side of peroxisomal membrane
     - reference_id: PMID:18694816
       supporting_text: We conclude that the absence of the peroxisomal peroxiredoxin
         leads to loss of peroxisome membrane integrity and necrotic cell death.
@@ -5063,9 +5079,10 @@ existing_annotations:
       source_entities:
       - source_id: PANTHER:PTN000046537
         source_status: SUPPORTS_TRANSFER
-        comment: Peroxisomal Pmp20 biology is conserved in fungal homologs, so the
-          ancestral assertion is defensible as non-core; direct S. pombe localization
-          and precise topology remain unverified.
+        comment: The PAINT node is supported by mammalian Prx5 donors; supplementary
+          fungal literature independently establishes peroxisomal Pmp20 biology.
+          Target transfer and precise topology remain unverified because S. pombe
+          Pmp20 lacks an obvious canonical PTS1.
   qualifier: is_active_in
 - term:
     id: GO:0042744
@@ -5190,6 +5207,10 @@ existing_annotations:
         comment: The fly descendant supports mitochondrial localization within its
           lineage, but supplies no target-specific targeting feature or evidence for
           mitochondrial localization of S. pombe Pmp20.
+      - source_id: RGD:71007
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Rat Prdx5 supports mitochondrial localization in a mammalian isoform
+          with an N-terminal targeting extension; that feature is absent from Pmp20.
   qualifier: is_active_in
 - term:
     id: GO:0005634

--- a/genes/SCHPO/pmp20/pmp20-ai-review.html
+++ b/genes/SCHPO/pmp20/pmp20-ai-review.html
@@ -975,7 +975,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PAINT placed peroxisomal localization at an ancestral node supported by experimentally localized descendants. No target-specific localization evidence was found, so the inference is retained without treating it as an established core location or inferring membrane association from the protein name. The positive support is family- and nomenclature-level, and Pmp20 lacks an obvious canonical C-terminal PTS1 motif.
+                            <strong>Reason:</strong> PAINT placed peroxisomal localization at an ancestral node supported by experimentally localized descendants. No target-specific localization evidence was found, so the inference is retained without treating it as an established core location or inferring membrane association from the protein name. The positive support includes peroxisomal Pmp20 homologs in methylotrophic fungi, unlike the lineage-specific transit-peptide logic behind the mitochondrial transfer. Pmp20 nevertheless lacks an obvious canonical C-terminal PTS1 motif.
                         </div>
 
 
@@ -998,7 +998,7 @@
                                     <span class="badge">SUPPORTS TRANSFER</span>
 
 
-                                    <div class="propagation-comment">The ancestral localization assertion is defensible, but direct S. pombe localization and precise peroxisomal topology remain unverified.</div>
+                                    <div class="propagation-comment">Peroxisomal Pmp20 biology is conserved in fungal homologs, so the ancestral assertion is defensible as non-core; direct S. pombe localization and precise topology remain unverified.</div>
 
                                 </div>
 
@@ -1019,6 +1019,32 @@
                                 </span>
 
                                 <div class="support-text">In the accessible literature, *S. pombe* Pmp20p is treated as **peroxisomal** in multiple yeast-focused reviews and models</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11278957" target="_blank" class="term-link">
+                                        PMID:11278957
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The His(6)-tagged CbPmp20 fusion protein was found to have glutathione peroxidase activity in vitro toward alkyl hydroperoxides and H(2)O(2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18694816" target="_blank" class="term-link">
+                                        PMID:18694816
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We conclude that the absence of the peroxisomal peroxiredoxin leads to loss of peroxisome membrane integrity and necrotic cell death.</div>
 
                             </div>
 
@@ -1448,11 +1474,49 @@
 
                                 </div>
 
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">FB:FBgn0038570</span>
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The fly descendant supports mitochondrial localization within its lineage, but supplies no target-specific targeting feature or evidence for mitochondrial localization of S. pombe Pmp20.</div>
+
+                                </div>
+
                             </div>
 
                         </div>
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/pmp20/pmp20-bioinformatics/data/uniprot_txt/P30044.txt
+
+                                </span>
+
+                                <div class="support-text">FT   TRANSIT         1..52</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/pmp20/pmp20-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -2568,6 +2632,38 @@
 
                     </li>
 
+                    <li class="finding-item">
+                        <div class="finding-statement">The reviewed record reports a cytoplasmic pool.</div>
+
+                        <div class="finding-text">"SUBCELLULAR LOCATION: Cytoplasm"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:SCHPO/pmp20/pmp20-bioinformatics/data/uniprot_txt/P30044.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB reviewed entry for human mitochondrial PRDX5 (P30044)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human mitochondrial PRDX5 has an N-terminal transit peptide spanning residues 1 through 52.</div>
+
+                        <div class="finding-text">"FT   TRANSIT         1..52"</div>
+
+                    </li>
+
                 </ul>
 
             </div>
@@ -2610,7 +2706,11 @@
                     <li class="finding-item">
                         <div class="finding-statement">Most Prx5-like homologs retain resolving-cysteine architecture, unlike pmp20</div>
 
-                        <div class="finding-text">"`pmp20` class: `peroxidatic_only` (`prx5_catalytic_state.tsv`)."</div>
+                        <div class="finding-text">"- Panel size: 27 reviewed eukaryotic Prx5-like proteins (`prx5_panel.tsv`).
+- Catalytic-state counts (`prx5_phylogeny_report.json`):
+  - `peroxidatic_plus_resolving`: 23
+  - `peroxidatic_only`: 4
+- `pmp20` class: `peroxidatic_only` (`prx5_catalytic_state.tsv`)."</div>
 
                     </li>
 
@@ -4667,6 +4767,20 @@ this with annotations you find in gene/protein databases, but these can be outda
 <li>Added explicit questions and experiments for endogenous holdase clients and direct<br />
   organelle-localization testing.</li>
 </ul>
+<h2 id="2026-09-01-post-merge-evidence-follow-up">2026-09-01 — post-merge evidence follow-up</h2>
+<ul>
+<li>Accounted explicitly for the fly mitochondrial PAINT donor rather than discussing<br />
+  only mammalian PRDX5; the fly localization can support that descendant without<br />
+  supplying a targeting mechanism or target-specific evidence for S. pombe Pmp20.</li>
+<li>Added direct file-backed evidence for the P30044 residues 1–52 transit peptide and<br />
+  for the reviewed cytoplasmic localization of O14313.</li>
+<li>Replaced the partial homolog-panel quote with the exact contiguous RESULTS.md block<br />
+  showing 27 proteins, 23 with resolving-cysteine architecture, and Pmp20 in the<br />
+  four-member peroxidatic-only class.</li>
+<li>Made the peroxisome/mitochondrion distinction explicit: peroxisomal Pmp20 biology<br />
+  has support in fungal homologs, whereas the mitochondrial transfer depends on<br />
+  targeting features in animal descendants that are absent from Pmp20.</li>
+</ul>
             </div>
         </details>
 
@@ -4931,19 +5045,27 @@ existing_annotations:
       experimentally localized descendants. No target-specific localization evidence
       was found, so the inference is retained without treating it as an established
       core location or inferring membrane association from the protein name. The
-      positive support is family- and nomenclature-level, and Pmp20 lacks an obvious
-      canonical C-terminal PTS1 motif.
+      positive support includes peroxisomal Pmp20 homologs in methylotrophic fungi,
+      unlike the lineage-specific transit-peptide logic behind the mitochondrial
+      transfer. Pmp20 nevertheless lacks an obvious canonical C-terminal PTS1 motif.
     supported_by:
     - reference_id: file:SCHPO/pmp20/pmp20-deep-research-falcon.md
       supporting_text: In the accessible literature, *S. pombe* Pmp20p is treated
         as **peroxisomal** in multiple yeast-focused reviews and models
+    - reference_id: PMID:11278957
+      supporting_text: The His(6)-tagged CbPmp20 fusion protein was found to have glutathione
+        peroxidase activity in vitro toward alkyl hydroperoxides and H(2)O(2).
+    - reference_id: PMID:18694816
+      supporting_text: We conclude that the absence of the peroxisomal peroxiredoxin
+        leads to loss of peroxisome membrane integrity and necrotic cell death.
     propagation_review:
       root_cause: NO_FAILURE_NON_CORE
       source_entities:
       - source_id: PANTHER:PTN000046537
         source_status: SUPPORTS_TRANSFER
-        comment: The ancestral localization assertion is defensible, but direct S.
-          pombe localization and precise peroxisomal topology remain unverified.
+        comment: Peroxisomal Pmp20 biology is conserved in fungal homologs, so the
+          ancestral assertion is defensible as non-core; direct S. pombe localization
+          and precise topology remain unverified.
   qualifier: is_active_in
 - term:
     id: GO:0042744
@@ -5048,6 +5170,11 @@ existing_annotations:
       localization is therefore possible only as an unsupported family transfer.
     additional_reference_ids:
     - PMID:16823372
+    supported_by:
+    - reference_id: file:SCHPO/pmp20/pmp20-bioinformatics/data/uniprot_txt/P30044.txt
+      supporting_text: FT   TRANSIT         1..52
+    - reference_id: file:SCHPO/pmp20/pmp20-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
@@ -5058,6 +5185,11 @@ existing_annotations:
         comment: Mammalian PRDX5 has an N-terminal mitochondrial transit peptide (residues
           1-52 of P30044) absent from the shorter Pmp20 target, whose observed pools
           are cytosolic and nuclear.
+      - source_id: FB:FBgn0038570
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The fly descendant supports mitochondrial localization within its
+          lineage, but supplies no target-specific targeting feature or evidence for
+          mitochondrial localization of S. pombe Pmp20.
   qualifier: is_active_in
 - term:
     id: GO:0005634
@@ -5277,6 +5409,14 @@ references:
   - statement: The reviewed record describes the target-specific catalytic-site
       divergence.
     supporting_text: Pmp20 lacks the resolving cysteine residue.
+  - statement: The reviewed record reports a cytoplasmic pool.
+    supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
+- id: file:SCHPO/pmp20/pmp20-bioinformatics/data/uniprot_txt/P30044.txt
+  title: UniProtKB reviewed entry for human mitochondrial PRDX5 (P30044)
+  findings:
+  - statement: Human mitochondrial PRDX5 has an N-terminal transit peptide spanning
+      residues 1 through 52.
+    supporting_text: FT   TRANSIT         1..52
 - id: file:SCHPO/pmp20/pmp20-bioinformatics/RESULTS.md
   title: Reproducible bioinformatics assessment of pmp20 thioredoxin-dependent peroxidase
     activity
@@ -5292,7 +5432,12 @@ references:
       pair geometry is possible in the monomer.&#39;
   - statement: Most Prx5-like homologs retain resolving-cysteine architecture, unlike
       pmp20
-    supporting_text: &#39;`pmp20` class: `peroxidatic_only` (`prx5_catalytic_state.tsv`).&#39;
+    supporting_text: |-
+      - Panel size: 27 reviewed eukaryotic Prx5-like proteins (`prx5_panel.tsv`).
+      - Catalytic-state counts (`prx5_phylogeny_report.json`):
+        - `peroxidatic_plus_resolving`: 23
+        - `peroxidatic_only`: 4
+      - `pmp20` class: `peroxidatic_only` (`prx5_catalytic_state.tsv`).
   - statement: Prx5 dimer template mapping does not support a template-like C(P)-C(R)
       pair in pmp20
     supporting_text: target_supports_template_like_cp_cr_pair = no

--- a/genes/SCHPO/pmp20/pmp20-ai-review.yaml
+++ b/genes/SCHPO/pmp20/pmp20-ai-review.yaml
@@ -47,16 +47,17 @@ existing_annotations:
       experimentally localized descendants. No target-specific localization evidence
       was found, so the inference is retained without treating it as an established
       core location or inferring membrane association from the protein name. The
-      positive support includes peroxisomal Pmp20 homologs in methylotrophic fungi,
-      unlike the lineage-specific transit-peptide logic behind the mitochondrial
-      transfer. Pmp20 nevertheless lacks an obvious canonical C-terminal PTS1 motif.
+      node has independent biological grounding from peroxisomal Pmp20 homologs in
+      methylotrophic fungi, but their localization also depends on targeting signals.
+      Because Pmp20 lacks an obvious canonical C-terminal PTS1 motif, transfer to the
+      S. pombe target remains unverified and is retained only as non-core.
     supported_by:
     - reference_id: file:SCHPO/pmp20/pmp20-deep-research-falcon.md
       supporting_text: In the accessible literature, *S. pombe* Pmp20p is treated
         as **peroxisomal** in multiple yeast-focused reviews and models
     - reference_id: PMID:11278957
-      supporting_text: The His(6)-tagged CbPmp20 fusion protein was found to have glutathione
-        peroxidase activity in vitro toward alkyl hydroperoxides and H(2)O(2).
+      supporting_text: Candida boidinii Pmp20 (CbPmp20), a protein associated with
+        the inner side of peroxisomal membrane
     - reference_id: PMID:18694816
       supporting_text: We conclude that the absence of the peroxisomal peroxiredoxin
         leads to loss of peroxisome membrane integrity and necrotic cell death.
@@ -65,9 +66,10 @@ existing_annotations:
       source_entities:
       - source_id: PANTHER:PTN000046537
         source_status: SUPPORTS_TRANSFER
-        comment: Peroxisomal Pmp20 biology is conserved in fungal homologs, so the
-          ancestral assertion is defensible as non-core; direct S. pombe localization
-          and precise topology remain unverified.
+        comment: The PAINT node is supported by mammalian Prx5 donors; supplementary
+          fungal literature independently establishes peroxisomal Pmp20 biology.
+          Target transfer and precise topology remain unverified because S. pombe
+          Pmp20 lacks an obvious canonical PTS1.
   qualifier: is_active_in
 - term:
     id: GO:0042744
@@ -192,6 +194,10 @@ existing_annotations:
         comment: The fly descendant supports mitochondrial localization within its
           lineage, but supplies no target-specific targeting feature or evidence for
           mitochondrial localization of S. pombe Pmp20.
+      - source_id: RGD:71007
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Rat Prdx5 supports mitochondrial localization in a mammalian isoform
+          with an N-terminal targeting extension; that feature is absent from Pmp20.
   qualifier: is_active_in
 - term:
     id: GO:0005634

--- a/genes/SCHPO/pmp20/pmp20-ai-review.yaml
+++ b/genes/SCHPO/pmp20/pmp20-ai-review.yaml
@@ -47,19 +47,27 @@ existing_annotations:
       experimentally localized descendants. No target-specific localization evidence
       was found, so the inference is retained without treating it as an established
       core location or inferring membrane association from the protein name. The
-      positive support is family- and nomenclature-level, and Pmp20 lacks an obvious
-      canonical C-terminal PTS1 motif.
+      positive support includes peroxisomal Pmp20 homologs in methylotrophic fungi,
+      unlike the lineage-specific transit-peptide logic behind the mitochondrial
+      transfer. Pmp20 nevertheless lacks an obvious canonical C-terminal PTS1 motif.
     supported_by:
     - reference_id: file:SCHPO/pmp20/pmp20-deep-research-falcon.md
       supporting_text: In the accessible literature, *S. pombe* Pmp20p is treated
         as **peroxisomal** in multiple yeast-focused reviews and models
+    - reference_id: PMID:11278957
+      supporting_text: The His(6)-tagged CbPmp20 fusion protein was found to have glutathione
+        peroxidase activity in vitro toward alkyl hydroperoxides and H(2)O(2).
+    - reference_id: PMID:18694816
+      supporting_text: We conclude that the absence of the peroxisomal peroxiredoxin
+        leads to loss of peroxisome membrane integrity and necrotic cell death.
     propagation_review:
       root_cause: NO_FAILURE_NON_CORE
       source_entities:
       - source_id: PANTHER:PTN000046537
         source_status: SUPPORTS_TRANSFER
-        comment: The ancestral localization assertion is defensible, but direct S.
-          pombe localization and precise peroxisomal topology remain unverified.
+        comment: Peroxisomal Pmp20 biology is conserved in fungal homologs, so the
+          ancestral assertion is defensible as non-core; direct S. pombe localization
+          and precise topology remain unverified.
   qualifier: is_active_in
 - term:
     id: GO:0042744
@@ -164,6 +172,11 @@ existing_annotations:
       localization is therefore possible only as an unsupported family transfer.
     additional_reference_ids:
     - PMID:16823372
+    supported_by:
+    - reference_id: file:SCHPO/pmp20/pmp20-bioinformatics/data/uniprot_txt/P30044.txt
+      supporting_text: FT   TRANSIT         1..52
+    - reference_id: file:SCHPO/pmp20/pmp20-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm'
     propagation_review:
       root_cause: PROPAGATION_BAD
       failure_modes:
@@ -174,6 +187,11 @@ existing_annotations:
         comment: Mammalian PRDX5 has an N-terminal mitochondrial transit peptide (residues
           1-52 of P30044) absent from the shorter Pmp20 target, whose observed pools
           are cytosolic and nuclear.
+      - source_id: FB:FBgn0038570
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The fly descendant supports mitochondrial localization within its
+          lineage, but supplies no target-specific targeting feature or evidence for
+          mitochondrial localization of S. pombe Pmp20.
   qualifier: is_active_in
 - term:
     id: GO:0005634
@@ -393,6 +411,14 @@ references:
   - statement: The reviewed record describes the target-specific catalytic-site
       divergence.
     supporting_text: Pmp20 lacks the resolving cysteine residue.
+  - statement: The reviewed record reports a cytoplasmic pool.
+    supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm'
+- id: file:SCHPO/pmp20/pmp20-bioinformatics/data/uniprot_txt/P30044.txt
+  title: UniProtKB reviewed entry for human mitochondrial PRDX5 (P30044)
+  findings:
+  - statement: Human mitochondrial PRDX5 has an N-terminal transit peptide spanning
+      residues 1 through 52.
+    supporting_text: FT   TRANSIT         1..52
 - id: file:SCHPO/pmp20/pmp20-bioinformatics/RESULTS.md
   title: Reproducible bioinformatics assessment of pmp20 thioredoxin-dependent peroxidase
     activity
@@ -408,7 +434,12 @@ references:
       pair geometry is possible in the monomer.'
   - statement: Most Prx5-like homologs retain resolving-cysteine architecture, unlike
       pmp20
-    supporting_text: '`pmp20` class: `peroxidatic_only` (`prx5_catalytic_state.tsv`).'
+    supporting_text: |-
+      - Panel size: 27 reviewed eukaryotic Prx5-like proteins (`prx5_panel.tsv`).
+      - Catalytic-state counts (`prx5_phylogeny_report.json`):
+        - `peroxidatic_plus_resolving`: 23
+        - `peroxidatic_only`: 4
+      - `pmp20` class: `peroxidatic_only` (`prx5_catalytic_state.tsv`).
   - statement: Prx5 dimer template mapping does not support a template-like C(P)-C(R)
       pair in pmp20
     supporting_text: target_supports_template_like_cp_cr_pair = no

--- a/genes/SCHPO/pmp20/pmp20-notes.md
+++ b/genes/SCHPO/pmp20/pmp20-notes.md
@@ -62,6 +62,10 @@
 - Replaced the partial homolog-panel quote with the exact contiguous RESULTS.md block
   showing 27 proteins, 23 with resolving-cysteine architecture, and Pmp20 in the
   four-member peroxidatic-only class.
-- Made the peroxisome/mitochondrion distinction explicit: peroxisomal Pmp20 biology
-  has support in fungal homologs, whereas the mitochondrial transfer depends on
-  targeting features in animal descendants that are absent from Pmp20.
+- Clarified the peroxisome/mitochondrion comparison after review: fungal homologs
+  independently ground peroxisomal Pmp20 biology, but they too require targeting
+  signals. Because S. pombe Pmp20 lacks an obvious canonical PTS1, the peroxisome
+  transfer remains unverified and is retained only as non-core rather than accepted.
+- Replaced an enzymatic-activity quote attached to the peroxisome annotation with the
+  direct CbPmp20 peroxisomal-membrane localization sentence, and accounted for the
+  rat mitochondrial donor alongside the human and fly sources.

--- a/genes/SCHPO/pmp20/pmp20-notes.md
+++ b/genes/SCHPO/pmp20/pmp20-notes.md
@@ -51,3 +51,17 @@
   inference and noted the absence of an obvious canonical C-terminal PTS1 motif.
 - Added explicit questions and experiments for endogenous holdase clients and direct
   organelle-localization testing.
+
+## 2026-09-01 — post-merge evidence follow-up
+
+- Accounted explicitly for the fly mitochondrial PAINT donor rather than discussing
+  only mammalian PRDX5; the fly localization can support that descendant without
+  supplying a targeting mechanism or target-specific evidence for S. pombe Pmp20.
+- Added direct file-backed evidence for the P30044 residues 1–52 transit peptide and
+  for the reviewed cytoplasmic localization of O14313.
+- Replaced the partial homolog-panel quote with the exact contiguous RESULTS.md block
+  showing 27 proteins, 23 with resolving-cysteine architecture, and Pmp20 in the
+  four-member peroxidatic-only class.
+- Made the peroxisome/mitochondrion distinction explicit: peroxisomal Pmp20 biology
+  has support in fungal homologs, whereas the mitochondrial transfer depends on
+  targeting features in animal descendants that are absent from Pmp20.


### PR DESCRIPTION
## Summary
- account for the fly donor in the mitochondrial PAINT propagation review
- add direct file-backed evidence for the mammalian transit peptide and target cytoplasmic localization
- align the homolog-panel finding with a complete verbatim results excerpt
- explain why fungal peroxisome evidence remains defensible while animal mitochondrial targeting does not transfer

## Validation
- just validate SCHPO pmp20
- just validate-families
- just render SCHPO pmp20
- git diff --check