### PR TITLE
Refine PSEPK ethanolamine EutE family grounding

### DIFF
--- a/modules/bacterial_ethanolamine_uptake_catabolism.yaml
+++ b/modules/bacterial_ethanolamine_uptake_catabolism.yaml
@@ -254,13 +254,18 @@ module:
               family:
                 preferred_term: acetylating EutE family
                 term:
-                  id: PANTHER:PTHR11699
-                  label: ALDEHYDE DEHYDROGENASE-RELATED
+                  id: PANTHER:PTHR11699:SF68
+                  label: ACETALDEHYDE DEHYDROGENASE (ACETYLATING) EUTE
                 representative_members:
                 - preferred_term: EutE (Salmonella Typhimurium LT2)
                   term:
                     id: UniProtKB:P41793
                     label: Acetaldehyde dehydrogenase (acetylating) EutE
+                description: >-
+                  P41793 is indexed in the EutE-specific PTHR11699:SF68
+                  subfamily. This selector applies only to the acetylating
+                  acetaldehyde-to-acetyl-CoA variant, not to non-acylating
+                  aldehyde dehydrogenases.
             function:
               preferred_term: acetaldehyde dehydrogenase (acetylating) activity
               term:

--- a/pages/modules/bacterial_ethanolamine_uptake_catabolism.html
+++ b/pages/modules/bacterial_ethanolamine_uptake_catabolism.html
@@ -950,7 +950,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>acetylating EutE family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11699" target="_blank" rel="noopener">PANTHER:PTHR11699</a>                    <div class="slot-row">
+            <span><strong>acetylating EutE family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11699%3ASF68" target="_blank" rel="noopener">PANTHER:PTHR11699:SF68</a>                <span class="descriptor-description">P41793 is indexed in the EutE-specific PTHR11699:SF68 subfamily. This selector applies only to the acetylating acetaldehyde-to-acetyl-CoA variant, not to non-acylating aldehyde dehydrogenases.</span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>EutE (Salmonella Typhimurium LT2)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P41793/entry" target="_blank" rel="noopener">UniProtKB:P41793</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>

--- a/pages/projects/P_PUTIDA/batches/ppu00564_ethanolamine_uptake_catabolism.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00564_ethanolamine_uptake_catabolism.html
@@ -517,6 +517,13 @@ its earlier Asta retrieval report as low-weight background.</p>
   needed to resolve the two transferred microcompartment annotations.</li>
 </ul>
 <p>2026-08-13: Started as module 19 of the current 20-module batch.</p>
+<h2 id="2026-09-01-eute-family-repair">2026-09-01 EutE family repair</h2>
+<p>The reusable module's acetylating EutE variant is now grounded on<br />
+<code>PANTHER:PTHR11699:SF68</code>, whose exact official label is<br />
+<code>ACETALDEHYDE DEHYDROGENASE (ACETYLATING) EUTE</code>. The Salmonella EutE exemplar<br />
+P41793 is indexed in that subfamily. This refinement does not change the<br />
+separate non-acylating aldehyde-dehydrogenase variant used to represent the<br />
+unresolved KT2440 AldB-I route.</p>
     </div>
 
     <footer>

--- a/projects/P_PUTIDA/batches/ppu00564_ethanolamine_uptake_catabolism.md
+++ b/projects/P_PUTIDA/batches/ppu00564_ethanolamine_uptake_catabolism.md
@@ -86,3 +86,12 @@ its earlier Asta retrieval report as low-weight background.
   needed to resolve the two transferred microcompartment annotations.
 
 2026-08-13: Started as module 19 of the current 20-module batch.
+
+## 2026-09-01 EutE family repair
+
+The reusable module's acetylating EutE variant is now grounded on
+`PANTHER:PTHR11699:SF68`, whose exact official label is
+`ACETALDEHYDE DEHYDROGENASE (ACETYLATING) EUTE`. The Salmonella EutE exemplar
+P41793 is indexed in that subfamily. This refinement does not change the
+separate non-acylating aldehyde-dehydrogenase variant used to represent the
+unresolved KT2440 AldB-I route.


### PR DESCRIPTION
## Summary

- narrow the acetylating EutE route from heterogeneous aldehyde-dehydrogenase parent PTHR11699 to exact PTHR11699:SF68
- retain Salmonella EutE P41793 as the indexed representative
- explicitly keep this selector separate from the PSEPK non-acylating AldB-I route
- update and rerender the PSEPK ethanolamine batch record

## Validation

- `linkml-validate -C ModuleReview modules/bacterial_ethanolamine_uptake_catabolism.yaml`
- `python -m ai_gene_review.validation.module_validator modules/bacterial_ethanolamine_uptake_catabolism.yaml`
- `just render-module modules/bacterial_ethanolamine_uptake_catabolism.yaml`
- `just render-project P_PUTIDA/batches/ppu00564_ethanolamine_uptake_catabolism`
- `git diff --check`

The prior EutE family-precision advisory is resolved. Remaining validator notices are the pre-existing InterPro-prefix and temporary taxonomy-ontology availability warnings.