### PR TITLE
Repair PSEPK riboflavin activation family variants

### DIFF
--- a/modules/riboflavin_biosynthesis.yaml
+++ b/modules/riboflavin_biosynthesis.yaml
@@ -46,6 +46,11 @@ evidence:
       Local UniProt-derived inventory provides the Pseudomonas putida KT2440
       exemplar accessions and GO/EC metadata used to ground representative
       members in this module.
+  - source_id: file:projects/P_PUTIDA/data/psepk_uniprot_metadata.tsv
+    title: PSEPK UniProt functional metadata
+    statement: >-
+      The Q88Q93 record assigns both riboflavin kinase and FMN
+      adenylyltransferase activities to the bifunctional KT2440 RibF protein.
   - source_id: file:modules/riboflavin_biosynthesis-deep-research-openscientist.md
     title: OpenScientist module research for riboflavin biosynthesis
     statement: >-
@@ -59,6 +64,11 @@ evidence:
       satisfiability, separates core rib genes from KEGG-map spillover, and
       flags ribAB-I/ribAB-II as DHBP/RibBX candidates rather than GTP
       cyclohydrolase II exemplars pending targeted gene review.
+  - source_id: file:interpro/panther/PTHR23293/PTHR23293-paint.tsv
+    title: PANTHER PAINT annotations for the eukaryotic FAD synthase family
+    statement: >-
+      PTN000591373 carries the GO:0003919 FMN adenylyltransferase assertion for
+      the PTHR23293 FAD synthase lineage, including human FLAD1.
 notes: >-
   The module deliberately separates riboflavin-ring synthesis from general
   flavoprotein use, FMN-dependent reductases, prenylated-FMN cofactor formation,
@@ -466,44 +476,116 @@ module:
               id: fmn_adenylyltransferase_step
               label: FMN adenylyltransferase
               module_type: REACTION
-              annotons:
-                - id: fmn_adenylyltransferase_activity
-                  label: "RibF/FADS: FMN adenylyltransferase"
-                  participant:
-                    selector_type: FAMILY
-                    family:
-                      preferred_term: RibF/FADS FMN adenylyltransferase family
-                      term:
-                        id: PANTHER:PTHR22749
-                        label: RIBOFLAVIN KINASE/FMN ADENYLYLTRANSFERASE
-                      representative_members:
-                        - preferred_term: ribF (Pseudomonas putida KT2440)
-                          term:
-                            id: UniProtKB:Q88Q93
-                            label: Riboflavin biosynthesis protein
-                        - preferred_term: ribF (Escherichia coli K-12)
-                          term:
-                            id: UniProtKB:P0AG40
-                            label: Bifunctional riboflavin kinase/FMN adenylyltransferase
-                        - preferred_term: FLAD1 (human)
-                          term:
-                            id: UniProtKB:Q8NFF5
-                            label: FAD synthase
-                  function:
-                    preferred_term: FMN adenylyltransferase activity
-                    term:
-                      id: GO:0003919
-                      label: FMN adenylyltransferase activity
-                    substrates:
-                      - preferred_term: FMN
-                      - preferred_term: ATP
-                    products:
-                      - preferred_term: FAD
-                      - preferred_term: diphosphate
-                    evidence:
-                      - source_id: EC:2.7.7.2
-                        statement: FMN adenylyltransferase.
-                  role_description: Adenylylates FMN to FAD.
+              variant_sets:
+                - id: fmn_adenylyltransferase_family_variants
+                  label: FMN adenylyltransferase enzyme-family variants
+                  axis: enzyme family and architecture
+                  selection: ONE_OR_MORE
+                  variants:
+                    - id: bacterial_ribf_adenylyltransferase_variant
+                      label: Bacterial bifunctional RibF implementation
+                      module_type: REACTION
+                      annotons:
+                        - id: bacterial_ribf_adenylyltransferase_activity
+                          label: "RibF: FMN adenylyltransferase"
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: bacterial bifunctional RibF family
+                              term:
+                                id: PANTHER:PTHR22749:SF6
+                                label: RIBOFLAVIN KINASE
+                              description: >-
+                                The subfamily groups the two RibF exemplars,
+                                but local PAINT supports only their kinase
+                                activity; the adenylyltransferase function is
+                                grounded separately by the exemplar records.
+                              representative_members:
+                                - preferred_term: ribF (Pseudomonas putida KT2440)
+                                  term:
+                                    id: UniProtKB:Q88Q93
+                                    label: Riboflavin biosynthesis protein
+                                - preferred_term: ribF (Escherichia coli K-12)
+                                  term:
+                                    id: UniProtKB:P0AG40
+                                    label: Bifunctional riboflavin kinase/FMN adenylyltransferase
+                            taxon:
+                              preferred_term: bacteria
+                              term:
+                                id: NCBITaxon:2
+                                label: Bacteria
+                          function:
+                            preferred_term: FMN adenylyltransferase activity
+                            term:
+                              id: GO:0003919
+                              label: FMN adenylyltransferase activity
+                            substrates:
+                              - preferred_term: FMN
+                              - preferred_term: ATP
+                            products:
+                              - preferred_term: FAD
+                              - preferred_term: diphosphate
+                            evidence:
+                              - source_id: EC:2.7.7.2
+                                statement: FMN adenylyltransferase.
+                              - source_id: file:projects/P_PUTIDA/data/psepk_uniprot_metadata.tsv
+                                statement: >-
+                                  Q88Q93 is annotated as a bifunctional RibF
+                                  with EC 2.7.7.2 and GO:0003919.
+                          role_description: >-
+                            The adenylyltransferase domain of bacterial RibF
+                            converts FMN to FAD in the same polypeptide that
+                            performs the preceding kinase reaction.
+                    - id: eukaryotic_fads_adenylyltransferase_variant
+                      label: Eukaryotic FAD synthase implementation
+                      module_type: REACTION
+                      annotons:
+                        - id: eukaryotic_fads_adenylyltransferase_activity
+                          label: "FADS/FLAD1: FMN adenylyltransferase"
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: eukaryotic FAD synthase family
+                              term:
+                                id: PANTHER:PTHR23293:SF9
+                                label: FAD SYNTHASE
+                              representative_members:
+                                - preferred_term: FLAD1 (human)
+                                  term:
+                                    id: UniProtKB:Q8NFF5
+                                    label: FAD synthase
+                              ancestral_nodes:
+                                - preferred_term: FAD synthase function node
+                                  term:
+                                    id: PANTHER:PTN000591373
+                                    label: PTN000591373
+                                  evidence:
+                                    - source_id: GO_REF:0000033
+                                      statement: >-
+                                        PAINT assigns GO:0003919 at
+                                        PTN000591373 in PTHR23293.
+                            taxon:
+                              preferred_term: eukaryota
+                              term:
+                                id: NCBITaxon:2759
+                                label: Eukaryota
+                          function:
+                            preferred_term: FMN adenylyltransferase activity
+                            term:
+                              id: GO:0003919
+                              label: FMN adenylyltransferase activity
+                            substrates:
+                              - preferred_term: FMN
+                              - preferred_term: ATP
+                            products:
+                              - preferred_term: FAD
+                              - preferred_term: diphosphate
+                            evidence:
+                              - source_id: EC:2.7.7.2
+                                statement: FMN adenylyltransferase.
+                          role_description: >-
+                            A dedicated eukaryotic FAD synthase performs the
+                            adenylylation separately from riboflavin kinase.
   connections:
     - source: gtp_cyclohydrolase_ii_step
       target: ribd_deaminase_step

--- a/pages/modules/riboflavin_biosynthesis.html
+++ b/pages/modules/riboflavin_biosynthesis.html
@@ -558,13 +558,13 @@
             <span>riboflavin biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009231" target="_blank" rel="noopener">GO:0009231</a></span>                <span class="descriptor">
             <span>FMN biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009398" target="_blank" rel="noopener">GO:0009398</a></span>                <span class="descriptor">
             <span>FAD biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006747" target="_blank" rel="noopener">GO:0006747</a></span>        </div>
-        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0009231" target="_blank" rel="noopener">GO:0009231</a><div><strong>riboflavin biosynthetic process</strong></div><div>GO biological-process term for de novo riboflavin biosynthesis; used as the primary process grounding for the ring-synthesis part of the module.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0009398" target="_blank" rel="noopener">GO:0009398</a><div><strong>FMN biosynthetic process</strong></div><div>GO biological-process term for phosphorylation of riboflavin to FMN, represented here as the first flavin-cofactor activation step.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006747" target="_blank" rel="noopener">GO:0006747</a><div><strong>FAD biosynthetic process</strong></div><div>GO biological-process term for adenylylation of FMN to FAD, represented here as the terminal flavin-cofactor activation step.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0043726" target="_blank" rel="noopener">GO:0043726</a><div><strong>5-amino-6-(5-phosphoribitylamino)uracil phosphatase activity</strong></div><div>GO molecular-function term for the required dephosphorylation between the RibD reductase product and the dephosphorylated RibH substrate.</div></div>                <div class="evidence-card small"><span class="source-id">KEGG:map00740</span><div><strong>Riboflavin metabolism</strong></div><div>KEGG pathway context for riboflavin-ring synthesis and downstream FMN/FAD metabolism; species-specific map members need curator filtering because flavin reductases, flavin-derived cofactor enzymes, and unrelated hydrolases can appear in the same map.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/data/psepk_gene_list.tsv</span><div><strong>PSEPK UniProt metadata inventory</strong></div><div>Local UniProt-derived inventory provides the Pseudomonas putida KT2440 exemplar accessions and GO/EC metadata used to ground representative members in this module.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/riboflavin_biosynthesis-deep-research-openscientist.md</span><div><strong>OpenScientist module research for riboflavin biosynthesis</strong></div><div>Provider-generated module research supports the reusable bacterial pathway boundary from de novo riboflavin-ring synthesis through FMN/FAD activation and highlights cross-organism gene-name differences.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__riboflavin_biosynthesis__ppu00740-deep-research-openscientist.md</span><div><strong>OpenScientist PSEPK ppu00740 riboflavin satisfiability research</strong></div><div>Provider-generated species/pathway research supports KT2440 pathway satisfiability, separates core rib genes from KEGG-map spillover, and flags ribAB-I/ribAB-II as DHBP/RibBX candidates rather than GTP cyclohydrolase II exemplars pending targeted gene review.</div></div>        </div><p class="muted small">The module deliberately separates riboflavin-ring synthesis from general flavoprotein use, FMN-dependent reductases, prenylated-FMN cofactor formation, and cobalamin lower-ligand biosynthesis. Those processes consume or transform flavins but are not required steps in de novo riboflavin formation. The downstream FMN/FAD activation step is included because bacterial RibF-family enzymes often connect riboflavin synthesis directly to active flavin-cofactor supply; animal-only uptake of dietary riboflavin is covered separately by modules/flavin_cofactor_biosynthesis.yaml. Human RFK and FLAD1 are included below only as cross-organism representatives of the shared activation activities, not as members of the bacterial de novo route. In the Pseudomonas putida KT2440 instantiation, OpenScientist flagged ribAB-I and ribAB-II as RibBX-like DHBP synthase candidates with apparently degenerate C-terminal GTP-CHII-fold domains, so this module does not use them as GTP cyclohydrolase II exemplars.</p></header>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0009231" target="_blank" rel="noopener">GO:0009231</a><div><strong>riboflavin biosynthetic process</strong></div><div>GO biological-process term for de novo riboflavin biosynthesis; used as the primary process grounding for the ring-synthesis part of the module.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0009398" target="_blank" rel="noopener">GO:0009398</a><div><strong>FMN biosynthetic process</strong></div><div>GO biological-process term for phosphorylation of riboflavin to FMN, represented here as the first flavin-cofactor activation step.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006747" target="_blank" rel="noopener">GO:0006747</a><div><strong>FAD biosynthetic process</strong></div><div>GO biological-process term for adenylylation of FMN to FAD, represented here as the terminal flavin-cofactor activation step.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0043726" target="_blank" rel="noopener">GO:0043726</a><div><strong>5-amino-6-(5-phosphoribitylamino)uracil phosphatase activity</strong></div><div>GO molecular-function term for the required dephosphorylation between the RibD reductase product and the dephosphorylated RibH substrate.</div></div>                <div class="evidence-card small"><span class="source-id">KEGG:map00740</span><div><strong>Riboflavin metabolism</strong></div><div>KEGG pathway context for riboflavin-ring synthesis and downstream FMN/FAD metabolism; species-specific map members need curator filtering because flavin reductases, flavin-derived cofactor enzymes, and unrelated hydrolases can appear in the same map.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/data/psepk_gene_list.tsv</span><div><strong>PSEPK UniProt metadata inventory</strong></div><div>Local UniProt-derived inventory provides the Pseudomonas putida KT2440 exemplar accessions and GO/EC metadata used to ground representative members in this module.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/data/psepk_uniprot_metadata.tsv</span><div><strong>PSEPK UniProt functional metadata</strong></div><div>The Q88Q93 record assigns both riboflavin kinase and FMN adenylyltransferase activities to the bifunctional KT2440 RibF protein.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/riboflavin_biosynthesis-deep-research-openscientist.md</span><div><strong>OpenScientist module research for riboflavin biosynthesis</strong></div><div>Provider-generated module research supports the reusable bacterial pathway boundary from de novo riboflavin-ring synthesis through FMN/FAD activation and highlights cross-organism gene-name differences.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__riboflavin_biosynthesis__ppu00740-deep-research-openscientist.md</span><div><strong>OpenScientist PSEPK ppu00740 riboflavin satisfiability research</strong></div><div>Provider-generated species/pathway research supports KT2440 pathway satisfiability, separates core rib genes from KEGG-map spillover, and flags ribAB-I/ribAB-II as DHBP/RibBX candidates rather than GTP cyclohydrolase II exemplars pending targeted gene review.</div></div>                <div class="evidence-card small"><span class="source-id">file:interpro/panther/PTHR23293/PTHR23293-paint.tsv</span><div><strong>PANTHER PAINT annotations for the eukaryotic FAD synthase family</strong></div><div>PTN000591373 carries the GO:0003919 FMN adenylyltransferase assertion for the PTHR23293 FAD synthase lineage, including human FLAD1.</div></div>        </div><p class="muted small">The module deliberately separates riboflavin-ring synthesis from general flavoprotein use, FMN-dependent reductases, prenylated-FMN cofactor formation, and cobalamin lower-ligand biosynthesis. Those processes consume or transform flavins but are not required steps in de novo riboflavin formation. The downstream FMN/FAD activation step is included because bacterial RibF-family enzymes often connect riboflavin synthesis directly to active flavin-cofactor supply; animal-only uptake of dietary riboflavin is covered separately by modules/flavin_cofactor_biosynthesis.yaml. Human RFK and FLAD1 are included below only as cross-organism representatives of the shared activation activities, not as members of the bacterial de novo route. In the Pseudomonas putida KT2440 instantiation, OpenScientist flagged ribAB-I and ribAB-II as RibBX-like DHBP synthase candidates with apparently degenerate C-terminal GTP-CHII-fold domains, so this module does not use them as GTP cyclohydrolase II exemplars.</p></header>
     <section class="stats" aria-label="Module counts">
-        <div class="stat"><span class="stat-value">12</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">14</span><span class="stat-label">Nodes</span></div>
         <div class="stat"><span class="stat-value">11</span><span class="stat-label">Parts</span></div>
-        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
-        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
-        <div class="stat"><span class="stat-value">9</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">1</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">10</span><span class="stat-label">Annotons</span></div>
         <div class="stat"><span class="stat-value">8</span><span class="stat-label">Connections</span></div>
     </section>    <section class="qc-panel panel" aria-label="Derived QC">
         <div class="panel-header">
@@ -862,13 +862,38 @@
                 <span class="tree-row">
                     <a class="tree-link" href="#node-fmn_adenylyltransferase_step">FMN adenylyltransferase</a><span class="pill type">Reaction</span><span class="tree-id">fmn_adenylyltransferase_step</span>
                 </span>
+            </summary>                <div class="tree-group-title">Variants</div>
+                <ol>                        <li>
+                            <div class="edge-note">
+                                FMN adenylyltransferase enzyme-family variants by enzyme family and architecture (One Or More)</div>
+                            <ol>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-bacterial_ribf_adenylyltransferase_variant">Bacterial bifunctional RibF implementation</a><span class="pill type">Reaction</span><span class="tree-id">bacterial_ribf_adenylyltransferase_variant</span>
+                </span>
             </summary>                <div class="tree-group-title">Annotons</div>
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
-                                <a href="#annoton-fmn_adenylyltransferase_activity">RibF/FADS: FMN adenylyltransferase</a>
-                                <span class="tree-id">Family: RibF/FADS FMN adenylyltransferase family</span>
+                                <a href="#annoton-bacterial_ribf_adenylyltransferase_activity">RibF: FMN adenylyltransferase</a>
+                                <span class="tree-id">Family: bacterial bifunctional RibF family</span>
                             </span>
                         </li>                </ul></details>
+    </li>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-eukaryotic_fads_adenylyltransferase_variant">Eukaryotic FAD synthase implementation</a><span class="pill type">Reaction</span><span class="tree-id">eukaryotic_fads_adenylyltransferase_variant</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-eukaryotic_fads_adenylyltransferase_activity">FADS/FLAD1: FMN adenylyltransferase</a>
+                                <span class="tree-id">Family: eukaryotic FAD synthase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                            </ol>
+                        </li>                </ol></details>
     </li>
                             </li>                </ol></details>
     </li>
@@ -1175,18 +1200,29 @@
             <span class="node-title">FMN adenylyltransferase</span><span class="pill type">Reaction</span><span class="pill">fmn_adenylyltransferase_step</span>
         </div>
 
+                    <div class="variant-set">
+                <div class="variant-marker">
+                    Variant set: FMN adenylyltransferase enzyme-family variants by enzyme family and architecture (One Or More)</div>
+                                    <section class="node-detail depth-3" id="node-bacterial_ribf_adenylyltransferase_variant">
+        <div class="node-heading">
+            <span class="node-title">Bacterial bifunctional RibF implementation</span><span class="pill type">Reaction</span><span class="pill">bacterial_ribf_adenylyltransferase_variant</span>
+        </div>
+
                     <h4>Annotons</h4>
-            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-fmn_adenylyltransferase_activity">
-        <div class="annoton-title">RibF/FADS: FMN adenylyltransferase</div>
-        <div class="small muted">fmn_adenylyltransferase_activity</div>            <div class="small"><strong>Participant:</strong> Family: RibF/FADS FMN adenylyltransferase family</div>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-bacterial_ribf_adenylyltransferase_activity">
+        <div class="annoton-title">RibF: FMN adenylyltransferase</div>
+        <div class="small muted">bacterial_ribf_adenylyltransferase_activity</div>            <div class="small"><strong>Participant:</strong> Family: bacterial bifunctional RibF family</div>
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>RibF/FADS FMN adenylyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR22749" target="_blank" rel="noopener">PANTHER:PTHR22749</a>                    <div class="slot-row">
+            <span><strong>bacterial bifunctional RibF family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR22749%3ASF6" target="_blank" rel="noopener">PANTHER:PTHR22749:SF6</a>                <span class="descriptor-description">The subfamily groups the two RibF exemplars, but local PAINT supports only their kinase activity; the adenylyltransferase function is grounded separately by the exemplar records.</span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>ribF (Pseudomonas putida KT2440)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88Q93/entry" target="_blank" rel="noopener">UniProtKB:Q88Q93</a></span>                            <span class="descriptor">
-            <span>ribF (Escherichia coli K-12)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0AG40/entry" target="_blank" rel="noopener">UniProtKB:P0AG40</a></span>                            <span class="descriptor">
-            <span>FLAD1 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8NFF5/entry" target="_blank" rel="noopener">UniProtKB:Q8NFF5</a></span>                    </div></div>
+            <span>ribF (Escherichia coli K-12)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0AG40/entry" target="_blank" rel="noopener">UniProtKB:P0AG40</a></span>                    </div></div>
+                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Taxon:</span>
+                        <div class="descriptor">
+            <span><strong>bacteria</strong></span><a class="term-id" href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2" target="_blank" rel="noopener">NCBITaxon:2</a></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>FMN adenylyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003919" target="_blank" rel="noopener">GO:0003919</a>                    <div class="slot-row">
@@ -1195,7 +1231,34 @@
             <span>ATP</span></span>                    </div>                    <div class="slot-row">
                         <span class="slot-name">Products:</span>                            <span class="descriptor">
             <span>FAD</span></span>                            <span class="descriptor">
-            <span>diphosphate</span></span>                    </div></div>            <p class="role-description">Adenylylates FMN to FAD.</p></article>            </div>    </section>    </section>    </section>
+            <span>diphosphate</span></span>                    </div></div>            <p class="role-description">The adenylyltransferase domain of bacterial RibF converts FMN to FAD in the same polypeptide that performs the preceding kinase reaction.</p></article>            </div>    </section>                    <section class="node-detail depth-3" id="node-eukaryotic_fads_adenylyltransferase_variant">
+        <div class="node-heading">
+            <span class="node-title">Eukaryotic FAD synthase implementation</span><span class="pill type">Reaction</span><span class="pill">eukaryotic_fads_adenylyltransferase_variant</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-eukaryotic_fads_adenylyltransferase_activity">
+        <div class="annoton-title">FADS/FLAD1: FMN adenylyltransferase</div>
+        <div class="small muted">eukaryotic_fads_adenylyltransferase_activity</div>            <div class="small"><strong>Participant:</strong> Family: eukaryotic FAD synthase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>eukaryotic FAD synthase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR23293%3ASF9" target="_blank" rel="noopener">PANTHER:PTHR23293:SF9</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>FLAD1 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8NFF5/entry" target="_blank" rel="noopener">UniProtKB:Q8NFF5</a></span>                    </div></div>
+                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Taxon:</span>
+                        <div class="descriptor">
+            <span><strong>eukaryota</strong></span><a class="term-id" href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=2759" target="_blank" rel="noopener">NCBITaxon:2759</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>FMN adenylyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0003919" target="_blank" rel="noopener">GO:0003919</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>FMN</span></span>                            <span class="descriptor">
+            <span>ATP</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>FAD</span></span>                            <span class="descriptor">
+            <span>diphosphate</span></span>                    </div></div>            <p class="role-description">A dedicated eukaryotic FAD synthase performs the adenylylation separately from riboflavin kinase.</p></article>            </div>    </section>            </div>    </section>    </section>    </section>
             </div>
         </section>
     </section>

--- a/pages/projects/P_PUTIDA/batches/ppu00740_riboflavin_biosynthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00740_riboflavin_biosynthesis.html
@@ -587,6 +587,14 @@
 </ul>
 <p>This PR is a module-first light pass. It does not create PENDING gene-review stubs for all 15 KEGG members. Full gene reviews should prioritize the core <code>rib</code> genes and any non-core entries whose current GO/pathway mappings look misleading after module-level review.</p>
 <p>Generated UTC: 2026-07-15T11:02:48.876044+00:00</p>
+<h2 id="repair-checkpoint">Repair Checkpoint</h2>
+<p>On 2026-09-01, the FMN adenylyltransferase step was split into bacterial<br />
+bifunctional RibF (<code>PTHR22749:SF6</code>) and eukaryotic FAD synthase<br />
+(<code>PTHR23293:SF9</code>) variants. Human FLAD1 is no longer incorrectly declared as a<br />
+member of the bacterial RibF family; its <a href="http://amigo.geneontology.org/amigo/term/GO:0003919">GO:0003919</a> activity is grounded by<br />
+<code>PTN000591373</code>. The bacterial variant is instead grounded by its Q88Q93 and<br />
+P0AG40 exemplar records because local PTHR22749 PAINT covers only the kinase<br />
+half of bifunctional RibF.</p>
     </div>
 
     <footer>

--- a/pages/projects/P_PUTIDA/batches/ppu00740_riboflavin_biosynthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00740_riboflavin_biosynthesis.html
@@ -595,6 +595,8 @@ member of the bacterial RibF family; its <a href="http://amigo.geneontology.org/
 <code>PTN000591373</code>. The bacterial variant is instead grounded by its Q88Q93 and<br />
 P0AG40 exemplar records because local PTHR22749 PAINT covers only the kinase<br />
 half of bifunctional RibF.</p>
+<p>Repair pull request: <a href="https://github.com/ai4curation/ai-gene-review/pull/2861">#2861</a><br />
+(<code>codex/putida-riboflavin-repair-wave90</code>).</p>
     </div>
 
     <footer>

--- a/projects/P_PUTIDA/batches/ppu00740_riboflavin_biosynthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00740_riboflavin_biosynthesis.md
@@ -76,3 +76,6 @@ member of the bacterial RibF family; its GO:0003919 activity is grounded by
 `PTN000591373`. The bacterial variant is instead grounded by its Q88Q93 and
 P0AG40 exemplar records because local PTHR22749 PAINT covers only the kinase
 half of bifunctional RibF.
+
+Repair pull request: [#2861](https://github.com/ai4curation/ai-gene-review/pull/2861)
+(`codex/putida-riboflavin-repair-wave90`).

--- a/projects/P_PUTIDA/batches/ppu00740_riboflavin_biosynthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00740_riboflavin_biosynthesis.md
@@ -66,3 +66,13 @@ OpenScientist conclusions:
 This PR is a module-first light pass. It does not create PENDING gene-review stubs for all 15 KEGG members. Full gene reviews should prioritize the core `rib` genes and any non-core entries whose current GO/pathway mappings look misleading after module-level review.
 
 Generated UTC: 2026-07-15T11:02:48.876044+00:00
+
+## Repair Checkpoint
+
+On 2026-09-01, the FMN adenylyltransferase step was split into bacterial
+bifunctional RibF (`PTHR22749:SF6`) and eukaryotic FAD synthase
+(`PTHR23293:SF9`) variants. Human FLAD1 is no longer incorrectly declared as a
+member of the bacterial RibF family; its GO:0003919 activity is grounded by
+`PTN000591373`. The bacterial variant is instead grounded by its Q88Q93 and
+P0AG40 exemplar records because local PTHR22749 PAINT covers only the kinase
+half of bifunctional RibF.


### PR DESCRIPTION
## Summary
- split the FMN adenylyltransferase step into bacterial bifunctional RibF and eukaryotic FAD synthase variants
- ground Q88Q93/P0AG40 on their exact PTHR22749:SF6 membership without claiming PAINT support for the adenylyltransferase half
- ground human FLAD1 on PTHR23293:SF9 and PTN000591373
- update and render the reusable module and PSEPK batch audit

## Validation
- `linkml-validate` (`ModuleReview`)
- semantic module validator (original cross-family representative warning removed; only taxonomy lookup advisories remain)
- independent annotation-reviewer audit
- module and project rendering
