### PR TITLE
Remove duplicated lipoprotein module location

### DIFF
--- a/modules/bacterial_lipoprotein_maturation.yaml
+++ b/modules/bacterial_lipoprotein_maturation.yaml
@@ -116,14 +116,6 @@ module:
           Lgt/LspA-dependent lipoprotein maturation is bacterial envelope
           biology; terminal acylation chemistry varies across bacterial
           lineages.
-    cellular_components:
-      - preferred_term: plasma membrane
-        term:
-          id: GO:0005886
-          label: plasma membrane
-        description: >-
-          Bacterial inner/cytoplasmic membrane context where Lgt, LspA, and Lnt
-          act on membrane-anchored lipoprotein intermediates.
   parts:
     - order: 1
       role: Diacylglyceryl transfer to prolipoprotein cysteine

--- a/modules/bacterial_lipoprotein_maturation.yaml
+++ b/modules/bacterial_lipoprotein_maturation.yaml
@@ -116,6 +116,14 @@ module:
           Lgt/LspA-dependent lipoprotein maturation is bacterial envelope
           biology; terminal acylation chemistry varies across bacterial
           lineages.
+    cellular_components:
+      - preferred_term: plasma membrane
+        term:
+          id: GO:0005886
+          label: plasma membrane
+        description: >-
+          Shared bacterial inner-membrane context for the ordered Lgt, LspA,
+          and Lnt maturation reactions.
   parts:
     - order: 1
       role: Diacylglyceryl transfer to prolipoprotein cysteine
@@ -158,11 +166,6 @@ module:
                 term:
                   id: GO:0042158
                   label: lipoprotein biosynthetic process
-            locations:
-              - preferred_term: plasma membrane
-                term:
-                  id: GO:0005886
-                  label: plasma membrane
             role_description: >-
               First committed lipidation step; creates the diacylglyceryl
               prolipoprotein substrate required by LspA.
@@ -207,11 +210,6 @@ module:
                 term:
                   id: GO:0042158
                   label: lipoprotein biosynthetic process
-            locations:
-              - preferred_term: plasma membrane
-                term:
-                  id: GO:0005886
-                  label: plasma membrane
             role_description: >-
               Ordered middle step; acts after Lgt lipidation and before terminal
               N-acylation by Lnt or a lineage-specific equivalent.
@@ -255,11 +253,6 @@ module:
                 term:
                   id: GO:0042158
                   label: lipoprotein biosynthetic process
-            locations:
-              - preferred_term: plasma membrane
-                term:
-                  id: GO:0005886
-                  label: plasma membrane
             role_description: >-
               Terminal diderm lipoprotein-maturation step; creates the mature
               triacylated lipoprotein used by downstream envelope sorting

--- a/pages/modules/bacterial_lipoprotein_maturation.html
+++ b/pages/modules/bacterial_lipoprotein_maturation.html
@@ -721,8 +721,7 @@
 
 
 
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>
+
 
             </div>
                 <section class="node-detail depth-0" id="node-bacterial_lipoprotein_maturation">
@@ -737,8 +736,7 @@
 
 
 
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>
+
 
             </div>
                     <h4>Connections</h4>

--- a/pages/modules/bacterial_lipoprotein_maturation.html
+++ b/pages/modules/bacterial_lipoprotein_maturation.html
@@ -721,7 +721,8 @@
 
 
 
-
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>
 
             </div>
                 <section class="node-detail depth-0" id="node-bacterial_lipoprotein_maturation">
@@ -736,7 +737,8 @@
 
 
 
-
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>
 
             </div>
                     <h4>Connections</h4>
@@ -773,9 +775,7 @@
             <div class="descriptor">
             <span><strong>phosphatidylglycerol-prolipoprotein diacylglyceryl transferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008961" target="_blank" rel="noopener">GO:0008961</a></div>            <h4>Processes</h4>
             <div class="descriptor-list">                <span class="descriptor">
-            <span>lipoprotein biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042158" target="_blank" rel="noopener">GO:0042158</a></span>        </div>            <h4>Locations</h4>
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>            <p class="role-description">First committed lipidation step; creates the diacylglyceryl prolipoprotein substrate required by LspA.</p></article>            </div>    </section>                <div class="part-marker">
+            <span>lipoprotein biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042158" target="_blank" rel="noopener">GO:0042158</a></span>        </div>            <p class="role-description">First committed lipidation step; creates the diacylglyceryl prolipoprotein substrate required by LspA.</p></article>            </div>    </section>                <div class="part-marker">
                     Part 2: Signal peptide cleavage from diacylglyceryl-prolipoprotein</div>
                 <section class="node-detail depth-1" id="node-lspa_signal_peptide_cleavage_step">
         <div class="node-heading">
@@ -796,9 +796,7 @@
             <div class="descriptor">
             <span><strong>aspartic-type endopeptidase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004190" target="_blank" rel="noopener">GO:0004190</a></div>            <h4>Processes</h4>
             <div class="descriptor-list">                <span class="descriptor">
-            <span>lipoprotein biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042158" target="_blank" rel="noopener">GO:0042158</a></span>        </div>            <h4>Locations</h4>
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>            <p class="role-description">Ordered middle step; acts after Lgt lipidation and before terminal N-acylation by Lnt or a lineage-specific equivalent.</p></article>            </div>    </section>                <div class="part-marker">
+            <span>lipoprotein biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042158" target="_blank" rel="noopener">GO:0042158</a></span>        </div>            <p class="role-description">Ordered middle step; acts after Lgt lipidation and before terminal N-acylation by Lnt or a lineage-specific equivalent.</p></article>            </div>    </section>                <div class="part-marker">
                     Part 3: Terminal N-acylation of apolipoprotein</div>
                 <section class="node-detail depth-1" id="node-lnt_n_acylation_step">
         <div class="node-heading">
@@ -819,9 +817,7 @@
             <div class="descriptor">
             <span><strong>apolipoprotein N-acyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016747" target="_blank" rel="noopener">GO:0016747</a></div>            <h4>Processes</h4>
             <div class="descriptor-list">                <span class="descriptor">
-            <span>lipoprotein biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042158" target="_blank" rel="noopener">GO:0042158</a></span>        </div>            <h4>Locations</h4>
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>            <p class="role-description">Terminal diderm lipoprotein-maturation step; creates the mature triacylated lipoprotein used by downstream envelope sorting systems.</p></article>            </div>    </section>    </section>
+            <span>lipoprotein biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042158" target="_blank" rel="noopener">GO:0042158</a></span>        </div>            <p class="role-description">Terminal diderm lipoprotein-maturation step; creates the mature triacylated lipoprotein used by downstream envelope sorting systems.</p></article>            </div>    </section>    </section>
             </div>
         </section>
     </section>

--- a/pages/projects/P_PUTIDA/batches/bacterial_lipoprotein_maturation.html
+++ b/pages/projects/P_PUTIDA/batches/bacterial_lipoprotein_maturation.html
@@ -474,9 +474,9 @@ biogenesis contexts, not part of the maturation chemistry.</p>
 <h2 id="notes">Notes</h2>
 <p>Structural review, 2026-09-01:</p>
 <ul>
-<li>Removed the module-level plasma-membrane context because each Lgt, LspA, and<br />
-  Lnt leaf annoton already carries <a href="http://amigo.geneontology.org/amigo/term/GO:0005886">GO:0005886</a>. The bacterial taxon context and<br />
-  the three ordered reaction parts remain unchanged.</li>
+<li>Consolidated <a href="http://amigo.geneontology.org/amigo/term/GO:0005886">GO:0005886</a> plasma membrane as shared module context and removed<br />
+  the three repeated leaf-location blocks. The bacterial taxon context and the<br />
+  three ordered reaction parts remain unchanged.</li>
 </ul>
 <p>Curator notes, 2026-07-14:</p>
 <ul>

--- a/pages/projects/P_PUTIDA/batches/bacterial_lipoprotein_maturation.html
+++ b/pages/projects/P_PUTIDA/batches/bacterial_lipoprotein_maturation.html
@@ -472,6 +472,12 @@ and Lnt performs terminal N-acylation where triacylated lipoproteins are made.</
 functions of mature substrate lipoproteins. Those are adjacent envelope<br />
 biogenesis contexts, not part of the maturation chemistry.</p>
 <h2 id="notes">Notes</h2>
+<p>Structural review, 2026-09-01:</p>
+<ul>
+<li>Removed the module-level plasma-membrane context because each Lgt, LspA, and<br />
+  Lnt leaf annoton already carries <a href="http://amigo.geneontology.org/amigo/term/GO:0005886">GO:0005886</a>. The bacterial taxon context and<br />
+  the three ordered reaction parts remain unchanged.</li>
+</ul>
 <p>Curator notes, 2026-07-14:</p>
 <ul>
 <li>Added <code>modules/bacterial_lipoprotein_maturation.yaml</code> as the multi-part<br />

--- a/projects/P_PUTIDA/batches/bacterial_lipoprotein_maturation.md
+++ b/projects/P_PUTIDA/batches/bacterial_lipoprotein_maturation.md
@@ -53,6 +53,12 @@ biogenesis contexts, not part of the maturation chemistry.
 
 ## Notes
 
+Structural review, 2026-09-01:
+
+- Removed the module-level plasma-membrane context because each Lgt, LspA, and
+  Lnt leaf annoton already carries GO:0005886. The bacterial taxon context and
+  the three ordered reaction parts remain unchanged.
+
 Curator notes, 2026-07-14:
 
 - Added `modules/bacterial_lipoprotein_maturation.yaml` as the multi-part

--- a/projects/P_PUTIDA/batches/bacterial_lipoprotein_maturation.md
+++ b/projects/P_PUTIDA/batches/bacterial_lipoprotein_maturation.md
@@ -55,9 +55,9 @@ biogenesis contexts, not part of the maturation chemistry.
 
 Structural review, 2026-09-01:
 
-- Removed the module-level plasma-membrane context because each Lgt, LspA, and
-  Lnt leaf annoton already carries GO:0005886. The bacterial taxon context and
-  the three ordered reaction parts remain unchanged.
+- Consolidated GO:0005886 plasma membrane as shared module context and removed
+  the three repeated leaf-location blocks. The bacterial taxon context and the
+  three ordered reaction parts remain unchanged.
 
 Curator notes, 2026-07-14:
 


### PR DESCRIPTION
## Summary
- remove the module-level plasma-membrane context duplicated by all three leaf annotons
- retain the meaningful bacterial taxon context and ordered Lgt-LspA-Lnt boundary
- document and render the structural repair

## Validation
- `uv run linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/bacterial_lipoprotein_maturation.yaml`
- `uv run python -m ai_gene_review.validation.module_validator modules/bacterial_lipoprotein_maturation.yaml`
- `just render-module modules/bacterial_lipoprotein_maturation.yaml`
- `uv run ai-gene-review render-projects projects/P_PUTIDA/batches/bacterial_lipoprotein_maturation.md -o pages/projects`
- `git diff --check`