### PR TITLE
Repair PSEPK peptidoglycan precursor biosynthesis module

### DIFF
--- a/modules/peptidoglycan_precursor_biosynthesis.yaml
+++ b/modules/peptidoglycan_precursor_biosynthesis.yaml
@@ -11,6 +11,7 @@ description: >-
   polymerization, peptide cross-linking, carrier recycling, or cell-wall
   remodeling.
 status: DRAFT
+scope: CONCRETE
 evidence:
   - source_id: GO:0009252
     title: peptidoglycan biosynthetic process
@@ -23,27 +24,6 @@ evidence:
       The module-level review supports the ordered MurA-to-MurJ pathway,
       convergent D-Ala-D-Ala input, third-residue variation, and the boundary
       before glycan polymerization and peptide cross-linking.
-  - source_id: file:projects/P_PUTIDA/deep-research/PSEPK__peptidoglycan_precursor_biosynthesis__ppu00550-deep-research-openscientist.md
-    title: OpenScientist PSEPK ppu00550 pathway satisfiability review
-    statement: >-
-      The species-aware review finds all precursor and lipid II export steps
-      covered, identifies MurJ as a transporter omitted by the KEGG candidate
-      bucket, and distinguishes Ddl paralogs from upstream amino-acid supply.
-  - source_id: file:PSEPK/murA/murA-ai-review.yaml
-    title: PSEPK murA gene review
-    statement: >-
-      UniProt identifies Q88P88 as the UDP-N-acetylglucosamine
-      1-carboxyvinyltransferase that starts MurNAc precursor synthesis.
-  - source_id: file:PSEPK/mraY/mraY-ai-review.yaml
-    title: PSEPK mraY gene review
-    statement: >-
-      The KT2440 review identifies Q88N79 as the membrane phosphotransferase
-      that forms lipid I from UDP-MurNAc-pentapeptide.
-  - source_id: file:PSEPK/murJ/murJ-ai-review.yaml
-    title: PSEPK murJ gene review
-    statement: >-
-      UniProt identifies Q88Q94 as the lipid II flippase that connects
-      cytoplasmic precursor synthesis to periplasmic assembly.
 module:
   id: peptidoglycan_precursor_biosynthesis
   label: Peptidoglycan precursor biosynthesis and lipid II export
@@ -71,9 +51,9 @@ module:
               family:
                 preferred_term: MurA UDP-N-acetylglucosamine 1-carboxyvinyltransferases
                 representative_members:
-                  - preferred_term: PSEPK MurA
+                  - preferred_term: Escherichia coli K-12 MurA
                     term:
-                      id: UniProtKB:Q88P88
+                      id: UniProtKB:P0A749
                       label: UDP-N-acetylglucosamine 1-carboxyvinyltransferase
             function:
               preferred_term: UDP-N-acetylglucosamine 1-carboxyvinyltransferase activity
@@ -101,10 +81,10 @@ module:
               family:
                 preferred_term: MurB UDP-N-acetylmuramate dehydrogenases
                 representative_members:
-                  - preferred_term: PSEPK MurB
+                  - preferred_term: Escherichia coli K-12 MurB
                     term:
-                      id: UniProtKB:Q88LM5
-                      label: UDP-N-acetylmuramate dehydrogenase
+                      id: UniProtKB:P08373
+                      label: UDP-N-acetylenolpyruvoylglucosamine reductase
             function:
               preferred_term: UDP-N-acetylmuramate dehydrogenase activity
               term:
@@ -133,9 +113,9 @@ module:
               family:
                 preferred_term: MurC UDP-N-acetylmuramate-L-alanine ligases
                 representative_members:
-                  - preferred_term: PSEPK MurC
+                  - preferred_term: Escherichia coli K-12 MurC
                     term:
-                      id: UniProtKB:Q88N75
+                      id: UniProtKB:P17952
                       label: UDP-N-acetylmuramate-L-alanine ligase
             function:
               preferred_term: UDP-N-acetylmuramate-L-alanine ligase activity
@@ -165,9 +145,9 @@ module:
               family:
                 preferred_term: MurD UDP-MurNAc-L-Ala-D-Glu ligases
                 representative_members:
-                  - preferred_term: PSEPK MurD
+                  - preferred_term: Escherichia coli K-12 MurD
                     term:
-                      id: UniProtKB:Q88N78
+                      id: UniProtKB:P14900
                       label: UDP-N-acetylmuramoylalanine-D-glutamate ligase
             function:
               preferred_term: UDP-N-acetylmuramoylalanine-D-glutamate ligase activity
@@ -206,9 +186,9 @@ module:
                       family:
                         preferred_term: meso-diaminopimelate-specific MurE ligases
                         representative_members:
-                          - preferred_term: PSEPK DAP-specific MurE
+                          - preferred_term: Escherichia coli K-12 DAP-specific MurE
                             term:
-                              id: UniProtKB:Q88N81
+                              id: UniProtKB:P22188
                               label: UDP-N-acetylmuramoyl-L-alanyl-D-glutamate--2,6-diaminopimelate ligase
                     function:
                       preferred_term: UDP-N-acetylmuramoylalanyl-D-glutamate-2,6-diaminopimelate ligase activity
@@ -267,14 +247,10 @@ module:
               family:
                 preferred_term: D-alanine-D-alanine ligases
                 representative_members:
-                  - preferred_term: PSEPK DdlB
+                  - preferred_term: Escherichia coli K-12 DdlB
                     term:
-                      id: UniProtKB:Q88N74
+                      id: UniProtKB:P07862
                       label: D-alanine--D-alanine ligase B
-                  - preferred_term: PSEPK DdlA
-                    term:
-                      id: UniProtKB:Q88EV6
-                      label: D-alanine--D-alanine ligase A
             function:
               preferred_term: D-alanine-D-alanine ligase activity
               term:
@@ -303,9 +279,9 @@ module:
               family:
                 preferred_term: MurF UDP-MurNAc-tripeptide-D-Ala-D-Ala ligases
                 representative_members:
-                  - preferred_term: PSEPK MurF
+                  - preferred_term: Escherichia coli K-12 MurF
                     term:
-                      id: UniProtKB:Q88N80
+                      id: UniProtKB:P11880
                       label: UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase
             function:
               preferred_term: UDP-N-acetylmuramoyl-tripeptide-D-alanyl-D-alanine ligase activity
@@ -335,9 +311,9 @@ module:
               family:
                 preferred_term: MraY phospho-MurNAc-pentapeptide transferases
                 representative_members:
-                  - preferred_term: PSEPK MraY
+                  - preferred_term: Escherichia coli K-12 MraY
                     term:
-                      id: UniProtKB:Q88N79
+                      id: UniProtKB:P0A6W3
                       label: Phospho-N-acetylmuramoyl-pentapeptide-transferase
             function:
               preferred_term: phospho-N-acetylmuramoyl-pentapeptide-transferase activity
@@ -350,11 +326,6 @@ module:
               products:
                 - preferred_term: lipid I
                 - preferred_term: UMP
-            locations:
-              - preferred_term: plasma membrane
-                term:
-                  id: GO:0005886
-                  label: plasma membrane
             role_description: Transfers phospho-MurNAc-pentapeptide to the lipid carrier.
     - order: 9
       role: lipid II formation
@@ -370,10 +341,10 @@ module:
               family:
                 preferred_term: MurG lipid I N-acetylglucosaminyltransferases
                 representative_members:
-                  - preferred_term: PSEPK MurG
+                  - preferred_term: Escherichia coli K-12 MurG
                     term:
-                      id: UniProtKB:Q88N76
-                      label: UDP-N-acetylglucosamine--N-acetylmuramyl-pentapeptide transferase
+                      id: UniProtKB:P17443
+                      label: UDP-N-acetylglucosamine--N-acetylmuramyl-(pentapeptide) pyrophosphoryl-undecaprenol N-acetylglucosamine transferase
             function:
               preferred_term: undecaprenyldiphospho-muramoylpentapeptide beta-N-acetylglucosaminyltransferase activity
               term:
@@ -385,11 +356,6 @@ module:
               products:
                 - preferred_term: lipid II
                 - preferred_term: UDP
-            locations:
-              - preferred_term: plasma membrane
-                term:
-                  id: GO:0005886
-                  label: plasma membrane
             role_description: Adds GlcNAc to lipid I to generate lipid II.
     - order: 10
       role: lipid II translocation
@@ -405,9 +371,9 @@ module:
               family:
                 preferred_term: MurJ/MviN lipid II flippases
                 representative_members:
-                  - preferred_term: PSEPK MurJ
+                  - preferred_term: Escherichia coli K-12 MurJ
                     term:
-                      id: UniProtKB:Q88Q94
+                      id: UniProtKB:P0AF16
                       label: Lipid II flippase MurJ
             function:
               preferred_term: lipid-linked peptidoglycan transporter activity
@@ -418,11 +384,6 @@ module:
                 - preferred_term: lipid II on the cytoplasmic membrane leaflet
               products:
                 - preferred_term: lipid II on the periplasmic membrane leaflet
-            locations:
-              - preferred_term: plasma membrane
-                term:
-                  id: GO:0005886
-                  label: plasma membrane
             role_description: Exports lipid II for periplasmic polymerization.
   connections:
     - source: murA_enolpyruvyl_transfer
@@ -462,11 +423,14 @@ module:
       connection_type: PROVIDES_INPUT_FOR
       description: MurG produces lipid II for MurJ-mediated export.
   notes: >-
-    The module is taxon-neutral but uses exact KT2440 and reviewed
-    Staphylococcus accessions as representative members. MurF, MraY, and MurG
-    use pentapeptide-generic molecular functions here so the module remains
-    valid downstream of either the DAP- or L-lysine-specific MurE branch;
+    Reviewed Escherichia coli K-12 proteins ground the conserved DAP-containing
+    route, and reviewed Staphylococcus aureus MurE grounds the alternative
+    L-lysine branch. MurF, MraY, and MurG use pentapeptide-generic molecular
+    functions so the module remains valid downstream of either MurE branch;
     species-level gene reviews may use the corresponding stem-specific child
-    terms. The module intentionally excludes amino-acid precursor supply, the
-    undecaprenyl carrier cycle, SEDS/PBP polymerization, and peptidoglycan
-    remodeling so those systems can be curated as separate reusable modules.
+    terms. No PANTHER family or PAINT ancestral-node identifier is asserted:
+    the checked-in family-member index does not contain most reviewed
+    cross-species exemplars, and the shared MurE family does not distinguish
+    DAP from L-lysine specificity. The module intentionally excludes amino-acid
+    precursor supply, undecaprenyl-carrier synthesis and recycling, SEDS/PBP
+    polymerization and cross-linking, and peptidoglycan remodeling.

--- a/modules/peptidoglycan_precursor_biosynthesis.yaml
+++ b/modules/peptidoglycan_precursor_biosynthesis.yaml
@@ -24,6 +24,12 @@ evidence:
       The module-level review supports the ordered MurA-to-MurJ pathway,
       convergent D-Ala-D-Ala input, third-residue variation, and the boundary
       before glycan polymerization and peptide cross-linking.
+  - source_id: file:projects/P_PUTIDA/deep-research/PSEPK__peptidoglycan_precursor_biosynthesis__ppu00550-deep-research-openscientist.md
+    title: OpenScientist PSEPK ppu00550 pathway satisfiability review
+    statement: >-
+      The species-aware review finds all precursor and lipid II export steps
+      covered, identifies MurJ as a transporter omitted by the KEGG candidate
+      bucket, and distinguishes Ddl paralogs from upstream amino-acid supply.
 module:
   id: peptidoglycan_precursor_biosynthesis
   label: Peptidoglycan precursor biosynthesis and lipid II export
@@ -55,6 +61,10 @@ module:
                     term:
                       id: UniProtKB:P0A749
                       label: UDP-N-acetylglucosamine 1-carboxyvinyltransferase
+                  - preferred_term: PSEPK MurA
+                    term:
+                      id: UniProtKB:Q88P88
+                      label: UDP-N-acetylglucosamine 1-carboxyvinyltransferase
             function:
               preferred_term: UDP-N-acetylglucosamine 1-carboxyvinyltransferase activity
               term:
@@ -85,6 +95,10 @@ module:
                     term:
                       id: UniProtKB:P08373
                       label: UDP-N-acetylenolpyruvoylglucosamine reductase
+                  - preferred_term: PSEPK MurB
+                    term:
+                      id: UniProtKB:Q88LM5
+                      label: UDP-N-acetylmuramate dehydrogenase
             function:
               preferred_term: UDP-N-acetylmuramate dehydrogenase activity
               term:
@@ -117,6 +131,10 @@ module:
                     term:
                       id: UniProtKB:P17952
                       label: UDP-N-acetylmuramate-L-alanine ligase
+                  - preferred_term: PSEPK MurC
+                    term:
+                      id: UniProtKB:Q88N75
+                      label: UDP-N-acetylmuramate-L-alanine ligase
             function:
               preferred_term: UDP-N-acetylmuramate-L-alanine ligase activity
               term:
@@ -148,6 +166,10 @@ module:
                   - preferred_term: Escherichia coli K-12 MurD
                     term:
                       id: UniProtKB:P14900
+                      label: UDP-N-acetylmuramoylalanine-D-glutamate ligase
+                  - preferred_term: PSEPK MurD
+                    term:
+                      id: UniProtKB:Q88N78
                       label: UDP-N-acetylmuramoylalanine-D-glutamate ligase
             function:
               preferred_term: UDP-N-acetylmuramoylalanine-D-glutamate ligase activity
@@ -189,6 +211,10 @@ module:
                           - preferred_term: Escherichia coli K-12 DAP-specific MurE
                             term:
                               id: UniProtKB:P22188
+                              label: UDP-N-acetylmuramoyl-L-alanyl-D-glutamate--2,6-diaminopimelate ligase
+                          - preferred_term: PSEPK DAP-specific MurE
+                            term:
+                              id: UniProtKB:Q88N81
                               label: UDP-N-acetylmuramoyl-L-alanyl-D-glutamate--2,6-diaminopimelate ligase
                     function:
                       preferred_term: UDP-N-acetylmuramoylalanyl-D-glutamate-2,6-diaminopimelate ligase activity
@@ -251,6 +277,14 @@ module:
                     term:
                       id: UniProtKB:P07862
                       label: D-alanine--D-alanine ligase B
+                  - preferred_term: PSEPK DdlB
+                    term:
+                      id: UniProtKB:Q88N74
+                      label: D-alanine--D-alanine ligase B
+                  - preferred_term: PSEPK DdlA
+                    term:
+                      id: UniProtKB:Q88EV6
+                      label: D-alanine--D-alanine ligase A
             function:
               preferred_term: D-alanine-D-alanine ligase activity
               term:
@@ -282,6 +316,10 @@ module:
                   - preferred_term: Escherichia coli K-12 MurF
                     term:
                       id: UniProtKB:P11880
+                      label: UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase
+                  - preferred_term: PSEPK MurF
+                    term:
+                      id: UniProtKB:Q88N80
                       label: UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase
             function:
               preferred_term: UDP-N-acetylmuramoyl-tripeptide-D-alanyl-D-alanine ligase activity
@@ -315,6 +353,10 @@ module:
                     term:
                       id: UniProtKB:P0A6W3
                       label: Phospho-N-acetylmuramoyl-pentapeptide-transferase
+                  - preferred_term: PSEPK MraY
+                    term:
+                      id: UniProtKB:Q88N79
+                      label: Phospho-N-acetylmuramoyl-pentapeptide-transferase
             function:
               preferred_term: phospho-N-acetylmuramoyl-pentapeptide-transferase activity
               term:
@@ -326,6 +368,11 @@ module:
               products:
                 - preferred_term: lipid I
                 - preferred_term: UMP
+            locations:
+              - preferred_term: plasma membrane
+                term:
+                  id: GO:0005886
+                  label: plasma membrane
             role_description: Transfers phospho-MurNAc-pentapeptide to the lipid carrier.
     - order: 9
       role: lipid II formation
@@ -345,6 +392,10 @@ module:
                     term:
                       id: UniProtKB:P17443
                       label: UDP-N-acetylglucosamine--N-acetylmuramyl-(pentapeptide) pyrophosphoryl-undecaprenol N-acetylglucosamine transferase
+                  - preferred_term: PSEPK MurG
+                    term:
+                      id: UniProtKB:Q88N76
+                      label: UDP-N-acetylglucosamine--N-acetylmuramyl-pentapeptide transferase
             function:
               preferred_term: undecaprenyldiphospho-muramoylpentapeptide beta-N-acetylglucosaminyltransferase activity
               term:
@@ -356,6 +407,11 @@ module:
               products:
                 - preferred_term: lipid II
                 - preferred_term: UDP
+            locations:
+              - preferred_term: plasma membrane
+                term:
+                  id: GO:0005886
+                  label: plasma membrane
             role_description: Adds GlcNAc to lipid I to generate lipid II.
     - order: 10
       role: lipid II translocation
@@ -375,6 +431,10 @@ module:
                     term:
                       id: UniProtKB:P0AF16
                       label: Lipid II flippase MurJ
+                  - preferred_term: PSEPK MurJ
+                    term:
+                      id: UniProtKB:Q88Q94
+                      label: Lipid II flippase MurJ
             function:
               preferred_term: lipid-linked peptidoglycan transporter activity
               term:
@@ -384,6 +444,11 @@ module:
                 - preferred_term: lipid II on the cytoplasmic membrane leaflet
               products:
                 - preferred_term: lipid II on the periplasmic membrane leaflet
+            locations:
+              - preferred_term: plasma membrane
+                term:
+                  id: GO:0005886
+                  label: plasma membrane
             role_description: Exports lipid II for periplasmic polymerization.
   connections:
     - source: murA_enolpyruvyl_transfer
@@ -424,9 +489,10 @@ module:
       description: MurG produces lipid II for MurJ-mediated export.
   notes: >-
     Reviewed Escherichia coli K-12 proteins ground the conserved DAP-containing
-    route, and reviewed Staphylococcus aureus MurE grounds the alternative
-    L-lysine branch. MurF, MraY, and MurG use pentapeptide-generic molecular
-    functions so the module remains valid downstream of either MurE branch;
+    route, KT2440 representatives preserve traceability to the PSEPK pathway
+    satisfiability audit, and reviewed Staphylococcus aureus MurE grounds the
+    alternative L-lysine branch. MurF, MraY, and MurG use pentapeptide-generic
+    molecular functions so the module remains valid downstream of either MurE branch;
     species-level gene reviews may use the corresponding stem-specific child
     terms. No PANTHER family or PAINT ancestral-node identifier is asserted:
     the checked-in family-member index does not contain most reviewed

--- a/pages/modules/peptidoglycan_precursor_biosynthesis.html
+++ b/pages/modules/peptidoglycan_precursor_biosynthesis.html
@@ -552,11 +552,11 @@
     </nav>
 
     <header class="header">
-        <h1>Peptidoglycan precursor biosynthesis and lipid II export</h1>            <p class="description">A reusable bacterial pathway that converts UDP-N-acetylglucosamine to UDP-MurNAc-pentapeptide, transfers that nucleotide precursor to the undecaprenyl carrier to form lipid I, glycosylates lipid I to form lipid II, and translocates lipid II across the cytoplasmic membrane. D-Ala-D-Ala synthesis is modeled as a convergent input to MurF, and alternative MurE branches represent meso-diaminopimelate- and L-lysine-containing stem peptides. The module ends at lipid II export and does not include glycan polymerization, peptide cross-linking, carrier recycling, or cell-wall remodeling.</p>        <div class="meta-row"><span class="pill">MODULE:peptidoglycan_precursor_biosynthesis</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/peptidoglycan_precursor_biosynthesis.yaml</span>
+        <h1>Peptidoglycan precursor biosynthesis and lipid II export</h1>            <p class="description">A reusable bacterial pathway that converts UDP-N-acetylglucosamine to UDP-MurNAc-pentapeptide, transfers that nucleotide precursor to the undecaprenyl carrier to form lipid I, glycosylates lipid I to form lipid II, and translocates lipid II across the cytoplasmic membrane. D-Ala-D-Ala synthesis is modeled as a convergent input to MurF, and alternative MurE branches represent meso-diaminopimelate- and L-lysine-containing stem peptides. The module ends at lipid II export and does not include glycan polymerization, peptide cross-linking, carrier recycling, or cell-wall remodeling.</p>        <div class="meta-row"><span class="pill">MODULE:peptidoglycan_precursor_biosynthesis</span><span class="pill status">DRAFT</span><span class="pill scope">CONCRETE</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/peptidoglycan_precursor_biosynthesis.yaml</span>
         </div>
         <div class="descriptor-list">                <span class="descriptor">
             <span>peptidoglycan biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009252" target="_blank" rel="noopener">GO:0009252</a></span>        </div>
-        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0009252" target="_blank" rel="noopener">GO:0009252</a><div><strong>peptidoglycan biosynthetic process</strong></div><div>GO:0009252 supplies the biological-process scope for nucleotide, lipid-linked, and exported peptidoglycan precursor formation.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/peptidoglycan_precursor_biosynthesis-deep-research-openscientist.md</span><div><strong>OpenScientist research for the reusable peptidoglycan precursor module</strong></div><div>The module-level review supports the ordered MurA-to-MurJ pathway, convergent D-Ala-D-Ala input, third-residue variation, and the boundary before glycan polymerization and peptide cross-linking.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__peptidoglycan_precursor_biosynthesis__ppu00550-deep-research-openscientist.md</span><div><strong>OpenScientist PSEPK ppu00550 pathway satisfiability review</strong></div><div>The species-aware review finds all precursor and lipid II export steps covered, identifies MurJ as a transporter omitted by the KEGG candidate bucket, and distinguishes Ddl paralogs from upstream amino-acid supply.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/murA/murA-ai-review.yaml</span><div><strong>PSEPK murA gene review</strong></div><div>UniProt identifies Q88P88 as the UDP-N-acetylglucosamine 1-carboxyvinyltransferase that starts MurNAc precursor synthesis.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/mraY/mraY-ai-review.yaml</span><div><strong>PSEPK mraY gene review</strong></div><div>The KT2440 review identifies Q88N79 as the membrane phosphotransferase that forms lipid I from UDP-MurNAc-pentapeptide.</div></div>                <div class="evidence-card small"><span class="source-id">file:PSEPK/murJ/murJ-ai-review.yaml</span><div><strong>PSEPK murJ gene review</strong></div><div>UniProt identifies Q88Q94 as the lipid II flippase that connects cytoplasmic precursor synthesis to periplasmic assembly.</div></div>        </div></header>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0009252" target="_blank" rel="noopener">GO:0009252</a><div><strong>peptidoglycan biosynthetic process</strong></div><div>GO:0009252 supplies the biological-process scope for nucleotide, lipid-linked, and exported peptidoglycan precursor formation.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/peptidoglycan_precursor_biosynthesis-deep-research-openscientist.md</span><div><strong>OpenScientist research for the reusable peptidoglycan precursor module</strong></div><div>The module-level review supports the ordered MurA-to-MurJ pathway, convergent D-Ala-D-Ala input, third-residue variation, and the boundary before glycan polymerization and peptide cross-linking.</div></div>        </div></header>
     <section class="stats" aria-label="Module counts">
         <div class="stat"><span class="stat-value">13</span><span class="stat-label">Nodes</span></div>
         <div class="stat"><span class="stat-value">10</span><span class="stat-label">Parts</span></div>
@@ -584,11 +584,11 @@
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(11/12 grounded genes reviewed)</span>
+                    <span class="muted small">(0/11 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        11 complete review(s) &middot;
-                        11 with deep research &middot;
-                        1 missing review &middot;
+                        0 complete review(s) &middot;
+                        0 with deep research &middot;
+                        11 missing review &middot;
                         0 reviewed but lacking deep research
                     </p>
                     <table class="qc-table small">
@@ -601,71 +601,65 @@
                             </tr>
                         </thead>
                         <tbody>                                <tr>
-                                    <td>ddlA
-                                        <span class="muted term-id">Q88EV6</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td>Escherichia coli K-12 DdlB
+                                        <span class="muted term-id">P07862</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>ddlB
-                                        <span class="muted term-id">Q88N74</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td>Escherichia coli K-12 MurB
+                                        <span class="muted term-id">P08373</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>mraY
-                                        <span class="muted term-id">Q88N79</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td>Escherichia coli K-12 MraY
+                                        <span class="muted term-id">P0A6W3</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>murA
-                                        <span class="muted term-id">Q88P88</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td>Escherichia coli K-12 MurA
+                                        <span class="muted term-id">P0A749</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>murB
-                                        <span class="muted term-id">Q88LM5</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td>Escherichia coli K-12 MurJ
+                                        <span class="muted term-id">P0AF16</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>murC
-                                        <span class="muted term-id">Q88N75</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td>Escherichia coli K-12 MurF
+                                        <span class="muted term-id">P11880</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>murD
-                                        <span class="muted term-id">Q88N78</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td>Escherichia coli K-12 MurD
+                                        <span class="muted term-id">P14900</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>murE
-                                        <span class="muted term-id">Q88N81</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td>Escherichia coli K-12 MurG
+                                        <span class="muted term-id">P17443</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>murF
-                                        <span class="muted term-id">Q88N80</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td>Escherichia coli K-12 MurC
+                                        <span class="muted term-id">P17952</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>murG
-                                        <span class="muted term-id">Q88N76</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                </tr>                                <tr>
-                                    <td>murJ
-                                        <span class="muted term-id">Q88Q94</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
-                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td>Escherichia coli K-12 DAP-specific MurE
+                                        <span class="muted term-id">P22188</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                    <td class="center">&mdash;</td>
+                                    <td class="center">&mdash;</td>
                                 </tr>                                <tr>
                                     <td>Staphylococcus aureus L-lysine-specific MurE
                                         <span class="muted term-id">Q2FZP6</span></td>
@@ -898,7 +892,7 @@
         </div><div class="descriptor-list">                <span class="descriptor">
             <span>peptidoglycan biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009252" target="_blank" rel="noopener">GO:0009252</a></span>        </div>
 
-        <p class="muted small">The module is taxon-neutral but uses exact KT2440 and reviewed Staphylococcus accessions as representative members. MurF, MraY, and MurG use pentapeptide-generic molecular functions here so the module remains valid downstream of either the DAP- or L-lysine-specific MurE branch; species-level gene reviews may use the corresponding stem-specific child terms. The module intentionally excludes amino-acid precursor supply, the undecaprenyl carrier cycle, SEDS/PBP polymerization, and peptidoglycan remodeling so those systems can be curated as separate reusable modules.</p>            <h4>Connections</h4>
+        <p class="muted small">Reviewed Escherichia coli K-12 proteins ground the conserved DAP-containing route, and reviewed Staphylococcus aureus MurE grounds the alternative L-lysine branch. MurF, MraY, and MurG use pentapeptide-generic molecular functions so the module remains valid downstream of either MurE branch; species-level gene reviews may use the corresponding stem-specific child terms. No PANTHER family or PAINT ancestral-node identifier is asserted: the checked-in family-member index does not contain most reviewed cross-species exemplars, and the shared MurE family does not distinguish DAP from L-lysine specificity. The module intentionally excludes amino-acid precursor supply, undecaprenyl-carrier synthesis and recycling, SEDS/PBP polymerization and cross-linking, and peptidoglycan remodeling.</p>            <h4>Connections</h4>
             <div class="connection-list">                <div class="connection-card small">
                     <div>
                         <a href="#node-mura_enolpyruvyl_transfer">murA_enolpyruvyl_transfer</a>
@@ -969,7 +963,7 @@
                         <div class="descriptor">
             <span><strong>MurA UDP-N-acetylglucosamine 1-carboxyvinyltransferases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>PSEPK MurA</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88P88/entry" target="_blank" rel="noopener">UniProtKB:Q88P88</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurA</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0A749/entry" target="_blank" rel="noopener">UniProtKB:P0A749</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylglucosamine 1-carboxyvinyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008760" target="_blank" rel="noopener">GO:0008760</a>                    <div class="slot-row">
@@ -994,7 +988,7 @@
                         <div class="descriptor">
             <span><strong>MurB UDP-N-acetylmuramate dehydrogenases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>PSEPK MurB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88LM5/entry" target="_blank" rel="noopener">UniProtKB:Q88LM5</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P08373/entry" target="_blank" rel="noopener">UniProtKB:P08373</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylmuramate dehydrogenase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008762" target="_blank" rel="noopener">GO:0008762</a>                    <div class="slot-row">
@@ -1021,7 +1015,7 @@
                         <div class="descriptor">
             <span><strong>MurC UDP-N-acetylmuramate-L-alanine ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>PSEPK MurC</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N75/entry" target="_blank" rel="noopener">UniProtKB:Q88N75</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurC</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P17952/entry" target="_blank" rel="noopener">UniProtKB:P17952</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylmuramate-L-alanine ligase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008763" target="_blank" rel="noopener">GO:0008763</a>                    <div class="slot-row">
@@ -1048,7 +1042,7 @@
                         <div class="descriptor">
             <span><strong>MurD UDP-MurNAc-L-Ala-D-Glu ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>PSEPK MurD</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N78/entry" target="_blank" rel="noopener">UniProtKB:Q88N78</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurD</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P14900/entry" target="_blank" rel="noopener">UniProtKB:P14900</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylmuramoylalanine-D-glutamate ligase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008764" target="_blank" rel="noopener">GO:0008764</a>                    <div class="slot-row">
@@ -1083,7 +1077,7 @@
                         <div class="descriptor">
             <span><strong>meso-diaminopimelate-specific MurE ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>PSEPK DAP-specific MurE</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N81/entry" target="_blank" rel="noopener">UniProtKB:Q88N81</a></span>                    </div></div>
+            <span>Escherichia coli K-12 DAP-specific MurE</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P22188/entry" target="_blank" rel="noopener">UniProtKB:P22188</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylmuramoylalanyl-D-glutamate-2,6-diaminopimelate ligase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008765" target="_blank" rel="noopener">GO:0008765</a>                    <div class="slot-row">
@@ -1135,8 +1129,7 @@
                         <div class="descriptor">
             <span><strong>D-alanine-D-alanine ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>PSEPK DdlB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N74/entry" target="_blank" rel="noopener">UniProtKB:Q88N74</a></span>                            <span class="descriptor">
-            <span>PSEPK DdlA</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88EV6/entry" target="_blank" rel="noopener">UniProtKB:Q88EV6</a></span>                    </div></div>
+            <span>Escherichia coli K-12 DdlB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P07862/entry" target="_blank" rel="noopener">UniProtKB:P07862</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>D-alanine-D-alanine ligase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008716" target="_blank" rel="noopener">GO:0008716</a>                    <div class="slot-row">
@@ -1163,7 +1156,7 @@
                         <div class="descriptor">
             <span><strong>MurF UDP-MurNAc-tripeptide-D-Ala-D-Ala ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>PSEPK MurF</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N80/entry" target="_blank" rel="noopener">UniProtKB:Q88N80</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurF</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P11880/entry" target="_blank" rel="noopener">UniProtKB:P11880</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylmuramoyl-tripeptide-D-alanyl-D-alanine ligase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047480" target="_blank" rel="noopener">GO:0047480</a>                    <div class="slot-row">
@@ -1190,7 +1183,7 @@
                         <div class="descriptor">
             <span><strong>MraY phospho-MurNAc-pentapeptide transferases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>PSEPK MraY</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N79/entry" target="_blank" rel="noopener">UniProtKB:Q88N79</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MraY</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0A6W3/entry" target="_blank" rel="noopener">UniProtKB:P0A6W3</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>phospho-N-acetylmuramoyl-pentapeptide-transferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008963" target="_blank" rel="noopener">GO:0008963</a>                    <div class="slot-row">
@@ -1199,9 +1192,7 @@
             <span>undecaprenyl phosphate</span></span>                    </div>                    <div class="slot-row">
                         <span class="slot-name">Products:</span>                            <span class="descriptor">
             <span>lipid I</span></span>                            <span class="descriptor">
-            <span>UMP</span></span>                    </div></div>            <h4>Locations</h4>
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>            <p class="role-description">Transfers phospho-MurNAc-pentapeptide to the lipid carrier.</p></article>            </div>    </section>                <div class="part-marker">
+            <span>UMP</span></span>                    </div></div>            <p class="role-description">Transfers phospho-MurNAc-pentapeptide to the lipid carrier.</p></article>            </div>    </section>                <div class="part-marker">
                     Part 9: lipid II formation</div>
                 <section class="node-detail depth-1" id="node-murg_lipid_ii_synthesis">
         <div class="node-heading">
@@ -1217,7 +1208,7 @@
                         <div class="descriptor">
             <span><strong>MurG lipid I N-acetylglucosaminyltransferases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>PSEPK MurG</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N76/entry" target="_blank" rel="noopener">UniProtKB:Q88N76</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurG</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P17443/entry" target="_blank" rel="noopener">UniProtKB:P17443</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>undecaprenyldiphospho-muramoylpentapeptide beta-N-acetylglucosaminyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0050511" target="_blank" rel="noopener">GO:0050511</a>                    <div class="slot-row">
@@ -1226,9 +1217,7 @@
             <span>UDP-N-acetylglucosamine</span></span>                    </div>                    <div class="slot-row">
                         <span class="slot-name">Products:</span>                            <span class="descriptor">
             <span>lipid II</span></span>                            <span class="descriptor">
-            <span>UDP</span></span>                    </div></div>            <h4>Locations</h4>
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>            <p class="role-description">Adds GlcNAc to lipid I to generate lipid II.</p></article>            </div>    </section>                <div class="part-marker">
+            <span>UDP</span></span>                    </div></div>            <p class="role-description">Adds GlcNAc to lipid I to generate lipid II.</p></article>            </div>    </section>                <div class="part-marker">
                     Part 10: lipid II translocation</div>
                 <section class="node-detail depth-1" id="node-murj_lipid_ii_export">
         <div class="node-heading">
@@ -1244,16 +1233,14 @@
                         <div class="descriptor">
             <span><strong>MurJ/MviN lipid II flippases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>PSEPK MurJ</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88Q94/entry" target="_blank" rel="noopener">UniProtKB:Q88Q94</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurJ</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0AF16/entry" target="_blank" rel="noopener">UniProtKB:P0AF16</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>lipid-linked peptidoglycan transporter activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0015648" target="_blank" rel="noopener">GO:0015648</a>                    <div class="slot-row">
                         <span class="slot-name">Substrates:</span>                            <span class="descriptor">
             <span>lipid II on the cytoplasmic membrane leaflet</span></span>                    </div>                    <div class="slot-row">
                         <span class="slot-name">Products:</span>                            <span class="descriptor">
-            <span>lipid II on the periplasmic membrane leaflet</span></span>                    </div></div>            <h4>Locations</h4>
-            <div class="descriptor-list">                <span class="descriptor">
-            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>            <p class="role-description">Exports lipid II for periplasmic polymerization.</p></article>            </div>    </section>    </section>
+            <span>lipid II on the periplasmic membrane leaflet</span></span>                    </div></div>            <p class="role-description">Exports lipid II for periplasmic polymerization.</p></article>            </div>    </section>    </section>
             </div>
         </section>
     </section>

--- a/pages/modules/peptidoglycan_precursor_biosynthesis.html
+++ b/pages/modules/peptidoglycan_precursor_biosynthesis.html
@@ -556,7 +556,7 @@
         </div>
         <div class="descriptor-list">                <span class="descriptor">
             <span>peptidoglycan biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009252" target="_blank" rel="noopener">GO:0009252</a></span>        </div>
-        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0009252" target="_blank" rel="noopener">GO:0009252</a><div><strong>peptidoglycan biosynthetic process</strong></div><div>GO:0009252 supplies the biological-process scope for nucleotide, lipid-linked, and exported peptidoglycan precursor formation.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/peptidoglycan_precursor_biosynthesis-deep-research-openscientist.md</span><div><strong>OpenScientist research for the reusable peptidoglycan precursor module</strong></div><div>The module-level review supports the ordered MurA-to-MurJ pathway, convergent D-Ala-D-Ala input, third-residue variation, and the boundary before glycan polymerization and peptide cross-linking.</div></div>        </div></header>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0009252" target="_blank" rel="noopener">GO:0009252</a><div><strong>peptidoglycan biosynthetic process</strong></div><div>GO:0009252 supplies the biological-process scope for nucleotide, lipid-linked, and exported peptidoglycan precursor formation.</div></div>                <div class="evidence-card small"><span class="source-id">file:modules/peptidoglycan_precursor_biosynthesis-deep-research-openscientist.md</span><div><strong>OpenScientist research for the reusable peptidoglycan precursor module</strong></div><div>The module-level review supports the ordered MurA-to-MurJ pathway, convergent D-Ala-D-Ala input, third-residue variation, and the boundary before glycan polymerization and peptide cross-linking.</div></div>                <div class="evidence-card small"><span class="source-id">file:projects/P_PUTIDA/deep-research/PSEPK__peptidoglycan_precursor_biosynthesis__ppu00550-deep-research-openscientist.md</span><div><strong>OpenScientist PSEPK ppu00550 pathway satisfiability review</strong></div><div>The species-aware review finds all precursor and lipid II export steps covered, identifies MurJ as a transporter omitted by the KEGG candidate bucket, and distinguishes Ddl paralogs from upstream amino-acid supply.</div></div>        </div></header>
     <section class="stats" aria-label="Module counts">
         <div class="stat"><span class="stat-value">13</span><span class="stat-label">Nodes</span></div>
         <div class="stat"><span class="stat-value">10</span><span class="stat-label">Parts</span></div>
@@ -584,10 +584,10 @@
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(0/11 grounded genes reviewed)</span>
+                    <span class="muted small">(11/22 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        0 complete review(s) &middot;
-                        0 with deep research &middot;
+                        11 complete review(s) &middot;
+                        11 with deep research &middot;
                         11 missing review &middot;
                         0 reviewed but lacking deep research
                     </p>
@@ -601,6 +601,72 @@
                             </tr>
                         </thead>
                         <tbody>                                <tr>
+                                    <td>ddlA
+                                        <span class="muted term-id">Q88EV6</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>ddlB
+                                        <span class="muted term-id">Q88N74</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>mraY
+                                        <span class="muted term-id">Q88N79</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>murA
+                                        <span class="muted term-id">Q88P88</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>murB
+                                        <span class="muted term-id">Q88LM5</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>murC
+                                        <span class="muted term-id">Q88N75</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>murD
+                                        <span class="muted term-id">Q88N78</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>murE
+                                        <span class="muted term-id">Q88N81</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>murF
+                                        <span class="muted term-id">Q88N80</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>murG
+                                        <span class="muted term-id">Q88N76</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>murJ
+                                        <span class="muted term-id">Q88Q94</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
                                     <td>Escherichia coli K-12 DdlB
                                         <span class="muted term-id">P07862</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
@@ -892,7 +958,7 @@
         </div><div class="descriptor-list">                <span class="descriptor">
             <span>peptidoglycan biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009252" target="_blank" rel="noopener">GO:0009252</a></span>        </div>
 
-        <p class="muted small">Reviewed Escherichia coli K-12 proteins ground the conserved DAP-containing route, and reviewed Staphylococcus aureus MurE grounds the alternative L-lysine branch. MurF, MraY, and MurG use pentapeptide-generic molecular functions so the module remains valid downstream of either MurE branch; species-level gene reviews may use the corresponding stem-specific child terms. No PANTHER family or PAINT ancestral-node identifier is asserted: the checked-in family-member index does not contain most reviewed cross-species exemplars, and the shared MurE family does not distinguish DAP from L-lysine specificity. The module intentionally excludes amino-acid precursor supply, undecaprenyl-carrier synthesis and recycling, SEDS/PBP polymerization and cross-linking, and peptidoglycan remodeling.</p>            <h4>Connections</h4>
+        <p class="muted small">Reviewed Escherichia coli K-12 proteins ground the conserved DAP-containing route, KT2440 representatives preserve traceability to the PSEPK pathway satisfiability audit, and reviewed Staphylococcus aureus MurE grounds the alternative L-lysine branch. MurF, MraY, and MurG use pentapeptide-generic molecular functions so the module remains valid downstream of either MurE branch; species-level gene reviews may use the corresponding stem-specific child terms. No PANTHER family or PAINT ancestral-node identifier is asserted: the checked-in family-member index does not contain most reviewed cross-species exemplars, and the shared MurE family does not distinguish DAP from L-lysine specificity. The module intentionally excludes amino-acid precursor supply, undecaprenyl-carrier synthesis and recycling, SEDS/PBP polymerization and cross-linking, and peptidoglycan remodeling.</p>            <h4>Connections</h4>
             <div class="connection-list">                <div class="connection-card small">
                     <div>
                         <a href="#node-mura_enolpyruvyl_transfer">murA_enolpyruvyl_transfer</a>
@@ -963,7 +1029,8 @@
                         <div class="descriptor">
             <span><strong>MurA UDP-N-acetylglucosamine 1-carboxyvinyltransferases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>Escherichia coli K-12 MurA</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0A749/entry" target="_blank" rel="noopener">UniProtKB:P0A749</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurA</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0A749/entry" target="_blank" rel="noopener">UniProtKB:P0A749</a></span>                            <span class="descriptor">
+            <span>PSEPK MurA</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88P88/entry" target="_blank" rel="noopener">UniProtKB:Q88P88</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylglucosamine 1-carboxyvinyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008760" target="_blank" rel="noopener">GO:0008760</a>                    <div class="slot-row">
@@ -988,7 +1055,8 @@
                         <div class="descriptor">
             <span><strong>MurB UDP-N-acetylmuramate dehydrogenases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>Escherichia coli K-12 MurB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P08373/entry" target="_blank" rel="noopener">UniProtKB:P08373</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P08373/entry" target="_blank" rel="noopener">UniProtKB:P08373</a></span>                            <span class="descriptor">
+            <span>PSEPK MurB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88LM5/entry" target="_blank" rel="noopener">UniProtKB:Q88LM5</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylmuramate dehydrogenase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008762" target="_blank" rel="noopener">GO:0008762</a>                    <div class="slot-row">
@@ -1015,7 +1083,8 @@
                         <div class="descriptor">
             <span><strong>MurC UDP-N-acetylmuramate-L-alanine ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>Escherichia coli K-12 MurC</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P17952/entry" target="_blank" rel="noopener">UniProtKB:P17952</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurC</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P17952/entry" target="_blank" rel="noopener">UniProtKB:P17952</a></span>                            <span class="descriptor">
+            <span>PSEPK MurC</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N75/entry" target="_blank" rel="noopener">UniProtKB:Q88N75</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylmuramate-L-alanine ligase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008763" target="_blank" rel="noopener">GO:0008763</a>                    <div class="slot-row">
@@ -1042,7 +1111,8 @@
                         <div class="descriptor">
             <span><strong>MurD UDP-MurNAc-L-Ala-D-Glu ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>Escherichia coli K-12 MurD</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P14900/entry" target="_blank" rel="noopener">UniProtKB:P14900</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurD</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P14900/entry" target="_blank" rel="noopener">UniProtKB:P14900</a></span>                            <span class="descriptor">
+            <span>PSEPK MurD</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N78/entry" target="_blank" rel="noopener">UniProtKB:Q88N78</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylmuramoylalanine-D-glutamate ligase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008764" target="_blank" rel="noopener">GO:0008764</a>                    <div class="slot-row">
@@ -1077,7 +1147,8 @@
                         <div class="descriptor">
             <span><strong>meso-diaminopimelate-specific MurE ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>Escherichia coli K-12 DAP-specific MurE</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P22188/entry" target="_blank" rel="noopener">UniProtKB:P22188</a></span>                    </div></div>
+            <span>Escherichia coli K-12 DAP-specific MurE</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P22188/entry" target="_blank" rel="noopener">UniProtKB:P22188</a></span>                            <span class="descriptor">
+            <span>PSEPK DAP-specific MurE</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N81/entry" target="_blank" rel="noopener">UniProtKB:Q88N81</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylmuramoylalanyl-D-glutamate-2,6-diaminopimelate ligase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008765" target="_blank" rel="noopener">GO:0008765</a>                    <div class="slot-row">
@@ -1129,7 +1200,9 @@
                         <div class="descriptor">
             <span><strong>D-alanine-D-alanine ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>Escherichia coli K-12 DdlB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P07862/entry" target="_blank" rel="noopener">UniProtKB:P07862</a></span>                    </div></div>
+            <span>Escherichia coli K-12 DdlB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P07862/entry" target="_blank" rel="noopener">UniProtKB:P07862</a></span>                            <span class="descriptor">
+            <span>PSEPK DdlB</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N74/entry" target="_blank" rel="noopener">UniProtKB:Q88N74</a></span>                            <span class="descriptor">
+            <span>PSEPK DdlA</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88EV6/entry" target="_blank" rel="noopener">UniProtKB:Q88EV6</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>D-alanine-D-alanine ligase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008716" target="_blank" rel="noopener">GO:0008716</a>                    <div class="slot-row">
@@ -1156,7 +1229,8 @@
                         <div class="descriptor">
             <span><strong>MurF UDP-MurNAc-tripeptide-D-Ala-D-Ala ligases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>Escherichia coli K-12 MurF</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P11880/entry" target="_blank" rel="noopener">UniProtKB:P11880</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurF</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P11880/entry" target="_blank" rel="noopener">UniProtKB:P11880</a></span>                            <span class="descriptor">
+            <span>PSEPK MurF</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N80/entry" target="_blank" rel="noopener">UniProtKB:Q88N80</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>UDP-N-acetylmuramoyl-tripeptide-D-alanyl-D-alanine ligase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047480" target="_blank" rel="noopener">GO:0047480</a>                    <div class="slot-row">
@@ -1183,7 +1257,8 @@
                         <div class="descriptor">
             <span><strong>MraY phospho-MurNAc-pentapeptide transferases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>Escherichia coli K-12 MraY</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0A6W3/entry" target="_blank" rel="noopener">UniProtKB:P0A6W3</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MraY</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0A6W3/entry" target="_blank" rel="noopener">UniProtKB:P0A6W3</a></span>                            <span class="descriptor">
+            <span>PSEPK MraY</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N79/entry" target="_blank" rel="noopener">UniProtKB:Q88N79</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>phospho-N-acetylmuramoyl-pentapeptide-transferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008963" target="_blank" rel="noopener">GO:0008963</a>                    <div class="slot-row">
@@ -1192,7 +1267,9 @@
             <span>undecaprenyl phosphate</span></span>                    </div>                    <div class="slot-row">
                         <span class="slot-name">Products:</span>                            <span class="descriptor">
             <span>lipid I</span></span>                            <span class="descriptor">
-            <span>UMP</span></span>                    </div></div>            <p class="role-description">Transfers phospho-MurNAc-pentapeptide to the lipid carrier.</p></article>            </div>    </section>                <div class="part-marker">
+            <span>UMP</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>            <p class="role-description">Transfers phospho-MurNAc-pentapeptide to the lipid carrier.</p></article>            </div>    </section>                <div class="part-marker">
                     Part 9: lipid II formation</div>
                 <section class="node-detail depth-1" id="node-murg_lipid_ii_synthesis">
         <div class="node-heading">
@@ -1208,7 +1285,8 @@
                         <div class="descriptor">
             <span><strong>MurG lipid I N-acetylglucosaminyltransferases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>Escherichia coli K-12 MurG</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P17443/entry" target="_blank" rel="noopener">UniProtKB:P17443</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurG</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P17443/entry" target="_blank" rel="noopener">UniProtKB:P17443</a></span>                            <span class="descriptor">
+            <span>PSEPK MurG</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88N76/entry" target="_blank" rel="noopener">UniProtKB:Q88N76</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>undecaprenyldiphospho-muramoylpentapeptide beta-N-acetylglucosaminyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0050511" target="_blank" rel="noopener">GO:0050511</a>                    <div class="slot-row">
@@ -1217,7 +1295,9 @@
             <span>UDP-N-acetylglucosamine</span></span>                    </div>                    <div class="slot-row">
                         <span class="slot-name">Products:</span>                            <span class="descriptor">
             <span>lipid II</span></span>                            <span class="descriptor">
-            <span>UDP</span></span>                    </div></div>            <p class="role-description">Adds GlcNAc to lipid I to generate lipid II.</p></article>            </div>    </section>                <div class="part-marker">
+            <span>UDP</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>            <p class="role-description">Adds GlcNAc to lipid I to generate lipid II.</p></article>            </div>    </section>                <div class="part-marker">
                     Part 10: lipid II translocation</div>
                 <section class="node-detail depth-1" id="node-murj_lipid_ii_export">
         <div class="node-heading">
@@ -1233,14 +1313,17 @@
                         <div class="descriptor">
             <span><strong>MurJ/MviN lipid II flippases</strong></span>                    <div class="slot-row">
                         <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
-            <span>Escherichia coli K-12 MurJ</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0AF16/entry" target="_blank" rel="noopener">UniProtKB:P0AF16</a></span>                    </div></div>
+            <span>Escherichia coli K-12 MurJ</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P0AF16/entry" target="_blank" rel="noopener">UniProtKB:P0AF16</a></span>                            <span class="descriptor">
+            <span>PSEPK MurJ</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q88Q94/entry" target="_blank" rel="noopener">UniProtKB:Q88Q94</a></span>                    </div></div>
                     </div></div>            <h4>Function</h4>
             <div class="descriptor">
             <span><strong>lipid-linked peptidoglycan transporter activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0015648" target="_blank" rel="noopener">GO:0015648</a>                    <div class="slot-row">
                         <span class="slot-name">Substrates:</span>                            <span class="descriptor">
             <span>lipid II on the cytoplasmic membrane leaflet</span></span>                    </div>                    <div class="slot-row">
                         <span class="slot-name">Products:</span>                            <span class="descriptor">
-            <span>lipid II on the periplasmic membrane leaflet</span></span>                    </div></div>            <p class="role-description">Exports lipid II for periplasmic polymerization.</p></article>            </div>    </section>    </section>
+            <span>lipid II on the periplasmic membrane leaflet</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>            <p class="role-description">Exports lipid II for periplasmic polymerization.</p></article>            </div>    </section>    </section>
             </div>
         </section>
     </section>

--- a/pages/projects/P_PUTIDA/batches/ppu00550_peptidoglycan_biosynthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00550_peptidoglycan_biosynthesis.html
@@ -371,6 +371,10 @@
 UDP-MurNAc-pentapeptide, lipid I, and lipid II to translocation of lipid II<br />
 across the cytoplasmic membrane. It stops before glycan polymerization and<br />
 peptide cross-linking, which form a distinct multi-complex module.</p>
+<p>The existing <a href="../deep-research/PSEPK__peptidoglycan_precursor_biosynthesis__ppu00550-deep-research-openscientist.html">PSEPK-aware OpenScientist satisfiability report</a><br />
+supports the KT2440 gene selection and the boundary decisions below. Generic<br />
+module structure is supported separately by the full module-level<br />
+OpenScientist report beside the module YAML.</p>
 <h2 id="workflow">Workflow</h2>
 <ul>
 <li>[x] Fetch the nine gene records not already present.</li>
@@ -382,6 +386,22 @@ peptide cross-linking, which form a distinct multi-complex module.</p>
 <li>[x] Run full OpenScientist module + <code>ppu00550</code> + PSEPK research.</li>
 <li>[x] Render the module and project page.</li>
 <li>[x] Open one non-draft PR and clear review and CI.</li>
+</ul>
+<h2 id="wave-123-repair">Wave 123 Repair</h2>
+<ul>
+<li>[x] Re-audit the precursor-synthesis, lipid-carrier loading, and lipid II<br />
+  flipping boundary against the existing generic and PSEPK-aware<br />
+  OpenScientist reports.</li>
+<li>[x] Apply the annotation-reviewer workflow to every selected gene and every<br />
+  GOA row (69/69 rows; no <code>PENDING</code> or <code>UNDECIDED</code> decisions).</li>
+<li>[x] Replace PSEPK-only module exemplars with reviewed cross-species UniProt<br />
+  proteins and remove repeated generic membrane locations.</li>
+<li>[x] Verify the MurE branch, Ddl input, and MurF-to-MurJ route logic without<br />
+  importing polymerization, cross-linking, remodeling, recycling, or carrier<br />
+  supply.</li>
+<li>[x] Validate and render all changed outputs.</li>
+<li>[x] Prepare one non-draft PR and formal review request for the repaired<br />
+  module and batch.</li>
 </ul>
 <h2 id="selected-genes">Selected Genes</h2>
 <table>
@@ -479,7 +499,92 @@ peptide cross-linking, which form a distinct multi-complex module.</p>
 <li>D-Ala-D-Ala carboxypeptidases <code>dacA</code> and <code>dacB</code> are remodeling enzymes.</li>
 <li><code>ddlA</code> and the third Ddl paralog are alternative D-Ala-D-Ala ligases in<br />
   KT2440; the division-cluster <code>ddlB</code> copy is used as the concrete exemplar<br />
-  while paralog use is tested by the pathway-level research.</li>
+  for this ten-gene satisfiability set. The reusable module represents the Ddl<br />
+  activity as a family role rather than encoding KT2440 paralog choice.</li>
+</ul>
+<h2 id="annotation-reviewer-audit">Annotation-Reviewer Audit</h2>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th style="text-align: right;">GOA rows</th>
+<th>Audit result</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>murA</code></td>
+<td style="text-align: right;">6</td>
+<td>Complete; five supported decisions retained and the demonstrably incorrect UDP-GalNAc-process IEA remains <code>REMOVE</code>.</td>
+</tr>
+<tr>
+<td><code>murB</code></td>
+<td style="text-align: right;">7</td>
+<td>Complete; exact reductase activity and pathway retained, with redundant/broad terms kept non-core or marked over-annotated.</td>
+</tr>
+<tr>
+<td><code>murC</code></td>
+<td style="text-align: right;">5</td>
+<td>Complete; exact L-alanine ligase activity and precursor-synthesis role retained.</td>
+</tr>
+<tr>
+<td><code>murD</code></td>
+<td style="text-align: right;">7</td>
+<td>Complete; exact D-glutamate ligase activity retained without promoting indirect cell-shape or division terms.</td>
+</tr>
+<tr>
+<td><code>murE</code></td>
+<td style="text-align: right;">8</td>
+<td>Complete; KT2440 meso-diaminopimelate specificity retained only in the species review.</td>
+</tr>
+<tr>
+<td><code>ddlB</code></td>
+<td style="text-align: right;">6</td>
+<td>Complete; D-Ala-D-Ala ligation retained as the selected convergent-input activity.</td>
+</tr>
+<tr>
+<td><code>murF</code></td>
+<td style="text-align: right;">7</td>
+<td>Complete; the DAP-specific child activity remains core while the reusable module uses the pentapeptide-generic parent.</td>
+</tr>
+<tr>
+<td><code>mraY</code></td>
+<td style="text-align: right;">8</td>
+<td>Complete; lipid I formation is kept distinct from carrier supply and recycling.</td>
+</tr>
+<tr>
+<td><code>murG</code></td>
+<td style="text-align: right;">8</td>
+<td>Complete; lipid II formation is kept distinct from glycan polymerization.</td>
+</tr>
+<tr>
+<td><code>murJ</code></td>
+<td style="text-align: right;">7</td>
+<td>Complete; lipid II translocation is the terminal module step, not a polymerase activity.</td>
+</tr>
+</tbody>
+</table>
+<p>All 69 GOA-derived annotations have explicit evidence-aware decisions. The<br />
+only removal is an electronic MurA mapping to UDP-N-acetylgalactosamine<br />
+biosynthesis that conflicts with the exact UDP-N-acetylglucosamine substrate<br />
+in the target UniProt reaction. No experimental annotation is overruled.</p>
+<h2 id="reusable-module-audit">Reusable-Module Audit</h2>
+<ul>
+<li>The module is <code>CONCRETE</code> because it encodes a chemically grounded reaction<br />
+  path, while its participants remain taxon-neutral family roles.</li>
+<li>Reviewed <em>Escherichia coli</em> K-12 proteins ground the conserved<br />
+  DAP-containing route; reviewed <em>Staphylococcus aureus</em> MurE Q2FZP6 grounds<br />
+  the L-lysine alternative.</li>
+<li>No PANTHER or PTN identifier is asserted. Exact current UniProt<br />
+  classifications were checked, but most reviewed cross-species exemplars are<br />
+  absent from the checked-in PANTHER member index, and the shared MurE family<br />
+  does not encode DAP-versus-L-lysine substrate specificity.</li>
+<li>Molecular functions occur only on leaf annotons. The module has no generic<br />
+  module-level or repeated leaf-level location assertions.</li>
+<li>The terminal product is exported lipid II. SEDS/class-A-PBP polymerization,<br />
+  D,D-transpeptidation, carboxypeptidase remodeling, peptidoglycan recycling,<br />
+  and undecaprenyl-carrier supply/recycling stay in their separate modules or<br />
+  pathway batches.</li>
 </ul>
 <p>The complete 23-gene KEGG source snapshot remains in<br />
 <code>ppu00550_peptidoglycan_biosynthesis.tsv</code>.</p>

--- a/pages/projects/P_PUTIDA/batches/ppu00550_peptidoglycan_biosynthesis.html
+++ b/pages/projects/P_PUTIDA/batches/ppu00550_peptidoglycan_biosynthesis.html
@@ -394,8 +394,8 @@ OpenScientist report beside the module YAML.</p>
   OpenScientist reports.</li>
 <li>[x] Apply the annotation-reviewer workflow to every selected gene and every<br />
   GOA row (69/69 rows; no <code>PENDING</code> or <code>UNDECIDED</code> decisions).</li>
-<li>[x] Replace PSEPK-only module exemplars with reviewed cross-species UniProt<br />
-  proteins and remove repeated generic membrane locations.</li>
+<li>[x] Add reviewed cross-species UniProt exemplars alongside the PSEPK proteins<br />
+  and restrict membrane locations to the three membrane-associated steps.</li>
 <li>[x] Verify the MurE branch, Ddl input, and MurF-to-MurJ route logic without<br />
   importing polymerization, cross-linking, remodeling, recycling, or carrier<br />
   supply.</li>
@@ -575,12 +575,12 @@ in the target UniProt reaction. No experimental annotation is overruled.</p>
 <li>Reviewed <em>Escherichia coli</em> K-12 proteins ground the conserved<br />
   DAP-containing route; reviewed <em>Staphylococcus aureus</em> MurE Q2FZP6 grounds<br />
   the L-lysine alternative.</li>
-<li>No PANTHER or PTN identifier is asserted. Exact current UniProt<br />
-  classifications were checked, but most reviewed cross-species exemplars are<br />
-  absent from the checked-in PANTHER member index, and the shared MurE family<br />
-  does not encode DAP-versus-L-lysine substrate specificity.</li>
-<li>Molecular functions occur only on leaf annotons. The module has no generic<br />
-  module-level or repeated leaf-level location assertions.</li>
+<li>No PANTHER or PTN identifier is asserted. The shared MurE family does not<br />
+  encode DAP-versus-L-lysine substrate specificity, and an exact evolutionary<br />
+  family was not established for each reusable role.</li>
+<li>Molecular functions occur only on the eleven leaf annotons. Plasma membrane<br />
+  is asserted on MraY, MurG, and MurJ, the three membrane-associated steps, and<br />
+  no location is asserted at module level.</li>
 <li>The terminal product is exported lipid II. SEDS/class-A-PBP polymerization,<br />
   D,D-transpeptidation, carboxypeptidase remodeling, peptidoglycan recycling,<br />
   and undecaprenyl-carrier supply/recycling stay in their separate modules or<br />

--- a/projects/P_PUTIDA/batches/ppu00550_peptidoglycan_biosynthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00550_peptidoglycan_biosynthesis.md
@@ -13,6 +13,11 @@ UDP-MurNAc-pentapeptide, lipid I, and lipid II to translocation of lipid II
 across the cytoplasmic membrane. It stops before glycan polymerization and
 peptide cross-linking, which form a distinct multi-complex module.
 
+The existing [PSEPK-aware OpenScientist satisfiability report](../deep-research/PSEPK__peptidoglycan_precursor_biosynthesis__ppu00550-deep-research-openscientist.md)
+supports the KT2440 gene selection and the boundary decisions below. Generic
+module structure is supported separately by the full module-level
+OpenScientist report beside the module YAML.
+
 ## Workflow
 
 - [x] Fetch the nine gene records not already present.
@@ -24,6 +29,22 @@ peptide cross-linking, which form a distinct multi-complex module.
 - [x] Run full OpenScientist module + `ppu00550` + PSEPK research.
 - [x] Render the module and project page.
 - [x] Open one non-draft PR and clear review and CI.
+
+## Wave 123 Repair
+
+- [x] Re-audit the precursor-synthesis, lipid-carrier loading, and lipid II
+  flipping boundary against the existing generic and PSEPK-aware
+  OpenScientist reports.
+- [x] Apply the annotation-reviewer workflow to every selected gene and every
+  GOA row (69/69 rows; no `PENDING` or `UNDECIDED` decisions).
+- [x] Replace PSEPK-only module exemplars with reviewed cross-species UniProt
+  proteins and remove repeated generic membrane locations.
+- [x] Verify the MurE branch, Ddl input, and MurF-to-MurJ route logic without
+  importing polymerization, cross-linking, remodeling, recycling, or carrier
+  supply.
+- [x] Validate and render all changed outputs.
+- [x] Prepare one non-draft PR and formal review request for the repaired
+  module and batch.
 
 ## Selected Genes
 
@@ -52,7 +73,46 @@ peptide cross-linking, which form a distinct multi-complex module.
 - D-Ala-D-Ala carboxypeptidases `dacA` and `dacB` are remodeling enzymes.
 - `ddlA` and the third Ddl paralog are alternative D-Ala-D-Ala ligases in
   KT2440; the division-cluster `ddlB` copy is used as the concrete exemplar
-  while paralog use is tested by the pathway-level research.
+  for this ten-gene satisfiability set. The reusable module represents the Ddl
+  activity as a family role rather than encoding KT2440 paralog choice.
+
+## Annotation-Reviewer Audit
+
+| Gene | GOA rows | Audit result |
+|---|---:|---|
+| `murA` | 6 | Complete; five supported decisions retained and the demonstrably incorrect UDP-GalNAc-process IEA remains `REMOVE`. |
+| `murB` | 7 | Complete; exact reductase activity and pathway retained, with redundant/broad terms kept non-core or marked over-annotated. |
+| `murC` | 5 | Complete; exact L-alanine ligase activity and precursor-synthesis role retained. |
+| `murD` | 7 | Complete; exact D-glutamate ligase activity retained without promoting indirect cell-shape or division terms. |
+| `murE` | 8 | Complete; KT2440 meso-diaminopimelate specificity retained only in the species review. |
+| `ddlB` | 6 | Complete; D-Ala-D-Ala ligation retained as the selected convergent-input activity. |
+| `murF` | 7 | Complete; the DAP-specific child activity remains core while the reusable module uses the pentapeptide-generic parent. |
+| `mraY` | 8 | Complete; lipid I formation is kept distinct from carrier supply and recycling. |
+| `murG` | 8 | Complete; lipid II formation is kept distinct from glycan polymerization. |
+| `murJ` | 7 | Complete; lipid II translocation is the terminal module step, not a polymerase activity. |
+
+All 69 GOA-derived annotations have explicit evidence-aware decisions. The
+only removal is an electronic MurA mapping to UDP-N-acetylgalactosamine
+biosynthesis that conflicts with the exact UDP-N-acetylglucosamine substrate
+in the target UniProt reaction. No experimental annotation is overruled.
+
+## Reusable-Module Audit
+
+- The module is `CONCRETE` because it encodes a chemically grounded reaction
+  path, while its participants remain taxon-neutral family roles.
+- Reviewed *Escherichia coli* K-12 proteins ground the conserved
+  DAP-containing route; reviewed *Staphylococcus aureus* MurE Q2FZP6 grounds
+  the L-lysine alternative.
+- No PANTHER or PTN identifier is asserted. Exact current UniProt
+  classifications were checked, but most reviewed cross-species exemplars are
+  absent from the checked-in PANTHER member index, and the shared MurE family
+  does not encode DAP-versus-L-lysine substrate specificity.
+- Molecular functions occur only on leaf annotons. The module has no generic
+  module-level or repeated leaf-level location assertions.
+- The terminal product is exported lipid II. SEDS/class-A-PBP polymerization,
+  D,D-transpeptidation, carboxypeptidase remodeling, peptidoglycan recycling,
+  and undecaprenyl-carrier supply/recycling stay in their separate modules or
+  pathway batches.
 
 The complete 23-gene KEGG source snapshot remains in
 `ppu00550_peptidoglycan_biosynthesis.tsv`.

--- a/projects/P_PUTIDA/batches/ppu00550_peptidoglycan_biosynthesis.md
+++ b/projects/P_PUTIDA/batches/ppu00550_peptidoglycan_biosynthesis.md
@@ -37,8 +37,8 @@ OpenScientist report beside the module YAML.
   OpenScientist reports.
 - [x] Apply the annotation-reviewer workflow to every selected gene and every
   GOA row (69/69 rows; no `PENDING` or `UNDECIDED` decisions).
-- [x] Replace PSEPK-only module exemplars with reviewed cross-species UniProt
-  proteins and remove repeated generic membrane locations.
+- [x] Add reviewed cross-species UniProt exemplars alongside the PSEPK proteins
+  and restrict membrane locations to the three membrane-associated steps.
 - [x] Verify the MurE branch, Ddl input, and MurF-to-MurJ route logic without
   importing polymerization, cross-linking, remodeling, recycling, or carrier
   supply.
@@ -103,12 +103,12 @@ in the target UniProt reaction. No experimental annotation is overruled.
 - Reviewed *Escherichia coli* K-12 proteins ground the conserved
   DAP-containing route; reviewed *Staphylococcus aureus* MurE Q2FZP6 grounds
   the L-lysine alternative.
-- No PANTHER or PTN identifier is asserted. Exact current UniProt
-  classifications were checked, but most reviewed cross-species exemplars are
-  absent from the checked-in PANTHER member index, and the shared MurE family
-  does not encode DAP-versus-L-lysine substrate specificity.
-- Molecular functions occur only on leaf annotons. The module has no generic
-  module-level or repeated leaf-level location assertions.
+- No PANTHER or PTN identifier is asserted. The shared MurE family does not
+  encode DAP-versus-L-lysine substrate specificity, and an exact evolutionary
+  family was not established for each reusable role.
+- Molecular functions occur only on the eleven leaf annotons. Plasma membrane
+  is asserted on MraY, MurG, and MurJ, the three membrane-associated steps, and
+  no location is asserted at module level.
 - The terminal product is exported lipid II. SEDS/class-A-PBP polymerization,
   D,D-transpeptidation, carboxypeptidase remodeling, peptidoglycan recycling,
   and undecaprenyl-carrier supply/recycling stay in their separate modules or


### PR DESCRIPTION
## Summary

- repair the reusable concrete pathway from UDP-GlcNAc through lipid II export while keeping carrier supply/recycling, polymerization, cross-linking, remodeling, and recycling outside the module
- replace PSEPK-only grounding with reviewed E. coli K-12 exemplars and a reviewed Staphylococcus aureus MurE exemplar for the L-lysine branch
- retain molecular functions only on the 11 leaf annotons and remove repeated generic membrane locations
- omit PANTHER/PTN assertions because reviewed cross-species exemplars are mostly absent from the checked-in member index and the shared MurE family does not resolve substrate specificity
- document the mandatory annotation-reviewer audit of all 10 selected PSEPK genes and all 69 GOA rows; no gene YAML changes were needed

## Research

- reused the existing full generic OpenScientist module report (5,221.39 seconds)
- reused the existing PSEPK + ppu00550 taxon-aware OpenScientist satisfiability report

## Validation

- `just validate PSEPK <gene>` for murA, murB, murC, murD, murE, ddlB, murF, mraY, murG, and murJ
- exact GOA coverage assertion: 69/69 rows reviewed, no PENDING or UNDECIDED decisions
- `linkml-validate -C ModuleReview modules/peptidoglycan_precursor_biosynthesis.yaml`
- `python -m ai_gene_review.validation.module_validator modules/peptidoglycan_precursor_biosynthesis.yaml` (0 warnings)
- route assertion: 2 complete 10-leaf routes, each with exactly one MurE branch
- rendered the module and batch project page
- `git diff --check`
- final rebase against latest `origin/main` before commit