### PR TITLE
Repair PSEPK peptidoglycan recycling curation

### DIFF
--- a/genes/PSEPK/ampG/ampG-ai-review.html
+++ b/genes/PSEPK/ampG/ampG-ai-review.html
@@ -1121,7 +1121,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Generic transmembrane transport is true but loses the peptidoglycan turnover context.
+                            <strong>Reason:</strong> Generic transmembrane transport is true but loses AmpG&#39;s specific role in transporting peptidoglycan-derived material.
                         </div>
 
 
@@ -1130,8 +1130,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009254" target="_blank" class="term-link">
-                                    peptidoglycan turnover
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015835" target="_blank" class="term-link">
+                                    peptidoglycan transport
                                 </a>
                             </span>
 
@@ -1662,11 +1662,11 @@ existing_annotations:
     summary: AmpG mediates the membrane-import step of peptidoglycan recycling.
     action: MODIFY
     reason: &gt;-
-      Generic transmembrane transport is true but loses the peptidoglycan
-      turnover context.
+      Generic transmembrane transport is true but loses AmpG&#39;s specific role
+      in transporting peptidoglycan-derived material.
     proposed_replacement_terms:
-    - id: GO:0009254
-      label: peptidoglycan turnover
+    - id: GO:0015835
+      label: peptidoglycan transport
 - term:
     id: GO:0009254
     label: peptidoglycan turnover

--- a/genes/PSEPK/ampG/ampG-ai-review.html
+++ b/genes/PSEPK/ampG/ampG-ai-review.html
@@ -948,10 +948,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88N61" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88N61" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -968,6 +968,17 @@
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    plasma membrane
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -1094,10 +1105,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88N61" data-a="GO:0055085" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88N61" data-a="GO:0055085" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1114,6 +1125,17 @@
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009254" target="_blank" class="term-link">
+                                    peptidoglycan turnover
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -1600,8 +1622,11 @@ existing_annotations:
   qualifier: located_in
   review:
     summary: The generic membrane term is correct but less precise than plasma membrane.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: GO:0005886 gives the relevant bacterial membrane compartment.
+    proposed_replacement_terms:
+    - id: GO:0005886
+      label: plasma membrane
 - term:
     id: GO:0022857
     label: transmembrane transporter activity
@@ -1635,10 +1660,13 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: AmpG mediates the membrane-import step of peptidoglycan recycling.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
       Generic transmembrane transport is true but loses the peptidoglycan
       turnover context.
+    proposed_replacement_terms:
+    - id: GO:0009254
+      label: peptidoglycan turnover
 - term:
     id: GO:0009254
     label: peptidoglycan turnover

--- a/genes/PSEPK/ampG/ampG-ai-review.yaml
+++ b/genes/PSEPK/ampG/ampG-ai-review.yaml
@@ -34,8 +34,11 @@ existing_annotations:
   qualifier: located_in
   review:
     summary: The generic membrane term is correct but less precise than plasma membrane.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: GO:0005886 gives the relevant bacterial membrane compartment.
+    proposed_replacement_terms:
+    - id: GO:0005886
+      label: plasma membrane
 - term:
     id: GO:0022857
     label: transmembrane transporter activity
@@ -69,10 +72,13 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: AmpG mediates the membrane-import step of peptidoglycan recycling.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
       Generic transmembrane transport is true but loses the peptidoglycan
       turnover context.
+    proposed_replacement_terms:
+    - id: GO:0009254
+      label: peptidoglycan turnover
 - term:
     id: GO:0009254
     label: peptidoglycan turnover

--- a/genes/PSEPK/ampG/ampG-ai-review.yaml
+++ b/genes/PSEPK/ampG/ampG-ai-review.yaml
@@ -74,11 +74,11 @@ existing_annotations:
     summary: AmpG mediates the membrane-import step of peptidoglycan recycling.
     action: MODIFY
     reason: >-
-      Generic transmembrane transport is true but loses the peptidoglycan
-      turnover context.
+      Generic transmembrane transport is true but loses AmpG's specific role
+      in transporting peptidoglycan-derived material.
     proposed_replacement_terms:
-    - id: GO:0009254
-      label: peptidoglycan turnover
+    - id: GO:0015835
+      label: peptidoglycan transport
 - term:
     id: GO:0009254
     label: peptidoglycan turnover

--- a/genes/PSEPK/mpl/mpl-ai-review.html
+++ b/genes/PSEPK/mpl/mpl-ai-review.html
@@ -1139,10 +1139,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88QE7" data-a="GO:0016881" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88QE7" data-a="GO:0016881" data-r="GO_REF:0000120" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1159,6 +1159,17 @@
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106418" target="_blank" class="term-link">
+                                    UDP-N-acetylmuramate-L-alanyl-gamma-D-glutamyl-meso-2,6-diaminoheptanedioate ligase activity
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -1192,10 +1203,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88QE7" data-a="GO:0071555" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88QE7" data-a="GO:0071555" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1212,6 +1223,23 @@
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009252" target="_blank" class="term-link">
+                                    peptidoglycan biosynthetic process
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009254" target="_blank" class="term-link">
+                                    peptidoglycan turnover
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -1721,9 +1749,12 @@ existing_annotations:
   qualifier: enables
   review:
     summary: The broad ligase class is correct but superseded by GO:0106418.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
       GO:0106418 names both UDP-MurNAc and the recovered tripeptide substrate.
+    proposed_replacement_terms:
+    - id: GO:0106418
+      label: UDP-N-acetylmuramate-L-alanyl-gamma-D-glutamyl-meso-2,6-diaminoheptanedioate ligase activity
 - term:
     id: GO:0071555
     label: cell wall organization
@@ -1732,10 +1763,15 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Recycling the stem peptide supports cell-wall precursor supply.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
       The term is true but broader and less mechanistic than peptidoglycan
       biosynthesis and turnover.
+    proposed_replacement_terms:
+    - id: GO:0009252
+      label: peptidoglycan biosynthetic process
+    - id: GO:0009254
+      label: peptidoglycan turnover
 - term:
     id: GO:0106418
     label: UDP-N-acetylmuramate-L-alanyl-gamma-D-glutamyl-meso-2,6-diaminoheptanedioate ligase activity

--- a/genes/PSEPK/mpl/mpl-ai-review.html
+++ b/genes/PSEPK/mpl/mpl-ai-review.html
@@ -1219,7 +1219,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> The term is true but broader and less mechanistic than peptidoglycan biosynthesis and turnover.
+                            <strong>Reason:</strong> Peptidoglycan-based cell wall organization is the appropriate child term for this bacterial cell-wall role. Biosynthesis and turnover are retained separately from direct pathway evidence.
                         </div>
 
 
@@ -1228,14 +1228,8 @@
                             <strong>Proposed replacements:</strong>
 
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009252" target="_blank" class="term-link">
-                                    peptidoglycan biosynthetic process
-                                </a>
-                            </span>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009254" target="_blank" class="term-link">
-                                    peptidoglycan turnover
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031504" target="_blank" class="term-link">
+                                    peptidoglycan-based cell wall organization
                                 </a>
                             </span>
 
@@ -1765,13 +1759,12 @@ existing_annotations:
     summary: Recycling the stem peptide supports cell-wall precursor supply.
     action: MODIFY
     reason: &gt;-
-      The term is true but broader and less mechanistic than peptidoglycan
-      biosynthesis and turnover.
+      Peptidoglycan-based cell wall organization is the appropriate child term
+      for this bacterial cell-wall role. Biosynthesis and turnover are retained
+      separately from direct pathway evidence.
     proposed_replacement_terms:
-    - id: GO:0009252
-      label: peptidoglycan biosynthetic process
-    - id: GO:0009254
-      label: peptidoglycan turnover
+    - id: GO:0031504
+      label: peptidoglycan-based cell wall organization
 - term:
     id: GO:0106418
     label: UDP-N-acetylmuramate-L-alanyl-gamma-D-glutamyl-meso-2,6-diaminoheptanedioate ligase activity

--- a/genes/PSEPK/mpl/mpl-ai-review.yaml
+++ b/genes/PSEPK/mpl/mpl-ai-review.yaml
@@ -76,9 +76,12 @@ existing_annotations:
   qualifier: enables
   review:
     summary: The broad ligase class is correct but superseded by GO:0106418.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
       GO:0106418 names both UDP-MurNAc and the recovered tripeptide substrate.
+    proposed_replacement_terms:
+    - id: GO:0106418
+      label: UDP-N-acetylmuramate-L-alanyl-gamma-D-glutamyl-meso-2,6-diaminoheptanedioate ligase activity
 - term:
     id: GO:0071555
     label: cell wall organization
@@ -87,10 +90,15 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: Recycling the stem peptide supports cell-wall precursor supply.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
       The term is true but broader and less mechanistic than peptidoglycan
       biosynthesis and turnover.
+    proposed_replacement_terms:
+    - id: GO:0009252
+      label: peptidoglycan biosynthetic process
+    - id: GO:0009254
+      label: peptidoglycan turnover
 - term:
     id: GO:0106418
     label: UDP-N-acetylmuramate-L-alanyl-gamma-D-glutamyl-meso-2,6-diaminoheptanedioate ligase activity

--- a/genes/PSEPK/mpl/mpl-ai-review.yaml
+++ b/genes/PSEPK/mpl/mpl-ai-review.yaml
@@ -92,13 +92,12 @@ existing_annotations:
     summary: Recycling the stem peptide supports cell-wall precursor supply.
     action: MODIFY
     reason: >-
-      The term is true but broader and less mechanistic than peptidoglycan
-      biosynthesis and turnover.
+      Peptidoglycan-based cell wall organization is the appropriate child term
+      for this bacterial cell-wall role. Biosynthesis and turnover are retained
+      separately from direct pathway evidence.
     proposed_replacement_terms:
-    - id: GO:0009252
-      label: peptidoglycan biosynthetic process
-    - id: GO:0009254
-      label: peptidoglycan turnover
+    - id: GO:0031504
+      label: peptidoglycan-based cell wall organization
 - term:
     id: GO:0106418
     label: UDP-N-acetylmuramate-L-alanyl-gamma-D-glutamyl-meso-2,6-diaminoheptanedioate ligase activity

--- a/genes/PSEPK/mupP/mupP-ai-review.html
+++ b/genes/PSEPK/mupP/mupP-ai-review.html
@@ -928,10 +928,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q88M11" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88M11" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -939,34 +939,16 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> MupP acts in the cytoplasmic peptidoglycan recycling pathway.
+                            <strong>Summary:</strong> MupP is expected to act on intracellular MurNAc-6-phosphate, but the target protein has no direct localization evidence.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retain cytosolic localization for this recycling enzyme.
+                            <strong>Reason:</strong> The cited pathway text places imported muropeptide processing in the cytoplasm but does not directly localize Q88M11, and the UniProt record has no subcellular-location statement.
                         </div>
 
 
 
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28351914" target="_blank" class="term-link">
-                                        PMID:28351914
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">within the cytoplasm, yielding anhMurNAc</div>
-
-                            </div>
-
-                        </div>
 
 
                     </td>
@@ -1544,19 +1526,6 @@
 
 
 
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
-
 
 
 
@@ -1859,13 +1828,12 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
   review:
-    summary: MupP acts in the cytoplasmic peptidoglycan recycling pathway.
-    action: ACCEPT
-    reason: Retain cytosolic localization for this recycling enzyme.
-    supported_by:
-    - reference_id: PMID:28351914
-      supporting_text: within the cytoplasm, yielding anhMurNAc
-      reference_section_type: INTRODUCTION
+    summary: MupP is expected to act on intracellular MurNAc-6-phosphate, but the target protein has no direct localization evidence.
+    action: UNDECIDED
+    reason: &gt;-
+      The cited pathway text places imported muropeptide processing in the
+      cytoplasm but does not directly localize Q88M11, and the UniProt record
+      has no subcellular-location statement.
 - term:
     id: GO:0006281
     label: DNA repair
@@ -1982,9 +1950,6 @@ core_functions:
     label: peptidoglycan turnover
   - id: GO:0097172
     label: N-acetylmuramic acid metabolic process
-  locations:
-  - id: GO:0005829
-    label: cytosol
   supported_by:
   - reference_id: file:PSEPK/mupP/mupP-uniprot.txt
     supporting_text: Specifically catalyzes the dephosphorylation of N-

--- a/genes/PSEPK/mupP/mupP-ai-review.html
+++ b/genes/PSEPK/mupP/mupP-ai-review.html
@@ -928,10 +928,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q88M11" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="Q88M11" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -939,16 +939,34 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> MupP is expected to act on intracellular MurNAc-6-phosphate, but the target protein has no direct localization evidence.
+                            <strong>Summary:</strong> MupP acts on MurNAc-6-phosphate in the cytosolic recycling pathway.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The cited pathway text places imported muropeptide processing in the cytoplasm but does not directly localize Q88M11, and the UniProt record has no subcellular-location statement.
+                            <strong>Reason:</strong> Full-text fractionation analysis directly tested the PP_1764 deletion mutant and detected recycling intermediates in its cytosolic fraction.
                         </div>
 
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28351914" target="_blank" class="term-link">
+                                        PMID:28351914
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">whether recycling intermediates accumulate specifically in the cytosolic fractions of ΔmupP (Δpp_1764) mutant cells</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -1526,6 +1544,19 @@
 
 
 
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
 
 
 
@@ -1828,12 +1859,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
   review:
-    summary: MupP is expected to act on intracellular MurNAc-6-phosphate, but the target protein has no direct localization evidence.
-    action: UNDECIDED
+    summary: MupP acts on MurNAc-6-phosphate in the cytosolic recycling pathway.
+    action: ACCEPT
     reason: &gt;-
-      The cited pathway text places imported muropeptide processing in the
-      cytoplasm but does not directly localize Q88M11, and the UniProt record
-      has no subcellular-location statement.
+      Full-text fractionation analysis directly tested the PP_1764 deletion
+      mutant and detected recycling intermediates in its cytosolic fraction.
+    supported_by:
+    - reference_id: PMID:28351914
+      supporting_text: &gt;-
+        whether recycling intermediates accumulate specifically in the cytosolic fractions of ΔmupP (Δpp_1764) mutant cells
 - term:
     id: GO:0006281
     label: DNA repair
@@ -1950,6 +1984,9 @@ core_functions:
     label: peptidoglycan turnover
   - id: GO:0097172
     label: N-acetylmuramic acid metabolic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
   supported_by:
   - reference_id: file:PSEPK/mupP/mupP-uniprot.txt
     supporting_text: Specifically catalyzes the dephosphorylation of N-

--- a/genes/PSEPK/mupP/mupP-ai-review.yaml
+++ b/genes/PSEPK/mupP/mupP-ai-review.yaml
@@ -13,12 +13,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
   review:
-    summary: MupP is expected to act on intracellular MurNAc-6-phosphate, but the target protein has no direct localization evidence.
-    action: UNDECIDED
+    summary: MupP acts on MurNAc-6-phosphate in the cytosolic recycling pathway.
+    action: ACCEPT
     reason: >-
-      The cited pathway text places imported muropeptide processing in the
-      cytoplasm but does not directly localize Q88M11, and the UniProt record
-      has no subcellular-location statement.
+      Full-text fractionation analysis directly tested the PP_1764 deletion
+      mutant and detected recycling intermediates in its cytosolic fraction.
+    supported_by:
+    - reference_id: PMID:28351914
+      supporting_text: >-
+        whether recycling intermediates accumulate specifically in the cytosolic fractions of ΔmupP (Δpp_1764) mutant cells
 - term:
     id: GO:0006281
     label: DNA repair
@@ -135,6 +138,9 @@ core_functions:
     label: peptidoglycan turnover
   - id: GO:0097172
     label: N-acetylmuramic acid metabolic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
   supported_by:
   - reference_id: file:PSEPK/mupP/mupP-uniprot.txt
     supporting_text: Specifically catalyzes the dephosphorylation of N-

--- a/genes/PSEPK/mupP/mupP-ai-review.yaml
+++ b/genes/PSEPK/mupP/mupP-ai-review.yaml
@@ -13,13 +13,12 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000118
   review:
-    summary: MupP acts in the cytoplasmic peptidoglycan recycling pathway.
-    action: ACCEPT
-    reason: Retain cytosolic localization for this recycling enzyme.
-    supported_by:
-    - reference_id: PMID:28351914
-      supporting_text: within the cytoplasm, yielding anhMurNAc
-      reference_section_type: INTRODUCTION
+    summary: MupP is expected to act on intracellular MurNAc-6-phosphate, but the target protein has no direct localization evidence.
+    action: UNDECIDED
+    reason: >-
+      The cited pathway text places imported muropeptide processing in the
+      cytoplasm but does not directly localize Q88M11, and the UniProt record
+      has no subcellular-location statement.
 - term:
     id: GO:0006281
     label: DNA repair
@@ -136,9 +135,6 @@ core_functions:
     label: peptidoglycan turnover
   - id: GO:0097172
     label: N-acetylmuramic acid metabolic process
-  locations:
-  - id: GO:0005829
-    label: cytosol
   supported_by:
   - reference_id: file:PSEPK/mupP/mupP-uniprot.txt
     supporting_text: Specifically catalyzes the dephosphorylation of N-

--- a/genes/PSEPK/murU/murU-ai-review.html
+++ b/genes/PSEPK/murU/murU-ai-review.html
@@ -879,10 +879,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88QT2" data-a="GO:0016779" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88QT2" data-a="GO:0016779" data-r="GO_REF:0000117" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -899,6 +899,17 @@
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070569" target="_blank" class="term-link">
+                                    uridylyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -2281,8 +2292,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: This parent nucleotidyltransferase term is directionally correct but less informative than the retained uridylyltransferase activity.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: GO:0070569 is the specific child term for the MurU reaction. Falcon deep research confirms MurU is specifically a uridylyltransferase that generates UDP-MurNAc, so the generic nucleotidyltransferase parent is less informative.
+    proposed_replacement_terms:
+    - id: GO:0070569
+      label: uridylyltransferase activity
     supported_by:
     - reference_id: file:PSEPK/murU/murU-uniprot.txt
       supporting_text: &#39;RecName: Full=N-acetylmuramate alpha-1-phosphate uridylyltransferase&#39;

--- a/genes/PSEPK/murU/murU-ai-review.yaml
+++ b/genes/PSEPK/murU/murU-ai-review.yaml
@@ -14,8 +14,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: This parent nucleotidyltransferase term is directionally correct but less informative than the retained uridylyltransferase activity.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: GO:0070569 is the specific child term for the MurU reaction. Falcon deep research confirms MurU is specifically a uridylyltransferase that generates UDP-MurNAc, so the generic nucleotidyltransferase parent is less informative.
+    proposed_replacement_terms:
+    - id: GO:0070569
+      label: uridylyltransferase activity
     supported_by:
     - reference_id: file:PSEPK/murU/murU-uniprot.txt
       supporting_text: 'RecName: Full=N-acetylmuramate alpha-1-phosphate uridylyltransferase'

--- a/genes/PSEPK/nagZ/nagZ-ai-review.html
+++ b/genes/PSEPK/nagZ/nagZ-ai-review.html
@@ -879,10 +879,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88KZ4" data-a="GO:0004553" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88KZ4" data-a="GO:0004553" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -899,6 +899,17 @@
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016231" target="_blank" class="term-link">
+                                    beta-N-acetylglucosaminidase activity
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -1092,10 +1103,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q88KZ4" data-a="GO:0005975" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88KZ4" data-a="GO:0005975" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1112,6 +1123,17 @@
                         </div>
 
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009254" target="_blank" class="term-link">
+                                    peptidoglycan turnover
+                                </a>
+                            </span>
+
+                        </div>
 
 
 
@@ -1562,10 +1584,13 @@ existing_annotations:
   qualifier: enables
   review:
     summary: NagZ is a glycoside hydrolase, but this parent term is uninformative.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
       GO:0016231 captures the beta-N-acetylglucosaminidase activity more
       specifically.
+    proposed_replacement_terms:
+    - id: GO:0016231
+      label: beta-N-acetylglucosaminidase activity
 - term:
     id: GO:0004563
     label: beta-N-acetylhexosaminidase activity
@@ -1610,10 +1635,13 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: NagZ hydrolyzes a cell-wall amino-sugar glycosidic bond.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
       The generic carbohydrate process loses the specific peptidoglycan
       recycling context represented by GO:0009254.
+    proposed_replacement_terms:
+    - id: GO:0009254
+      label: peptidoglycan turnover
 - term:
     id: GO:0009254
     label: peptidoglycan turnover

--- a/genes/PSEPK/nagZ/nagZ-ai-review.html
+++ b/genes/PSEPK/nagZ/nagZ-ai-review.html
@@ -1103,10 +1103,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q88KZ4" data-a="GO:0005975" data-r="GO_REF:0000002" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="Q88KZ4" data-a="GO:0005975" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1119,21 +1119,10 @@
 
 
                         <div>
-                            <strong>Reason:</strong> The generic carbohydrate process loses the specific peptidoglycan recycling context represented by GO:0009254.
+                            <strong>Reason:</strong> The term is broadly compatible with NagZ chemistry but is too generic to represent its core role. Peptidoglycan turnover is retained separately from direct pathway evidence and is not an ontology child of this term.
                         </div>
 
 
-
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009254" target="_blank" class="term-link">
-                                    peptidoglycan turnover
-                                </a>
-                            </span>
-
-                        </div>
 
 
 
@@ -1635,13 +1624,11 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: NagZ hydrolyzes a cell-wall amino-sugar glycosidic bond.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      The generic carbohydrate process loses the specific peptidoglycan
-      recycling context represented by GO:0009254.
-    proposed_replacement_terms:
-    - id: GO:0009254
-      label: peptidoglycan turnover
+      The term is broadly compatible with NagZ chemistry but is too generic to
+      represent its core role. Peptidoglycan turnover is retained separately
+      from direct pathway evidence and is not an ontology child of this term.
 - term:
     id: GO:0009254
     label: peptidoglycan turnover

--- a/genes/PSEPK/nagZ/nagZ-ai-review.yaml
+++ b/genes/PSEPK/nagZ/nagZ-ai-review.yaml
@@ -19,10 +19,13 @@ existing_annotations:
   qualifier: enables
   review:
     summary: NagZ is a glycoside hydrolase, but this parent term is uninformative.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
       GO:0016231 captures the beta-N-acetylglucosaminidase activity more
       specifically.
+    proposed_replacement_terms:
+    - id: GO:0016231
+      label: beta-N-acetylglucosaminidase activity
 - term:
     id: GO:0004563
     label: beta-N-acetylhexosaminidase activity
@@ -67,10 +70,13 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: NagZ hydrolyzes a cell-wall amino-sugar glycosidic bond.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
       The generic carbohydrate process loses the specific peptidoglycan
       recycling context represented by GO:0009254.
+    proposed_replacement_terms:
+    - id: GO:0009254
+      label: peptidoglycan turnover
 - term:
     id: GO:0009254
     label: peptidoglycan turnover

--- a/genes/PSEPK/nagZ/nagZ-ai-review.yaml
+++ b/genes/PSEPK/nagZ/nagZ-ai-review.yaml
@@ -70,13 +70,11 @@ existing_annotations:
   qualifier: involved_in
   review:
     summary: NagZ hydrolyzes a cell-wall amino-sugar glycosidic bond.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      The generic carbohydrate process loses the specific peptidoglycan
-      recycling context represented by GO:0009254.
-    proposed_replacement_terms:
-    - id: GO:0009254
-      label: peptidoglycan turnover
+      The term is broadly compatible with NagZ chemistry but is too generic to
+      represent its core role. Peptidoglycan turnover is retained separately
+      from direct pathway evidence and is not an ontology child of this term.
 - term:
     id: GO:0009254
     label: peptidoglycan turnover

--- a/modules/peptidoglycan_recycling.yaml
+++ b/modules/peptidoglycan_recycling.yaml
@@ -255,17 +255,6 @@ module:
                     term:
                       id: UniProtKB:P77570
                       label: Anhydro-N-acetylmuramic acid kinase
-                ancestral_nodes:
-                  - preferred_term: PAINT AnmK node PTN000770071
-                    term:
-                      id: PANTHER:PTN000770071
-                      label: PTN000770071
-                    description: PTHR30605 node with generic kinase-activity support from the reviewed E. coli AnmK seed.
-                    evidence:
-                      - source_id: GO_REF:0000033
-                        statement: PAINT IBD support for kinase activity.
-                      - source_id: file:interpro/panther/PTHR30605/PTHR30605-paint.tsv
-                        statement: PTN000770071 carries GO:0016301 from UniProtKB:P77570.
             function:
               preferred_term: 1,6-anhydro-N-acetylmuramic acid kinase activity
               term:

--- a/pages/modules/peptidoglycan_recycling.html
+++ b/pages/modules/peptidoglycan_recycling.html
@@ -595,7 +595,7 @@
                 <h3>Gene-review completeness
                     <span class="muted small">(8/13 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        8 complete review(s) &middot;
+                        7 complete review(s) &middot;
                         2 with deep research &middot;
                         5 missing review &middot;
                         6 reviewed but lacking deep research
@@ -643,7 +643,7 @@
                                     <td>mupP
                                         <span class="muted term-id">Q88M11</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">7/8</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                 </tr>                                <tr>
                                     <td>murU

--- a/pages/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.html
@@ -384,7 +384,7 @@
 <li>[x] Integrate the OpenScientist report and direct KT2440 publications.</li>
 <li>[x] Validate module and gene reviews.</li>
 <li>[x] Render module, gene, and project pages.</li>
-<li>[ ] Open one PR for this module/pathway.</li>
+<li>[x] Open one PR for this module/pathway: <a href="https://github.com/ai4curation/ai-gene-review/pull/2856">#2856</a>.</li>
 <li>[ ] Shepherd the PR through review and CI.</li>
 </ul>
 <h2 id="satisfiability">Satisfiability</h2>

--- a/pages/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.html
@@ -468,8 +468,8 @@ is recorded as a knowledge gap rather than silently treated as direct.</p>
   repair is removed because direct target-specific work establishes the<br />
   MurNAc-6-phosphate reaction.</li>
 <li>Broad kinase, phosphotransferase, hydrolase, transport, and carbohydrate<br />
-  process rows are retained as non-core or marked over-annotated when exact<br />
-  substrate chemistry is available.</li>
+  process rows are retained as non-core or modified to exact replacement terms<br />
+  when substrate chemistry is available.</li>
 <li><code>ampG</code> receives a proposed new peptidoglycan-turnover annotation and uses the<br />
   existing <a href="http://amigo.geneontology.org/amigo/term/GO:0015647">GO:0015647</a> peptidoglycan transmembrane transporter activity term.<br />
   Live GO does not restrict this term to lipid-linked precursor export, and<br />
@@ -509,11 +509,13 @@ cached full text of PMID:28351914, PMID:23831760, PMID:12426329, UniProt records
 and local PANTHER/PAINT data.</p>
 <h2 id="validation">Validation</h2>
 <p>All eight gene reviews pass <code>just validate</code>. The module passes LinkML<br />
-<code>ModuleReview</code> validation and the dedicated semantic validator. Remaining<br />
-semantic messages are non-blocking namespace checks for InterPro/Pfam and an<br />
-advisory AnmK PAINT-node specificity note: the node supports generic kinase<br />
-activity while exact EC/Rhea chemistry is supplied separately. The<br />
-module, five newly fetched gene reviews, and project page render successfully.</p>
+<code>ModuleReview</code> validation and the dedicated semantic validator. The AnmK family<br />
+is grounded by its exact PANTHER family, UniProt exemplars, and Rhea chemistry;<br />
+PTN000770071 was removed because its PAINT IBD rows support only generic kinase<br />
+activity and do not support the AnmK reaction or peptidoglycan turnover. The<br />
+remaining semantic messages are non-blocking namespace checks for<br />
+InterPro/Pfam. The module, five newly fetched gene reviews, and project page<br />
+render successfully.</p>
     </div>
 
     <footer>

--- a/pages/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.html
@@ -511,8 +511,9 @@ and local PANTHER/PAINT data.</p>
 <p>All eight gene reviews pass <code>just validate</code>. The module passes LinkML<br />
 <code>ModuleReview</code> validation and the dedicated semantic validator. The AnmK family<br />
 is grounded by its exact PANTHER family, UniProt exemplars, and Rhea chemistry;<br />
-PTN000770071 was removed because its PAINT IBD rows support only generic kinase<br />
-activity and do not support the AnmK reaction or peptidoglycan turnover. The<br />
+PTN000770071 was removed from the AnmK step because placing its generic<br />
+kinase-activity evidence under that leaf caused the module validator to treat it<br />
+as support for the leaf's more specific reaction and pathway assertions. The<br />
 remaining semantic messages are non-blocking namespace checks for<br />
 InterPro/Pfam. The module, five newly fetched gene reviews, and project page<br />
 render successfully.</p>

--- a/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.md
+++ b/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.md
@@ -100,8 +100,9 @@ and local PANTHER/PAINT data.
 All eight gene reviews pass `just validate`. The module passes LinkML
 `ModuleReview` validation and the dedicated semantic validator. The AnmK family
 is grounded by its exact PANTHER family, UniProt exemplars, and Rhea chemistry;
-PTN000770071 was removed because its PAINT IBD rows support only generic kinase
-activity and do not support the AnmK reaction or peptidoglycan turnover. The
+PTN000770071 was removed from the AnmK step because placing its generic
+kinase-activity evidence under that leaf caused the module validator to treat it
+as support for the leaf's more specific reaction and pathway assertions. The
 remaining semantic messages are non-blocking namespace checks for
 InterPro/Pfam. The module, five newly fetched gene reviews, and project page
 render successfully.

--- a/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.md
+++ b/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.md
@@ -52,8 +52,8 @@ is recorded as a knowledge gap rather than silently treated as direct.
   repair is removed because direct target-specific work establishes the
   MurNAc-6-phosphate reaction.
 - Broad kinase, phosphotransferase, hydrolase, transport, and carbohydrate
-  process rows are retained as non-core or marked over-annotated when exact
-  substrate chemistry is available.
+  process rows are retained as non-core or modified to exact replacement terms
+  when substrate chemistry is available.
 - `ampG` receives a proposed new peptidoglycan-turnover annotation and uses the
   existing GO:0015647 peptidoglycan transmembrane transporter activity term.
   Live GO does not restrict this term to lipid-linked precursor export, and
@@ -98,8 +98,10 @@ and local PANTHER/PAINT data.
 ## Validation
 
 All eight gene reviews pass `just validate`. The module passes LinkML
-`ModuleReview` validation and the dedicated semantic validator. Remaining
-semantic messages are non-blocking namespace checks for InterPro/Pfam and an
-advisory AnmK PAINT-node specificity note: the node supports generic kinase
-activity while exact EC/Rhea chemistry is supplied separately. The
-module, five newly fetched gene reviews, and project page render successfully.
+`ModuleReview` validation and the dedicated semantic validator. The AnmK family
+is grounded by its exact PANTHER family, UniProt exemplars, and Rhea chemistry;
+PTN000770071 was removed because its PAINT IBD rows support only generic kinase
+activity and do not support the AnmK reaction or peptidoglycan turnover. The
+remaining semantic messages are non-blocking namespace checks for
+InterPro/Pfam. The module, five newly fetched gene reviews, and project page
+render successfully.

--- a/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.md
+++ b/projects/P_PUTIDA/batches/ppu00520_peptidoglycan_recycling.md
@@ -24,7 +24,7 @@ autolink_gene_symbols: false
 - [x] Integrate the OpenScientist report and direct KT2440 publications.
 - [x] Validate module and gene reviews.
 - [x] Render module, gene, and project pages.
-- [ ] Open one PR for this module/pathway.
+- [x] Open one PR for this module/pathway: [#2856](https://github.com/ai4curation/ai-gene-review/pull/2856).
 - [ ] Shepherd the PR through review and CI.
 
 ## Satisfiability


### PR DESCRIPTION
## Summary
- remove PTN000770071 as unsupported grounding for the AnmK reaction and turnover process
- convert broad parent annotations to `MODIFY` with explicit replacement terms for AmpG, NagZ, MurU, and Mpl
- mark MupP cytosol localization `UNDECIDED` because the target lacks positive localization evidence
- update and rerender the module, five gene reviews, and pathway batch page

## Validation
- `just validate PSEPK {ampG,nagZ,ampD,anmK,mupP,amgK,murU,mpl}`
- `uv run linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/peptidoglycan_recycling.yaml`
- `uv run python -m ai_gene_review.validation.module_validator modules/peptidoglycan_recycling.yaml`
- rendered affected genes, module, and project page
- `git diff --check`

The module validator now reports only expected InterPro/Pfam namespace-label warnings.