### PR TITLE
Repair PSEPK CoA module evolutionary evidence

### DIFF
--- a/modules/coenzyme_a_biosynthesis.yaml
+++ b/modules/coenzyme_a_biosynthesis.yaml
@@ -332,8 +332,8 @@ module:
                                     family:
                                       preferred_term: type I pantothenate kinase family
                                       term:
-                                        id: PANTHER:PTHR10285
-                                        label: URIDINE KINASE
+                                        id: PANTHER:PTHR10285:SF139
+                                        label: PANTOTHENATE KINASE
                                       representative_members:
                                         - preferred_term: Escherichia coli CoaA
                                           term:
@@ -622,8 +622,8 @@ module:
                       family:
                         preferred_term: PPCS family
                         term:
-                          id: PANTHER:PTHR12290
-                          label: CORNICHON-RELATED
+                          id: PANTHER:PTHR12290:SF2
+                          label: PHOSPHOPANTOTHENATE--CYSTEINE LIGASE
                         representative_members:
                           - preferred_term: Human PPCS
                             term:
@@ -853,16 +853,16 @@ module:
                               id: UniProtKB:Q13057
                               label: Bifunctional coenzyme A synthase
                         ancestral_nodes:
-                          - preferred_term: COASY PPAT function node PTN000075343
+                          - preferred_term: COASY PPAT function node PTN000708653
                             term:
-                              id: PANTHER:PTN000075343
-                              label: PTN000075343
+                              id: PANTHER:PTN000708653
+                              label: PTN000708653
                             description: >-
                               PAINT IBD function node in PTHR10695 with
                               descendant evidence for GO:0004595.
                             evidence:
                               - source_id: GO_REF:0000033
-                                statement: IBD propagation from PTN000075343 in PTHR10695.
+                                statement: IBD propagation from PTN000708653 in PTHR10695.
                     function:
                       preferred_term: pantetheine-phosphate adenylyltransferase activity
                       term:

--- a/pages/modules/coenzyme_a_biosynthesis.html
+++ b/pages/modules/coenzyme_a_biosynthesis.html
@@ -1242,7 +1242,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>type I pantothenate kinase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10285" target="_blank" rel="noopener">PANTHER:PTHR10285</a>                    <div class="slot-row">
+            <span><strong>type I pantothenate kinase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10285%3ASF139" target="_blank" rel="noopener">PANTHER:PTHR10285:SF139</a>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>Escherichia coli CoaA</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0A6I3/entry" target="_blank" rel="noopener">UniProtKB:P0A6I3</a></span>                    </div></div>
                     </div>                    <div class="slot-row">
@@ -1410,7 +1410,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>PPCS family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12290" target="_blank" rel="noopener">PANTHER:PTHR12290</a>                    <div class="slot-row">
+            <span><strong>PPCS family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12290%3ASF2" target="_blank" rel="noopener">PANTHER:PTHR12290:SF2</a>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>Human PPCS</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9HAB8/entry" target="_blank" rel="noopener">UniProtKB:Q9HAB8</a></span>                    </div></div>
                     </div>                    <div class="slot-row">

--- a/pages/projects/P_PUTIDA/batches/ppu00770_coenzyme_a_biosynthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00770_coenzyme_a_biosynthesis.html
@@ -600,7 +600,9 @@ a species-level question outside this reusable module.</p>
 <p>The machine-generated source table is retained at<br />
 <a href="ppu00770_coenzyme_a_biosynthesis.tsv"><code>ppu00770_coenzyme_a_biosynthesis.tsv</code></a>.</p>
 <p>Pull request: <a href="https://github.com/ai4curation/ai-gene-review/pull/2180">#2180</a><br />
-(<code>codex/putida-pantothenate-coa-biosynthesis</code>).</p>
+(<code>codex/putida-pantothenate-coa-biosynthesis</code>).<br />
+Evolutionary-evidence repair: <a href="https://github.com/ai4curation/ai-gene-review/pull/2859">#2859</a><br />
+(<code>codex/putida-coa-repair-wave88</code>).</p>
 <h2 id="curation-decisions">Curation Decisions</h2>
 <ul>
 <li><code>panE</code> Q88N64 is the canonical KT2440 ketopantoate reductase and is the only<br />

--- a/pages/projects/P_PUTIDA/batches/ppu00770_coenzyme_a_biosynthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00770_coenzyme_a_biosynthesis.html
@@ -645,13 +645,16 @@ without returning an artifact. A retry commissioned against the final module<br 
 completed successfully in 1,889.79 seconds; it exposed the archaeal PoK/PPS<br />
 route now represented explicitly in the reusable module.</p>
 <h2 id="validation">Validation</h2>
-<p>Checkpoint results on 2026-07-18:</p>
+<p>Checkpoint results on 2026-09-01:</p>
 <ul>
 <li>All 12 reviews pass schema, GO-term, reference, and best-practice validation.</li>
 <li>Every fetched GOA row has a reviewed action and no <code>PENDING</code> values remain.</li>
 <li>The module passes <code>ModuleReview</code> LinkML validation and the custom semantic<br />
-  validator. The only advisory is that the established <code>NCBIfam:TIGR00521</code><br />
-  prefix is not configured for label lookup.</li>
+  validator. Type I PanK and standalone PPCS are grounded on their exact<br />
+  PANTHER subfamilies. The COASY PPAT variant uses the <a href="http://amigo.geneontology.org/amigo/term/GO:0004595">GO:0004595</a>-bearing PAINT<br />
+  node PTN000708653 rather than the unrelated mitochondrial-matrix node<br />
+  PTN000075343. The only remaining advisory is that the established<br />
+<code>NCBIfam:TIGR00521</code> prefix is not configured for label lookup.</li>
 <li>Deep-research frontmatter validation passes for all 12 gene reports, the<br />
   species-aware module/pathway/taxon report, and the generic module report.</li>
 <li>All 12 gene pages, the module page, and the project pages render successfully.</li>

--- a/projects/P_PUTIDA/batches/ppu00770_coenzyme_a_biosynthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00770_coenzyme_a_biosynthesis.md
@@ -91,6 +91,8 @@ The machine-generated source table is retained at
 
 Pull request: [#2180](https://github.com/ai4curation/ai-gene-review/pull/2180)
 (`codex/putida-pantothenate-coa-biosynthesis`).
+Evolutionary-evidence repair: [#2859](https://github.com/ai4curation/ai-gene-review/pull/2859)
+(`codex/putida-coa-repair-wave88`).
 
 ## Curation Decisions
 

--- a/projects/P_PUTIDA/batches/ppu00770_coenzyme_a_biosynthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00770_coenzyme_a_biosynthesis.md
@@ -138,13 +138,16 @@ route now represented explicitly in the reusable module.
 
 ## Validation
 
-Checkpoint results on 2026-07-18:
+Checkpoint results on 2026-09-01:
 
 - All 12 reviews pass schema, GO-term, reference, and best-practice validation.
 - Every fetched GOA row has a reviewed action and no `PENDING` values remain.
 - The module passes `ModuleReview` LinkML validation and the custom semantic
-  validator. The only advisory is that the established `NCBIfam:TIGR00521`
-  prefix is not configured for label lookup.
+  validator. Type I PanK and standalone PPCS are grounded on their exact
+  PANTHER subfamilies. The COASY PPAT variant uses the GO:0004595-bearing PAINT
+  node PTN000708653 rather than the unrelated mitochondrial-matrix node
+  PTN000075343. The only remaining advisory is that the established
+  `NCBIfam:TIGR00521` prefix is not configured for label lookup.
 - Deep-research frontmatter validation passes for all 12 gene reports, the
   species-aware module/pathway/taxon report, and the generic module report.
 - All 12 gene pages, the module page, and the project pages render successfully.


### PR DESCRIPTION
## Summary
- replace the incorrect COASY mitochondrial-matrix PAINT node with the GO:0004595 PPAT node
- narrow Type I PanK and standalone PPCS selectors to verified PANTHER subfamilies
- refresh the batch validation checkpoint and rendered module/project pages

## Validation
- `linkml-validate` (`ModuleReview`)
- `python -m ai_gene_review.validation.module_validator modules/coenzyme_a_biosynthesis.yaml` (only known NCBIfam namespace advisory)
- `just validate PSEPK <gene>` for all 12 selected batch reviews
- independent annotation-reviewer audit of all seven PTN claims
- module and project rendering
