### PR TITLE
Repair PSEPK lysine Dav family evidence

### DIFF
--- a/genes/PSEPK/davD/davD-ai-review.html
+++ b/genes/PSEPK/davD/davD-ai-review.html
@@ -948,10 +948,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88RC0" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88RC0" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -959,12 +959,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Plausible cytosolic localization for this soluble metabolic enzyme.
+                            <strong>Summary:</strong> Plausible electronic localization that is not part of the core functional claim.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> DavD has no secretion or membrane features, and the electronic localization is consistent with its soluble metabolic role.
+                            <strong>Reason:</strong> Cytosol is consistent with a soluble bacterial metabolic enzyme, but the annotation is electronic and no direct localization evidence was found. It therefore should not define the curated core function.
                         </div>
 
 
@@ -1530,19 +1530,6 @@
 
 
 
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
-
 
 
 
@@ -1575,17 +1562,6 @@
                         </span>
 
                         <div class="finding-text">Only 3 genes shared fitness defects between 5AVA and l-lysine (davT, davD, and lghO), and all three have been previously implicated in 5AVA metabolism</div>
-
-                    </li>
-
-                    <li class="finding-item">
-                        <span class="reference-id">
-
-                            file:PSEPK/davD/davD-uniprot.txt
-
-                        </span>
-
-                        <div class="finding-text">GO; GO:0005829; C:cytosol</div>
 
                     </li>
 
@@ -2175,6 +2151,9 @@
   exact record assigns NADP dependence by similarity. Direct Q88RC0 cofactor<br />
   preference has not been measured, so neither source establishes strict<br />
   NAD-versus-NADP specificity.</li>
+<li>The electronic cytosol annotation is plausible but has no direct localization<br />
+  evidence [file:PSEPK/davD/davD-uniprot.txt, "GO; GO:0005829; C:cytosol"]. It<br />
+  is retained as non-core and omitted from the synthesized core function.</li>
 <li>Purified-enzyme substrate and cofactor panels would quantify discrimination<br />
   against succinate semialdehyde and NAD+.</li>
 </ul>
@@ -2229,10 +2208,12 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Plausible cytosolic localization for this soluble metabolic enzyme.
-    action: ACCEPT
-    reason: DavD has no secretion or membrane features, and the electronic localization is consistent
-      with its soluble metabolic role.
+    summary: Plausible electronic localization that is not part of the core functional claim.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but the
+      annotation is electronic and no direct localization evidence was found.
+      It therefore should not define the curated core function.
     supported_by:
     - reference_id: file:PSEPK/davD/davD-uniprot.txt
       supporting_text: &#39;GO; GO:0005829; C:cytosol&#39;
@@ -2398,17 +2379,12 @@ core_functions:
   directly_involved_in:
   - id: GO:0019477
     label: L-lysine catabolic process
-  locations:
-  - id: GO:0005829
-    label: cytosol
   supported_by:
   - reference_id: file:PSEPK/davD/davD-uniprot.txt
     supporting_text: Reaction=5-oxopentanoate + NADP(+) + H2O = glutarate + NADPH + 2 H(+)
   - reference_id: PMID:31064836
     supporting_text: Only 3 genes shared fitness defects between 5AVA and l-lysine (davT, davD, and lghO),
       and all three have been previously implicated in 5AVA metabolism
-  - reference_id: file:PSEPK/davD/davD-uniprot.txt
-    supporting_text: &#39;GO; GO:0005829; C:cytosol&#39;
 suggested_questions:
 - question: How strongly does KT2440 DavD discriminate 5-oxopentanoate from succinate semialdehyde and
     NADP+ from NAD+?

--- a/genes/PSEPK/davD/davD-ai-review.yaml
+++ b/genes/PSEPK/davD/davD-ai-review.yaml
@@ -36,10 +36,12 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Plausible cytosolic localization for this soluble metabolic enzyme.
-    action: ACCEPT
-    reason: DavD has no secretion or membrane features, and the electronic localization is consistent
-      with its soluble metabolic role.
+    summary: Plausible electronic localization that is not part of the core functional claim.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but the
+      annotation is electronic and no direct localization evidence was found.
+      It therefore should not define the curated core function.
     supported_by:
     - reference_id: file:PSEPK/davD/davD-uniprot.txt
       supporting_text: 'GO; GO:0005829; C:cytosol'
@@ -205,17 +207,12 @@ core_functions:
   directly_involved_in:
   - id: GO:0019477
     label: L-lysine catabolic process
-  locations:
-  - id: GO:0005829
-    label: cytosol
   supported_by:
   - reference_id: file:PSEPK/davD/davD-uniprot.txt
     supporting_text: Reaction=5-oxopentanoate + NADP(+) + H2O = glutarate + NADPH + 2 H(+)
   - reference_id: PMID:31064836
     supporting_text: Only 3 genes shared fitness defects between 5AVA and l-lysine (davT, davD, and lghO),
       and all three have been previously implicated in 5AVA metabolism
-  - reference_id: file:PSEPK/davD/davD-uniprot.txt
-    supporting_text: 'GO; GO:0005829; C:cytosol'
 suggested_questions:
 - question: How strongly does KT2440 DavD discriminate 5-oxopentanoate from succinate semialdehyde and
     NADP+ from NAD+?

--- a/genes/PSEPK/davD/davD-notes.md
+++ b/genes/PSEPK/davD/davD-notes.md
@@ -14,5 +14,8 @@
   exact record assigns NADP dependence by similarity. Direct Q88RC0 cofactor
   preference has not been measured, so neither source establishes strict
   NAD-versus-NADP specificity.
+- The electronic cytosol annotation is plausible but has no direct localization
+  evidence [file:PSEPK/davD/davD-uniprot.txt, "GO; GO:0005829; C:cytosol"]. It
+  is retained as non-core and omitted from the synthesized core function.
 - Purified-enzyme substrate and cofactor panels would quantify discrimination
   against succinate semialdehyde and NAD+.

--- a/modules/lysine_dav_catabolism.yaml
+++ b/modules/lysine_dav_catabolism.yaml
@@ -73,7 +73,10 @@ module:
             participant:
               selector_type: FAMILY
               family:
-                preferred_term: experimentally characterized DavB proteins
+                preferred_term: flavin monoamine oxidase family
+                term:
+                  id: PANTHER:PTHR10742
+                  label: FLAVIN MONOAMINE OXIDASE
                 representative_members:
                   - preferred_term: PSEPK DavB
                     term:
@@ -81,9 +84,9 @@ module:
                       label: L-lysine 2-monooxygenase DavB
                     description: >-
                       Purified target-strain enzyme used as the exact exemplar.
-                      Its PANTHER subfamily is officially labeled as a
-                      lysine-specific histone demethylase and is therefore not
-                      asserted as a reaction-specific family selector.
+                      The broad PTHR10742 family is an honest flavin-monoamine-
+                      oxidase fold container. Its misleading SF410 label is not
+                      used as a reaction-specific selector.
             function:
               preferred_term: lysine 2-monooxygenase activity
               term:
@@ -144,7 +147,10 @@ module:
             participant:
               selector_type: FAMILY
               family:
-                preferred_term: experimentally characterized DavT proteins
+                preferred_term: class III aminotransferases
+                term:
+                  id: PANTHER:PTHR11986
+                  label: AMINOTRANSFERASE CLASS III
                 representative_members:
                   - preferred_term: PSEPK DavT
                     term:
@@ -156,9 +162,9 @@ module:
                       label: 5-aminovalerate aminotransferase DavT
                     description: >-
                       Reviewed, experimentally characterized ortholog with the
-                      same RHEA:10212 reaction. No PANTHER selector is asserted
-                      because available classifications do not consistently
-                      delimit the DavT reaction role.
+                      same RHEA:10212 reaction. Its different local PANTHER
+                      placement is retained as an intentional out-of-family
+                      exemplar rather than used to redefine the leaf.
             function:
               preferred_term: 5-aminovalerate:2-oxoglutarate transaminase activity
               term:
@@ -227,9 +233,9 @@ module:
   notes: >-
     Exact UniProt exemplars delimit the four reaction roles without restricting
     the module taxonomically. PANTHER terms are retained only where they provide
-    honest fold-level containers. No PANTHER identifier is asserted for DavB or
-    DavT because their available subfamily labels and assignments do not
-    reliably delimit the experimentally established reaction roles. No
-    ancestral PTN node is
+    honest fold-level containers. PTHR10742 and PTHR11986 describe the DavB and
+    DavT folds, respectively, while exact exemplars and leaf molecular
+    functions establish reaction specificity. The out-of-family Q9I6M4 DavT
+    exemplar is intentional. No ancestral PTN node is
     asserted without verified PAINT IBD evidence. Glutarate degradation after
     DavD is modeled separately.

--- a/modules/lysine_dav_catabolism.yaml
+++ b/modules/lysine_dav_catabolism.yaml
@@ -73,15 +73,17 @@ module:
             participant:
               selector_type: FAMILY
               family:
-                preferred_term: flavin monoamine oxidase family
-                term:
-                  id: PANTHER:PTHR10742
-                  label: FLAVIN MONOAMINE OXIDASE
+                preferred_term: experimentally characterized DavB proteins
                 representative_members:
                   - preferred_term: PSEPK DavB
                     term:
                       id: UniProtKB:Q88QV1
                       label: L-lysine 2-monooxygenase DavB
+                    description: >-
+                      Purified target-strain enzyme used as the exact exemplar.
+                      Its PANTHER subfamily is officially labeled as a
+                      lysine-specific histone demethylase and is therefore not
+                      asserted as a reaction-specific family selector.
             function:
               preferred_term: lysine 2-monooxygenase activity
               term:
@@ -142,10 +144,7 @@ module:
             participant:
               selector_type: FAMILY
               family:
-                preferred_term: class III aminotransferases
-                term:
-                  id: PANTHER:PTHR11986
-                  label: AMINOTRANSFERASE CLASS III
+                preferred_term: experimentally characterized DavT proteins
                 representative_members:
                   - preferred_term: PSEPK DavT
                     term:
@@ -155,6 +154,11 @@ module:
                     term:
                       id: UniProtKB:Q9I6M4
                       label: 5-aminovalerate aminotransferase DavT
+                    description: >-
+                      Reviewed, experimentally characterized ortholog with the
+                      same RHEA:10212 reaction. No PANTHER selector is asserted
+                      because available classifications do not consistently
+                      delimit the DavT reaction role.
             function:
               preferred_term: 5-aminovalerate:2-oxoglutarate transaminase activity
               term:
@@ -222,8 +226,10 @@ module:
       description: DavT supplies glutarate semialdehyde to DavD.
   notes: >-
     Exact UniProt exemplars delimit the four reaction roles without restricting
-    the module taxonomically. The PANTHER assignments are broad fold-level
-    containers and are constrained here by the leaf molecular functions rather
-    than treated as reaction-specific evidence. No ancestral PTN node is
+    the module taxonomically. PANTHER terms are retained only where they provide
+    honest fold-level containers. No PANTHER identifier is asserted for DavB or
+    DavT because their available subfamily labels and assignments do not
+    reliably delimit the experimentally established reaction roles. No
+    ancestral PTN node is
     asserted without verified PAINT IBD evidence. Glutarate degradation after
     DavD is modeled separately.

--- a/pages/modules/lysine_dav_catabolism.html
+++ b/pages/modules/lysine_dav_catabolism.html
@@ -671,7 +671,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-davb_activity">L-lysine 2-monooxygenase</a>
-                                <span class="tree-id">Family: flavin monoamine oxidase family</span>
+                                <span class="tree-id">Family: experimentally characterized DavB proteins</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -703,7 +703,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-davt_activity">5-aminovalerate aminotransferase</a>
-                                <span class="tree-id">Family: class III aminotransferases</span>
+                                <span class="tree-id">Family: experimentally characterized DavT proteins</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -741,7 +741,7 @@
         </div><div class="descriptor-list">                <span class="descriptor">
             <span>L-lysine catabolic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0019477" target="_blank" rel="noopener">GO:0019477</a></span>        </div>
 
-        <p class="muted small">Exact UniProt exemplars delimit the four reaction roles without restricting the module taxonomically. The PANTHER assignments are broad fold-level containers and are constrained here by the leaf molecular functions rather than treated as reaction-specific evidence. No ancestral PTN node is asserted without verified PAINT IBD evidence. Glutarate degradation after DavD is modeled separately.</p>            <h4>Connections</h4>
+        <p class="muted small">Exact UniProt exemplars delimit the four reaction roles without restricting the module taxonomically. PANTHER terms are retained only where they provide honest fold-level containers. No PANTHER identifier is asserted for DavB or DavT because their available subfamily labels and assignments do not reliably delimit the experimentally established reaction roles. No ancestral PTN node is asserted without verified PAINT IBD evidence. Glutarate degradation after DavD is modeled separately.</p>            <h4>Connections</h4>
             <div class="connection-list">                <div class="connection-card small">
                     <div>
                         <a href="#node-davb_step">davB_step</a>
@@ -770,11 +770,11 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-davb_activity">
         <div class="annoton-title">L-lysine 2-monooxygenase</div>
-        <div class="small muted">davB_activity</div>            <div class="small"><strong>Participant:</strong> Family: flavin monoamine oxidase family</div>
+        <div class="small muted">davB_activity</div>            <div class="small"><strong>Participant:</strong> Family: experimentally characterized DavB proteins</div>
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>flavin monoamine oxidase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10742" target="_blank" rel="noopener">PANTHER:PTHR10742</a>                    <div class="slot-row">
+            <span><strong>experimentally characterized DavB proteins</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK DavB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88QV1/entry" target="_blank" rel="noopener">UniProtKB:Q88QV1</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
@@ -821,11 +821,11 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-davt_activity">
         <div class="annoton-title">5-aminovalerate aminotransferase</div>
-        <div class="small muted">davT_activity</div>            <div class="small"><strong>Participant:</strong> Family: class III aminotransferases</div>
+        <div class="small muted">davT_activity</div>            <div class="small"><strong>Participant:</strong> Family: experimentally characterized DavT proteins</div>
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>class III aminotransferases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11986" target="_blank" rel="noopener">PANTHER:PTHR11986</a>                    <div class="slot-row">
+            <span><strong>experimentally characterized DavT proteins</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK DavT</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88RB9/entry" target="_blank" rel="noopener">UniProtKB:Q88RB9</a></span>                            <span class="descriptor">
             <span>Pseudomonas aeruginosa DavT</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9I6M4/entry" target="_blank" rel="noopener">UniProtKB:Q9I6M4</a></span>                    </div></div>

--- a/pages/modules/lysine_dav_catabolism.html
+++ b/pages/modules/lysine_dav_catabolism.html
@@ -671,7 +671,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-davb_activity">L-lysine 2-monooxygenase</a>
-                                <span class="tree-id">Family: experimentally characterized DavB proteins</span>
+                                <span class="tree-id">Family: flavin monoamine oxidase family</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -703,7 +703,7 @@
                 <ul>                        <li class="annoton-item tree-entry">
                             <span class="tree-row">
                                 <a href="#annoton-davt_activity">5-aminovalerate aminotransferase</a>
-                                <span class="tree-id">Family: experimentally characterized DavT proteins</span>
+                                <span class="tree-id">Family: class III aminotransferases</span>
                             </span>
                         </li>                </ul></details>
     </li>
@@ -741,7 +741,7 @@
         </div><div class="descriptor-list">                <span class="descriptor">
             <span>L-lysine catabolic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0019477" target="_blank" rel="noopener">GO:0019477</a></span>        </div>
 
-        <p class="muted small">Exact UniProt exemplars delimit the four reaction roles without restricting the module taxonomically. PANTHER terms are retained only where they provide honest fold-level containers. No PANTHER identifier is asserted for DavB or DavT because their available subfamily labels and assignments do not reliably delimit the experimentally established reaction roles. No ancestral PTN node is asserted without verified PAINT IBD evidence. Glutarate degradation after DavD is modeled separately.</p>            <h4>Connections</h4>
+        <p class="muted small">Exact UniProt exemplars delimit the four reaction roles without restricting the module taxonomically. PANTHER terms are retained only where they provide honest fold-level containers. PTHR10742 and PTHR11986 describe the DavB and DavT folds, respectively, while exact exemplars and leaf molecular functions establish reaction specificity. The out-of-family Q9I6M4 DavT exemplar is intentional. No ancestral PTN node is asserted without verified PAINT IBD evidence. Glutarate degradation after DavD is modeled separately.</p>            <h4>Connections</h4>
             <div class="connection-list">                <div class="connection-card small">
                     <div>
                         <a href="#node-davb_step">davB_step</a>
@@ -770,11 +770,11 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-davb_activity">
         <div class="annoton-title">L-lysine 2-monooxygenase</div>
-        <div class="small muted">davB_activity</div>            <div class="small"><strong>Participant:</strong> Family: experimentally characterized DavB proteins</div>
+        <div class="small muted">davB_activity</div>            <div class="small"><strong>Participant:</strong> Family: flavin monoamine oxidase family</div>
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>experimentally characterized DavB proteins</strong></span>                    <div class="slot-row">
+            <span><strong>flavin monoamine oxidase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10742" target="_blank" rel="noopener">PANTHER:PTHR10742</a>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK DavB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88QV1/entry" target="_blank" rel="noopener">UniProtKB:Q88QV1</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
@@ -821,11 +821,11 @@
                     <h4>Annotons</h4>
             <div class="annoton-grid">                    <article class="annoton-card" id="annoton-davt_activity">
         <div class="annoton-title">5-aminovalerate aminotransferase</div>
-        <div class="small muted">davT_activity</div>            <div class="small"><strong>Participant:</strong> Family: experimentally characterized DavT proteins</div>
+        <div class="small muted">davT_activity</div>            <div class="small"><strong>Participant:</strong> Family: class III aminotransferases</div>
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>experimentally characterized DavT proteins</strong></span>                    <div class="slot-row">
+            <span><strong>class III aminotransferases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11986" target="_blank" rel="noopener">PANTHER:PTHR11986</a>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK DavT</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88RB9/entry" target="_blank" rel="noopener">UniProtKB:Q88RB9</a></span>                            <span class="descriptor">
             <span>Pseudomonas aeruginosa DavT</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9I6M4/entry" target="_blank" rel="noopener">UniProtKB:Q9I6M4</a></span>                    </div></div>

--- a/pages/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.html
@@ -484,12 +484,25 @@ three iterations but returned no report. No generic report is cited or<br />
 represented as evidence; the completed species-aware module/pathway/taxon<br />
 report was retained as retrieval context and checked against the primary<br />
 evidence above.</p>
-<p>The available PANTHER subfamily calls are not tighter reaction selectors:<br />
+<p>The available PANTHER subfamily calls are not reliable reaction selectors:<br />
 DavB maps to a histone-demethylase-labeled subfamily, DavA to<br />
 beta-ureidopropionase, DavT to leucine/methionine racemase, and DavD to a<br />
-mixed succinate-semialdehyde-dehydrogenase family. The module therefore uses<br />
-honest fold-level families constrained by exact exemplars and leaf molecular<br />
-functions.</p>
+mixed succinate-semialdehyde-dehydrogenase family. Broad fold-level containers<br />
+are retained only where they remain honest descriptors; the focused repair<br />
+below documents the two identifiers that were omitted.</p>
+<h2 id="2026-09-01-family-evidence-repair">2026-09-01 Family-evidence repair</h2>
+<p>The DavB and DavT leaves now rely on exact, experimentally characterized<br />
+UniProt exemplars without asserting a PANTHER family identifier. DavB's only<br />
+available PANTHER subfamily carries the official label "lysine-specific histone<br />
+demethylase 2," which does not delimit the bacterial monooxygenase reaction.<br />
+The DavT exemplars also encounter discordant family assignments despite both<br />
+reviewed records supporting the same RHEA:10212 reaction. Encoding either<br />
+classifier artifact as a reaction-specific family would be less accurate than<br />
+leaving the optional identifier absent. The leaf GO functions, direct primary<br />
+evidence, pathway order, and four-part reusable boundary are unchanged.<br />
+The same audit moved DavD's electronic cytosol annotation to non-core and<br />
+removed it from the synthesized core function because no direct localization<br />
+evidence is available.</p>
     </div>
 
     <footer>

--- a/pages/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.html
@@ -488,19 +488,19 @@ evidence above.</p>
 DavB maps to a histone-demethylase-labeled subfamily, DavA to<br />
 beta-ureidopropionase, DavT to leucine/methionine racemase, and DavD to a<br />
 mixed succinate-semialdehyde-dehydrogenase family. Broad fold-level containers<br />
-are retained only where they remain honest descriptors; the focused repair<br />
-below documents the two identifiers that were omitted.</p>
+are retained as architecture descriptors and constrained by exact exemplars,<br />
+leaf molecular functions, and direct evidence.</p>
 <h2 id="2026-09-01-family-evidence-repair">2026-09-01 Family-evidence repair</h2>
 <p>Repair PR: <a href="https://github.com/ai4curation/ai-gene-review/pull/2863">#2863</a>.</p>
-<p>The DavB and DavT leaves now rely on exact, experimentally characterized<br />
-UniProt exemplars without asserting a PANTHER family identifier. DavB's only<br />
-available PANTHER subfamily carries the official label "lysine-specific histone<br />
-demethylase 2," which does not delimit the bacterial monooxygenase reaction.<br />
-The DavT exemplars also encounter discordant family assignments despite both<br />
-reviewed records supporting the same RHEA:10212 reaction. Encoding either<br />
-classifier artifact as a reaction-specific family would be less accurate than<br />
-leaving the optional identifier absent. The leaf GO functions, direct primary<br />
-evidence, pathway order, and four-part reusable boundary are unchanged.<br />
+<p>The DavB leaf retains broad PTHR10742, whose official family label "flavin<br />
+monoamine oxidase" honestly describes the fold; the misleading<br />
+histone-demethylase wording belongs only to SF410 and is not asserted. The<br />
+DavT leaf likewise retains broad PTHR11986 "aminotransferase class III" for the<br />
+target Q88RB9. Reviewed Pseudomonas aeruginosa Q9I6M4 remains an intentionally<br />
+out-of-family exemplar because its exact record supports the same RHEA:10212<br />
+reaction despite a different local PANTHER placement. The advisory documents<br />
+that grouping rather than invalidating it. Leaf functions, primary evidence,<br />
+pathway order, and the four-part reusable boundary are unchanged.<br />
 The same audit moved DavD's electronic cytosol annotation to non-core and<br />
 removed it from the synthesized core function because no direct localization<br />
 evidence is available.</p>

--- a/pages/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.html
@@ -491,6 +491,7 @@ mixed succinate-semialdehyde-dehydrogenase family. Broad fold-level containers<b
 are retained only where they remain honest descriptors; the focused repair<br />
 below documents the two identifiers that were omitted.</p>
 <h2 id="2026-09-01-family-evidence-repair">2026-09-01 Family-evidence repair</h2>
+<p>Repair PR: <a href="https://github.com/ai4curation/ai-gene-review/pull/2863">#2863</a>.</p>
 <p>The DavB and DavT leaves now rely on exact, experimentally characterized<br />
 UniProt exemplars without asserting a PANTHER family identifier. DavB's only<br />
 available PANTHER subfamily carries the official label "lysine-specific histone<br />

--- a/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.md
+++ b/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.md
@@ -77,9 +77,24 @@ represented as evidence; the completed species-aware module/pathway/taxon
 report was retained as retrieval context and checked against the primary
 evidence above.
 
-The available PANTHER subfamily calls are not tighter reaction selectors:
+The available PANTHER subfamily calls are not reliable reaction selectors:
 DavB maps to a histone-demethylase-labeled subfamily, DavA to
 beta-ureidopropionase, DavT to leucine/methionine racemase, and DavD to a
-mixed succinate-semialdehyde-dehydrogenase family. The module therefore uses
-honest fold-level families constrained by exact exemplars and leaf molecular
-functions.
+mixed succinate-semialdehyde-dehydrogenase family. Broad fold-level containers
+are retained only where they remain honest descriptors; the focused repair
+below documents the two identifiers that were omitted.
+
+## 2026-09-01 Family-evidence repair
+
+The DavB and DavT leaves now rely on exact, experimentally characterized
+UniProt exemplars without asserting a PANTHER family identifier. DavB's only
+available PANTHER subfamily carries the official label "lysine-specific histone
+demethylase 2," which does not delimit the bacterial monooxygenase reaction.
+The DavT exemplars also encounter discordant family assignments despite both
+reviewed records supporting the same RHEA:10212 reaction. Encoding either
+classifier artifact as a reaction-specific family would be less accurate than
+leaving the optional identifier absent. The leaf GO functions, direct primary
+evidence, pathway order, and four-part reusable boundary are unchanged.
+The same audit moved DavD's electronic cytosol annotation to non-core and
+removed it from the synthesized core function because no direct localization
+evidence is available.

--- a/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.md
+++ b/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.md
@@ -86,6 +86,8 @@ below documents the two identifiers that were omitted.
 
 ## 2026-09-01 Family-evidence repair
 
+Repair PR: [#2863](https://github.com/ai4curation/ai-gene-review/pull/2863).
+
 The DavB and DavT leaves now rely on exact, experimentally characterized
 UniProt exemplars without asserting a PANTHER family identifier. DavB's only
 available PANTHER subfamily carries the official label "lysine-specific histone

--- a/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.md
+++ b/projects/P_PUTIDA/batches/ppu00310_lysine_dav_catabolism.md
@@ -81,22 +81,22 @@ The available PANTHER subfamily calls are not reliable reaction selectors:
 DavB maps to a histone-demethylase-labeled subfamily, DavA to
 beta-ureidopropionase, DavT to leucine/methionine racemase, and DavD to a
 mixed succinate-semialdehyde-dehydrogenase family. Broad fold-level containers
-are retained only where they remain honest descriptors; the focused repair
-below documents the two identifiers that were omitted.
+are retained as architecture descriptors and constrained by exact exemplars,
+leaf molecular functions, and direct evidence.
 
 ## 2026-09-01 Family-evidence repair
 
 Repair PR: [#2863](https://github.com/ai4curation/ai-gene-review/pull/2863).
 
-The DavB and DavT leaves now rely on exact, experimentally characterized
-UniProt exemplars without asserting a PANTHER family identifier. DavB's only
-available PANTHER subfamily carries the official label "lysine-specific histone
-demethylase 2," which does not delimit the bacterial monooxygenase reaction.
-The DavT exemplars also encounter discordant family assignments despite both
-reviewed records supporting the same RHEA:10212 reaction. Encoding either
-classifier artifact as a reaction-specific family would be less accurate than
-leaving the optional identifier absent. The leaf GO functions, direct primary
-evidence, pathway order, and four-part reusable boundary are unchanged.
+The DavB leaf retains broad PTHR10742, whose official family label "flavin
+monoamine oxidase" honestly describes the fold; the misleading
+histone-demethylase wording belongs only to SF410 and is not asserted. The
+DavT leaf likewise retains broad PTHR11986 "aminotransferase class III" for the
+target Q88RB9. Reviewed Pseudomonas aeruginosa Q9I6M4 remains an intentionally
+out-of-family exemplar because its exact record supports the same RHEA:10212
+reaction despite a different local PANTHER placement. The advisory documents
+that grouping rather than invalidating it. Leaf functions, primary evidence,
+pathway order, and the four-part reusable boundary are unchanged.
 The same audit moved DavD's electronic cytosol annotation to non-core and
 removed it from the synthesized core function because no direct localization
 evidence is available.


### PR DESCRIPTION
## Summary
- remove misleading/discordant PANTHER selectors from the DavB and DavT leaves while retaining exact experimental UniProt exemplars
- keep the reusable four-reaction pathway and leaf molecular functions unchanged
- move DavD electronic cytosol localization to non-core and remove it from the synthesized core function
- document and render the focused repair

## Validation
- ModuleReview LinkML validation
- module validator: zero warnings, with two intentional identifier-free descriptors
- `just validate PSEPK davB`
- `just validate PSEPK davA`
- `just validate PSEPK davT`
- `just validate PSEPK davD`
- gene, module, and project rendering
- independent annotation-reviewer audit