### PR TITLE
Repair PSEPK phosphorylated L-serine biosynthesis module

### DIFF
--- a/genes/PSEPK/serA/serA-ai-review.html
+++ b/genes/PSEPK/serA/serA-ai-review.html
@@ -1234,10 +1234,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q88CM5" data-a="GO:0120568" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="Q88CM5" data-a="GO:0120568" data-r="GO_REF:0000120" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1245,12 +1245,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Plausible inferred secondary activity outside the serine-pathway role.
+                            <strong>Summary:</strong> The predicted secondary activity is not established for Q88CM5.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> UniProt assigns EC 1.1.1.399 and an alternative 2-oxoglutarate reductase name, but direct KT2440 physiological evidence is not available.
+                            <strong>Reason:</strong> UniProt assigns EC 1.1.1.399 and an alternative 2-oxoglutarate reductase name through automated rules, but direct KT2440 biochemical or physiological evidence is not available and this activity varies among phosphoglycerate dehydrogenases.
                         </div>
 
 
@@ -1738,10 +1738,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: enables
   review:
-    summary: Plausible inferred secondary activity outside the serine-pathway role.
-    action: KEEP_AS_NON_CORE
-    reason: UniProt assigns EC 1.1.1.399 and an alternative 2-oxoglutarate reductase name, but direct
-      KT2440 physiological evidence is not available.
+    summary: The predicted secondary activity is not established for Q88CM5.
+    action: UNDECIDED
+    reason: &gt;-
+      UniProt assigns EC 1.1.1.399 and an alternative 2-oxoglutarate reductase
+      name through automated rules, but direct KT2440 biochemical or
+      physiological evidence is not available and this activity varies among
+      phosphoglycerate dehydrogenases.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms

--- a/genes/PSEPK/serA/serA-ai-review.html
+++ b/genes/PSEPK/serA/serA-ai-review.html
@@ -1234,10 +1234,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q88CM5" data-a="GO:0120568" data-r="GO_REF:0000120" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="Q88CM5" data-a="GO:0120568" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1739,7 +1739,7 @@ existing_annotations:
   qualifier: enables
   review:
     summary: The predicted secondary activity is not established for Q88CM5.
-    action: UNDECIDED
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       UniProt assigns EC 1.1.1.399 and an alternative 2-oxoglutarate reductase
       name through automated rules, but direct KT2440 biochemical or

--- a/genes/PSEPK/serA/serA-ai-review.yaml
+++ b/genes/PSEPK/serA/serA-ai-review.yaml
@@ -104,7 +104,7 @@ existing_annotations:
   qualifier: enables
   review:
     summary: The predicted secondary activity is not established for Q88CM5.
-    action: UNDECIDED
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       UniProt assigns EC 1.1.1.399 and an alternative 2-oxoglutarate reductase
       name through automated rules, but direct KT2440 biochemical or

--- a/genes/PSEPK/serA/serA-ai-review.yaml
+++ b/genes/PSEPK/serA/serA-ai-review.yaml
@@ -103,10 +103,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000120
   qualifier: enables
   review:
-    summary: Plausible inferred secondary activity outside the serine-pathway role.
-    action: KEEP_AS_NON_CORE
-    reason: UniProt assigns EC 1.1.1.399 and an alternative 2-oxoglutarate reductase name, but direct
-      KT2440 physiological evidence is not available.
+    summary: The predicted secondary activity is not established for Q88CM5.
+    action: UNDECIDED
+    reason: >-
+      UniProt assigns EC 1.1.1.399 and an alternative 2-oxoglutarate reductase
+      name through automated rules, but direct KT2440 biochemical or
+      physiological evidence is not available and this activity varies among
+      phosphoglycerate dehydrogenases.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms

--- a/genes/PSEPK/serB/serB-ai-review.html
+++ b/genes/PSEPK/serB/serB-ai-review.html
@@ -961,10 +961,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q88DB8" data-a="GO:0005737" data-r="GO_REF:0000118" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q88DB8" data-a="GO:0005737" data-r="GO_REF:0000118" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -972,12 +972,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct expected location for a soluble bacterial metabolic enzyme.
+                            <strong>Summary:</strong> Cytoplasmic localization is plausible but is not a defining catalytic property.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> TreeGrafter provides positive phylogenetic support for a cytoplasmic location, consistent with a soluble phosphoserine phosphatase; no direct localization experiment is available for Q88DB8.
+                            <strong>Reason:</strong> TreeGrafter provides indirect phylogenetic support for cytoplasmic localization, but no direct localization experiment is available for Q88DB8. Retain the annotation as secondary context rather than core function.
                         </div>
 
 
@@ -1201,19 +1201,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
-                                cytoplasm
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -1495,12 +1482,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct expected location for a soluble bacterial metabolic enzyme.
-    action: ACCEPT
+    summary: Cytoplasmic localization is plausible but is not a defining catalytic property.
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      TreeGrafter provides positive phylogenetic support for a cytoplasmic
-      location, consistent with a soluble phosphoserine phosphatase; no direct
-      localization experiment is available for Q88DB8.
+      TreeGrafter provides indirect phylogenetic support for cytoplasmic
+      localization, but no direct localization experiment is available for
+      Q88DB8. Retain the annotation as secondary context rather than core
+      function.
     supported_by:
     - reference_id: GO_REF:0000118
 - term:
@@ -1597,9 +1585,6 @@ core_functions:
     supporting_text: &#39;RecName: Full=Phosphoserine phosphatase&#39;
   - reference_id: PMID:25037224
     supporting_text: Phosphoserine phosphatase (PSP), a key essential metabolic enzyme involved in conversion of O-phospho-l-serine to l-serine, was characterized in this study.
-  locations:
-  - id: GO:0005737
-    label: cytoplasm
 suggested_experiments:
 - description: Test a clean serB deletion for serine auxotrophy and restore growth by L-serine supplementation
     or gene complementation.

--- a/genes/PSEPK/serB/serB-ai-review.yaml
+++ b/genes/PSEPK/serB/serB-ai-review.yaml
@@ -34,12 +34,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000118
   qualifier: located_in
   review:
-    summary: Correct expected location for a soluble bacterial metabolic enzyme.
-    action: ACCEPT
+    summary: Cytoplasmic localization is plausible but is not a defining catalytic property.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      TreeGrafter provides positive phylogenetic support for a cytoplasmic
-      location, consistent with a soluble phosphoserine phosphatase; no direct
-      localization experiment is available for Q88DB8.
+      TreeGrafter provides indirect phylogenetic support for cytoplasmic
+      localization, but no direct localization experiment is available for
+      Q88DB8. Retain the annotation as secondary context rather than core
+      function.
     supported_by:
     - reference_id: GO_REF:0000118
 - term:
@@ -136,9 +137,6 @@ core_functions:
     supporting_text: 'RecName: Full=Phosphoserine phosphatase'
   - reference_id: PMID:25037224
     supporting_text: Phosphoserine phosphatase (PSP), a key essential metabolic enzyme involved in conversion of O-phospho-l-serine to l-serine, was characterized in this study.
-  locations:
-  - id: GO:0005737
-    label: cytoplasm
 suggested_experiments:
 - description: Test a clean serB deletion for serine auxotrophy and restore growth by L-serine supplementation
     or gene complementation.

--- a/genes/PSEPK/serC/serC-ai-review.html
+++ b/genes/PSEPK/serC/serC-ai-review.html
@@ -1013,6 +1013,22 @@
 
 
 
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:PSEPK/serC/serC-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
 
                     </td>
                 </tr>
@@ -1272,6 +1288,22 @@
 
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:PSEPK/serC/serC-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Binds 1 pyridoxal phosphate per subunit.</div>
+
+                            </div>
+
+                        </div>
 
 
                     </td>
@@ -1985,6 +2017,9 @@ existing_annotations:
       summary: SerC is a soluble cytoplasmic metabolic enzyme.
       action: KEEP_AS_NON_CORE
       reason: Localization is useful context but does not distinguish either reaction.
+      supported_by:
+        - reference_id: file:PSEPK/serC/serC-uniprot.txt
+          supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm&#34;
   - term:
       id: GO:0006564
       label: L-serine biosynthetic process
@@ -2040,6 +2075,9 @@ existing_annotations:
       summary: PLP is the covalently bound aminotransferase cofactor.
       action: KEEP_AS_NON_CORE
       reason: The cofactor annotation is valid but secondary to the catalytic activity.
+      supported_by:
+        - reference_id: file:PSEPK/serC/serC-uniprot.txt
+          supporting_text: Binds 1 pyridoxal phosphate per subunit.
 references:
   - id: GO_REF:0000104
     title: &gt;-

--- a/genes/PSEPK/serC/serC-ai-review.yaml
+++ b/genes/PSEPK/serC/serC-ai-review.yaml
@@ -42,6 +42,9 @@ existing_annotations:
       summary: SerC is a soluble cytoplasmic metabolic enzyme.
       action: KEEP_AS_NON_CORE
       reason: Localization is useful context but does not distinguish either reaction.
+      supported_by:
+        - reference_id: file:PSEPK/serC/serC-uniprot.txt
+          supporting_text: "SUBCELLULAR LOCATION: Cytoplasm"
   - term:
       id: GO:0006564
       label: L-serine biosynthetic process
@@ -97,6 +100,9 @@ existing_annotations:
       summary: PLP is the covalently bound aminotransferase cofactor.
       action: KEEP_AS_NON_CORE
       reason: The cofactor annotation is valid but secondary to the catalytic activity.
+      supported_by:
+        - reference_id: file:PSEPK/serC/serC-uniprot.txt
+          supporting_text: Binds 1 pyridoxal phosphate per subunit.
 references:
   - id: GO_REF:0000104
     title: >-

--- a/modules/phosphorylated_serine_biosynthesis.yaml
+++ b/modules/phosphorylated_serine_biosynthesis.yaml
@@ -66,8 +66,8 @@ module:
               family:
                 preferred_term: D-isomer-specific 2-hydroxyacid dehydrogenases
                 term:
-                  id: PANTHER:PTHR43761
-                  label: D-ISOMER SPECIFIC 2-HYDROXYACID DEHYDROGENASE FAMILY PROTEIN (AFU_ORTHOLOGUE AFUA_1G13630)
+                  id: PANTHER:PTHR43761:SF1
+                  label: D-ISOMER SPECIFIC 2-HYDROXYACID DEHYDROGENASE CATALYTIC DOMAIN-CONTAINING PROTEIN-RELATED
                 representative_members:
                   - preferred_term: PSEPK SerA
                     term:
@@ -111,7 +111,7 @@ module:
               family:
                 preferred_term: SerC phosphoserine aminotransferases
                 term:
-                  id: PANTHER:PTHR43247
+                  id: PANTHER:PTHR43247:SF1
                   label: PHOSPHOSERINE AMINOTRANSFERASE
                 representative_members:
                   - preferred_term: PSEPK SerC
@@ -155,7 +155,7 @@ module:
               family:
                 preferred_term: SerB phosphoserine phosphatases
                 term:
-                  id: PANTHER:PTHR43344
+                  id: PANTHER:PTHR43344:SF2
                   label: PHOSPHOSERINE PHOSPHATASE
                 representative_members:
                   - preferred_term: PSEPK SerB
@@ -196,4 +196,5 @@ module:
     module. Some bacterial SerA proteins use an ACT domain for L-serine
     feedback, but effector sensitivity is a lineage- and sequence-dependent
     regulatory property rather than an additional pathway part. No ancestral
-    PTN node is asserted without verified PAINT IBD evidence.
+    PTN is asserted: the local PAINT exports identify family-level IBD nodes
+    but do not establish that the PSEPK targets descend from those nodes.

--- a/pages/modules/phosphorylated_serine_biosynthesis.html
+++ b/pages/modules/phosphorylated_serine_biosynthesis.html
@@ -586,7 +586,7 @@
                 <h3>Gene-review completeness
                     <span class="muted small">(3/6 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        2 complete review(s) &middot;
+                        3 complete review(s) &middot;
                         1 with deep research &middot;
                         3 missing review &middot;
                         2 reviewed but lacking deep research
@@ -622,7 +622,7 @@
                                     <td>serA
                                         <span class="muted term-id">Q88CM5</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="warn">5/6</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                 </tr>                                <tr>
                                     <td>serB

--- a/pages/modules/phosphorylated_serine_biosynthesis.html
+++ b/pages/modules/phosphorylated_serine_biosynthesis.html
@@ -586,7 +586,7 @@
                 <h3>Gene-review completeness
                     <span class="muted small">(3/6 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        3 complete review(s) &middot;
+                        2 complete review(s) &middot;
                         1 with deep research &middot;
                         3 missing review &middot;
                         2 reviewed but lacking deep research
@@ -622,7 +622,7 @@
                                     <td>serA
                                         <span class="muted term-id">Q88CM5</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">5/6</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                 </tr>                                <tr>
                                     <td>serB
@@ -725,7 +725,7 @@
         </div><div class="descriptor-list">                <span class="descriptor">
             <span>L-serine biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006564" target="_blank" rel="noopener">GO:0006564</a></span>        </div>
 
-        <p class="muted small">Exact UniProt exemplars delimit the three reaction roles without restricting the module taxonomically. No cellular location or molecular function is repeated at module level. SerC can also catalyze phosphohydroxythreonine transamination in DXP-dependent vitamin B6 biosynthesis, but that separate reaction is not a fourth part of this module. Some bacterial SerA proteins use an ACT domain for L-serine feedback, but effector sensitivity is a lineage- and sequence-dependent regulatory property rather than an additional pathway part. No ancestral PTN node is asserted without verified PAINT IBD evidence.</p>            <h4>Connections</h4>
+        <p class="muted small">Exact UniProt exemplars delimit the three reaction roles without restricting the module taxonomically. No cellular location or molecular function is repeated at module level. SerC can also catalyze phosphohydroxythreonine transamination in DXP-dependent vitamin B6 biosynthesis, but that separate reaction is not a fourth part of this module. Some bacterial SerA proteins use an ACT domain for L-serine feedback, but effector sensitivity is a lineage- and sequence-dependent regulatory property rather than an additional pathway part. No ancestral PTN is asserted: the local PAINT exports identify family-level IBD nodes but do not establish that the PSEPK targets descend from those nodes.</p>            <h4>Connections</h4>
             <div class="connection-list">                <div class="connection-card small">
                     <div>
                         <a href="#node-phosphoglycerate_dehydrogenase_step">phosphoglycerate_dehydrogenase_step</a>
@@ -752,7 +752,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>D-isomer-specific 2-hydroxyacid dehydrogenases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43761" target="_blank" rel="noopener">PANTHER:PTHR43761</a>                    <div class="slot-row">
+            <span><strong>D-isomer-specific 2-hydroxyacid dehydrogenases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43761%3ASF1" target="_blank" rel="noopener">PANTHER:PTHR43761:SF1</a>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK SerA</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88CM5/entry" target="_blank" rel="noopener">UniProtKB:Q88CM5</a></span>                            <span class="descriptor">
             <span>Haemophilus influenzae SerA</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P43885/entry" target="_blank" rel="noopener">UniProtKB:P43885</a></span>                    </div></div>
@@ -783,7 +783,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>SerC phosphoserine aminotransferases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43247" target="_blank" rel="noopener">PANTHER:PTHR43247</a>                    <div class="slot-row">
+            <span><strong>SerC phosphoserine aminotransferases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43247%3ASF1" target="_blank" rel="noopener">PANTHER:PTHR43247:SF1</a>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK SerC</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88M07/entry" target="_blank" rel="noopener">UniProtKB:Q88M07</a></span>                            <span class="descriptor">
             <span>Escherichia coli SerC</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P23721/entry" target="_blank" rel="noopener">UniProtKB:P23721</a></span>                    </div></div>
@@ -813,7 +813,7 @@
             <div class="participant-detail">                    <div class="slot-row">
                         <span class="slot-name">Family:</span>
                         <div class="descriptor">
-            <span><strong>SerB phosphoserine phosphatases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43344" target="_blank" rel="noopener">PANTHER:PTHR43344</a>                    <div class="slot-row">
+            <span><strong>SerB phosphoserine phosphatases</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43344%3ASF2" target="_blank" rel="noopener">PANTHER:PTHR43344:SF2</a>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
             <span>PSEPK SerB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88DB8/entry" target="_blank" rel="noopener">UniProtKB:Q88DB8</a></span>                            <span class="descriptor">
             <span>Escherichia coli SerB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0AGB0/entry" target="_blank" rel="noopener">UniProtKB:P0AGB0</a></span>                    </div></div>

--- a/pages/projects/P_PUTIDA/batches/ppu00260_phosphorylated_serine_biosynthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00260_phosphorylated_serine_biosynthesis.html
@@ -445,11 +445,32 @@ and phospholipid synthesis.</p>
 </tr>
 </tbody>
 </table>
+<h2 id="wave108-repair">Wave108 Repair</h2>
+<ul>
+<li>The module remains a reusable, species-neutral three-reaction pathway with<br />
+  molecular functions confined to its leaf annotons.</li>
+<li>Each reaction selector now uses the exact PANTHER subfamily shared by its<br />
+  PSEPK target and reviewed cross-species exemplar: <code>PTHR43761:SF1</code> for SerA,<br />
+<code>PTHR43247:SF1</code> for SerC, and <code>PTHR43344:SF2</code> for SerB.</li>
+<li>No PTN is asserted. The local PAINT exports identify family-level IBD nodes<br />
+  but do not establish that the PSEPK targets descend from those nodes.</li>
+<li>The <code>serA</code> secondary R-2-hydroxyglutarate activity is now <code>UNDECIDED</code><br />
+  because its target-specific support is automated rather than biochemical.</li>
+<li>The <code>serC</code> non-core cytoplasm and PLP-binding decisions now cite exact<br />
+  UniProt text. The <code>serB</code> cytoplasm annotation is retained as non-core<br />
+  phylogenetic context and removed from its core function.</li>
+<li>Two independent annotation-reviewer passes covered all three gene reviews.<br />
+  The first identified the unsupported PTN and SerA confidence issues; the<br />
+  second found no blocking findings after repair.</li>
+<li>The wave108 module/pathway/PSEPK OpenScientist request was left running for<br />
+  the full configured 7,200 seconds. It reached the client timeout without<br />
+  returning a report, so no partial or nonexistent provider output is cited.</li>
+</ul>
 <h2 id="boundary-notes">Boundary Notes</h2>
 <ul>
-<li><code>serA</code> also carries an inferred (R)-2-hydroxyglutarate dehydrogenase<br />
-  activity; that secondary reaction is retained as non-core in its gene<br />
-  review but is outside this pathway.</li>
+<li><code>serA</code> also carries an automated annotation to (R)-2-hydroxyglutarate<br />
+  dehydrogenase activity. Its gene-level decision is <code>UNDECIDED</code>, and the<br />
+  secondary reaction is outside this pathway boundary.</li>
 <li><code>serC</code> also supplies phosphohydroxythreonine aminotransferase chemistry to<br />
   DXP-dependent vitamin B6 synthesis; that is captured by the separate<br />
   vitamin B6 module and does not make this a one-enzyme module.</li>

--- a/pages/projects/P_PUTIDA/batches/ppu00260_phosphorylated_serine_biosynthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00260_phosphorylated_serine_biosynthesis.html
@@ -449,12 +449,14 @@ and phospholipid synthesis.</p>
 <ul>
 <li>The module remains a reusable, species-neutral three-reaction pathway with<br />
   molecular functions confined to its leaf annotons.</li>
-<li>Each reaction selector now uses the exact PANTHER subfamily shared by its<br />
-  PSEPK target and reviewed cross-species exemplar: <code>PTHR43761:SF1</code> for SerA,<br />
-<code>PTHR43247:SF1</code> for SerC, and <code>PTHR43344:SF2</code> for SerB.</li>
+<li>Each reaction selector uses the exact PANTHER subfamily shared by its PSEPK<br />
+  target and reviewed cross-species exemplar. SerC (<code>PTHR43247:SF1</code>) and SerB<br />
+  (<code>PTHR43344:SF2</code>) are genuine refinements over multi-subfamily parents. SerA<br />
+  uses <code>PTHR43761:SF1</code>, but that is the sole subfamily of <code>PTHR43761</code>; its<br />
+  specificity comes from the required <a href="http://amigo.geneontology.org/amigo/term/GO:0004617">GO:0004617</a> function, not family narrowing.</li>
 <li>No PTN is asserted. The local PAINT exports identify family-level IBD nodes<br />
   but do not establish that the PSEPK targets descend from those nodes.</li>
-<li>The <code>serA</code> secondary R-2-hydroxyglutarate activity is now <code>UNDECIDED</code><br />
+<li>The <code>serA</code> secondary R-2-hydroxyglutarate activity is marked over-annotated<br />
   because its target-specific support is automated rather than biochemical.</li>
 <li>The <code>serC</code> non-core cytoplasm and PLP-binding decisions now cite exact<br />
   UniProt text. The <code>serB</code> cytoplasm annotation is retained as non-core<br />
@@ -469,7 +471,7 @@ and phospholipid synthesis.</p>
 <h2 id="boundary-notes">Boundary Notes</h2>
 <ul>
 <li><code>serA</code> also carries an automated annotation to (R)-2-hydroxyglutarate<br />
-  dehydrogenase activity. Its gene-level decision is <code>UNDECIDED</code>, and the<br />
+  dehydrogenase activity. Its gene-level decision is <code>MARK_AS_OVER_ANNOTATED</code>, and the<br />
   secondary reaction is outside this pathway boundary.</li>
 <li><code>serC</code> also supplies phosphohydroxythreonine aminotransferase chemistry to<br />
   DXP-dependent vitamin B6 synthesis; that is captured by the separate<br />

--- a/projects/P_PUTIDA/batches/ppu00260_phosphorylated_serine_biosynthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00260_phosphorylated_serine_biosynthesis.md
@@ -44,12 +44,14 @@ and phospholipid synthesis.
 
 - The module remains a reusable, species-neutral three-reaction pathway with
   molecular functions confined to its leaf annotons.
-- Each reaction selector now uses the exact PANTHER subfamily shared by its
-  PSEPK target and reviewed cross-species exemplar: `PTHR43761:SF1` for SerA,
-  `PTHR43247:SF1` for SerC, and `PTHR43344:SF2` for SerB.
+- Each reaction selector uses the exact PANTHER subfamily shared by its PSEPK
+  target and reviewed cross-species exemplar. SerC (`PTHR43247:SF1`) and SerB
+  (`PTHR43344:SF2`) are genuine refinements over multi-subfamily parents. SerA
+  uses `PTHR43761:SF1`, but that is the sole subfamily of `PTHR43761`; its
+  specificity comes from the required GO:0004617 function, not family narrowing.
 - No PTN is asserted. The local PAINT exports identify family-level IBD nodes
   but do not establish that the PSEPK targets descend from those nodes.
-- The `serA` secondary R-2-hydroxyglutarate activity is now `UNDECIDED`
+- The `serA` secondary R-2-hydroxyglutarate activity is marked over-annotated
   because its target-specific support is automated rather than biochemical.
 - The `serC` non-core cytoplasm and PLP-binding decisions now cite exact
   UniProt text. The `serB` cytoplasm annotation is retained as non-core
@@ -64,7 +66,7 @@ and phospholipid synthesis.
 ## Boundary Notes
 
 - `serA` also carries an automated annotation to (R)-2-hydroxyglutarate
-  dehydrogenase activity. Its gene-level decision is `UNDECIDED`, and the
+  dehydrogenase activity. Its gene-level decision is `MARK_AS_OVER_ANNOTATED`, and the
   secondary reaction is outside this pathway boundary.
 - `serC` also supplies phosphohydroxythreonine aminotransferase chemistry to
   DXP-dependent vitamin B6 synthesis; that is captured by the separate

--- a/projects/P_PUTIDA/batches/ppu00260_phosphorylated_serine_biosynthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00260_phosphorylated_serine_biosynthesis.md
@@ -40,11 +40,32 @@ and phospholipid synthesis.
 | 2 | `serC` | PP_1768 | Q88M07 | phosphoserine aminotransferase | PR #2174 |
 | 3 | `serB` | PP_4909 | Q88DB8 | phosphoserine phosphatase | this batch |
 
+## Wave108 Repair
+
+- The module remains a reusable, species-neutral three-reaction pathway with
+  molecular functions confined to its leaf annotons.
+- Each reaction selector now uses the exact PANTHER subfamily shared by its
+  PSEPK target and reviewed cross-species exemplar: `PTHR43761:SF1` for SerA,
+  `PTHR43247:SF1` for SerC, and `PTHR43344:SF2` for SerB.
+- No PTN is asserted. The local PAINT exports identify family-level IBD nodes
+  but do not establish that the PSEPK targets descend from those nodes.
+- The `serA` secondary R-2-hydroxyglutarate activity is now `UNDECIDED`
+  because its target-specific support is automated rather than biochemical.
+- The `serC` non-core cytoplasm and PLP-binding decisions now cite exact
+  UniProt text. The `serB` cytoplasm annotation is retained as non-core
+  phylogenetic context and removed from its core function.
+- Two independent annotation-reviewer passes covered all three gene reviews.
+  The first identified the unsupported PTN and SerA confidence issues; the
+  second found no blocking findings after repair.
+- The wave108 module/pathway/PSEPK OpenScientist request was left running for
+  the full configured 7,200 seconds. It reached the client timeout without
+  returning a report, so no partial or nonexistent provider output is cited.
+
 ## Boundary Notes
 
-- `serA` also carries an inferred (R)-2-hydroxyglutarate dehydrogenase
-  activity; that secondary reaction is retained as non-core in its gene
-  review but is outside this pathway.
+- `serA` also carries an automated annotation to (R)-2-hydroxyglutarate
+  dehydrogenase activity. Its gene-level decision is `UNDECIDED`, and the
+  secondary reaction is outside this pathway boundary.
 - `serC` also supplies phosphohydroxythreonine aminotransferase chemistry to
   DXP-dependent vitamin B6 synthesis; that is captured by the separate
   vitamin B6 module and does not make this a one-enzyme module.


### PR DESCRIPTION
## Summary
- tighten the three phosphorylated-serine reaction selectors to exact verified PANTHER subfamilies with reviewed cross-species exemplars
- omit uncertain PTNs and keep molecular functions on leaf annotons in the reusable species-neutral module
- calibrate serA, serC, and serB review decisions and document the wave108 independent annotation-reviewer audit
- record the uninterrupted 7,200-second OpenScientist module/pathway/taxon timeout without citing nonexistent output

## Validation
- `uv run linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/phosphorylated_serine_biosynthesis.yaml`
- `uv run python -m ai_gene_review.validation.module_validator modules/phosphorylated_serine_biosynthesis.yaml` (0 warnings)
- `just validate PSEPK serA`
- `just validate PSEPK serC`
- `just validate PSEPK serB`
- rendered module, batch project, and all three gene reviews
- `git diff --check`

Two read-only annotation-reviewer passes covered all three gene reviews. The follow-up pass reported no blocking findings.