### PR TITLE
Fix PMC nested HTML full-text extraction

### DIFF
--- a/src/ai_gene_review/etl/publication.py
+++ b/src/ai_gene_review/etl/publication.py
@@ -41,7 +41,7 @@ import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import requests
 import yaml
@@ -651,192 +651,147 @@ def fetch_pmc_fulltext(pmcid: str) -> FullTextResult:
         return FullTextResult(content=None, available=False, extraction_method=None, is_complete=False)
 
 
+_PMC_BOILERPLATE_PREFIXES = (
+    "PMCID:",
+    "PMID:",
+    "DOI:",
+    "COPYRIGHT",
+    "DOWNLOAD PDF",
+    "CITE THIS ARTICLE",
+    "SHARE THIS ARTICLE",
+    "AUTHOR INFORMATION",
+    "FUNDING STATEMENT",
+    "ETHICS STATEMENT",
+    "DECLARATION OF INTERESTS",
+    "DATA AVAILABILITY",
+    "AUTHOR CONTRIBUTIONS",
+)
+
+_PMC_TERMINAL_HEADINGS = {
+    "ACKNOWLEDGMENTS",
+    "ACKNOWLEDGEMENTS",
+    "CITED BY",
+    "REFERENCES",
+    "SIMILAR ARTICLES",
+    "SUPPLEMENTARY MATERIAL",
+}
+
+
+def _extract_pmc_article_text(html: bytes | str) -> Optional[str]:
+    """Extract body headings and paragraphs from current and legacy PMC HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    article_content = cast(
+        Optional[Tag], soup.select_one("section.body.main-article-body")
+    )
+    if not article_content:
+        article_content = cast(
+            Optional[Tag], soup.select_one("section[aria-label='Article content']")
+        )
+    if not article_content:
+        article_content = cast(Optional[Tag], soup.find("article"))
+    if not article_content:
+        article_content = cast(
+            Optional[Tag],
+            soup.find("div", class_="article") or soup.find("div", class_="tsec"),
+        )
+    if not article_content:
+        article_content = cast(
+            Optional[Tag], soup.find("div", id="article-body") or soup.find("main")
+        )
+    if not article_content:
+        for div in soup.find_all("div"):
+            if isinstance(div, Tag) and len(div.find_all("p", recursive=False)) >= 3:
+                article_content = div
+                break
+    if not article_content:
+        article_content = cast(Tag, soup)
+
+    parts: List[str] = []
+    pending_headings: List[str] = []
+    for element in article_content.find_all(["h1", "h2", "h3", "h4", "p"]):
+        if not isinstance(element, Tag):
+            continue
+        if element.find_parent(["figcaption", "table", "nav", "aside", "footer"]):
+            continue
+
+        text = element.get_text(separator=" ", strip=True)
+        if element.name in ["h1", "h2", "h3", "h4"]:
+            normalized_heading = re.sub(r"\s+", " ", text).strip().upper()
+            if normalized_heading in _PMC_TERMINAL_HEADINGS:
+                break
+            if text:
+                pending_headings.append(text)
+            continue
+
+        upper_text = text.lstrip().upper()
+        if len(text) <= 30 or upper_text.startswith(_PMC_BOILERPLATE_PREFIXES):
+            continue
+
+        parts.extend(pending_headings)
+        pending_headings.clear()
+        parts.append(text)
+
+    if not parts:
+        return None
+
+    return "\n\n".join(dict.fromkeys(parts))
+
+
+def _classify_pmc_html_content(content: Optional[str]) -> Optional[FullTextResult]:
+    """Classify extracted HTML without inflating headings-only fragments."""
+    if content and len(content) > 3000:
+        return FullTextResult(
+            content=content,
+            available=True,
+            extraction_method="html",
+            is_complete=True,
+        )
+    if content and len(content) > 500:
+        return FullTextResult(
+            content=content,
+            available=True,
+            extraction_method="html_abstract_only",
+            is_complete=False,
+        )
+    return None
+
+
 def fetch_pmc_html_fallback(pmcid: str) -> FullTextResult:
-    """Fallback method to scrape PMC HTML when XML API is publisher-restricted.
-
-    This method is used when publishers allow PMC to host articles for web access
-    but restrict programmatic XML API access. Since all PMC articles provide
-    HTML versions regardless of XML restrictions, this approach successfully
-    retrieves content from publisher-restricted journals.
-
-    Uses multiple strategies to locate main article content and filters out
-    navigation, metadata, and supplementary sections.
-
-    Args:
-        pmcid: PMC ID (with or without PMC prefix)
-
-    Returns:
-        FullTextResult object with content from HTML scraping.
-        Typically achieves 85-90% success rate on restricted articles.
-    """
+    """Scrape PMC HTML when XML access is publisher-restricted."""
     try:
-        # Ensure PMC prefix
         if not pmcid.startswith("PMC"):
             pmcid = f"PMC{pmcid}"
 
         url = f"https://pmc.ncbi.nlm.nih.gov/articles/{pmcid}/"
-
-        # Add user agent to avoid blocking
         headers = {
             "User-Agent": "Mozilla/5.0 (compatible; ai-gene-review/1.0; +https://github.com/monarch-initiative/ai-gene-review)"
         }
-
         response = requests.get(url, headers=headers, timeout=30)
         response.raise_for_status()
 
-        soup = BeautifulSoup(response.content, "html.parser")
+        content = _extract_pmc_article_text(response.content)
+        result = _classify_pmc_html_content(content)
+        if result:
+            return result
 
-        # Extract main article content
-        content_parts = []
-
-        # Try multiple strategies to find the main article content
-
-        # Strategy 1: Look for PMC's article content structure
-        article_content = soup.find("div", class_="tsec") or soup.find(
-            "div", class_="article"
-        )
-
-        # Strategy 2: Look for sections with typical academic paper structure
-        if not article_content:
-            article_content = soup.find("div", id="article-body") or soup.find("main")
-
-        # Strategy 3: Find div containing multiple paragraphs
-        if not article_content:
-            # Look for a div that contains multiple paragraphs (likely main content)
-            divs_with_paragraphs = soup.find_all("div")
-            for div in divs_with_paragraphs:
-                if hasattr(div, "find_all"):  # Type guard for Tag objects
-                    paragraphs = div.find_all("p", recursive=False)
-                    if (
-                        len(paragraphs) >= 3
-                    ):  # Likely main content if has multiple paragraphs
-                        article_content = div
-                        break
-
-        # Strategy 4: Fallback to entire body
-        if not article_content:
-            article_content = soup
-
-        # Look for section headers and content
-        sections = []
-
-        # Find sections with headers (Introduction, Methods, Results, etc.)
-        header_tags = []
-        if hasattr(article_content, "find_all"):  # Type guard for Tag objects
-            # Find header tags that contain relevant section names
-            for tag in article_content.find_all(["h1", "h2", "h3", "h4"]):
-                if isinstance(tag, Tag):
-                    header_text = tag.get_text(strip=True)
-                    if re.search(
-                        r"(Introduction|Abstract|Methods?|Results?|Discussion|Conclusion)",
-                        header_text,
-                        re.I,
-                    ):
-                        header_tags.append(tag)
-
-        for header in header_tags:
-            section_content = []
-            section_content.append(header.get_text(strip=True))
-
-            # Get content following the header
-            for sibling in header.find_next_siblings():
-                if isinstance(sibling, Tag) and sibling.name in [
-                    "h1",
-                    "h2",
-                    "h3",
-                    "h4",
-                ]:
-                    break  # Stop at next header
-                if isinstance(sibling, Tag) and sibling.name == "p":
-                    text = sibling.get_text(separator=" ", strip=True)
-                    if len(text) > 30:
-                        section_content.append(text)
-
-            if len(section_content) > 1:  # Has header and content
-                sections.extend(section_content)
-
-        # If no structured sections found, get all substantial paragraphs
-        if not sections:
-            if hasattr(article_content, "find_all"):  # Type guard for Tag objects
-                paragraphs = article_content.find_all("p")
-            else:
-                paragraphs = []
-            for p in paragraphs:
-                text = p.get_text(separator=" ", strip=True)
-
-                # Filter out metadata and short snippets
-                if (
-                    len(text) > 50
-                    and not any(
-                        keyword in text.upper()
-                        for keyword in [
-                            "PMCID:",
-                            "PMID:",
-                            "DOI:",
-                            "COPYRIGHT",
-                            "DOWNLOAD PDF",
-                            "SUPPLEMENTARY DATA",
-                            "CITE THIS ARTICLE",
-                            "SHARE THIS ARTICLE",
-                            "AUTHOR INFORMATION",
-                            "FUNDING STATEMENT",
-                            "ETHICS STATEMENT",
-                            "DECLARATION OF INTERESTS",
-                            "SUPPLEMENTAL INFORMATION",
-                            "DATA AVAILABILITY",
-                            "AUTHOR CONTRIBUTIONS",
-                        ]
-                    )
-                    and "Fig." not in text
-                    and "Table" not in text[:20]
-                ):  # Skip figure/table captions
-                    sections.append(text)
-
-        content_parts = sections
-
-        if content_parts:
-            # Remove duplicates while preserving order
-            seen = set()
-            unique_parts = []
-            for part in content_parts:
-                if part not in seen:
-                    seen.add(part)
-                    unique_parts.append(part)
-
-            content = "\n\n".join(unique_parts)
-
-            # Check if we got substantial content (not just abstract repetition)
-            if len(content) > 3000:  # Reasonable threshold for full article
-                return FullTextResult(
-                    content=content,
-                    available=True,
-                    extraction_method="html",
-                    is_complete=True
-                )
-            elif len(content) > 500:  # Got something, but probably just abstract
-                return FullTextResult(
-                    content=content,
-                    available=True,
-                    extraction_method="html_abstract_only",
-                    is_complete=False
-                )
-            else:
-                print(
-                    f"{pmcid}: HTML content too short ({len(content)} chars), trying PDF fallback..."
-                )
-                return fetch_pmc_pdf_fallback(pmcid)
-        else:
+        if content:
             print(
-                f"{pmcid}: No substantial content found in HTML, trying PDF fallback..."
+                f"{pmcid}: HTML content too short ({len(content)} chars), trying PDF fallback..."
             )
-            return fetch_pmc_pdf_fallback(pmcid)
+        else:
+            print(f"{pmcid}: No substantial content found in HTML, trying PDF fallback...")
+        return fetch_pmc_pdf_fallback(pmcid)
 
     except requests.RequestException as e:
         print(f"{pmcid}: HTTP request failed - {e}")
-        return FullTextResult(content=None, available=False, extraction_method=None, is_complete=False)
+        return FullTextResult(
+            content=None, available=False, extraction_method=None, is_complete=False
+        )
     except Exception as e:
         print(f"{pmcid}: HTML scraping error - {e}")
-        return FullTextResult(content=None, available=False, extraction_method=None, is_complete=False)
+        return FullTextResult(
+            content=None, available=False, extraction_method=None, is_complete=False
+        )
 
 
 def fetch_pmc_pdf_fallback(pmcid: str) -> FullTextResult:

--- a/tests/test_pmc_html_fallback.py
+++ b/tests/test_pmc_html_fallback.py
@@ -1,0 +1,83 @@
+"""Regression tests for PMC HTML full-text extraction."""
+
+from ai_gene_review.etl.publication import (
+    _classify_pmc_html_content,
+    _extract_pmc_article_text,
+)
+
+
+def test_current_pmc_body_wins_over_legacy_section_fragment():
+    """Extract all nested sections from PMC's current article-body markup."""
+    fragment = "Misleading legacy fragment. " * 180
+    methods = "The complete methods cite PMID: 12345 within the assay text. " * 35
+    results = "The complete results report DOI: 10.1/example within the finding. " * 35
+    discussion = "The discussion interprets the complete experiment. " * 35
+    html = f"""
+    <html><body>
+      <div class="tsec"><h2>Results</h2><p>{fragment}</p></div>
+      <main id="main-content"><article>
+        <section aria-label="Article content">
+          <section class="body main-article-body">
+            <section><h2 class="pmc_sec_title">MATERIALS AND METHODS</h2>
+              <section><h3 class="pmc_sec_title">Microscopy.</h3><p>{methods}</p></section>
+            </section>
+            <section><h2 class="pmc_sec_title">RESULTS</h2>
+              <section><h3 class="pmc_sec_title">Rad3 localization.</h3><p>{results}</p></section>
+            </section>
+            <figure><figcaption><p>Excluded figure caption.</p></figcaption></figure>
+            <section><h2 class="pmc_sec_title">DISCUSSION</h2><p>{discussion}</p></section>
+          </section>
+        </section>
+      </article></main>
+    </body></html>
+    """
+    content = _extract_pmc_article_text(html)
+    result = _classify_pmc_html_content(content)
+
+    assert result is not None
+    assert result.is_complete is True
+    assert result.extraction_method == "html"
+    assert "MATERIALS AND METHODS" in result.content
+    assert "Rad3 localization." in result.content
+    assert "PMID: 12345" in result.content
+    assert "DOI: 10.1/example" in result.content
+    assert "Misleading legacy fragment" not in result.content
+    assert "Excluded figure caption" not in result.content
+
+
+def test_legacy_tsec_only_page_is_still_extracted():
+    body = "Legacy PMC body paragraph with experimental findings. " * 80
+    html = f"""
+    <div class="tsec">
+      <h2>Introduction</h2><p>{body}</p>
+      <h2>Results</h2><p>{body}</p>
+    </div>
+    """
+
+    content = _extract_pmc_article_text(html)
+    result = _classify_pmc_html_content(content)
+
+    assert result is not None
+    assert result.is_complete is True
+    assert "Introduction" in result.content
+    assert "Results" in result.content
+
+
+def test_abstract_only_content_is_not_marked_complete():
+    abstract = "This abstract reports one concise experimental finding. " * 20
+    html = f"<article><h2>Abstract</h2><p>{abstract}</p></article>"
+
+    content = _extract_pmc_article_text(html)
+    result = _classify_pmc_html_content(content)
+
+    assert result is not None
+    assert result.is_complete is False
+    assert result.extraction_method == "html_abstract_only"
+
+
+def test_headings_without_body_text_do_not_inflate_content():
+    furniture = "".join(f"<h2>Navigation heading {index}</h2>" for index in range(200))
+
+    content = _extract_pmc_article_text(f"<article>{furniture}</article>")
+
+    assert content is None


### PR DESCRIPTION
## Summary
- prefer the current PMC main article body over legacy fragment containers
- extract nested headings and paragraphs in document order
- add a regression test covering a misleading legacy fragment beside the complete body

## Verification
- `just pytest` (1970 passed, 63 deselected)
- `just format`
- live `just fetch-pmid 18180284 --force` expanded the cache from 69 to 258 lines and recovered Methods, Results, Discussion, and Rad3 passages (generated cache excluded from this code-only PR)