### PR TITLE
Repair bacterial TCA cycle module structure

### DIFF
--- a/genes/PSEPK/sdhA/sdhA-ai-review.html
+++ b/genes/PSEPK/sdhA/sdhA-ai-review.html
@@ -1107,7 +1107,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Biologically true but more generic than the specific succinate dehydrogenase (quinone) activity that captures SdhA&#39;s core function. Retain as supporting/non-core rather than primary.
+                            <strong>Reason:</strong> Biologically true but more generic than the subunit-level succinate dehydrogenase activity that captures SdhA&#39;s core function. Retain as supporting/non-core rather than primary.
                         </div>
 
 
@@ -1208,12 +1208,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Generic parent of the specific succinate dehydrogenase (quinone) activity already annotated.
+                            <strong>Summary:</strong> Generic parent of the specific subunit-level succinate dehydrogenase activity already annotated.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Correct but uninformative high-level term; subsumed by the specific EC 1.3.5.1 annotation. Retain as non-core.
+                            <strong>Reason:</strong> Correct but uninformative high-level term; subsumed by GO:0000104 succinate dehydrogenase activity for SdhA. Retain as non-core.
                         </div>
 
 
@@ -1261,7 +1261,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Accurate intermediate-level description of the chemistry (oxidation of the succinate CH-CH bond to the fumarate C=C bond), but less specific than succinate dehydrogenase (quinone) activity.
+                            <strong>Summary:</strong> Accurate intermediate-level description of the chemistry (oxidation of the succinate CH-CH bond to the fumarate C=C bond), but less specific than SdhA&#39;s succinate dehydrogenase activity.
                         </div>
 
 
@@ -1425,7 +1425,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Accurately captures the FAD-coupled catalytic step intrinsic to the SdhA subunit; complementary to the holo-enzyme quinone-coupled term GO:0008177. Both are valid and informative.
+                            <strong>Reason:</strong> Accurately captures the FAD-coupled catalytic step intrinsic to the SdhA subunit and complements GO:0000104. SdhA contributes to, but does not independently enable, the holo-enzyme quinone-coupled activity GO:0008177.
                         </div>
 
 
@@ -2473,7 +2473,7 @@ existing_annotations:
   review:
     summary: SdhA participates in electron transfer, passing electrons abstracted from succinate via FAD toward the iron-sulfur clusters of SdhB and the quinone pool.
     action: KEEP_AS_NON_CORE
-    reason: Biologically true but more generic than the specific succinate dehydrogenase (quinone) activity that captures SdhA&#39;s core function. Retain as supporting/non-core rather than primary.
+    reason: Biologically true but more generic than the subunit-level succinate dehydrogenase activity that captures SdhA&#39;s core function. Retain as supporting/non-core rather than primary.
 - term:
     id: GO:0009061
     label: anaerobic respiration
@@ -2491,9 +2491,9 @@ existing_annotations:
   original_reference_id: GO_REF:0000002
   qualifier: enables
   review:
-    summary: Generic parent of the specific succinate dehydrogenase (quinone) activity already annotated.
+    summary: Generic parent of the specific subunit-level succinate dehydrogenase activity already annotated.
     action: KEEP_AS_NON_CORE
-    reason: Correct but uninformative high-level term; subsumed by the specific EC 1.3.5.1 annotation. Retain as non-core.
+    reason: Correct but uninformative high-level term; subsumed by GO:0000104 succinate dehydrogenase activity for SdhA. Retain as non-core.
 - term:
     id: GO:0016627
     label: oxidoreductase activity, acting on the CH-CH group of donors
@@ -2501,7 +2501,7 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: enables
   review:
-    summary: Accurate intermediate-level description of the chemistry (oxidation of the succinate CH-CH bond to the fumarate C=C bond), but less specific than succinate dehydrogenase (quinone) activity.
+    summary: Accurate intermediate-level description of the chemistry (oxidation of the succinate CH-CH bond to the fumarate C=C bond), but less specific than SdhA&#39;s succinate dehydrogenase activity.
     action: KEEP_AS_NON_CORE
     reason: Correct grouping term but subsumed by the specific MF term; keep as non-core supporting annotation.
 - term:
@@ -2533,7 +2533,7 @@ existing_annotations:
   review:
     summary: Describes the FAD-dependent succinate-&gt;fumarate half-reaction occurring at the SdhA flavin site, prior to electron transfer to quinone.
     action: ACCEPT
-    reason: Accurately captures the FAD-coupled catalytic step intrinsic to the SdhA subunit; complementary to the holo-enzyme quinone-coupled term GO:0008177. Both are valid and informative.
+    reason: Accurately captures the FAD-coupled catalytic step intrinsic to the SdhA subunit and complements GO:0000104. SdhA contributes to, but does not independently enable, the holo-enzyme quinone-coupled activity GO:0008177.
 core_functions:
 - description: Catalytic flavoprotein subunit of succinate dehydrogenase (Complex II) that oxidises succinate to fumarate using a covalently bound FAD cofactor, the rate-limiting catalytic step linking the TCA cycle to the respiratory chain.
   molecular_function:

--- a/genes/PSEPK/sdhA/sdhA-ai-review.html
+++ b/genes/PSEPK/sdhA/sdhA-ai-review.html
@@ -1038,10 +1038,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q88FA7" data-a="GO:0008177" data-r="GO_REF:0000120" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88FA7" data-a="GO:0008177" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1054,7 +1054,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Directly matches the UniProt CATALYTIC ACTIVITY (RHEA:40523) and EC 1.3.5.1. Most informative molecular-function term for the complex&#39;s overall reaction.
+                            <strong>Reason:</strong> SdhA performs the FAD-dependent succinate-oxidation half-reaction, but quinone reduction requires the SdhB electron-transfer chain and SdhC/D membrane domain. The term is correct for the assembled SdhABCD complex and should be represented as a contribution for this subunit.
                         </div>
 
 
@@ -1460,8 +1460,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008177" target="_blank" class="term-link">
-                            succinate dehydrogenase (quinone) activity
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000104" target="_blank" class="term-link">
+                            succinate dehydrogenase activity
                         </a>
                     </span>
                 </div>
@@ -2458,8 +2458,12 @@ existing_annotations:
   qualifier: enables
   review:
     summary: This is the precise quinone-coupled reaction (succinate + quinone = fumarate + quinol, RHEA:40523, EC 1.3.5.1) catalysed by the holo-enzyme to which SdhA contributes the catalytic flavoprotein head.
-    action: ACCEPT
-    reason: Directly matches the UniProt CATALYTIC ACTIVITY (RHEA:40523) and EC 1.3.5.1. Most informative molecular-function term for the complex&#39;s overall reaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      SdhA performs the FAD-dependent succinate-oxidation half-reaction, but
+      quinone reduction requires the SdhB electron-transfer chain and SdhC/D
+      membrane domain. The term is correct for the assembled SdhABCD complex
+      and should be represented as a contribution for this subunit.
 - term:
     id: GO:0009055
     label: electron transfer activity
@@ -2533,6 +2537,9 @@ existing_annotations:
 core_functions:
 - description: Catalytic flavoprotein subunit of succinate dehydrogenase (Complex II) that oxidises succinate to fumarate using a covalently bound FAD cofactor, the rate-limiting catalytic step linking the TCA cycle to the respiratory chain.
   molecular_function:
+    id: GO:0000104
+    label: succinate dehydrogenase activity
+  contributes_to_molecular_function:
     id: GO:0008177
     label: succinate dehydrogenase (quinone) activity
   supported_by:

--- a/genes/PSEPK/sdhA/sdhA-ai-review.yaml
+++ b/genes/PSEPK/sdhA/sdhA-ai-review.yaml
@@ -45,8 +45,12 @@ existing_annotations:
   qualifier: enables
   review:
     summary: This is the precise quinone-coupled reaction (succinate + quinone = fumarate + quinol, RHEA:40523, EC 1.3.5.1) catalysed by the holo-enzyme to which SdhA contributes the catalytic flavoprotein head.
-    action: ACCEPT
-    reason: Directly matches the UniProt CATALYTIC ACTIVITY (RHEA:40523) and EC 1.3.5.1. Most informative molecular-function term for the complex's overall reaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      SdhA performs the FAD-dependent succinate-oxidation half-reaction, but
+      quinone reduction requires the SdhB electron-transfer chain and SdhC/D
+      membrane domain. The term is correct for the assembled SdhABCD complex
+      and should be represented as a contribution for this subunit.
 - term:
     id: GO:0009055
     label: electron transfer activity
@@ -120,6 +124,9 @@ existing_annotations:
 core_functions:
 - description: Catalytic flavoprotein subunit of succinate dehydrogenase (Complex II) that oxidises succinate to fumarate using a covalently bound FAD cofactor, the rate-limiting catalytic step linking the TCA cycle to the respiratory chain.
   molecular_function:
+    id: GO:0000104
+    label: succinate dehydrogenase activity
+  contributes_to_molecular_function:
     id: GO:0008177
     label: succinate dehydrogenase (quinone) activity
   supported_by:

--- a/genes/PSEPK/sdhA/sdhA-ai-review.yaml
+++ b/genes/PSEPK/sdhA/sdhA-ai-review.yaml
@@ -60,7 +60,7 @@ existing_annotations:
   review:
     summary: SdhA participates in electron transfer, passing electrons abstracted from succinate via FAD toward the iron-sulfur clusters of SdhB and the quinone pool.
     action: KEEP_AS_NON_CORE
-    reason: Biologically true but more generic than the specific succinate dehydrogenase (quinone) activity that captures SdhA's core function. Retain as supporting/non-core rather than primary.
+    reason: Biologically true but more generic than the subunit-level succinate dehydrogenase activity that captures SdhA's core function. Retain as supporting/non-core rather than primary.
 - term:
     id: GO:0009061
     label: anaerobic respiration
@@ -78,9 +78,9 @@ existing_annotations:
   original_reference_id: GO_REF:0000002
   qualifier: enables
   review:
-    summary: Generic parent of the specific succinate dehydrogenase (quinone) activity already annotated.
+    summary: Generic parent of the specific subunit-level succinate dehydrogenase activity already annotated.
     action: KEEP_AS_NON_CORE
-    reason: Correct but uninformative high-level term; subsumed by the specific EC 1.3.5.1 annotation. Retain as non-core.
+    reason: Correct but uninformative high-level term; subsumed by GO:0000104 succinate dehydrogenase activity for SdhA. Retain as non-core.
 - term:
     id: GO:0016627
     label: oxidoreductase activity, acting on the CH-CH group of donors
@@ -88,7 +88,7 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: enables
   review:
-    summary: Accurate intermediate-level description of the chemistry (oxidation of the succinate CH-CH bond to the fumarate C=C bond), but less specific than succinate dehydrogenase (quinone) activity.
+    summary: Accurate intermediate-level description of the chemistry (oxidation of the succinate CH-CH bond to the fumarate C=C bond), but less specific than SdhA's succinate dehydrogenase activity.
     action: KEEP_AS_NON_CORE
     reason: Correct grouping term but subsumed by the specific MF term; keep as non-core supporting annotation.
 - term:
@@ -120,7 +120,7 @@ existing_annotations:
   review:
     summary: Describes the FAD-dependent succinate->fumarate half-reaction occurring at the SdhA flavin site, prior to electron transfer to quinone.
     action: ACCEPT
-    reason: Accurately captures the FAD-coupled catalytic step intrinsic to the SdhA subunit; complementary to the holo-enzyme quinone-coupled term GO:0008177. Both are valid and informative.
+    reason: Accurately captures the FAD-coupled catalytic step intrinsic to the SdhA subunit and complements GO:0000104. SdhA contributes to, but does not independently enable, the holo-enzyme quinone-coupled activity GO:0008177.
 core_functions:
 - description: Catalytic flavoprotein subunit of succinate dehydrogenase (Complex II) that oxidises succinate to fumarate using a covalently bound FAD cofactor, the rate-limiting catalytic step linking the TCA cycle to the respiratory chain.
   molecular_function:

--- a/modules/tca_cycle.yaml
+++ b/modules/tca_cycle.yaml
@@ -6,9 +6,10 @@ description: >-
   interconversion, oxidative decarboxylation to succinyl-CoA, succinate-level
   phosphorylation, succinate oxidation through respiratory complex II, fumarate
   hydration, and malate oxidation to regenerate oxaloacetate. The module also
-  records common bacterial alternatives at the malate/oxaloacetate node and
-  pyruvate carboxylase as an anaplerotic input to oxaloacetate.
+  records common bacterial alternatives at the aconitase, isocitrate
+  dehydrogenase, fumarase, and malate/oxaloacetate steps.
 status: DRAFT
+scope: CONCRETE
 evidence:
   - source_id: GO:0006099
     title: tricarboxylic acid cycle
@@ -43,8 +44,8 @@ evidence:
 notes: >-
   Reusable boundary: this module describes the oxidative TCA cycle and its
   immediate bacterial alternatives, not every KEGG ppu00020 neighbor. Pyruvate
-  dehydrogenase supplies acetyl-CoA upstream, pyruvate carboxylase is modeled as
-  an anaplerotic oxaloacetate input, and methylcitrate/propionyl-CoA
+  dehydrogenase supplies acetyl-CoA upstream, pyruvate carboxylase supplies an
+  external anaplerotic oxaloacetate input, and methylcitrate/propionyl-CoA
   CoA-transferase proteins should be treated as adjacent propionate-metabolism
   context unless direct evidence places them in the main cyclic flux. The PSEPK
   instantiation is satisfiable with gltA/Q88FA4, acnB/Q88KF1 plus acnA-I/Q88L24,
@@ -66,20 +67,6 @@ module:
         Oxidative central-carbon cycle from acetyl-CoA entry to regeneration of
         oxaloacetate through citrate, isocitrate, 2-oxoglutarate, succinyl-CoA,
         succinate, fumarate, and malate.
-  context:
-    cellular_components:
-      - preferred_term: cytosol
-        term:
-          id: GO:0005829
-          label: cytosol
-        description: Most bacterial TCA enzymes are soluble cytosolic enzymes.
-      - preferred_term: plasma membrane
-        term:
-          id: GO:0005886
-          label: plasma membrane
-        description: >-
-          Bacterial succinate dehydrogenase is an inner-membrane respiratory
-          complex that faces the cytoplasm and transfers electrons to quinone.
   parts:
     - order: 1
       role: acetyl-CoA entry
@@ -91,12 +78,14 @@ module:
           - id: citrate_synthase_activity
             label: Citrate synthase
             participant:
-              selector_type: ANY_WITH_FUNCTION
-              required_function:
-                preferred_term: citrate synthase activity
-                term:
-                  id: GO:0036440
-                  label: citrate synthase activity
+              selector_type: FAMILY
+              family:
+                preferred_term: bacterial citrate synthase family
+                representative_members:
+                  - preferred_term: PSEPK GltA exemplar
+                    term:
+                      id: UniProtKB:Q88FA4
+                      label: Citrate synthase
             function:
               preferred_term: citrate synthase activity
               term:
@@ -122,12 +111,18 @@ module:
           - id: aconitate_hydratase_activity
             label: Aconitase
             participant:
-              selector_type: ANY_WITH_FUNCTION
-              required_function:
-                preferred_term: aconitate hydratase activity
-                term:
-                  id: GO:0003994
-                  label: aconitate hydratase activity
+              selector_type: FAMILY
+              family:
+                preferred_term: bacterial aconitate hydratase families
+                representative_members:
+                  - preferred_term: PSEPK AcnA-I exemplar
+                    term:
+                      id: UniProtKB:Q88L24
+                      label: Aconitate hydratase
+                  - preferred_term: PSEPK AcnB exemplar
+                    term:
+                      id: UniProtKB:Q88KF1
+                      label: Aconitate hydratase B
             function:
               preferred_term: aconitate hydratase activity
               term:
@@ -150,12 +145,18 @@ module:
           - id: isocitrate_dehydrogenase_nadp_activity
             label: NADP-dependent isocitrate dehydrogenase
             participant:
-              selector_type: ANY_WITH_FUNCTION
-              required_function:
-                preferred_term: isocitrate dehydrogenase (NADP+) activity
-                term:
-                  id: GO:0004450
-                  label: isocitrate dehydrogenase (NADP+) activity
+              selector_type: FAMILY
+              family:
+                preferred_term: bacterial NADP-dependent isocitrate dehydrogenase families
+                representative_members:
+                  - preferred_term: PSEPK Icd exemplar
+                    term:
+                      id: UniProtKB:Q88FS2
+                      label: Isocitrate dehydrogenase [NADP]
+                  - preferred_term: PSEPK Idh exemplar
+                    term:
+                      id: UniProtKB:Q88FS1
+                      label: Isocitrate dehydrogenase [NADP]
             function:
               preferred_term: isocitrate dehydrogenase (NADP+) activity
               term:
@@ -191,12 +192,14 @@ module:
                 - id: oxoglutarate_dehydrogenase_activity
                   label: 2-oxoglutarate dehydrogenase
                   participant:
-                    selector_type: ANY_WITH_FUNCTION
-                    required_function:
-                      preferred_term: oxoglutarate dehydrogenase (succinyl-transferring) activity
-                      term:
-                        id: GO:0004591
-                        label: oxoglutarate dehydrogenase (succinyl-transferring) activity
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: bacterial SucA E1 family
+                      representative_members:
+                        - preferred_term: PSEPK SucA exemplar
+                          term:
+                            id: UniProtKB:Q88FA9
+                            label: 2-oxoglutarate dehydrogenase E1 component
                   function:
                     preferred_term: oxoglutarate dehydrogenase (succinyl-transferring) activity
                     term:
@@ -216,12 +219,14 @@ module:
                 - id: dihydrolipoyl_succinyltransferase_activity
                   label: Dihydrolipoyllysine-residue succinyltransferase
                   participant:
-                    selector_type: ANY_WITH_FUNCTION
-                    required_function:
-                      preferred_term: dihydrolipoyllysine-residue succinyltransferase activity
-                      term:
-                        id: GO:0004149
-                        label: dihydrolipoyllysine-residue succinyltransferase activity
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: bacterial SucB E2 family
+                      representative_members:
+                        - preferred_term: PSEPK SucB exemplar
+                          term:
+                            id: UniProtKB:Q88FB0
+                            label: Dihydrolipoyllysine-residue succinyltransferase component of 2-oxoglutarate dehydrogenase complex
                   function:
                     preferred_term: dihydrolipoyllysine-residue succinyltransferase activity
                     term:
@@ -242,12 +247,14 @@ module:
                 - id: dihydrolipoyl_dehydrogenase_activity
                   label: Dihydrolipoyl dehydrogenase
                   participant:
-                    selector_type: ANY_WITH_FUNCTION
-                    required_function:
-                      preferred_term: dihydrolipoyl dehydrogenase (NADH) activity
-                      term:
-                        id: GO:0004148
-                        label: dihydrolipoyl dehydrogenase (NADH) activity
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: bacterial Lpd E3 family
+                      representative_members:
+                        - preferred_term: PSEPK LpdG provisional exemplar
+                          term:
+                            id: UniProtKB:Q88FB1
+                            label: Dihydrolipoyl dehydrogenase
                   function:
                     preferred_term: dihydrolipoyl dehydrogenase (NADH) activity
                     term:
@@ -269,12 +276,34 @@ module:
           - id: succinate_coa_ligase_adp_activity
             label: ADP-forming succinate-CoA ligase
             participant:
-              selector_type: ANY_WITH_FUNCTION
-              required_function:
-                preferred_term: succinate-CoA ligase (ADP-forming) activity
-                term:
-                  id: GO:0004775
-                  label: succinate-CoA ligase (ADP-forming) activity
+              selector_type: PROTEIN_COMPLEX
+              protein_complex:
+                preferred_term: bacterial SucCD succinate-CoA ligase complex
+                active_units:
+                  - id: succinate_coa_ligase_beta_unit
+                    label: SucC beta subunit
+                    role: Nucleotide-binding beta subunit of the heteromeric ligase.
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: bacterial SucC family
+                        representative_members:
+                          - preferred_term: PSEPK SucC exemplar
+                            term:
+                              id: UniProtKB:Q88FB2
+                              label: Succinate--CoA ligase [ADP-forming] subunit beta
+                  - id: succinate_coa_ligase_alpha_unit
+                    label: SucD alpha subunit
+                    role: CoA- and phosphate-handling alpha subunit of the heteromeric ligase.
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: bacterial SucD family
+                        representative_members:
+                          - preferred_term: PSEPK SucD exemplar
+                            term:
+                              id: UniProtKB:Q88FB3
+                              label: Succinate--CoA ligase [ADP-forming] subunit alpha
             function:
               preferred_term: succinate-CoA ligase (ADP-forming) activity
               term:
@@ -302,12 +331,68 @@ module:
           - id: succinate_dehydrogenase_quinone_activity
             label: Succinate dehydrogenase (quinone)
             participant:
-              selector_type: ANY_WITH_FUNCTION
-              required_function:
-                preferred_term: succinate dehydrogenase (quinone) activity
-                term:
-                  id: GO:0008177
-                  label: succinate dehydrogenase (quinone) activity
+              selector_type: PROTEIN_COMPLEX
+              protein_complex:
+                preferred_term: bacterial SdhABCD succinate dehydrogenase complex
+                active_units:
+                  - id: sdha_flavoprotein_unit
+                    label: SdhA flavoprotein subunit
+                    role: Catalyzes succinate oxidation at the FAD-containing active site.
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: bacterial SdhA family
+                        representative_members:
+                          - preferred_term: PSEPK SdhA exemplar
+                            term:
+                              id: UniProtKB:Q88FA7
+                              label: Succinate dehydrogenase flavoprotein subunit
+                    function:
+                      preferred_term: succinate dehydrogenase (quinone) activity
+                      term:
+                        id: GO:0008177
+                        label: succinate dehydrogenase (quinone) activity
+                  - id: sdhb_iron_sulfur_unit
+                    label: SdhB iron-sulfur subunit
+                    role: Relays electrons from SdhA toward the membrane quinone site.
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: bacterial SdhB family
+                        representative_members:
+                          - preferred_term: PSEPK SdhB exemplar
+                            term:
+                              id: UniProtKB:Q88FA8
+                              label: Succinate dehydrogenase iron-sulfur subunit
+                    function:
+                      preferred_term: electron transfer activity
+                      term:
+                        id: GO:0009055
+                        label: electron transfer activity
+                  - id: sdhc_membrane_unit
+                    label: SdhC membrane subunit
+                    role: Contributes the cytochrome-b membrane anchor and quinone-interaction domain.
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: bacterial SdhC family
+                        representative_members:
+                          - preferred_term: PSEPK SdhC exemplar
+                            term:
+                              id: UniProtKB:Q88FA5
+                              label: Succinate dehydrogenase cytochrome b556 subunit
+                  - id: sdhd_membrane_unit
+                    label: SdhD membrane subunit
+                    role: Completes the membrane anchor and contributes to quinone-linked electron transfer.
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: bacterial SdhD family
+                        representative_members:
+                          - preferred_term: PSEPK SdhD exemplar
+                            term:
+                              id: UniProtKB:Q88FA6
+                              label: Succinate dehydrogenase hydrophobic membrane anchor subunit
             function:
               preferred_term: succinate dehydrogenase (quinone) activity
               term:
@@ -337,12 +422,22 @@ module:
           - id: fumarate_hydratase_activity
             label: Fumarate hydratase
             participant:
-              selector_type: ANY_WITH_FUNCTION
-              required_function:
-                preferred_term: fumarate hydratase activity
-                term:
-                  id: GO:0004333
-                  label: fumarate hydratase activity
+              selector_type: FAMILY
+              family:
+                preferred_term: bacterial class-I and class-II fumarate hydratase families
+                representative_members:
+                  - preferred_term: PSEPK class-I fumarase exemplar
+                    term:
+                      id: UniProtKB:Q88PF3
+                      label: Fumarate hydratase class I
+                  - preferred_term: PSEPK FumC-I exemplar
+                    term:
+                      id: UniProtKB:Q88PA6
+                      label: Fumarate hydratase class II
+                  - preferred_term: PSEPK FumC exemplar
+                    term:
+                      id: UniProtKB:Q88M20
+                      label: Fumarate hydratase class II
             function:
               preferred_term: fumarate hydratase activity
               term:
@@ -367,12 +462,14 @@ module:
           - id: malate_dehydrogenase_nad_activity
             label: NAD-dependent L-malate dehydrogenase
             participant:
-              selector_type: ANY_WITH_FUNCTION
-              required_function:
-                preferred_term: L-malate dehydrogenase (NAD+) activity
-                term:
-                  id: GO:0030060
-                  label: L-malate dehydrogenase (NAD+) activity
+              selector_type: FAMILY
+              family:
+                preferred_term: bacterial NAD-dependent malate dehydrogenase family
+                representative_members:
+                  - preferred_term: PSEPK Mdh exemplar
+                    term:
+                      id: UniProtKB:Q88Q44
+                      label: Probable malate dehydrogenase
             function:
               preferred_term: L-malate dehydrogenase (NAD+) activity
               term:
@@ -387,12 +484,22 @@ module:
           - id: malate_dehydrogenase_quinone_activity
             label: L-malate dehydrogenase (quinone)
             participant:
-              selector_type: ANY_WITH_FUNCTION
-              required_function:
-                preferred_term: L-malate dehydrogenase (quinone) activity
-                term:
-                  id: GO:0008924
-                  label: L-malate dehydrogenase (quinone) activity
+              selector_type: FAMILY
+              family:
+                preferred_term: bacterial malate:quinone oxidoreductase family
+                representative_members:
+                  - preferred_term: PSEPK Mqo1 exemplar
+                    term:
+                      id: UniProtKB:Q88PU7
+                      label: Probable malate:quinone oxidoreductase 1
+                  - preferred_term: PSEPK Mqo2 exemplar
+                    term:
+                      id: UniProtKB:Q88NF9
+                      label: Probable malate:quinone oxidoreductase 2
+                  - preferred_term: PSEPK Mqo3 exemplar
+                    term:
+                      id: UniProtKB:Q88IS4
+                      label: Probable malate:quinone oxidoreductase 3
             function:
               preferred_term: L-malate dehydrogenase (quinone) activity
               term:
@@ -404,35 +511,23 @@ module:
               products:
                 - preferred_term: oxaloacetate
                 - preferred_term: quinol
-    - order: 9
-      role: anaplerotic oxaloacetate input
-      node:
-        id: pyruvate_carboxylase_step
-        label: Pyruvate carboxylase
-        module_type: REACTION
-        annotons:
-          - id: pyruvate_carboxylase_activity
-            label: Pyruvate carboxylase
-            participant:
-              selector_type: ANY_WITH_FUNCTION
-              required_function:
-                preferred_term: pyruvate carboxylase activity
-                term:
-                  id: GO:0004736
-                  label: pyruvate carboxylase activity
-            function:
-              preferred_term: pyruvate carboxylase activity
-              term:
-                id: GO:0004736
-                label: pyruvate carboxylase activity
-              substrates:
-                - preferred_term: pyruvate
-                - preferred_term: bicarbonate
-                - preferred_term: ATP
-              products:
-                - preferred_term: oxaloacetate
-                - preferred_term: ADP
-                - preferred_term: phosphate
-            role_description: >-
-              An anaplerotic entry into the oxaloacetate pool rather than a
-              strict cyclic TCA reaction.
+  knowledge_gaps:
+    - gap_statement: >-
+        The physiological division of labor among bacterial paralogs at the
+        aconitase, isocitrate-dehydrogenase, fumarase, and malate-oxidation
+        steps is often condition dependent.
+      boundary: >-
+        Treat verified paralogs as alternative implementations of the same
+        cyclic step rather than as additional required steps.
+      gap_kind:
+        - BIOLOGY
+    - gap_statement: >-
+        Shared Lpd-family E3 enzymes can serve several lipoyl-dependent
+        complexes, and the physiological E3 partner of a particular bacterial
+        2-oxoglutarate dehydrogenase may not be established.
+      boundary: >-
+        Use a provisional E3 exemplar only where genomic or experimental
+        evidence supports it, and do not infer complex specificity from
+        dihydrolipoyl dehydrogenase activity alone.
+      gap_kind:
+        - BIOLOGY

--- a/modules/tca_cycle.yaml
+++ b/modules/tca_cycle.yaml
@@ -279,6 +279,9 @@ module:
               selector_type: PROTEIN_COMPLEX
               protein_complex:
                 preferred_term: bacterial SucCD succinate-CoA ligase complex
+                term:
+                  id: GO:0009361
+                  label: succinate-CoA ligase complex (ADP-forming)
                 active_units:
                   - id: succinate_coa_ligase_beta_unit
                     label: SucC beta subunit
@@ -334,6 +337,9 @@ module:
               selector_type: PROTEIN_COMPLEX
               protein_complex:
                 preferred_term: bacterial SdhABCD succinate dehydrogenase complex
+                term:
+                  id: GO:0045273
+                  label: respiratory chain complex II (succinate dehydrogenase)
                 active_units:
                   - id: sdha_flavoprotein_unit
                     label: SdhA flavoprotein subunit
@@ -348,10 +354,10 @@ module:
                               id: UniProtKB:Q88FA7
                               label: Succinate dehydrogenase flavoprotein subunit
                     function:
-                      preferred_term: succinate dehydrogenase (quinone) activity
+                      preferred_term: succinate dehydrogenase activity
                       term:
-                        id: GO:0008177
-                        label: succinate dehydrogenase (quinone) activity
+                        id: GO:0000104
+                        label: succinate dehydrogenase activity
                   - id: sdhb_iron_sulfur_unit
                     label: SdhB iron-sulfur subunit
                     role: Relays electrons from SdhA toward the membrane quinone site.

--- a/pages/modules/tca_cycle.html
+++ b/pages/modules/tca_cycle.html
@@ -552,17 +552,17 @@
     </nav>
 
     <header class="header">
-        <h1>Tricarboxylic acid cycle</h1>            <p class="description">A taxon-neutral module for the oxidative tricarboxylic acid (TCA) cycle, covering acetyl-CoA entry through citrate synthase, citrate/isocitrate interconversion, oxidative decarboxylation to succinyl-CoA, succinate-level phosphorylation, succinate oxidation through respiratory complex II, fumarate hydration, and malate oxidation to regenerate oxaloacetate. The module also records common bacterial alternatives at the malate/oxaloacetate node and pyruvate carboxylase as an anaplerotic input to oxaloacetate.</p>        <div class="meta-row"><span class="pill">MODULE:tca_cycle</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/tca_cycle.yaml</span>
+        <h1>Tricarboxylic acid cycle</h1>            <p class="description">A taxon-neutral module for the oxidative tricarboxylic acid (TCA) cycle, covering acetyl-CoA entry through citrate synthase, citrate/isocitrate interconversion, oxidative decarboxylation to succinyl-CoA, succinate-level phosphorylation, succinate oxidation through respiratory complex II, fumarate hydration, and malate oxidation to regenerate oxaloacetate. The module also records common bacterial alternatives at the aconitase, isocitrate dehydrogenase, fumarase, and malate/oxaloacetate steps.</p>        <div class="meta-row"><span class="pill">MODULE:tca_cycle</span><span class="pill status">DRAFT</span><span class="pill scope">CONCRETE</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/tca_cycle.yaml</span>
         </div>
         <div class="descriptor-list">                <span class="descriptor">
             <span>tricarboxylic acid cycle</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006099" target="_blank" rel="noopener">GO:0006099</a></span>        </div>
-        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006099" target="_blank" rel="noopener">GO:0006099</a><div><strong>tricarboxylic acid cycle</strong></div><div>GO represents the TCA cycle as the pathway that oxidizes acetyl-CoA to CO2 while generating reducing equivalents and regenerating oxaloacetate.</div></div>                <div class="evidence-card small"><span class="source-id">file:genes/PSEPK/gltA/gltA-ai-review.yaml</span><div><strong>PSEPK gltA gene review</strong></div><div>PSEPK GltA is a curated citrate synthase and marks acetyl-CoA entry into the KT2440 TCA cycle.</div></div>                <div class="evidence-card small"><span class="source-id">file:genes/PSEPK/sdhA/sdhA-ai-review.yaml</span><div><strong>PSEPK sdhA gene review</strong></div><div>PSEPK SdhA is curated as the catalytic flavoprotein subunit of succinate dehydrogenase, connecting the TCA cycle to the respiratory quinone pool.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/tca_cycle-deep-research-openscientist.md</span><div><strong>OpenScientist module research for the TCA cycle</strong></div><div>The generic module-level research supports the oxidative TCA-cycle boundary, including bacterial variants at fumarase and malate oxidation and treating pyruvate carboxylase as an anaplerotic input rather than a cyclic reaction.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__tca_cycle__ppu00020-deep-research-openscientist.md</span><div><strong>OpenScientist PSEPK/ppu00020 TCA-cycle research</strong></div><div>The P. putida KT2440 pathway report concludes that the oxidative TCA cycle is satisfiable, with quinone-linked MQO as the primary malate oxidation branch and with scpC/prpC treated as methylcitrate or CoA-transferase boundary cases rather than core SCS/citrate synthase replacements.</div></div>        </div><p class="muted small">Reusable boundary: this module describes the oxidative TCA cycle and its immediate bacterial alternatives, not every KEGG ppu00020 neighbor. Pyruvate dehydrogenase supplies acetyl-CoA upstream, pyruvate carboxylase is modeled as an anaplerotic oxaloacetate input, and methylcitrate/propionyl-CoA CoA-transferase proteins should be treated as adjacent propionate-metabolism context unless direct evidence places them in the main cyclic flux. The PSEPK instantiation is satisfiable with gltA/Q88FA4, acnB/Q88KF1 plus acnA-I/Q88L24, icd/Q88FS2 plus idh/Q88FS1, sucA/Q88FA9-sucB/Q88FB0 with lpdG/Q88FB1 or related E3 components, sucD/Q88FB3-sucC/Q88FB2, sdhABCD/Q88FA7-Q88FA8-Q88FA5-Q88FA6, fumarase paralogs including the class-I enzyme PP_0897/Q88PF3 and the class-II enzymes fumC/Q88M20 and fumC-I/Q88PA6, and malate oxidation by mqo1/Q88PU7, mqo2/Q88NF9, mqo3/Q88IS4, and/or mdh/Q88Q44.</p></header>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006099" target="_blank" rel="noopener">GO:0006099</a><div><strong>tricarboxylic acid cycle</strong></div><div>GO represents the TCA cycle as the pathway that oxidizes acetyl-CoA to CO2 while generating reducing equivalents and regenerating oxaloacetate.</div></div>                <div class="evidence-card small"><span class="source-id">file:genes/PSEPK/gltA/gltA-ai-review.yaml</span><div><strong>PSEPK gltA gene review</strong></div><div>PSEPK GltA is a curated citrate synthase and marks acetyl-CoA entry into the KT2440 TCA cycle.</div></div>                <div class="evidence-card small"><span class="source-id">file:genes/PSEPK/sdhA/sdhA-ai-review.yaml</span><div><strong>PSEPK sdhA gene review</strong></div><div>PSEPK SdhA is curated as the catalytic flavoprotein subunit of succinate dehydrogenase, connecting the TCA cycle to the respiratory quinone pool.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/tca_cycle-deep-research-openscientist.md</span><div><strong>OpenScientist module research for the TCA cycle</strong></div><div>The generic module-level research supports the oxidative TCA-cycle boundary, including bacterial variants at fumarase and malate oxidation and treating pyruvate carboxylase as an anaplerotic input rather than a cyclic reaction.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__tca_cycle__ppu00020-deep-research-openscientist.md</span><div><strong>OpenScientist PSEPK/ppu00020 TCA-cycle research</strong></div><div>The P. putida KT2440 pathway report concludes that the oxidative TCA cycle is satisfiable, with quinone-linked MQO as the primary malate oxidation branch and with scpC/prpC treated as methylcitrate or CoA-transferase boundary cases rather than core SCS/citrate synthase replacements.</div></div>        </div><p class="muted small">Reusable boundary: this module describes the oxidative TCA cycle and its immediate bacterial alternatives, not every KEGG ppu00020 neighbor. Pyruvate dehydrogenase supplies acetyl-CoA upstream, pyruvate carboxylase supplies an external anaplerotic oxaloacetate input, and methylcitrate/propionyl-CoA CoA-transferase proteins should be treated as adjacent propionate-metabolism context unless direct evidence places them in the main cyclic flux. The PSEPK instantiation is satisfiable with gltA/Q88FA4, acnB/Q88KF1 plus acnA-I/Q88L24, icd/Q88FS2 plus idh/Q88FS1, sucA/Q88FA9-sucB/Q88FB0 with lpdG/Q88FB1 or related E3 components, sucD/Q88FB3-sucC/Q88FB2, sdhABCD/Q88FA7-Q88FA8-Q88FA5-Q88FA6, fumarase paralogs including the class-I enzyme PP_0897/Q88PF3 and the class-II enzymes fumC/Q88M20 and fumC-I/Q88PA6, and malate oxidation by mqo1/Q88PU7, mqo2/Q88NF9, mqo3/Q88IS4, and/or mdh/Q88Q44.</p></header>
     <section class="stats" aria-label="Module counts">
-        <div class="stat"><span class="stat-value">13</span><span class="stat-label">Nodes</span></div>
-        <div class="stat"><span class="stat-value">12</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">12</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">11</span><span class="stat-label">Parts</span></div>
         <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
         <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
-        <div class="stat"><span class="stat-value">12</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">11</span><span class="stat-label">Annotons</span></div>
         <div class="stat"><span class="stat-value">0</span><span class="stat-label">Connections</span></div>
     </section>    <section class="qc-panel panel" aria-label="Derived QC">
         <div class="panel-header">
@@ -570,23 +570,168 @@
         </div>
         <div class="panel-body qc-grid">
             <div class="qc-card">
-                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
-                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">55.6%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <ul class="qc-list small">                                <li><code>module.knowledge_gaps[0]</code> &middot; status
+                                    <span class="muted">(0/1)</span></li>                                <li><code>module.knowledge_gaps[0]</code> &middot; provenance
+                                    <span class="muted">(0/1)</span></li>                                <li><code>module.knowledge_gaps[1]</code> &middot; status
+                                    <span class="muted">(0/1)</span></li>                                <li><code>module.knowledge_gaps[1]</code> &middot; provenance
+                                    <span class="muted">(0/1)</span></li>                        </ul>            </div>
 
             <div class="qc-card">
                 <h3>Module deep research</h3>                    <p><span class="ok">&#10003; present</span></p>
                     <ul class="qc-list small">                            <li>tca_cycle-deep-research-openscientist.md <span class="muted">(openscientist)</span></li>                    </ul>            </div>
 
             <div class="qc-card">
-                <h3>Leaf nodes lacking representative members</h3>                    <p class="small">11 leaf node(s) with no concrete protein grounding:</p>
-                    <ul class="qc-list small">                            <li><a href="#node-citrate_synthase_step">Citrate synthase</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-aconitate_hydratase_step">Aconitate hydratase</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-isocitrate_dehydrogenase_step">Isocitrate dehydrogenase</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-oxoglutarate_dehydrogenase_e1_step">2-oxoglutarate dehydrogenase E1</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-dihydrolipoyl_succinyltransferase_step">Dihydrolipoyllysine-residue succinyltransferase</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-dihydrolipoyl_dehydrogenase_step">Dihydrolipoyl dehydrogenase</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-succinate_coa_ligase_step">Succinate-CoA ligase</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-succinate_dehydrogenase_step">Succinate dehydrogenase</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-fumarate_hydratase_step">Fumarate hydratase</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-malate_to_oxaloacetate_step">Malate to oxaloacetate</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                            <li><a href="#node-pyruvate_carboxylase_step">Pyruvate carboxylase</a> <span class="muted">ANY_WITH_FUNCTION</span></li>                    </ul>            </div>
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
 
             <div class="qc-card">
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(0/0 grounded genes reviewed)</span>
-                </h3>                    <p class="muted small">No concrete UniProt-grounded genes in this module.</p>            </div>
+                    <span class="muted small">(21/21 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        21 complete review(s) &middot;
+                        21 with deep research &middot;
+                        0 missing review &middot;
+                        0 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>acnA-I
+                                        <span class="muted term-id">Q88L24</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>acnB
+                                        <span class="muted term-id">Q88KF1</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>fumC
+                                        <span class="muted term-id">Q88M20</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>fumC-I
+                                        <span class="muted term-id">Q88PA6</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>gltA
+                                        <span class="muted term-id">Q88FA4</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>icd
+                                        <span class="muted term-id">Q88FS2</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>idh
+                                        <span class="muted term-id">Q88FS1</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>lpdG
+                                        <span class="muted term-id">Q88FB1</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>mdh
+                                        <span class="muted term-id">Q88Q44</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>mqo1
+                                        <span class="muted term-id">Q88PU7</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>mqo2
+                                        <span class="muted term-id">Q88NF9</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>mqo3
+                                        <span class="muted term-id">Q88IS4</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>PP_0897
+                                        <span class="muted term-id">Q88PF3</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>sdhA
+                                        <span class="muted term-id">Q88FA7</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>sdhB
+                                        <span class="muted term-id">Q88FA8</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>sdhC
+                                        <span class="muted term-id">Q88FA5</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>sdhD
+                                        <span class="muted term-id">Q88FA6</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>sucA
+                                        <span class="muted term-id">Q88FA9</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>sucB
+                                        <span class="muted term-id">Q88FB0</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>sucC
+                                        <span class="muted term-id">Q88FB2</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>sucD
+                                        <span class="muted term-id">Q88FB3</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
         </div>
     </section>
     <section class="browser">
@@ -620,7 +765,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-citrate_synthase_activity">Citrate synthase</a>
-                                <span class="tree-id">Any With Function: citrate synthase activity</span>
+                                <span class="tree-id">Family: bacterial citrate synthase family</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -636,7 +781,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-aconitate_hydratase_activity">Aconitase</a>
-                                <span class="tree-id">Any With Function: aconitate hydratase activity</span>
+                                <span class="tree-id">Family: bacterial aconitate hydratase families</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -652,7 +797,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-isocitrate_dehydrogenase_nadp_activity">NADP-dependent isocitrate dehydrogenase</a>
-                                <span class="tree-id">Any With Function: isocitrate dehydrogenase (NADP+) activity</span>
+                                <span class="tree-id">Family: bacterial NADP-dependent isocitrate dehydrogenase families</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -677,7 +822,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-oxoglutarate_dehydrogenase_activity">2-oxoglutarate dehydrogenase</a>
-                                <span class="tree-id">Any With Function: oxoglutarate dehydrogenase (succinyl-transferring) activity</span>
+                                <span class="tree-id">Family: bacterial SucA E1 family</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -693,7 +838,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-dihydrolipoyl_succinyltransferase_activity">Dihydrolipoyllysine-residue succinyltransferase</a>
-                                <span class="tree-id">Any With Function: dihydrolipoyllysine-residue succinyltransferase activity</span>
+                                <span class="tree-id">Family: bacterial SucB E2 family</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -709,7 +854,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-dihydrolipoyl_dehydrogenase_activity">Dihydrolipoyl dehydrogenase</a>
-                                <span class="tree-id">Any With Function: dihydrolipoyl dehydrogenase (NADH) activity</span>
+                                <span class="tree-id">Family: bacterial Lpd E3 family</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -727,7 +872,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-succinate_coa_ligase_adp_activity">ADP-forming succinate-CoA ligase</a>
-                                <span class="tree-id">Any With Function: succinate-CoA ligase (ADP-forming) activity</span>
+                                <span class="tree-id">Protein Complex: bacterial SucCD succinate-CoA ligase complex</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -743,7 +888,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-succinate_dehydrogenase_quinone_activity">Succinate dehydrogenase (quinone)</a>
-                                <span class="tree-id">Any With Function: succinate dehydrogenase (quinone) activity</span>
+                                <span class="tree-id">Protein Complex: bacterial SdhABCD succinate dehydrogenase complex</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -759,7 +904,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-fumarate_hydratase_activity">Fumarate hydratase</a>
-                                <span class="tree-id">Any With Function: fumarate hydratase activity</span>
+                                <span class="tree-id">Family: bacterial class-I and class-II fumarate hydratase families</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -775,28 +920,12 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-malate_dehydrogenase_nad_activity">NAD-dependent L-malate dehydrogenase</a>
-                                <span class="tree-id">Any With Function: L-malate dehydrogenase (NAD+) activity</span>
+                                <span class="tree-id">Family: bacterial NAD-dependent malate dehydrogenase family</span>
                             </span>
                         </li>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-malate_dehydrogenase_quinone_activity">L-malate dehydrogenase (quinone)</a>
-                                <span class="tree-id">Any With Function: L-malate dehydrogenase (quinone) activity</span>
-                            </span>
-                        </li>                </ul></details>
-    </li>
-                            </li>                            <li>
-                                <div class="edge-note">9. anaplerotic oxaloacetate input</div>
-                                <li class="tree-entry">
-        <details class="tree-node" open>
-            <summary>
-                <span class="tree-row">
-                    <a class="tree-link" href="#node-pyruvate_carboxylase_step">Pyruvate carboxylase</a><span class="pill type">Reaction</span><span class="tree-id">pyruvate_carboxylase_step</span>
-                </span>
-            </summary>                <div class="tree-group-title">Annotons</div>
-                <ul>                        <li class="annoton-item tree-entry">
-                            <span class="tree-row">
-                                <a href="#annoton-pyruvate_carboxylase_activity">Pyruvate carboxylase</a>
-                                <span class="tree-id">Any With Function: pyruvate carboxylase activity</span>
+                                <span class="tree-id">Family: bacterial malate:quinone oxidoreductase family</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -811,33 +940,13 @@
                 <h2>Details</h2>
             </div>
             <div class="panel-body">
-                <div class="context-card small">
-            <strong>Context</strong>
 
-
-
-
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>                <span class="descriptor">
-            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>
-
-            </div>
                 <section class="node-detail depth-0" id="node-tca_cycle">
         <div class="node-heading">
             <span class="node-title">Tricarboxylic acid cycle</span><span class="pill type">Metabolic Pathway</span><span class="pill">tca_cycle</span>
         </div><div class="descriptor-list">                <span class="descriptor">
             <span>tricarboxylic acid cycle</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006099" target="_blank" rel="noopener">GO:0006099</a></span>        </div>
-        <div class="context-card small">
-            <strong>Context</strong>
 
-
-
-
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>                <span class="descriptor">
-            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>
-
-            </div>
                         <div class="part-marker">
                     Part 1: acetyl-CoA entry</div>
                 <section class="node-detail depth-1" id="node-citrate_synthase_step">
@@ -848,11 +957,13 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-citrate_synthase_activity">
         <div class="annoton-title">Citrate synthase</div>
-        <div class="small muted">citrate_synthase_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: citrate synthase activity</div>
+        <div class="small muted">citrate_synthase_activity</div>            <div class="small"><strong>Participant:</strong> Family: bacterial citrate synthase family</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>citrate synthase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0036440" target="_blank" rel="noopener">GO:0036440</a></div>
+            <span><strong>bacterial citrate synthase family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK GltA exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FA4/entry" target="_blank" rel="noopener">UniProtKB:Q88FA4</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>citrate synthase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0036440" target="_blank" rel="noopener">GO:0036440</a>                    <div class="slot-row">
@@ -872,11 +983,14 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-aconitate_hydratase_activity">
         <div class="annoton-title">Aconitase</div>
-        <div class="small muted">aconitate_hydratase_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: aconitate hydratase activity</div>
+        <div class="small muted">aconitate_hydratase_activity</div>            <div class="small"><strong>Participant:</strong> Family: bacterial aconitate hydratase families</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>aconitate hydratase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003994" target="_blank" rel="noopener">GO:0003994</a></div>
+            <span><strong>bacterial aconitate hydratase families</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK AcnA-I exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88L24/entry" target="_blank" rel="noopener">UniProtKB:Q88L24</a></span>                            <span class="descriptor">
+            <span>PSEPK AcnB exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88KF1/entry" target="_blank" rel="noopener">UniProtKB:Q88KF1</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>aconitate hydratase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003994" target="_blank" rel="noopener">GO:0003994</a>                    <div class="slot-row">
@@ -893,11 +1007,14 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-isocitrate_dehydrogenase_nadp_activity">
         <div class="annoton-title">NADP-dependent isocitrate dehydrogenase</div>
-        <div class="small muted">isocitrate_dehydrogenase_nadp_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: isocitrate dehydrogenase (NADP+) activity</div>
+        <div class="small muted">isocitrate_dehydrogenase_nadp_activity</div>            <div class="small"><strong>Participant:</strong> Family: bacterial NADP-dependent isocitrate dehydrogenase families</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>isocitrate dehydrogenase (NADP+) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004450" target="_blank" rel="noopener">GO:0004450</a></div>
+            <span><strong>bacterial NADP-dependent isocitrate dehydrogenase families</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK Icd exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FS2/entry" target="_blank" rel="noopener">UniProtKB:Q88FS2</a></span>                            <span class="descriptor">
+            <span>PSEPK Idh exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FS1/entry" target="_blank" rel="noopener">UniProtKB:Q88FS1</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>isocitrate dehydrogenase (NADP+) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004450" target="_blank" rel="noopener">GO:0004450</a>                    <div class="slot-row">
@@ -924,11 +1041,13 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-oxoglutarate_dehydrogenase_activity">
         <div class="annoton-title">2-oxoglutarate dehydrogenase</div>
-        <div class="small muted">oxoglutarate_dehydrogenase_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: oxoglutarate dehydrogenase (succinyl-transferring) activity</div>
+        <div class="small muted">oxoglutarate_dehydrogenase_activity</div>            <div class="small"><strong>Participant:</strong> Family: bacterial SucA E1 family</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>oxoglutarate dehydrogenase (succinyl-transferring) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004591" target="_blank" rel="noopener">GO:0004591</a></div>
+            <span><strong>bacterial SucA E1 family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK SucA exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FA9/entry" target="_blank" rel="noopener">UniProtKB:Q88FA9</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>oxoglutarate dehydrogenase (succinyl-transferring) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004591" target="_blank" rel="noopener">GO:0004591</a>                    <div class="slot-row">
@@ -945,11 +1064,13 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-dihydrolipoyl_succinyltransferase_activity">
         <div class="annoton-title">Dihydrolipoyllysine-residue succinyltransferase</div>
-        <div class="small muted">dihydrolipoyl_succinyltransferase_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: dihydrolipoyllysine-residue succinyltransferase activity</div>
+        <div class="small muted">dihydrolipoyl_succinyltransferase_activity</div>            <div class="small"><strong>Participant:</strong> Family: bacterial SucB E2 family</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>dihydrolipoyllysine-residue succinyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004149" target="_blank" rel="noopener">GO:0004149</a></div>
+            <span><strong>bacterial SucB E2 family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK SucB exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FB0/entry" target="_blank" rel="noopener">UniProtKB:Q88FB0</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>dihydrolipoyllysine-residue succinyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004149" target="_blank" rel="noopener">GO:0004149</a>                    <div class="slot-row">
@@ -967,11 +1088,13 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-dihydrolipoyl_dehydrogenase_activity">
         <div class="annoton-title">Dihydrolipoyl dehydrogenase</div>
-        <div class="small muted">dihydrolipoyl_dehydrogenase_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: dihydrolipoyl dehydrogenase (NADH) activity</div>
+        <div class="small muted">dihydrolipoyl_dehydrogenase_activity</div>            <div class="small"><strong>Participant:</strong> Family: bacterial Lpd E3 family</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>dihydrolipoyl dehydrogenase (NADH) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004148" target="_blank" rel="noopener">GO:0004148</a></div>
+            <span><strong>bacterial Lpd E3 family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK LpdG provisional exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FB1/entry" target="_blank" rel="noopener">UniProtKB:Q88FB1</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>dihydrolipoyl dehydrogenase (NADH) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004148" target="_blank" rel="noopener">GO:0004148</a>                    <div class="slot-row">
@@ -990,11 +1113,32 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-succinate_coa_ligase_adp_activity">
         <div class="annoton-title">ADP-forming succinate-CoA ligase</div>
-        <div class="small muted">succinate_coa_ligase_adp_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: succinate-CoA ligase (ADP-forming) activity</div>
+        <div class="small muted">succinate_coa_ligase_adp_activity</div>            <div class="small"><strong>Participant:</strong> Protein Complex: bacterial SucCD succinate-CoA ligase complex</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Protein Complex:</span>
                         <div class="descriptor">
-            <span><strong>succinate-CoA ligase (ADP-forming) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004775" target="_blank" rel="noopener">GO:0004775</a></div>
+            <span><strong>bacterial SucCD succinate-CoA ligase complex</strong></span>                <div class="slot-row">
+                    <span class="slot-name">Active units:</span>
+                    <div class="active-unit-list">                            <div class="complex-unit">
+        <div>
+            <strong>SucC beta subunit</strong></div>            <div class="small"><strong>Participant:</strong> Family: bacterial SucC family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>bacterial SucC family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK SucC exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FB2/entry" target="_blank" rel="noopener">UniProtKB:Q88FB2</a></span>                    </div></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> Nucleotide-binding beta subunit of the heteromeric ligase.</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>SucD alpha subunit</strong></div>            <div class="small"><strong>Participant:</strong> Family: bacterial SucD family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>bacterial SucD family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK SucD exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FB3/entry" target="_blank" rel="noopener">UniProtKB:Q88FB3</a></span>                    </div></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> CoA- and phosphate-handling alpha subunit of the heteromeric ligase.</div></div>                    </div>
+                </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>succinate-CoA ligase (ADP-forming) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004775" target="_blank" rel="noopener">GO:0004775</a>                    <div class="slot-row">
@@ -1015,11 +1159,52 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-succinate_dehydrogenase_quinone_activity">
         <div class="annoton-title">Succinate dehydrogenase (quinone)</div>
-        <div class="small muted">succinate_dehydrogenase_quinone_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: succinate dehydrogenase (quinone) activity</div>
+        <div class="small muted">succinate_dehydrogenase_quinone_activity</div>            <div class="small"><strong>Participant:</strong> Protein Complex: bacterial SdhABCD succinate dehydrogenase complex</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Protein Complex:</span>
                         <div class="descriptor">
-            <span><strong>succinate dehydrogenase (quinone) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008177" target="_blank" rel="noopener">GO:0008177</a></div>
+            <span><strong>bacterial SdhABCD succinate dehydrogenase complex</strong></span>                <div class="slot-row">
+                    <span class="slot-name">Active units:</span>
+                    <div class="active-unit-list">                            <div class="complex-unit">
+        <div>
+            <strong>SdhA flavoprotein subunit</strong></div>            <div class="small"><strong>Participant:</strong> Family: bacterial SdhA family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>bacterial SdhA family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK SdhA exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FA7/entry" target="_blank" rel="noopener">UniProtKB:Q88FA7</a></span>                    </div></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> Catalyzes succinate oxidation at the FAD-containing active site.</div>            <div class="small"><strong>Function:</strong> <div class="descriptor">
+            <span><strong>succinate dehydrogenase (quinone) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008177" target="_blank" rel="noopener">GO:0008177</a></div></div></div>                            <div class="complex-unit">
+        <div>
+            <strong>SdhB iron-sulfur subunit</strong></div>            <div class="small"><strong>Participant:</strong> Family: bacterial SdhB family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>bacterial SdhB family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK SdhB exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FA8/entry" target="_blank" rel="noopener">UniProtKB:Q88FA8</a></span>                    </div></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> Relays electrons from SdhA toward the membrane quinone site.</div>            <div class="small"><strong>Function:</strong> <div class="descriptor">
+            <span><strong>electron transfer activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009055" target="_blank" rel="noopener">GO:0009055</a></div></div></div>                            <div class="complex-unit">
+        <div>
+            <strong>SdhC membrane subunit</strong></div>            <div class="small"><strong>Participant:</strong> Family: bacterial SdhC family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>bacterial SdhC family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK SdhC exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FA5/entry" target="_blank" rel="noopener">UniProtKB:Q88FA5</a></span>                    </div></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> Contributes the cytochrome-b membrane anchor and quinone-interaction domain.</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>SdhD membrane subunit</strong></div>            <div class="small"><strong>Participant:</strong> Family: bacterial SdhD family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>bacterial SdhD family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK SdhD exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FA6/entry" target="_blank" rel="noopener">UniProtKB:Q88FA6</a></span>                    </div></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> Completes the membrane anchor and contributes to quinone-linked electron transfer.</div></div>                    </div>
+                </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>succinate dehydrogenase (quinone) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008177" target="_blank" rel="noopener">GO:0008177</a>                    <div class="slot-row">
@@ -1040,11 +1225,15 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-fumarate_hydratase_activity">
         <div class="annoton-title">Fumarate hydratase</div>
-        <div class="small muted">fumarate_hydratase_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: fumarate hydratase activity</div>
+        <div class="small muted">fumarate_hydratase_activity</div>            <div class="small"><strong>Participant:</strong> Family: bacterial class-I and class-II fumarate hydratase families</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>fumarate hydratase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004333" target="_blank" rel="noopener">GO:0004333</a></div>
+            <span><strong>bacterial class-I and class-II fumarate hydratase families</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK class-I fumarase exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88PF3/entry" target="_blank" rel="noopener">UniProtKB:Q88PF3</a></span>                            <span class="descriptor">
+            <span>PSEPK FumC-I exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88PA6/entry" target="_blank" rel="noopener">UniProtKB:Q88PA6</a></span>                            <span class="descriptor">
+            <span>PSEPK FumC exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88M20/entry" target="_blank" rel="noopener">UniProtKB:Q88M20</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>fumarate hydratase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004333" target="_blank" rel="noopener">GO:0004333</a>                    <div class="slot-row">
@@ -1062,11 +1251,13 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-malate_dehydrogenase_nad_activity">
         <div class="annoton-title">NAD-dependent L-malate dehydrogenase</div>
-        <div class="small muted">malate_dehydrogenase_nad_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: L-malate dehydrogenase (NAD+) activity</div>
+        <div class="small muted">malate_dehydrogenase_nad_activity</div>            <div class="small"><strong>Participant:</strong> Family: bacterial NAD-dependent malate dehydrogenase family</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>L-malate dehydrogenase (NAD+) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0030060" target="_blank" rel="noopener">GO:0030060</a></div>
+            <span><strong>bacterial NAD-dependent malate dehydrogenase family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK Mdh exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88Q44/entry" target="_blank" rel="noopener">UniProtKB:Q88Q44</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>L-malate dehydrogenase (NAD+) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0030060" target="_blank" rel="noopener">GO:0030060</a>                    <div class="slot-row">
@@ -1077,11 +1268,15 @@
             <span>oxaloacetate</span></span>                            <span class="descriptor">
             <span>NADH</span></span>                    </div></div></article>                    <article class="annoton-card" id="annoton-malate_dehydrogenase_quinone_activity">
         <div class="annoton-title">L-malate dehydrogenase (quinone)</div>
-        <div class="small muted">malate_dehydrogenase_quinone_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: L-malate dehydrogenase (quinone) activity</div>
+        <div class="small muted">malate_dehydrogenase_quinone_activity</div>            <div class="small"><strong>Participant:</strong> Family: bacterial malate:quinone oxidoreductase family</div>
             <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
+                        <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>L-malate dehydrogenase (quinone) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008924" target="_blank" rel="noopener">GO:0008924</a></div>
+            <span><strong>bacterial malate:quinone oxidoreductase family</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PSEPK Mqo1 exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88PU7/entry" target="_blank" rel="noopener">UniProtKB:Q88PU7</a></span>                            <span class="descriptor">
+            <span>PSEPK Mqo2 exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88NF9/entry" target="_blank" rel="noopener">UniProtKB:Q88NF9</a></span>                            <span class="descriptor">
+            <span>PSEPK Mqo3 exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88IS4/entry" target="_blank" rel="noopener">UniProtKB:Q88IS4</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>L-malate dehydrogenase (quinone) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008924" target="_blank" rel="noopener">GO:0008924</a>                    <div class="slot-row">
@@ -1090,32 +1285,7 @@
             <span>quinone</span></span>                    </div>                    <div class="slot-row">
                         <span class="slot-name">Products:</span>                            <span class="descriptor">
             <span>oxaloacetate</span></span>                            <span class="descriptor">
-            <span>quinol</span></span>                    </div></div></article>            </div>    </section>                <div class="part-marker">
-                    Part 9: anaplerotic oxaloacetate input</div>
-                <section class="node-detail depth-1" id="node-pyruvate_carboxylase_step">
-        <div class="node-heading">
-            <span class="node-title">Pyruvate carboxylase</span><span class="pill type">Reaction</span><span class="pill">pyruvate_carboxylase_step</span>
-        </div>
-
-                    <h4>Annotons</h4>
-            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pyruvate_carboxylase_activity">
-        <div class="annoton-title">Pyruvate carboxylase</div>
-        <div class="small muted">pyruvate_carboxylase_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: pyruvate carboxylase activity</div>
-            <div class="participant-detail">                    <div class="slot-row">
-                        <span class="slot-name">Required Function:</span>
-                        <div class="descriptor">
-            <span><strong>pyruvate carboxylase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004736" target="_blank" rel="noopener">GO:0004736</a></div>
-                    </div></div>            <h4>Function</h4>
-            <div class="descriptor">
-            <span><strong>pyruvate carboxylase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004736" target="_blank" rel="noopener">GO:0004736</a>                    <div class="slot-row">
-                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
-            <span>pyruvate</span></span>                            <span class="descriptor">
-            <span>bicarbonate</span></span>                            <span class="descriptor">
-            <span>ATP</span></span>                    </div>                    <div class="slot-row">
-                        <span class="slot-name">Products:</span>                            <span class="descriptor">
-            <span>oxaloacetate</span></span>                            <span class="descriptor">
-            <span>ADP</span></span>                            <span class="descriptor">
-            <span>phosphate</span></span>                    </div></div>            <p class="role-description">An anaplerotic entry into the oxaloacetate pool rather than a strict cyclic TCA reaction.</p></article>            </div>    </section>    </section>
+            <span>quinol</span></span>                    </div></div></article>            </div>    </section>    </section>
             </div>
         </section>
     </section>

--- a/pages/modules/tca_cycle.html
+++ b/pages/modules/tca_cycle.html
@@ -1117,7 +1117,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Protein Complex:</span>
                         <div class="descriptor">
-            <span><strong>bacterial SucCD succinate-CoA ligase complex</strong></span>                <div class="slot-row">
+            <span><strong>bacterial SucCD succinate-CoA ligase complex</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009361" target="_blank" rel="noopener">GO:0009361</a>                <div class="slot-row">
                     <span class="slot-name">Active units:</span>
                     <div class="active-unit-list">                            <div class="complex-unit">
         <div>
@@ -1163,7 +1163,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Protein Complex:</span>
                         <div class="descriptor">
-            <span><strong>bacterial SdhABCD succinate dehydrogenase complex</strong></span>                <div class="slot-row">
+            <span><strong>bacterial SdhABCD succinate dehydrogenase complex</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0045273" target="_blank" rel="noopener">GO:0045273</a>                <div class="slot-row">
                     <span class="slot-name">Active units:</span>
                     <div class="active-unit-list">                            <div class="complex-unit">
         <div>
@@ -1175,7 +1175,7 @@
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK SdhA exemplar</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FA7/entry" target="_blank" rel="noopener">UniProtKB:Q88FA7</a></span>                    </div></div>
                     </div></div>            <div class="small"><strong>Role:</strong> Catalyzes succinate oxidation at the FAD-containing active site.</div>            <div class="small"><strong>Function:</strong> <div class="descriptor">
-            <span><strong>succinate dehydrogenase (quinone) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008177" target="_blank" rel="noopener">GO:0008177</a></div></div></div>                            <div class="complex-unit">
+            <span><strong>succinate dehydrogenase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0000104" target="_blank" rel="noopener">GO:0000104</a></div></div></div>                            <div class="complex-unit">
         <div>
             <strong>SdhB iron-sulfur subunit</strong></div>            <div class="small"><strong>Participant:</strong> Family: bacterial SdhB family</div>
             <div class="participant-detail">                    <div class="slot-row">

--- a/pages/projects/P_PUTIDA/batches/ppu00020_tca_cycle.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00020_tca_cycle.html
@@ -384,7 +384,7 @@
 <li>[x] Run OpenScientist deep research for selected genes.</li>
 <li>[x] Curate each selected gene review.</li>
 <li>[x] Validate module and gene reviews.</li>
-<li>[ ] Open one PR for this module/pathway.</li>
+<li>[x] Open one PR for this module/pathway: <a href="https://github.com/ai4curation/ai-gene-review/pull/2121">PR #2121</a>.</li>
 <li>[ ] Shepherd PR through review, CI, and merge readiness.</li>
 </ul>
 <h2 id="candidate-genes">Candidate Genes</h2>
@@ -737,6 +737,13 @@
 </table>
 <h2 id="notes">Notes</h2>
 <p>Generated UTC: 2026-09-01T06:53:58.399357+00:00</p>
+<p>Completed pass:</p>
+<ul>
+<li>Added the species-neutral <code>modules/tca_cycle.yaml</code> module review and<br />
+  OpenScientist module/pathway reports.</li>
+<li>Generated OpenScientist gene-level reports for all 30 batch genes.</li>
+<li>Curated and validated all 30 selected PSEPK gene review files.</li>
+</ul>
 <h2 id="follow-up-module-repair">Follow-up module repair</h2>
 <p>The eight-step oxidative cycle is retained, but pyruvate carboxylase has been<br />
 removed as a ninth part because it is an external anaplerotic input rather than<br />

--- a/pages/projects/P_PUTIDA/batches/ppu00020_tca_cycle.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00020_tca_cycle.html
@@ -384,7 +384,7 @@
 <li>[x] Run OpenScientist deep research for selected genes.</li>
 <li>[x] Curate each selected gene review.</li>
 <li>[x] Validate module and gene reviews.</li>
-<li>[x] Open one PR for this module/pathway: <a href="https://github.com/ai4curation/ai-gene-review/pull/2121">PR #2121</a>.</li>
+<li>[ ] Open one PR for this module/pathway.</li>
 <li>[ ] Shepherd PR through review, CI, and merge readiness.</li>
 </ul>
 <h2 id="candidate-genes">Candidate Genes</h2>
@@ -736,14 +736,21 @@
 </tbody>
 </table>
 <h2 id="notes">Notes</h2>
-<p>Generated UTC: 2026-07-12T00:20:26.410305+00:00</p>
-<p>Completed pass:</p>
-<ul>
-<li>Added the species-neutral <code>modules/tca_cycle.yaml</code> module review and<br />
-  OpenScientist module/pathway reports.</li>
-<li>Generated OpenScientist gene-level reports for all 30 batch genes.</li>
-<li>Curated and validated all 30 selected PSEPK gene review files.</li>
-</ul>
+<p>Generated UTC: 2026-09-01T06:53:58.399357+00:00</p>
+<h2 id="follow-up-module-repair">Follow-up module repair</h2>
+<p>The eight-step oxidative cycle is retained, but pyruvate carboxylase has been<br />
+removed as a ninth part because it is an external anaplerotic input rather than<br />
+a cyclic reaction. The mixed cytosol/plasma-membrane module-level locations<br />
+were also removed; membrane localization remains only on the succinate<br />
+dehydrogenase leaf.</p>
+<p>Every retained step now has concrete PSEPK UniProt exemplars. SucC/SucD and<br />
+SdhA/SdhB/SdhC/SdhD are represented as assembled complexes rather than as a<br />
+single unspecified protein selected only by collective molecular function.<br />
+Alternative aconitases, NADP-dependent isocitrate dehydrogenases, fumarases,<br />
+and malate-oxidation enzymes remain alternative implementations of their<br />
+respective steps, not extra required steps. LpdG remains a provisional E3<br />
+exemplar because the physiological division of labor among KT2440 Lpd-family<br />
+enzymes is unresolved.</p>
     </div>
 
     <footer>

--- a/projects/P_PUTIDA/batches/ppu00020_tca_cycle.md
+++ b/projects/P_PUTIDA/batches/ppu00020_tca_cycle.md
@@ -24,7 +24,7 @@ autolink_gene_symbols: false
 - [x] Run OpenScientist deep research for selected genes.
 - [x] Curate each selected gene review.
 - [x] Validate module and gene reviews.
-- [x] Open one PR for this module/pathway: [PR #2121](https://github.com/ai4curation/ai-gene-review/pull/2121).
+- [ ] Open one PR for this module/pathway.
 - [ ] Shepherd PR through review, CI, and merge readiness.
 
 ## Candidate Genes
@@ -64,11 +64,21 @@ autolink_gene_symbols: false
 
 ## Notes
 
-Generated UTC: 2026-07-12T00:20:26.410305+00:00
+Generated UTC: 2026-09-01T06:53:58.399357+00:00
 
-Completed pass:
+## Follow-up module repair
 
-- Added the species-neutral `modules/tca_cycle.yaml` module review and
-  OpenScientist module/pathway reports.
-- Generated OpenScientist gene-level reports for all 30 batch genes.
-- Curated and validated all 30 selected PSEPK gene review files.
+The eight-step oxidative cycle is retained, but pyruvate carboxylase has been
+removed as a ninth part because it is an external anaplerotic input rather than
+a cyclic reaction. The mixed cytosol/plasma-membrane module-level locations
+were also removed; membrane localization remains only on the succinate
+dehydrogenase leaf.
+
+Every retained step now has concrete PSEPK UniProt exemplars. SucC/SucD and
+SdhA/SdhB/SdhC/SdhD are represented as assembled complexes rather than as a
+single unspecified protein selected only by collective molecular function.
+Alternative aconitases, NADP-dependent isocitrate dehydrogenases, fumarases,
+and malate-oxidation enzymes remain alternative implementations of their
+respective steps, not extra required steps. LpdG remains a provisional E3
+exemplar because the physiological division of labor among KT2440 Lpd-family
+enzymes is unresolved.

--- a/projects/P_PUTIDA/batches/ppu00020_tca_cycle.md
+++ b/projects/P_PUTIDA/batches/ppu00020_tca_cycle.md
@@ -24,7 +24,7 @@ autolink_gene_symbols: false
 - [x] Run OpenScientist deep research for selected genes.
 - [x] Curate each selected gene review.
 - [x] Validate module and gene reviews.
-- [ ] Open one PR for this module/pathway.
+- [x] Open one PR for this module/pathway: [PR #2121](https://github.com/ai4curation/ai-gene-review/pull/2121).
 - [ ] Shepherd PR through review, CI, and merge readiness.
 
 ## Candidate Genes
@@ -65,6 +65,13 @@ autolink_gene_symbols: false
 ## Notes
 
 Generated UTC: 2026-09-01T06:53:58.399357+00:00
+
+Completed pass:
+
+- Added the species-neutral `modules/tca_cycle.yaml` module review and
+  OpenScientist module/pathway reports.
+- Generated OpenScientist gene-level reports for all 30 batch genes.
+- Curated and validated all 30 selected PSEPK gene review files.
 
 ## Follow-up module repair
 


### PR DESCRIPTION
## Summary
- remove mixed module-level cytosol/plasma-membrane locations
- keep the module at eight cyclic reactions by moving pyruvate carboxylase outside the core boundary
- add concrete PSEPK UniProt exemplars and model SucCD and SdhABCD as complexes
- retain paralog alternatives and explicit Lpd E3 uncertainty

## Validation
- `linkml-validate -C ModuleReview`
- semantic module validator: 0 warnings
- module and project rendering
- `git diff --check`