### PR TITLE
Deduplicate projected GOA rows

### DIFF
--- a/src/ai_gene_review/etl/gene.py
+++ b/src/ai_gene_review/etl/gene.py
@@ -963,7 +963,9 @@ def fetch_uniprot_data(uniprot_id: str) -> str:
 def fetch_goa_data(uniprot_id: str) -> str:
     """Fetch Gene Ontology Annotation (GOA) data from QuickGO API.
 
-    Fetches ALL annotations using pagination if necessary.
+    Fetches ALL annotations using pagination if necessary. Byte-identical TSV rows
+    are deduplicated after projection, so annotations that differ only in fields the
+    TSV does not represent (such as annotation extensions) collapse to one row.
 
     Args:
         uniprot_id: UniProt accession ID
@@ -1062,6 +1064,9 @@ def fetch_goa_data(uniprot_id: str) -> str:
     tsv_lines = [
         "GENE PRODUCT DB\tGENE PRODUCT ID\tSYMBOL\tQUALIFIER\tGO TERM\tGO NAME\tGO ASPECT\tECO ID\tGO EVIDENCE CODE\tREFERENCE\tWITH/FROM\tTAXON ID\tTAXON NAME\tASSIGNED BY\tGENE NAME\tDATE"
     ]
+    # Extensions are not represented in the TSV; collapse rows that become identical
+    # after projection while retaining annotations that differ in any exported field.
+    seen_tsv_rows: set[str] = set()
 
     for result in sorted_results:
         # Extract database and ID from geneProductId
@@ -1102,7 +1107,11 @@ def fetch_goa_data(uniprot_id: str) -> str:
             result.get("date", ""),  # DATE
         ]
 
-        tsv_lines.append("\t".join(row))
+        tsv_row = "\t".join(row)
+        if tsv_row in seen_tsv_rows:
+            continue
+        seen_tsv_rows.add(tsv_row)
+        tsv_lines.append(tsv_row)
 
     return "\n".join(tsv_lines) + "\n"
 

--- a/tests/test_goa_sorting.py
+++ b/tests/test_goa_sorting.py
@@ -191,3 +191,69 @@ def test_goa_sorting_no_iba():
         # Should be sorted by date (most recent first)
         assert annotations[0] == ("GO:0005737", "20210101")  # More recent
         assert annotations[1] == ("GO:0005515", "20200101")  # Older
+
+
+def test_goa_deduplicates_identical_projected_rows():
+    """Annotation extensions must not create duplicate rows in the TSV projection."""
+
+    base_result = {
+        "geneProductId": "UniProtKB:TEST",
+        "symbol": "TEST",
+        "goId": "GO:0034506",
+        "goName": "chromosome, centromeric core domain",
+        "goEvidence": "IDA",
+        "date": "20091201",
+        "goAspect": "C",
+        "evidenceCode": "ECO:0000314",
+        "reference": "PMID:19217403",
+        "assignedBy": "PomBase",
+        "taxonId": 4896,
+        "taxonName": "Schizosaccharomyces pombe",
+        "name": "Centromere protein Scm3",
+    }
+    mock_data = {
+        "results": [
+            {
+                **base_result,
+                "id": "annotation-1",
+                "extensions": [
+                    {
+                        "relation": "existence_overlaps",
+                        "connectedXrefs": [{"db": "GO", "id": "0000088"}],
+                    }
+                ],
+            },
+            {
+                **base_result,
+                "id": "annotation-2",
+                "extensions": [
+                    {
+                        "relation": "existence_overlaps",
+                        "connectedXrefs": [{"db": "GO", "id": "0000093"}],
+                    }
+                ],
+            },
+            {
+                **base_result,
+                "id": "annotation-3",
+                "withFrom": [
+                    {"connectedXrefs": [{"db": "PomBase", "id": "SPAC25G10.01"}]}
+                ],
+            },
+        ],
+        "numberOfHits": 3,
+    }
+
+    with patch("requests.get") as mock_get:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_data
+        mock_get.return_value = mock_response
+
+        data_lines = fetch_goa_data("TEST").strip().split("\n")[1:]
+
+    assert len(data_lines) == 2
+    assert {line.split("\t")[10] for line in data_lines} == {
+        "",
+        "PomBase:SPAC25G10.01",
+    }


### PR DESCRIPTION
## Summary
- deduplicate byte-identical rows after QuickGO annotations are projected into the repository TSV format
- preserve distinct annotations whenever an exported field differs
- cover extension-only variants and WITH/FROM distinctions with a regression test

## Validation
- `just format`
- `just pytest` (1974 passed, 63 deselected)