### PR TITLE
Repair PSEPK de novo purine module evidence

### DIFF
--- a/genes/PSEPK/purB/purB-ai-review.html
+++ b/genes/PSEPK/purB/purB-ai-review.html
@@ -1002,10 +1002,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88FR7" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88FR7" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1013,12 +1013,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct specific location for a soluble bacterial enzyme.
+                            <strong>Summary:</strong> Plausible electronic localization that is not core to either lyase activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The enzyme acts on soluble intermediates of de novo purine synthesis.
+                            <strong>Reason:</strong> Cytosol is consistent with a soluble bacterial metabolic enzyme, but no direct localization evidence was found.
                         </div>
 
 
@@ -1433,19 +1433,6 @@
 
 
 
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
-
 
 
 
@@ -1511,19 +1498,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -1801,9 +1775,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to either lyase activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006188
     label: IMP biosynthetic process
@@ -1918,9 +1894,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purB/purB-uniprot.txt
     supporting_text: &#39;RecName: Full=Adenylosuccinate lyase&#39;
-  locations:
-  - id: GO:0005829
-    label: cytosol
 - description: Converts adenylosuccinate to AMP and fumarate in de novo AMP synthesis.
   molecular_function:
     id: GO:0004018
@@ -1931,9 +1904,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purB/purB-uniprot.txt
     supporting_text: &#39;RecName: Full=Adenylosuccinate lyase&#39;
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_experiments:
 - description: Test a clean purB deletion for purine auxotrophy and rescue by the appropriate downstream
     purine intermediate or by gene complementation.

--- a/genes/PSEPK/purB/purB-ai-review.yaml
+++ b/genes/PSEPK/purB/purB-ai-review.yaml
@@ -41,9 +41,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to either lyase activity.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006188
     label: IMP biosynthetic process
@@ -158,9 +160,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purB/purB-uniprot.txt
     supporting_text: 'RecName: Full=Adenylosuccinate lyase'
-  locations:
-  - id: GO:0005829
-    label: cytosol
 - description: Converts adenylosuccinate to AMP and fumarate in de novo AMP synthesis.
   molecular_function:
     id: GO:0004018
@@ -171,9 +170,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purB/purB-uniprot.txt
     supporting_text: 'RecName: Full=Adenylosuccinate lyase'
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_experiments:
 - description: Test a clean purB deletion for purine auxotrophy and rescue by the appropriate downstream
     purine intermediate or by gene complementation.

--- a/genes/PSEPK/purC/purC-ai-review.html
+++ b/genes/PSEPK/purC/purC-ai-review.html
@@ -932,10 +932,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88NG9" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88NG9" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -943,12 +943,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct specific location for a soluble bacterial enzyme.
+                            <strong>Summary:</strong> Plausible electronic localization that is not core to the enzyme function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The enzyme acts on soluble intermediates of de novo purine synthesis.
+                            <strong>Reason:</strong> Cytosol is consistent with a soluble bacterial metabolic enzyme, but no direct localization evidence was found.
                         </div>
 
 
@@ -1191,19 +1191,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -1641,9 +1628,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006164
     label: purine nucleotide biosynthetic process
@@ -1711,9 +1700,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purC/purC-uniprot.txt
     supporting_text: &#39;RecName: Full=Phosphoribosylaminoimidazole-succinocarboxamide synthase&#39;
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_questions:
 - question: Should the cobalamin-process InterPro mapping be narrowed so it is not transferred to canonical
     PurC proteins?

--- a/genes/PSEPK/purC/purC-ai-review.yaml
+++ b/genes/PSEPK/purC/purC-ai-review.yaml
@@ -26,9 +26,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006164
     label: purine nucleotide biosynthetic process
@@ -96,9 +98,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purC/purC-uniprot.txt
     supporting_text: 'RecName: Full=Phosphoribosylaminoimidazole-succinocarboxamide synthase'
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_questions:
 - question: Should the cobalamin-process InterPro mapping be narrowed so it is not transferred to canonical
     PurC proteins?

--- a/genes/PSEPK/purH/purH-ai-review.html
+++ b/genes/PSEPK/purH/purH-ai-review.html
@@ -985,10 +985,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88DK3" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88DK3" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -996,12 +996,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct specific location for a soluble bacterial enzyme.
+                            <strong>Summary:</strong> Plausible electronic localization that is not core to either catalytic activity.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The enzyme acts on soluble intermediates of de novo purine synthesis.
+                            <strong>Reason:</strong> Cytosol is consistent with a soluble bacterial metabolic enzyme, but no direct localization evidence was found.
                         </div>
 
 
@@ -1176,19 +1176,6 @@
 
 
 
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
-
 
 
 
@@ -1254,19 +1241,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -1491,9 +1465,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to either catalytic activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006164
     label: purine nucleotide biosynthetic process
@@ -1549,9 +1525,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purH/purH-uniprot.txt
     supporting_text: &#39;RecName: Full=Bifunctional purine biosynthesis protein PurH&#39;
-  locations:
-  - id: GO:0005829
-    label: cytosol
 - description: Closes the purine ring to form IMP in the terminal reaction.
   molecular_function:
     id: GO:0003937
@@ -1561,9 +1534,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purH/purH-uniprot.txt
     supporting_text: &#39;RecName: Full=Bifunctional purine biosynthesis protein PurH&#39;
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_experiments:
 - description: Test a clean purH deletion for purine auxotrophy and rescue by the appropriate downstream
     purine intermediate or by gene complementation.

--- a/genes/PSEPK/purH/purH-ai-review.yaml
+++ b/genes/PSEPK/purH/purH-ai-review.yaml
@@ -36,9 +36,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to either catalytic activity.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006164
     label: purine nucleotide biosynthetic process
@@ -94,9 +96,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purH/purH-uniprot.txt
     supporting_text: 'RecName: Full=Bifunctional purine biosynthesis protein PurH'
-  locations:
-  - id: GO:0005829
-    label: cytosol
 - description: Closes the purine ring to form IMP in the terminal reaction.
   molecular_function:
     id: GO:0003937
@@ -106,9 +105,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purH/purH-uniprot.txt
     supporting_text: 'RecName: Full=Bifunctional purine biosynthesis protein PurH'
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_experiments:
 - description: Test a clean purH deletion for purine auxotrophy and rescue by the appropriate downstream
     purine intermediate or by gene complementation.

--- a/genes/PSEPK/purK/purK-ai-review.html
+++ b/genes/PSEPK/purK/purK-ai-review.html
@@ -1049,10 +1049,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88C48" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88C48" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1060,12 +1060,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct specific location for a soluble bacterial enzyme.
+                            <strong>Summary:</strong> Plausible electronic localization that is not core to the enzyme function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The enzyme acts on soluble intermediates of de novo purine synthesis.
+                            <strong>Reason:</strong> Cytosol is consistent with a soluble bacterial metabolic enzyme, but no direct localization evidence was found.
                         </div>
 
 
@@ -1281,19 +1281,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -1587,9 +1574,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006189
     label: &#39;&#39;&#39;de novo&#39;&#39; IMP biosynthetic process&#39;
@@ -1678,9 +1667,6 @@ core_functions:
       Conversion of 5-aminoimidazole ribonucleotide (AIR) to
       4-carboxyaminoimidazole ribonucleotide (CAIR) in Escherichia coli
       requires two proteins - PurK and PurE.
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_experiments:
 - description: Test a clean purK deletion for purine auxotrophy and rescue by the appropriate downstream
     purine intermediate or by gene complementation.

--- a/genes/PSEPK/purK/purK-ai-review.yaml
+++ b/genes/PSEPK/purK/purK-ai-review.yaml
@@ -48,9 +48,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006189
     label: '''de novo'' IMP biosynthetic process'
@@ -139,9 +141,6 @@ core_functions:
       Conversion of 5-aminoimidazole ribonucleotide (AIR) to
       4-carboxyaminoimidazole ribonucleotide (CAIR) in Escherichia coli
       requires two proteins - PurK and PurE.
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_experiments:
 - description: Test a clean purK deletion for purine auxotrophy and rescue by the appropriate downstream
     purine intermediate or by gene complementation.

--- a/genes/PSEPK/purL/purL-ai-review.html
+++ b/genes/PSEPK/purL/purL-ai-review.html
@@ -985,10 +985,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88P16" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88P16" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -996,12 +996,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct expected location.
+                            <strong>Summary:</strong> Plausible electronic localization that is not core to the enzyme function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> PurL is a soluble bacterial metabolic enzyme.
+                            <strong>Reason:</strong> Cytoplasm is consistent with a soluble bacterial metabolic enzyme, but no direct localization evidence was found.
                         </div>
 
 
@@ -1175,19 +1175,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
-                                cytoplasm
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -1394,9 +1381,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: located_in
   review:
-    summary: Correct expected location.
-    action: ACCEPT
-    reason: PurL is a soluble bacterial metabolic enzyme.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cytoplasm is consistent with a soluble bacterial metabolic enzyme, but
+      no direct localization evidence was found.
 - term:
     id: GO:0006164
     label: purine nucleotide biosynthetic process
@@ -1449,9 +1438,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purL/purL-uniprot.txt
     supporting_text: &#39;RecName: Full=Phosphoribosylformylglycinamidine synthase&#39;
-  locations:
-  - id: GO:0005737
-    label: cytoplasm
 suggested_experiments:
 - description: Test a clean purL deletion for purine auxotrophy and rescue by the appropriate downstream
     purine intermediate or by gene complementation.

--- a/genes/PSEPK/purL/purL-ai-review.yaml
+++ b/genes/PSEPK/purL/purL-ai-review.yaml
@@ -35,9 +35,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: located_in
   review:
-    summary: Correct expected location.
-    action: ACCEPT
-    reason: PurL is a soluble bacterial metabolic enzyme.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Cytoplasm is consistent with a soluble bacterial metabolic enzyme, but
+      no direct localization evidence was found.
 - term:
     id: GO:0006164
     label: purine nucleotide biosynthetic process
@@ -90,9 +92,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purL/purL-uniprot.txt
     supporting_text: 'RecName: Full=Phosphoribosylformylglycinamidine synthase'
-  locations:
-  - id: GO:0005737
-    label: cytoplasm
 suggested_experiments:
 - description: Test a clean purL deletion for purine auxotrophy and rescue by the appropriate downstream
     purine intermediate or by gene complementation.

--- a/genes/PSEPK/purM/purM-ai-review.html
+++ b/genes/PSEPK/purM/purM-ai-review.html
@@ -1001,10 +1001,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q88MA9" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="Q88MA9" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1012,26 +1012,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct but less specific than the coexisting cytosol annotation.
+                            <strong>Summary:</strong> Plausible but redundant broad electronic localization.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Replace the broad cytoplasm term with cytosol.
+                            <strong>Reason:</strong> Cytoplasm is broader than the coexisting electronic cytosol annotation and does not define the enzyme&#39;s core function.
                         </div>
 
 
-
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                    cytosol
-                                </a>
-                            </span>
-
-                        </div>
 
 
 
@@ -1065,10 +1054,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88MA9" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88MA9" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1076,12 +1065,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct specific location for a soluble bacterial enzyme.
+                            <strong>Summary:</strong> Plausible electronic localization that is not core to the enzyme function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The enzyme acts on soluble intermediates of de novo purine synthesis.
+                            <strong>Reason:</strong> Cytosol is consistent with a soluble bacterial metabolic enzyme, but no direct localization evidence was found.
                         </div>
 
 
@@ -1308,19 +1297,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -1552,12 +1528,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: located_in
   review:
-    summary: Correct but less specific than the coexisting cytosol annotation.
-    action: MODIFY
-    reason: Replace the broad cytoplasm term with cytosol.
-    proposed_replacement_terms:
-    - id: GO:0005829
-      label: cytosol
+    summary: Plausible but redundant broad electronic localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Cytoplasm is broader than the coexisting electronic cytosol annotation
+      and does not define the enzyme&#39;s core function.
 - term:
     id: GO:0005829
     label: cytosol
@@ -1565,9 +1540,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006164
     label: purine nucleotide biosynthetic process
@@ -1631,9 +1608,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purM/purM-uniprot.txt
     supporting_text: &#39;RecName: Full=Phosphoribosylformylglycinamidine cyclo-ligase&#39;
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_questions:
 - question: Should the current PANTHER subfamily assignment be split to separate bacterial PurM from eukaryotic
     trifunctional GART proteins?

--- a/genes/PSEPK/purM/purM-ai-review.html
+++ b/genes/PSEPK/purM/purM-ai-review.html
@@ -1001,10 +1001,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88MA9" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88MA9" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1012,12 +1012,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Plausible but redundant broad electronic localization.
+                            <strong>Summary:</strong> Plausible broad electronic localization that is not core to the enzyme function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Cytoplasm is broader than the coexisting electronic cytosol annotation and does not define the enzyme&#39;s core function.
+                            <strong>Reason:</strong> Cytoplasm is consistent with a soluble bacterial metabolic enzyme, but it is broad, electronically inferred, and not supported by direct localization evidence.
                         </div>
 
 
@@ -1469,10 +1469,13 @@
 <ul>
 <li>UniProt identifies Q88MA9 as Phosphoribosylformylglycinamidine cyclo-ligase [file:PSEPK/purM/purM-uniprot.txt "RecName: Full=Phosphoribosylformylglycinamidine cyclo-ligase"].</li>
 <li>Remove the transferred PurD ligase activity because the exact protein is PurM/AIR<br />
-  synthetase. Replace cytoplasm and broad purine biosynthesis with cytosol and<br />
-<code>GO:0006189</code>; adenine synthesis branches downstream from IMP and is therefore<br />
-  outside PurM's de novo IMP pathway role.</li>
-<li>Open question: Should the current PANTHER subfamily assignment be split to separate bacterial PurM from eukaryotic trifunctional GART proteins?</li>
+  synthetase. Retain both electronic cytoplasm and cytosol localizations as<br />
+  non-core, and replace broad purine biosynthesis with <code>GO:0006189</code>; adenine<br />
+  synthesis branches downstream from IMP and is therefore outside PurM's de<br />
+  novo IMP pathway role.</li>
+<li>PTHR10520:SF12 contains both standalone bacterial PurM and eukaryotic<br />
+  trifunctional GART proteins; the exact PurM molecular function is therefore<br />
+  required to constrain the family selector.</li>
 </ul>
             </div>
         </details>
@@ -1528,11 +1531,12 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: located_in
   review:
-    summary: Plausible but redundant broad electronic localization.
-    action: MARK_AS_OVER_ANNOTATED
+    summary: Plausible broad electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Cytoplasm is broader than the coexisting electronic cytosol annotation
-      and does not define the enzyme&#39;s core function.
+      Cytoplasm is consistent with a soluble bacterial metabolic enzyme, but
+      it is broad, electronically inferred, and not supported by direct
+      localization evidence.
 - term:
     id: GO:0005829
     label: cytosol

--- a/genes/PSEPK/purM/purM-ai-review.yaml
+++ b/genes/PSEPK/purM/purM-ai-review.yaml
@@ -39,11 +39,12 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: located_in
   review:
-    summary: Plausible but redundant broad electronic localization.
-    action: MARK_AS_OVER_ANNOTATED
+    summary: Plausible broad electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Cytoplasm is broader than the coexisting electronic cytosol annotation
-      and does not define the enzyme's core function.
+      Cytoplasm is consistent with a soluble bacterial metabolic enzyme, but
+      it is broad, electronically inferred, and not supported by direct
+      localization evidence.
 - term:
     id: GO:0005829
     label: cytosol

--- a/genes/PSEPK/purM/purM-ai-review.yaml
+++ b/genes/PSEPK/purM/purM-ai-review.yaml
@@ -39,12 +39,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: located_in
   review:
-    summary: Correct but less specific than the coexisting cytosol annotation.
-    action: MODIFY
-    reason: Replace the broad cytoplasm term with cytosol.
-    proposed_replacement_terms:
-    - id: GO:0005829
-      label: cytosol
+    summary: Plausible but redundant broad electronic localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Cytoplasm is broader than the coexisting electronic cytosol annotation
+      and does not define the enzyme's core function.
 - term:
     id: GO:0005829
     label: cytosol
@@ -52,9 +51,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006164
     label: purine nucleotide biosynthetic process
@@ -118,9 +119,6 @@ core_functions:
   supported_by:
   - reference_id: file:PSEPK/purM/purM-uniprot.txt
     supporting_text: 'RecName: Full=Phosphoribosylformylglycinamidine cyclo-ligase'
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_questions:
 - question: Should the current PANTHER subfamily assignment be split to separate bacterial PurM from eukaryotic
     trifunctional GART proteins?

--- a/genes/PSEPK/purM/purM-notes.md
+++ b/genes/PSEPK/purM/purM-notes.md
@@ -2,7 +2,10 @@
 
 - UniProt identifies Q88MA9 as Phosphoribosylformylglycinamidine cyclo-ligase [file:PSEPK/purM/purM-uniprot.txt "RecName: Full=Phosphoribosylformylglycinamidine cyclo-ligase"].
 - Remove the transferred PurD ligase activity because the exact protein is PurM/AIR
-  synthetase. Replace cytoplasm and broad purine biosynthesis with cytosol and
-  `GO:0006189`; adenine synthesis branches downstream from IMP and is therefore
-  outside PurM's de novo IMP pathway role.
-- Open question: Should the current PANTHER subfamily assignment be split to separate bacterial PurM from eukaryotic trifunctional GART proteins?
+  synthetase. Retain both electronic cytoplasm and cytosol localizations as
+  non-core, and replace broad purine biosynthesis with `GO:0006189`; adenine
+  synthesis branches downstream from IMP and is therefore outside PurM's de
+  novo IMP pathway role.
+- PTHR10520:SF12 contains both standalone bacterial PurM and eukaryotic
+  trifunctional GART proteins; the exact PurM molecular function is therefore
+  required to constrain the family selector.

--- a/genes/PSEPK/purN/purN-ai-review.html
+++ b/genes/PSEPK/purN/purN-ai-review.html
@@ -996,10 +996,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q88MB0" data-a="GO:0005737" data-r="GO_REF:0000118" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="Q88MB0" data-a="GO:0005737" data-r="GO_REF:0000118" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1007,26 +1007,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct but less specific than the coexisting cytosol annotation.
+                            <strong>Summary:</strong> Plausible but redundant broad electronic localization.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Replace the broad cytoplasm term with cytosol.
+                            <strong>Reason:</strong> Cytoplasm is broader than the coexisting electronic cytosol annotation and does not define the enzyme&#39;s core function.
                         </div>
 
 
-
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                    cytosol
-                                </a>
-                            </span>
-
-                        </div>
 
 
 
@@ -1060,10 +1049,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88MB0" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88MB0" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1071,12 +1060,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct specific location for a soluble bacterial enzyme.
+                            <strong>Summary:</strong> Plausible electronic localization that is not core to the enzyme function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The enzyme acts on soluble intermediates of de novo purine synthesis.
+                            <strong>Reason:</strong> Cytosol is consistent with a soluble bacterial metabolic enzyme, but no direct localization evidence was found.
                         </div>
 
 
@@ -1250,19 +1239,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -1918,12 +1894,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct but less specific than the coexisting cytosol annotation.
-    action: MODIFY
-    reason: Replace the broad cytoplasm term with cytosol.
-    proposed_replacement_terms:
-    - id: GO:0005829
-      label: cytosol
+    summary: Plausible but redundant broad electronic localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Cytoplasm is broader than the coexisting electronic cytosol annotation
+      and does not define the enzyme&#39;s core function.
 - term:
     id: GO:0005829
     label: cytosol
@@ -1931,9 +1906,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006189
     label: &#39;&#39;&#39;de novo&#39;&#39; IMP biosynthetic process&#39;
@@ -2030,9 +2007,6 @@ core_functions:
       We demonstrate here that Escherichia coli synthesizes two different
       glycinamide ribonucleotide (GAR) transformylases, both catalyzing the
       third step in the purine biosynthetic pathway.
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_questions:
 - question: Under which carbon and folate conditions does PurN rather than PurT provide most GAR transformylase
     flux?

--- a/genes/PSEPK/purN/purN-ai-review.html
+++ b/genes/PSEPK/purN/purN-ai-review.html
@@ -996,10 +996,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88MB0" data-a="GO:0005737" data-r="GO_REF:0000118" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q88MB0" data-a="GO:0005737" data-r="GO_REF:0000118" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1007,12 +1007,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Plausible but redundant broad electronic localization.
+                            <strong>Summary:</strong> Plausible broad electronic localization that is not core to the enzyme function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Cytoplasm is broader than the coexisting electronic cytosol annotation and does not define the enzyme&#39;s core function.
+                            <strong>Reason:</strong> Cytoplasm is consistent with a soluble bacterial metabolic enzyme, but it is broad, electronically inferred, and not supported by direct localization evidence.
                         </div>
 
 
@@ -1836,8 +1836,9 @@
 <li>UniProt identifies Q88MB0 as Phosphoribosylglycinamide formyltransferase [file:PSEPK/purN/purN-uniprot.txt "RecName: Full=Phosphoribosylglycinamide formyltransferase"].</li>
 <li>E. coli genetics established PurN and PurT as alternative enzymes at this pathway<br />
   position; either route can support purine synthesis <a href="https://pubmed.ncbi.nlm.nih.gov/8501063" title="Only strains defective in both genes require an exogenous purine source for growth.">PMID:8501063</a>.</li>
-<li>Replace generic catalytic activity, cytoplasm, and broad purine biosynthesis with the<br />
-  exact activity, cytosol, and <code>GO:0006189</code>, respectively.</li>
+<li>Replace generic catalytic activity and broad purine biosynthesis with the<br />
+  exact activity and <code>GO:0006189</code>, respectively. Retain both electronic<br />
+  cytoplasm and cytosol localizations as plausible but non-core.</li>
 <li>Open question: Under which carbon and folate conditions does PurN rather than PurT provide most GAR transformylase flux?</li>
 </ul>
             </div>
@@ -1894,11 +1895,12 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Plausible but redundant broad electronic localization.
-    action: MARK_AS_OVER_ANNOTATED
+    summary: Plausible broad electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Cytoplasm is broader than the coexisting electronic cytosol annotation
-      and does not define the enzyme&#39;s core function.
+      Cytoplasm is consistent with a soluble bacterial metabolic enzyme, but
+      it is broad, electronically inferred, and not supported by direct
+      localization evidence.
 - term:
     id: GO:0005829
     label: cytosol

--- a/genes/PSEPK/purN/purN-ai-review.yaml
+++ b/genes/PSEPK/purN/purN-ai-review.yaml
@@ -39,11 +39,12 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Plausible but redundant broad electronic localization.
-    action: MARK_AS_OVER_ANNOTATED
+    summary: Plausible broad electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Cytoplasm is broader than the coexisting electronic cytosol annotation
-      and does not define the enzyme's core function.
+      Cytoplasm is consistent with a soluble bacterial metabolic enzyme, but
+      it is broad, electronically inferred, and not supported by direct
+      localization evidence.
 - term:
     id: GO:0005829
     label: cytosol

--- a/genes/PSEPK/purN/purN-ai-review.yaml
+++ b/genes/PSEPK/purN/purN-ai-review.yaml
@@ -39,12 +39,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct but less specific than the coexisting cytosol annotation.
-    action: MODIFY
-    reason: Replace the broad cytoplasm term with cytosol.
-    proposed_replacement_terms:
-    - id: GO:0005829
-      label: cytosol
+    summary: Plausible but redundant broad electronic localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Cytoplasm is broader than the coexisting electronic cytosol annotation
+      and does not define the enzyme's core function.
 - term:
     id: GO:0005829
     label: cytosol
@@ -52,9 +51,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006189
     label: '''de novo'' IMP biosynthetic process'
@@ -151,9 +152,6 @@ core_functions:
       We demonstrate here that Escherichia coli synthesizes two different
       glycinamide ribonucleotide (GAR) transformylases, both catalyzing the
       third step in the purine biosynthetic pathway.
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_questions:
 - question: Under which carbon and folate conditions does PurN rather than PurT provide most GAR transformylase
     flux?

--- a/genes/PSEPK/purN/purN-notes.md
+++ b/genes/PSEPK/purN/purN-notes.md
@@ -3,6 +3,7 @@
 - UniProt identifies Q88MB0 as Phosphoribosylglycinamide formyltransferase [file:PSEPK/purN/purN-uniprot.txt "RecName: Full=Phosphoribosylglycinamide formyltransferase"].
 - E. coli genetics established PurN and PurT as alternative enzymes at this pathway
   position; either route can support purine synthesis [PMID:8501063 "Only strains defective in both genes require an exogenous purine source for growth."].
-- Replace generic catalytic activity, cytoplasm, and broad purine biosynthesis with the
-  exact activity, cytosol, and `GO:0006189`, respectively.
+- Replace generic catalytic activity and broad purine biosynthesis with the
+  exact activity and `GO:0006189`, respectively. Retain both electronic
+  cytoplasm and cytosol localizations as plausible but non-core.
 - Open question: Under which carbon and folate conditions does PurN rather than PurT provide most GAR transformylase flux?

--- a/genes/PSEPK/purT/purT-ai-review.html
+++ b/genes/PSEPK/purT/purT-ai-review.html
@@ -1171,10 +1171,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88MW1" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88MW1" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1182,12 +1182,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct specific location for a soluble bacterial enzyme.
+                            <strong>Summary:</strong> Plausible electronic localization that is not core to the enzyme function.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The enzyme acts on soluble intermediates of de novo purine synthesis.
+                            <strong>Reason:</strong> Cytosol is consistent with a soluble bacterial metabolic enzyme, but no direct localization evidence was found.
                         </div>
 
 
@@ -1536,19 +1536,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -1904,9 +1891,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006189
     label: &#39;&#39;&#39;de novo&#39;&#39; IMP biosynthetic process&#39;
@@ -2019,9 +2008,6 @@ core_functions:
     supporting_text: &#39;RecName: Full=Formate-dependent phosphoribosylglycinamide formyltransferase&#39;
   - reference_id: PMID:8117714
     supporting_text: catalyzes the production of beta-formyl GAR from formate, ATP, and beta-GAR.
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_questions:
 - question: Under which carbon and folate conditions does PurT rather than PurN provide most GAR transformylase
     flux?

--- a/genes/PSEPK/purT/purT-ai-review.yaml
+++ b/genes/PSEPK/purT/purT-ai-review.yaml
@@ -73,9 +73,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct specific location for a soluble bacterial enzyme.
-    action: ACCEPT
-    reason: The enzyme acts on soluble intermediates of de novo purine synthesis.
+    summary: Plausible electronic localization that is not core to the enzyme function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Cytosol is consistent with a soluble bacterial metabolic enzyme, but no
+      direct localization evidence was found.
 - term:
     id: GO:0006189
     label: '''de novo'' IMP biosynthetic process'
@@ -188,9 +190,6 @@ core_functions:
     supporting_text: 'RecName: Full=Formate-dependent phosphoribosylglycinamide formyltransferase'
   - reference_id: PMID:8117714
     supporting_text: catalyzes the production of beta-formyl GAR from formate, ATP, and beta-GAR.
-  locations:
-  - id: GO:0005829
-    label: cytosol
 suggested_questions:
 - question: Under which carbon and folate conditions does PurT rather than PurN provide most GAR transformylase
     flux?

--- a/modules/de_novo_purine_synthesis.yaml
+++ b/modules/de_novo_purine_synthesis.yaml
@@ -150,9 +150,11 @@ module:
               selector_type: FAMILY
               family:
                 preferred_term: PurD phosphoribosylamine--glycine ligases
-                term:
-                  id: PANTHER:PTHR43472
-                  label: PHOSPHORIBOSYLAMINE--GLYCINE LIGASE
+                family_terms:
+                  - id: PANTHER:PTHR43472
+                    label: PHOSPHORIBOSYLAMINE--GLYCINE LIGASE
+                  - id: PANTHER:PTHR10520:SF12
+                    label: TRIFUNCTIONAL PURINE BIOSYNTHETIC PROTEIN ADENOSINE-3
                 representative_members:
                   - preferred_term: PSEPK PurD
                     term:
@@ -166,6 +168,10 @@ module:
                     term:
                       id: UniProtKB:P22102
                       label: Trifunctional purine biosynthetic protein adenosine-3
+                    description: >-
+                      The whole fusion is classified as PTHR10520:SF12; its
+                      N-terminal ATP-grasp domain performs this PurD reaction,
+                      as documented by the exact reviewed UniProt record.
             function:
               preferred_term: phosphoribosylamine-glycine ligase activity
               term:
@@ -202,9 +208,11 @@ module:
                       selector_type: FAMILY
                       family:
                         preferred_term: PurN GAR transformylases
-                        term:
-                          id: PANTHER:PTHR43369
-                          label: PHOSPHORIBOSYLGLYCINAMIDE FORMYLTRANSFERASE
+                        family_terms:
+                          - id: PANTHER:PTHR43369
+                            label: PHOSPHORIBOSYLGLYCINAMIDE FORMYLTRANSFERASE
+                          - id: PANTHER:PTHR10520:SF12
+                            label: TRIFUNCTIONAL PURINE BIOSYNTHETIC PROTEIN ADENOSINE-3
                         representative_members:
                           - preferred_term: PSEPK PurN
                             term:
@@ -218,6 +226,11 @@ module:
                             term:
                               id: UniProtKB:P22102
                               label: Trifunctional purine biosynthetic protein adenosine-3
+                            description: >-
+                              The whole fusion is classified as
+                              PTHR10520:SF12; its C-terminal transformylase
+                              domain performs this PurN reaction, as documented
+                              by the exact reviewed UniProt record.
                     function:
                       preferred_term: phosphoribosylglycinamide formyltransferase activity
                       term:
@@ -527,9 +540,11 @@ module:
               selector_type: FAMILY
               family:
                 preferred_term: PurB adenylosuccinate lyases
-                term:
-                  id: PANTHER:PTHR43411
-                  label: ADENYLOSUCCINATE LYASE
+                family_terms:
+                  - id: PANTHER:PTHR43411
+                    label: ADENYLOSUCCINATE LYASE
+                  - id: PANTHER:PTHR43172:SF1
+                    label: ADENYLOSUCCINATE LYASE
                 representative_members:
                   - preferred_term: PSEPK PurB
                     term:
@@ -543,6 +558,9 @@ module:
                     term:
                       id: UniProtKB:P30566
                       label: Adenylosuccinate lyase
+                    description: >-
+                      Reviewed eukaryotic PurB exemplar in the distinct
+                      PTHR43172:SF1 adenylosuccinate-lyase family.
             function:
               preferred_term: SAICAR lyase activity
               term:
@@ -679,7 +697,13 @@ module:
     module taxonomically. A multidomain protein may satisfy more than one leaf:
     GART combines PurD-, PurN-, and PurM-like roles, PAICS combines direct AIR
     carboxylase and SAICAR synthetase roles, and PurH/ATIC commonly combines the
-    final two reactions. Parent PANTHER families containing both standalone
-    enzymes and fusion proteins are selector scaffolds constrained by the leaf
+    final two reactions. GART's exact PTHR10520:SF12 whole-protein assignment is
+    listed on the PurD and PurN leaves where it accounts for the fusion
+    exemplar, while the exact record's domain descriptions establish those
+    activities. The PurM leaf retains parent PTHR10520 because the officially
+    GART-labeled SF12 also contains standalone bacterial PurM proteins. Separate
+    bacterial and eukaryotic adenylosuccinate-lyase families are retained for
+    the PurB leaf. Parent PANTHER families containing both standalone enzymes
+    and fusion proteins are selector scaffolds constrained by the leaf
     molecular function and exemplars. No ancestral PTN node is asserted without
     verified PAINT IBD evidence.

--- a/modules/de_novo_purine_synthesis.yaml
+++ b/modules/de_novo_purine_synthesis.yaml
@@ -150,11 +150,9 @@ module:
               selector_type: FAMILY
               family:
                 preferred_term: PurD phosphoribosylamine--glycine ligases
-                family_terms:
-                  - id: PANTHER:PTHR43472
-                    label: PHOSPHORIBOSYLAMINE--GLYCINE LIGASE
-                  - id: PANTHER:PTHR10520:SF12
-                    label: TRIFUNCTIONAL PURINE BIOSYNTHETIC PROTEIN ADENOSINE-3
+                term:
+                  id: PANTHER:PTHR43472
+                  label: PHOSPHORIBOSYLAMINE--GLYCINE LIGASE
                 representative_members:
                   - preferred_term: PSEPK PurD
                     term:
@@ -208,11 +206,9 @@ module:
                       selector_type: FAMILY
                       family:
                         preferred_term: PurN GAR transformylases
-                        family_terms:
-                          - id: PANTHER:PTHR43369
-                            label: PHOSPHORIBOSYLGLYCINAMIDE FORMYLTRANSFERASE
-                          - id: PANTHER:PTHR10520:SF12
-                            label: TRIFUNCTIONAL PURINE BIOSYNTHETIC PROTEIN ADENOSINE-3
+                        term:
+                          id: PANTHER:PTHR43369
+                          label: PHOSPHORIBOSYLGLYCINAMIDE FORMYLTRANSFERASE
                         representative_members:
                           - preferred_term: PSEPK PurN
                             term:
@@ -338,8 +334,8 @@ module:
               family:
                 preferred_term: PurM AIR synthetases
                 term:
-                  id: PANTHER:PTHR10520
-                  label: TRIFUNCTIONAL PURINE BIOSYNTHETIC PROTEIN ADENOSINE-3-RELATED
+                  id: PANTHER:PTHR10520:SF12
+                  label: TRIFUNCTIONAL PURINE BIOSYNTHETIC PROTEIN ADENOSINE-3
                 representative_members:
                   - preferred_term: PSEPK PurM
                     term:
@@ -353,6 +349,11 @@ module:
                     term:
                       id: UniProtKB:P22102
                       label: Trifunctional purine biosynthetic protein adenosine-3
+                description: >-
+                  PTHR10520:SF12 contains both standalone bacterial PurM
+                  proteins and multidomain GART proteins. The leaf molecular
+                  function and exact exemplars constrain this whole-protein
+                  selector to the shared PurM cyclo-ligase role.
             function:
               preferred_term: phosphoribosylformylglycinamidine cyclo-ligase activity
               term:
@@ -697,11 +698,12 @@ module:
     module taxonomically. A multidomain protein may satisfy more than one leaf:
     GART combines PurD-, PurN-, and PurM-like roles, PAICS combines direct AIR
     carboxylase and SAICAR synthetase roles, and PurH/ATIC commonly combines the
-    final two reactions. GART's exact PTHR10520:SF12 whole-protein assignment is
-    listed on the PurD and PurN leaves where it accounts for the fusion
-    exemplar, while the exact record's domain descriptions establish those
-    activities. The PurM leaf retains parent PTHR10520 because the officially
-    GART-labeled SF12 also contains standalone bacterial PurM proteins. Separate
+    final two reactions. GART remains an exact fusion exemplar on the PurD and
+    PurN leaves, where its reviewed domain descriptions establish those
+    activities without using its whole-protein family as a reaction selector.
+    The PurM leaf uses PTHR10520:SF12 because that whole-protein subfamily
+    contains both standalone bacterial PurM proteins and the GART fusion; the
+    leaf molecular function constrains it to the shared cyclo-ligase role. Separate
     bacterial and eukaryotic adenylosuccinate-lyase families are retained for
     the PurB leaf. Parent PANTHER families containing both standalone enzymes
     and fusion proteins are selector scaffolds constrained by the leaf

--- a/pages/modules/de_novo_purine_synthesis.html
+++ b/pages/modules/de_novo_purine_synthesis.html
@@ -1040,7 +1040,7 @@
         </div><div class="descriptor-list">                <span class="descriptor">
             <span>&#39;de novo&#39; IMP biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006189" target="_blank" rel="noopener">GO:0006189</a></span>        </div>
 
-        <p class="muted small">Exact UniProt exemplars delimit each reaction role without restricting the module taxonomically. A multidomain protein may satisfy more than one leaf: GART combines PurD-, PurN-, and PurM-like roles, PAICS combines direct AIR carboxylase and SAICAR synthetase roles, and PurH/ATIC commonly combines the final two reactions. Parent PANTHER families containing both standalone enzymes and fusion proteins are selector scaffolds constrained by the leaf molecular function and exemplars. No ancestral PTN node is asserted without verified PAINT IBD evidence.</p>            <h4>Connections</h4>
+        <p class="muted small">Exact UniProt exemplars delimit each reaction role without restricting the module taxonomically. A multidomain protein may satisfy more than one leaf: GART combines PurD-, PurN-, and PurM-like roles, PAICS combines direct AIR carboxylase and SAICAR synthetase roles, and PurH/ATIC commonly combines the final two reactions. GART&#39;s exact PTHR10520:SF12 whole-protein assignment is listed on the PurD and PurN leaves where it accounts for the fusion exemplar, while the exact record&#39;s domain descriptions establish those activities. The PurM leaf retains parent PTHR10520 because the officially GART-labeled SF12 also contains standalone bacterial PurM proteins. Separate bacterial and eukaryotic adenylosuccinate-lyase families are retained for the PurB leaf. Parent PANTHER families containing both standalone enzymes and fusion proteins are selector scaffolds constrained by the leaf molecular function and exemplars. No ancestral PTN node is asserted without verified PAINT IBD evidence.</p>            <h4>Connections</h4>
             <div class="connection-list">                <div class="connection-card small">
                     <div>
                         <a href="#node-purf_step">purF_step</a>
@@ -1138,7 +1138,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>PurD phosphoribosylamine--glycine ligases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43472" target="_blank" rel="noopener">PANTHER:PTHR43472</a>                    <div class="slot-row">
+            <span><strong>PurD phosphoribosylamine--glycine ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK PurD</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88DK2/entry" target="_blank" rel="noopener">UniProtKB:Q88DK2</a></span>                            <span class="descriptor">
             <span>Escherichia coli PurD</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P15640/entry" target="_blank" rel="noopener">UniProtKB:P15640</a></span>                            <span class="descriptor">
@@ -1175,7 +1175,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>PurN GAR transformylases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43369" target="_blank" rel="noopener">PANTHER:PTHR43369</a>                    <div class="slot-row">
+            <span><strong>PurN GAR transformylases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK PurN</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88MB0/entry" target="_blank" rel="noopener">UniProtKB:Q88MB0</a></span>                            <span class="descriptor">
             <span>Escherichia coli PurN</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P08179/entry" target="_blank" rel="noopener">UniProtKB:P08179</a></span>                            <span class="descriptor">
@@ -1411,7 +1411,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>PurB adenylosuccinate lyases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43411" target="_blank" rel="noopener">PANTHER:PTHR43411</a>                    <div class="slot-row">
+            <span><strong>PurB adenylosuccinate lyases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK PurB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88FR7/entry" target="_blank" rel="noopener">UniProtKB:Q88FR7</a></span>                            <span class="descriptor">
             <span>Escherichia coli PurB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0AB89/entry" target="_blank" rel="noopener">UniProtKB:P0AB89</a></span>                            <span class="descriptor">

--- a/pages/modules/de_novo_purine_synthesis.html
+++ b/pages/modules/de_novo_purine_synthesis.html
@@ -1040,7 +1040,7 @@
         </div><div class="descriptor-list">                <span class="descriptor">
             <span>&#39;de novo&#39; IMP biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006189" target="_blank" rel="noopener">GO:0006189</a></span>        </div>
 
-        <p class="muted small">Exact UniProt exemplars delimit each reaction role without restricting the module taxonomically. A multidomain protein may satisfy more than one leaf: GART combines PurD-, PurN-, and PurM-like roles, PAICS combines direct AIR carboxylase and SAICAR synthetase roles, and PurH/ATIC commonly combines the final two reactions. GART&#39;s exact PTHR10520:SF12 whole-protein assignment is listed on the PurD and PurN leaves where it accounts for the fusion exemplar, while the exact record&#39;s domain descriptions establish those activities. The PurM leaf retains parent PTHR10520 because the officially GART-labeled SF12 also contains standalone bacterial PurM proteins. Separate bacterial and eukaryotic adenylosuccinate-lyase families are retained for the PurB leaf. Parent PANTHER families containing both standalone enzymes and fusion proteins are selector scaffolds constrained by the leaf molecular function and exemplars. No ancestral PTN node is asserted without verified PAINT IBD evidence.</p>            <h4>Connections</h4>
+        <p class="muted small">Exact UniProt exemplars delimit each reaction role without restricting the module taxonomically. A multidomain protein may satisfy more than one leaf: GART combines PurD-, PurN-, and PurM-like roles, PAICS combines direct AIR carboxylase and SAICAR synthetase roles, and PurH/ATIC commonly combines the final two reactions. GART remains an exact fusion exemplar on the PurD and PurN leaves, where its reviewed domain descriptions establish those activities without using its whole-protein family as a reaction selector. The PurM leaf uses PTHR10520:SF12 because that whole-protein subfamily contains both standalone bacterial PurM proteins and the GART fusion; the leaf molecular function constrains it to the shared cyclo-ligase role. Separate bacterial and eukaryotic adenylosuccinate-lyase families are retained for the PurB leaf. Parent PANTHER families containing both standalone enzymes and fusion proteins are selector scaffolds constrained by the leaf molecular function and exemplars. No ancestral PTN node is asserted without verified PAINT IBD evidence.</p>            <h4>Connections</h4>
             <div class="connection-list">                <div class="connection-card small">
                     <div>
                         <a href="#node-purf_step">purF_step</a>
@@ -1138,7 +1138,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>PurD phosphoribosylamine--glycine ligases</strong></span>                    <div class="slot-row">
+            <span><strong>PurD phosphoribosylamine--glycine ligases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43472" target="_blank" rel="noopener">PANTHER:PTHR43472</a>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK PurD</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88DK2/entry" target="_blank" rel="noopener">UniProtKB:Q88DK2</a></span>                            <span class="descriptor">
             <span>Escherichia coli PurD</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P15640/entry" target="_blank" rel="noopener">UniProtKB:P15640</a></span>                            <span class="descriptor">
@@ -1175,7 +1175,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>PurN GAR transformylases</strong></span>                    <div class="slot-row">
+            <span><strong>PurN GAR transformylases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43369" target="_blank" rel="noopener">PANTHER:PTHR43369</a>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK PurN</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88MB0/entry" target="_blank" rel="noopener">UniProtKB:Q88MB0</a></span>                            <span class="descriptor">
             <span>Escherichia coli PurN</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P08179/entry" target="_blank" rel="noopener">UniProtKB:P08179</a></span>                            <span class="descriptor">
@@ -1259,7 +1259,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>PurM AIR synthetases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10520" target="_blank" rel="noopener">PANTHER:PTHR10520</a>                    <div class="slot-row">
+            <span><strong>PurM AIR synthetases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10520%3ASF12" target="_blank" rel="noopener">PANTHER:PTHR10520:SF12</a>                <span class="descriptor-description">PTHR10520:SF12 contains both standalone bacterial PurM proteins and multidomain GART proteins. The leaf molecular function and exact exemplars constrain this whole-protein selector to the shared PurM cyclo-ligase role.</span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK PurM</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88MA9/entry" target="_blank" rel="noopener">UniProtKB:Q88MA9</a></span>                            <span class="descriptor">
             <span>Escherichia coli PurM</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P08178/entry" target="_blank" rel="noopener">UniProtKB:P08178</a></span>                            <span class="descriptor">

--- a/pages/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.html
@@ -576,6 +576,23 @@ also returned no report. These retrieval outcomes do not create pathway holes:<b
 all eleven target assignments were adjudicated against exact UniProt records,<br />
 domain/family evidence, the completed generic module research, and the<br />
 available primary literature.</p>
+<h2 id="2026-09-01-fusion-and-family-repair">2026-09-01 Fusion and family repair</h2>
+<p>The human GART fusion P22102 is classified as<br />
+PANTHER:PTHR10520:SF12 at the whole-protein level. The PurD and PurN leaves now<br />
+include that exact fusion family alongside their standalone bacterial families,<br />
+while the reviewed GART record's N-terminal ATP-grasp and C-terminal<br />
+transformylase domain assignments establish the leaf activities. The existing<br />
+PurM leaf already carried the same PANTHER family lineage and deliberately<br />
+retains parent PTHR10520 because SF12 conflates standalone PurM proteins with<br />
+the GART fusion. Human ADSL P30566 is now<br />
+represented by its exact eukaryotic PTHR43172:SF1 family alongside the distinct<br />
+bacterial PTHR43411 PurB family. These repairs preserve ten ordered reaction<br />
+positions and do not treat a fusion as a one-step module.<br />
+The same audit moved purely electronic cytosol or cytoplasm annotations to<br />
+non-core in <code>purN</code>, <code>purT</code>, <code>purL</code>, <code>purM</code>, <code>purK</code>, <code>purC</code>, <code>purB</code>, and <code>purH</code>,<br />
+and removed those locations from synthesized core functions. Redundant broad<br />
+cytoplasm rows in <code>purN</code> and <code>purM</code> are marked over-annotated rather than<br />
+converted into duplicate cytosol assertions.</p>
     </div>
 
     <footer>

--- a/pages/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.html
@@ -577,6 +577,7 @@ all eleven target assignments were adjudicated against exact UniProt records,<br
 domain/family evidence, the completed generic module research, and the<br />
 available primary literature.</p>
 <h2 id="2026-09-01-fusion-and-family-repair">2026-09-01 Fusion and family repair</h2>
+<p>Repair PR: <a href="https://github.com/ai4curation/ai-gene-review/pull/2865">#2865</a>.</p>
 <p>The human GART fusion P22102 is classified as<br />
 PANTHER:PTHR10520:SF12 at the whole-protein level. The PurD and PurN leaves now<br />
 include that exact fusion family alongside their standalone bacterial families,<br />

--- a/pages/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.html
@@ -579,21 +579,21 @@ available primary literature.</p>
 <h2 id="2026-09-01-fusion-and-family-repair">2026-09-01 Fusion and family repair</h2>
 <p>Repair PR: <a href="https://github.com/ai4curation/ai-gene-review/pull/2865">#2865</a>.</p>
 <p>The human GART fusion P22102 is classified as<br />
-PANTHER:PTHR10520:SF12 at the whole-protein level. The PurD and PurN leaves now<br />
-include that exact fusion family alongside their standalone bacterial families,<br />
-while the reviewed GART record's N-terminal ATP-grasp and C-terminal<br />
-transformylase domain assignments establish the leaf activities. The existing<br />
-PurM leaf already carried the same PANTHER family lineage and deliberately<br />
-retains parent PTHR10520 because SF12 conflates standalone PurM proteins with<br />
-the GART fusion. Human ADSL P30566 is now<br />
+PANTHER:PTHR10520:SF12 at the whole-protein level. The PurD and PurN leaves<br />
+retain GART as an exact fusion exemplar, while the reviewed record's N-terminal<br />
+ATP-grasp and C-terminal transformylase domain assignments establish those leaf<br />
+activities without using the whole-protein subfamily as their selector. The<br />
+PurM leaf now uses PTHR10520:SF12 because it contains both standalone bacterial<br />
+PurM proteins and the GART fusion; the exact leaf function constrains the<br />
+selector to their shared cyclo-ligase role. Human ADSL P30566 is now<br />
 represented by its exact eukaryotic PTHR43172:SF1 family alongside the distinct<br />
 bacterial PTHR43411 PurB family. These repairs preserve ten ordered reaction<br />
 positions and do not treat a fusion as a one-step module.<br />
 The same audit moved purely electronic cytosol or cytoplasm annotations to<br />
 non-core in <code>purN</code>, <code>purT</code>, <code>purL</code>, <code>purM</code>, <code>purK</code>, <code>purC</code>, <code>purB</code>, and <code>purH</code>,<br />
-and removed those locations from synthesized core functions. Redundant broad<br />
-cytoplasm rows in <code>purN</code> and <code>purM</code> are marked over-annotated rather than<br />
-converted into duplicate cytosol assertions.</p>
+and removed those locations from synthesized core functions. The coexisting<br />
+broad cytoplasm and narrower cytosol rows in <code>purN</code> and <code>purM</code> are both retained<br />
+as plausible electronic localizations, but neither is treated as core.</p>
     </div>
 
     <footer>

--- a/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.md
@@ -104,18 +104,18 @@ available primary literature.
 Repair PR: [#2865](https://github.com/ai4curation/ai-gene-review/pull/2865).
 
 The human GART fusion P22102 is classified as
-PANTHER:PTHR10520:SF12 at the whole-protein level. The PurD and PurN leaves now
-include that exact fusion family alongside their standalone bacterial families,
-while the reviewed GART record's N-terminal ATP-grasp and C-terminal
-transformylase domain assignments establish the leaf activities. The existing
-PurM leaf already carried the same PANTHER family lineage and deliberately
-retains parent PTHR10520 because SF12 conflates standalone PurM proteins with
-the GART fusion. Human ADSL P30566 is now
+PANTHER:PTHR10520:SF12 at the whole-protein level. The PurD and PurN leaves
+retain GART as an exact fusion exemplar, while the reviewed record's N-terminal
+ATP-grasp and C-terminal transformylase domain assignments establish those leaf
+activities without using the whole-protein subfamily as their selector. The
+PurM leaf now uses PTHR10520:SF12 because it contains both standalone bacterial
+PurM proteins and the GART fusion; the exact leaf function constrains the
+selector to their shared cyclo-ligase role. Human ADSL P30566 is now
 represented by its exact eukaryotic PTHR43172:SF1 family alongside the distinct
 bacterial PTHR43411 PurB family. These repairs preserve ten ordered reaction
 positions and do not treat a fusion as a one-step module.
 The same audit moved purely electronic cytosol or cytoplasm annotations to
 non-core in `purN`, `purT`, `purL`, `purM`, `purK`, `purC`, `purB`, and `purH`,
-and removed those locations from synthesized core functions. Redundant broad
-cytoplasm rows in `purN` and `purM` are marked over-annotated rather than
-converted into duplicate cytosol assertions.
+and removed those locations from synthesized core functions. The coexisting
+broad cytoplasm and narrower cytosol rows in `purN` and `purM` are both retained
+as plausible electronic localizations, but neither is treated as core.

--- a/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.md
@@ -98,3 +98,22 @@ also returned no report. These retrieval outcomes do not create pathway holes:
 all eleven target assignments were adjudicated against exact UniProt records,
 domain/family evidence, the completed generic module research, and the
 available primary literature.
+
+## 2026-09-01 Fusion and family repair
+
+The human GART fusion P22102 is classified as
+PANTHER:PTHR10520:SF12 at the whole-protein level. The PurD and PurN leaves now
+include that exact fusion family alongside their standalone bacterial families,
+while the reviewed GART record's N-terminal ATP-grasp and C-terminal
+transformylase domain assignments establish the leaf activities. The existing
+PurM leaf already carried the same PANTHER family lineage and deliberately
+retains parent PTHR10520 because SF12 conflates standalone PurM proteins with
+the GART fusion. Human ADSL P30566 is now
+represented by its exact eukaryotic PTHR43172:SF1 family alongside the distinct
+bacterial PTHR43411 PurB family. These repairs preserve ten ordered reaction
+positions and do not treat a fusion as a one-step module.
+The same audit moved purely electronic cytosol or cytoplasm annotations to
+non-core in `purN`, `purT`, `purL`, `purM`, `purK`, `purC`, `purB`, and `purH`,
+and removed those locations from synthesized core functions. Redundant broad
+cytoplasm rows in `purN` and `purM` are marked over-annotated rather than
+converted into duplicate cytosol assertions.

--- a/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00230_de_novo_purine_synthesis.md
@@ -101,6 +101,8 @@ available primary literature.
 
 ## 2026-09-01 Fusion and family repair
 
+Repair PR: [#2865](https://github.com/ai4curation/ai-gene-review/pull/2865).
+
 The human GART fusion P22102 is classified as
 PANTHER:PTHR10520:SF12 at the whole-protein level. The PurD and PurN leaves now
 include that exact fusion family alongside their standalone bacterial families,


### PR DESCRIPTION
## Summary
- represent human GART fusion membership explicitly on the PurD and PurN leaves without collapsing the ten-step pathway
- add the exact eukaryotic ADSL family alongside the bacterial PurB family
- clarify why the PurM leaf retains parent PTHR10520 rather than the misleading SF12 selector
- move unsupported electronic cytosol/cytoplasm annotations to non-core in eight PSEPK reviews and remove them from synthesized core functions
- render all changed reviews, the module, and the batch page

## Validation
- ModuleReview LinkML validation
- module validator: zero warnings
- all eleven selected PSEPK gene reviews validated
- eight changed gene pages, module page, and project page rendered
- independent annotation-reviewer audit