### PR TITLE
Remove redundant pentose-phosphate module location

### DIFF
--- a/modules/pentose_phosphate_pathway.yaml
+++ b/modules/pentose_phosphate_pathway.yaml
@@ -124,15 +124,6 @@ module:
       description: >-
         Core central-carbon route producing NADPH and rearranging pentose
         phosphates with glycolytic sugar phosphates.
-  context:
-    cellular_components:
-      - preferred_term: cytosol
-        term:
-          id: GO:0005829
-          label: cytosol
-        description: >-
-          The represented PSEPK exemplars are soluble central-carbon enzymes
-          acting on cytosolic sugar phosphates.
   parts:
     - order: 1
       role: oxidative branch from glucose 6-phosphate to ribulose 5-phosphate

--- a/pages/modules/pentose_phosphate_pathway.html
+++ b/pages/modules/pentose_phosphate_pathway.html
@@ -850,31 +850,13 @@
                 <h2>Details</h2>
             </div>
             <div class="panel-body">
-                <div class="context-card small">
-            <strong>Context</strong>
 
-
-
-
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
-
-            </div>
                 <section class="node-detail depth-0" id="node-pentose_phosphate_pathway">
         <div class="node-heading">
             <span class="node-title">Pentose phosphate pathway</span><span class="pill type">Metabolic Pathway</span><span class="pill">pentose_phosphate_pathway</span>
         </div><div class="descriptor-list">                <span class="descriptor">
             <span>pentose-phosphate shunt</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006098" target="_blank" rel="noopener">GO:0006098</a></span>        </div>
-        <div class="context-card small">
-            <strong>Context</strong>
 
-
-
-
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
-
-            </div>
                         <div class="part-marker">
                     Part 1: oxidative branch from glucose 6-phosphate to ribulose 5-phosphate</div>
                 <section class="node-detail depth-1" id="node-oxidative_branch">

--- a/pages/projects/P_PUTIDA/batches/ppu00030_pentose_phosphate_pathway.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00030_pentose_phosphate_pathway.html
@@ -386,7 +386,7 @@
 <li>[x] Run OpenScientist deep research for selected genes.</li>
 <li>[x] Curate each selected first-pass gene review.</li>
 <li>[x] Validate module and selected gene reviews.</li>
-<li>[ ] Render module and project pages.</li>
+<li>[x] Render module and project pages.</li>
 <li>[ ] Open one PR for this module/pathway.</li>
 <li>[ ] Shepherd PR through review, CI, and merge readiness.</li>
 </ul>
@@ -823,6 +823,12 @@
 <li>Reused existing curated <code>zwf</code> and <code>pgl</code> reviews, then attached completed OpenScientist research to keep this batch consistent.</li>
 <li>Initial OpenScientist gene-level jobs for <code>gntZ</code>, <code>rpe</code>, <code>rpiA</code>, and <code>tktA</code> hit the provider's default 3600 s timeout; they completed after restart with provider parameter <code>timeout=7200</code>.</li>
 <li>The pathway/taxon OpenScientist report supports treating KEGG ppu00030 as over-broad: ED, peripheral glucose oxidation, PRPP synthesis, and gluconeogenic/reductive spillovers should not be counted as PPP holes.</li>
+</ul>
+<h2 id="2026-09-01-structural-repair">2026-09-01 structural repair</h2>
+<ul>
+<li>Removed the generic cytosol assertion from module context. The reusable<br />
+  pathway is defined by ordered chemistry; localization need not be repeated<br />
+  at module level for every represented soluble bacterial exemplar.</li>
 </ul>
     </div>
 

--- a/pages/projects/P_PUTIDA/batches/ppu00030_pentose_phosphate_pathway.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00030_pentose_phosphate_pathway.html
@@ -387,7 +387,7 @@
 <li>[x] Curate each selected first-pass gene review.</li>
 <li>[x] Validate module and selected gene reviews.</li>
 <li>[x] Render module and project pages.</li>
-<li>[ ] Open one PR for this module/pathway.</li>
+<li>[x] Open one PR for this module/pathway: <a href="https://github.com/ai4curation/ai-gene-review/pull/2848">PR #2848</a>.</li>
 <li>[ ] Shepherd PR through review, CI, and merge readiness.</li>
 </ul>
 <h2 id="curated-scope">Curated Scope</h2>
@@ -827,8 +827,9 @@
 <h2 id="2026-09-01-structural-repair">2026-09-01 structural repair</h2>
 <ul>
 <li>Removed the generic cytosol assertion from module context. The reusable<br />
-  pathway is defined by ordered chemistry; localization need not be repeated<br />
-  at module level for every represented soluble bacterial exemplar.</li>
+  pathway is defined by conserved chemistry across taxa, whereas the deleted<br />
+  location was justified only by the soluble PSEPK exemplars and would not<br />
+  hold for compartmentalized instances such as plastidial PPP chemistry.</li>
 </ul>
     </div>
 

--- a/projects/P_PUTIDA/batches/ppu00030_pentose_phosphate_pathway.md
+++ b/projects/P_PUTIDA/batches/ppu00030_pentose_phosphate_pathway.md
@@ -26,7 +26,7 @@ autolink_gene_symbols: false
 - [x] Run OpenScientist deep research for selected genes.
 - [x] Curate each selected first-pass gene review.
 - [x] Validate module and selected gene reviews.
-- [ ] Render module and project pages.
+- [x] Render module and project pages.
 - [ ] Open one PR for this module/pathway.
 - [ ] Shepherd PR through review, CI, and merge readiness.
 
@@ -94,3 +94,9 @@ Generated UTC: 2026-07-15T14:52:59.970771+00:00
 - Reused existing curated `zwf` and `pgl` reviews, then attached completed OpenScientist research to keep this batch consistent.
 - Initial OpenScientist gene-level jobs for `gntZ`, `rpe`, `rpiA`, and `tktA` hit the provider's default 3600 s timeout; they completed after restart with provider parameter `timeout=7200`.
 - The pathway/taxon OpenScientist report supports treating KEGG ppu00030 as over-broad: ED, peripheral glucose oxidation, PRPP synthesis, and gluconeogenic/reductive spillovers should not be counted as PPP holes.
+
+## 2026-09-01 structural repair
+
+- Removed the generic cytosol assertion from module context. The reusable
+  pathway is defined by ordered chemistry; localization need not be repeated
+  at module level for every represented soluble bacterial exemplar.

--- a/projects/P_PUTIDA/batches/ppu00030_pentose_phosphate_pathway.md
+++ b/projects/P_PUTIDA/batches/ppu00030_pentose_phosphate_pathway.md
@@ -27,7 +27,7 @@ autolink_gene_symbols: false
 - [x] Curate each selected first-pass gene review.
 - [x] Validate module and selected gene reviews.
 - [x] Render module and project pages.
-- [ ] Open one PR for this module/pathway.
+- [x] Open one PR for this module/pathway: [PR #2848](https://github.com/ai4curation/ai-gene-review/pull/2848).
 - [ ] Shepherd PR through review, CI, and merge readiness.
 
 ## Curated Scope
@@ -98,5 +98,6 @@ Generated UTC: 2026-07-15T14:52:59.970771+00:00
 ## 2026-09-01 structural repair
 
 - Removed the generic cytosol assertion from module context. The reusable
-  pathway is defined by ordered chemistry; localization need not be repeated
-  at module level for every represented soluble bacterial exemplar.
+  pathway is defined by conserved chemistry across taxa, whereas the deleted
+  location was justified only by the soluble PSEPK exemplars and would not
+  hold for compartmentalized instances such as plastidial PPP chemistry.


### PR DESCRIPTION
## Summary
- remove the generic cytosol assertion from the reusable PPP module context
- retain the two-branch, eight-reaction pathway structure and leaf-level molecular functions
- refresh module and project rendering

## Validation
- LinkML ModuleReview validation
- semantic module validation
- module and project rendering
- `git diff --check`