### PR TITLE
Preserve GOA WITH/FROM identities when seeding reviews

### DIFF
--- a/docs/goa_source_refresh.md
+++ b/docs/goa_source_refresh.md
@@ -42,3 +42,7 @@ Use the same explicit retirement path when a complete term/evidence/reference
 assertion disappears. The seeder does not automatically retire curator-authored
 records, because a transient or incomplete upstream snapshot must not silently
 withdraw them.
+
+`fix-goa-retired` does not implement donor replacement: it matches at a broader
+term/evidence level and skips several inference codes. Use the explicit review
+and retirement steps above for a WITH/FROM change.

--- a/docs/goa_source_refresh.md
+++ b/docs/goa_source_refresh.md
@@ -10,6 +10,13 @@ rows. Validation compatibility does not imply that seeding is unnecessary:
 `uv run ai-gene-review seed-goa PATH --dry-run` previews source expansion and
 metadata backfills without changing the input.
 
+When seeding adds pending rows, it recomputes status using the shared status
+rules. A previously finished review with new pending work becomes `IN_PROGRESS`;
+a review containing only pending work is `INITIALIZED`. Metadata-only backfills
+do not change status. After completing curation and validation, check status with
+`uv run ai-gene-review update-status PATH --verbose`. That helper fills a missing
+status but only reports an existing mismatch, which the curator must reconcile.
+
 Older reviews also combined multiple source lists into one `supporting_entities`
 list. Such a row remains valid when it is exactly the union of complete GOA
 source lists for the same term, evidence, reference, and polarity. Unsupported

--- a/docs/goa_source_refresh.md
+++ b/docs/goa_source_refresh.md
@@ -10,6 +10,14 @@ rows. Validation compatibility does not imply that seeding is unnecessary:
 `uv run ai-gene-review seed-goa PATH --dry-run` previews source expansion and
 metadata backfills without changing the input.
 
+Older reviews also combined multiple source lists into one `supporting_entities`
+list. Such a row remains valid when it is exactly the union of complete GOA
+source lists for the same term, evidence, reference, and polarity. Unsupported
+IDs and truncated source groups still fail. Only the represented source rows
+are covered; other GOA sources still need review records. Seeding preserves the
+combined historical review and adds distinct source rows as PENDING, without
+transferring its judgment to each source.
+
 ## When a source changes
 
 An explicitly recorded source that no longer occurs in refreshed GOA fails source

--- a/docs/goa_source_refresh.md
+++ b/docs/goa_source_refresh.md
@@ -1,0 +1,36 @@
+# Refreshing GOA source records
+
+`just fetch-gene ORGANISM GENE --force` and `just seed-goa ORGANISM GENE`
+preserve distinct WITH/FROM sources in `supporting_entities`. They retain an
+existing review while backfilling its missing source metadata and create PENDING
+rows for additional sources. Source ordering is deterministic.
+
+Legacy rows without source metadata remain valid, including historically collapsed
+rows. Validation compatibility does not imply that seeding is unnecessary:
+`uv run ai-gene-review seed-goa PATH --dry-run` previews source expansion and
+metadata backfills without changing the input.
+
+## When a source changes
+
+An explicitly recorded source that no longer occurs in refreshed GOA fails source
+validation. A new donor or PAINT node can change the evidence behind an assertion;
+the old judgment must not automatically transfer to the new source.
+
+1. Refresh through `just fetch-gene ORGANISM GENE --force`. The new source is
+   seeded as a PENDING annotation. The old record and its review are preserved.
+2. Compare the old and current source evidence. If the old source has been
+   withdrawn or replaced, set `retired: true` on its annotation record. Retain its
+   original source and review, and explain the retirement in the gene notes.
+   Do not delete the historical record or guess an equivalent replacement node.
+3. Review the new record against its actual evidence, then run
+   `just validate ORGANISM GENE`.
+
+Retirement records disappearance from the current annotation snapshot; it is not
+a biological REMOVE judgment. Retired rows are excluded from current GOA matching
+and seeding. If a retired source later reappears, the seeder creates a new PENDING
+record rather than silently reactivating the historical judgment.
+
+Use the same explicit retirement path when a complete term/evidence/reference
+assertion disappears. The seeder does not automatically retire curator-authored
+records, because a transient or incomplete upstream snapshot must not silently
+withdraw them.

--- a/docs/goa_source_refresh.md
+++ b/docs/goa_source_refresh.md
@@ -18,6 +18,13 @@ are covered; other GOA sources still need review records. Seeding preserves the
 combined historical review and adds distinct source rows as PENDING, without
 transferring its judgment to each source.
 
+Expansion temporarily leaves the combined row alongside its new source rows.
+After assessing every new row, preserve the combined historical rationale and
+its source list in the gene notes, then remove the combined annotation row to
+avoid counting the same evidence twice. Do not mark it `retired`: its sources
+have not disappeared. This cleanup is a curator decision; the seeder neither
+copies the old judgment to every source nor deletes the historical row.
+
 ## When a source changes
 
 An explicitly recorded source that no longer occurs in refreshed GOA fails source

--- a/genes/human/SHH/SHH-ai-review.yaml
+++ b/genes/human/SHH/SHH-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q15465
 gene_symbol: SHH
 product_type: PROTEIN
-status: COMPLETE
+status: IN_PROGRESS
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens

--- a/genes/human/SHH/SHH-ai-review.yaml
+++ b/genes/human/SHH/SHH-ai-review.yaml
@@ -30,6 +30,18 @@ existing_annotations:
       reason: Retained as a defining SHH activity, pathway role, or active extracellular location. 
         The extracellular region annotation is consistent with the processed ligand's established 
         PTCH-SMO signaling mechanism or the precursor's intrinsic maturation chemistry.
+    supporting_entities:
+      - FB:FBgn0004644
+      - MGI:MGI:94891
+      - MGI:MGI:96533
+      - MGI:MGI:98297
+      - PANTHER:PTN001726121
+      - RGD:3673
+      - UniProtKB:O43323
+      - UniProtKB:Q14623
+      - UniProtKB:Q15465
+      - UniProtKB:Q91035
+      - UniProtKB:Q98938
   - term:
       id: GO:0007224
       label: smoothened signaling pathway
@@ -53,6 +65,18 @@ existing_annotations:
             17, 18).
       additional_reference_ids:
         - PMID:30139912
+    supporting_entities:
+      - FB:FBgn0004644
+      - MGI:MGI:94891
+      - MGI:MGI:96533
+      - MGI:MGI:98297
+      - PANTHER:PTN001726121
+      - UniProtKB:O43323
+      - UniProtKB:Q14623
+      - UniProtKB:Q15465
+      - UniProtKB:Q98938
+      - ZFIN:ZDB-GENE-051010-1
+      - ZFIN:ZDB-GENE-980526-166
   - term:
       id: GO:0010468
       label: regulation of gene expression
@@ -77,6 +101,14 @@ existing_annotations:
             17, 18).
       additional_reference_ids:
         - PMID:30139912
+    supporting_entities:
+      - MGI:MGI:96533
+      - MGI:MGI:98297
+      - PANTHER:PTN001726121
+      - UniProtKB:Q15465
+      - UniProtKB:Q91035
+      - UniProtKB:Q98938
+      - ZFIN:ZDB-GENE-980526-166
   - term:
       id: GO:0005113
       label: patched binding
@@ -100,6 +132,15 @@ existing_annotations:
             17, 18).
       additional_reference_ids:
         - PMID:30139912
+    supporting_entities:
+      - FB:FBgn0004644
+      - MGI:MGI:94891
+      - MGI:MGI:96533
+      - MGI:MGI:98297
+      - PANTHER:PTN001726121
+      - UniProtKB:O43323
+      - UniProtKB:Q14623
+      - UniProtKB:Q15465
   - term:
       id: GO:0001708
       label: cell fate specification
@@ -114,6 +155,13 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - FB:FBgn0004644
+      - MGI:MGI:96533
+      - MGI:MGI:98297
+      - PANTHER:PTN001726121
+      - RGD:3673
+      - ZFIN:ZDB-GENE-980526-166
   - term:
       id: GO:0048709
       label: oligodendrocyte differentiation
@@ -128,6 +176,9 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - MGI:MGI:98297
+      - PANTHER:PTN000223625
   - term:
       id: GO:0005509
       label: calcium ion binding
@@ -142,6 +193,11 @@ existing_annotations:
         SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream 
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - PANTHER:PTN001726121
+      - UniProtKB:O43323
+      - UniProtKB:Q14623
+      - UniProtKB:Q15465
   - term:
       id: GO:0000139
       label: Golgi membrane
@@ -155,6 +211,8 @@ existing_annotations:
       reason: Retained because the Golgi membrane annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB-SubCell:SL-0134
   - term:
       id: GO:0005509
       label: calcium ion binding
@@ -169,6 +227,8 @@ existing_annotations:
         SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream 
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - ARBA:ARBA00043315
   - term:
       id: GO:0005576
       label: extracellular region
@@ -183,6 +243,8 @@ existing_annotations:
       reason: Retained as a defining SHH activity, pathway role, or active extracellular location. 
         The extracellular region annotation is consistent with the processed ligand's established 
         PTCH-SMO signaling mechanism or the precursor's intrinsic maturation chemistry.
+    supporting_entities:
+      - UniProtKB-SubCell:SL-0243
   - term:
       id: GO:0005789
       label: endoplasmic reticulum membrane
@@ -197,6 +259,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB-SubCell:SL-0097
   - term:
       id: GO:0005886
       label: plasma membrane
@@ -211,6 +275,8 @@ existing_annotations:
       reason: Retained because the plasma membrane annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB-SubCell:SL-0039
   - term:
       id: GO:0007267
       label: cell-cell signaling
@@ -224,6 +290,9 @@ existing_annotations:
       reason: Retained as a defining SHH activity, pathway role, or active extracellular location. 
         The cell-cell signaling annotation is consistent with the processed ligand's established 
         PTCH-SMO signaling mechanism or the precursor's intrinsic maturation chemistry.
+    supporting_entities:
+      - InterPro:IPR000320
+      - InterPro:IPR001657
   - term:
       id: GO:0007389
       label: pattern specification process
@@ -239,6 +308,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - ARBA:ARBA00027400
   - term:
       id: GO:0007417
       label: central nervous system development
@@ -253,6 +324,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - ARBA:ARBA00026561
   - term:
       id: GO:0009888
       label: tissue development
@@ -266,6 +339,8 @@ existing_annotations:
       reason: The tissue development term is not false, but it is an uninformative umbrella 
         consequence of SHH signaling and is superseded by multiple more specific developmental 
         annotations.
+    supporting_entities:
+      - ARBA:ARBA00028065
   - term:
       id: GO:0016539
       label: intein-mediated protein splicing
@@ -280,6 +355,8 @@ existing_annotations:
       reason: Remove the InterPro-derived intein-splicing annotation. Homology of the SHH C-terminal
         HINT domain to inteins does not mean that SHH performs intein excision/protein splicing; its
         supported reaction is autocleavage coupled to cholesterol transfer.
+    supporting_entities:
+      - InterPro:IPR006141
   - term:
       id: GO:0016540
       label: protein autoprocessing
@@ -300,6 +377,10 @@ existing_annotations:
             autoprocessing domain endowed with autoproteolysis and cholesterol transferase activity.
       additional_reference_ids:
         - PMID:24342078
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
+      - InterPro:IPR001767
   - term:
       id: GO:0030182
       label: neuron differentiation
@@ -314,6 +395,8 @@ existing_annotations:
         SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream 
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - ARBA:ARBA00027575
   - term:
       id: GO:0035295
       label: tube development
@@ -328,6 +411,8 @@ existing_annotations:
       reason: The tube development term is not false, but it is an uninformative umbrella 
         consequence of SHH signaling and is superseded by multiple more specific developmental 
         annotations.
+    supporting_entities:
+      - ARBA:ARBA00027800
   - term:
       id: GO:0042127
       label: regulation of cell population proliferation
@@ -342,6 +427,8 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - ARBA:ARBA00027546
   - term:
       id: GO:0045165
       label: cell fate commitment
@@ -356,6 +443,8 @@ existing_annotations:
         SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream 
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - ARBA:ARBA00043601
   - term:
       id: GO:0045880
       label: positive regulation of smoothened signaling pathway
@@ -380,6 +469,8 @@ existing_annotations:
             17, 18).
       additional_reference_ids:
         - PMID:30139912
+    supporting_entities:
+      - ARBA:ARBA00086559
   - term:
       id: GO:0048468
       label: cell development
@@ -394,6 +485,8 @@ existing_annotations:
       reason: The cell development term is not false, but it is an uninformative umbrella 
         consequence of SHH signaling and is superseded by multiple more specific developmental 
         annotations.
+    supporting_entities:
+      - ARBA:ARBA00028665
   - term:
       id: GO:0048513
       label: animal organ development
@@ -407,6 +500,8 @@ existing_annotations:
       reason: The animal organ development term is not false, but it is an uninformative umbrella 
         consequence of SHH signaling and is superseded by multiple more specific developmental 
         annotations.
+    supporting_entities:
+      - ARBA:ARBA00029247
   - term:
       id: GO:0050793
       label: regulation of developmental process
@@ -421,6 +516,8 @@ existing_annotations:
       reason: The regulation of developmental process term is not false, but it is an uninformative 
         umbrella consequence of SHH signaling and is superseded by multiple more specific 
         developmental annotations.
+    supporting_entities:
+      - ARBA:ARBA00028689
   - term:
       id: GO:0005515
       label: protein binding
@@ -454,6 +551,8 @@ existing_annotations:
       proposed_replacement_terms:
         - id: GO:0005113
           label: patched binding
+    supporting_entities:
+      - UniProtKB:Q13635-1
   - term:
       id: GO:0005515
       label: protein binding
@@ -471,6 +570,8 @@ existing_annotations:
       proposed_replacement_terms:
         - id: GO:0005113
           label: patched binding
+    supporting_entities:
+      - UniProtKB:Q13635-1
   - term:
       id: GO:0005515
       label: protein binding
@@ -488,6 +589,8 @@ existing_annotations:
       proposed_replacement_terms:
         - id: GO:0005113
           label: patched binding
+    supporting_entities:
+      - UniProtKB:Q13635-1
   - term:
       id: GO:0000122
       label: negative regulation of transcription by RNA polymerase II
@@ -502,6 +605,9 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0001656
       label: metanephros development
@@ -516,6 +622,9 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0001947
       label: heart looping
@@ -529,6 +638,9 @@ existing_annotations:
       reason: Retained because the heart looping annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0002320
       label: lymphoid progenitor cell differentiation
@@ -543,6 +655,9 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0003140
       label: determination of left/right asymmetry in lateral mesoderm
@@ -558,6 +673,9 @@ existing_annotations:
         transferred from mouse, but its underlying source experiment is not exposed in this GOA
         record and independent causal evidence was not available in the cached sources. It is left
         undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0004175
       label: endopeptidase activity
@@ -583,6 +701,9 @@ existing_annotations:
             autoprocessing domain endowed with autoproteolysis and cholesterol transferase activity.
       additional_reference_ids:
         - PMID:24342078
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0005113
       label: patched binding
@@ -606,6 +727,10 @@ existing_annotations:
             17, 18).
       additional_reference_ids:
         - PMID:30139912
+    supporting_entities:
+      - ARBA:ARBA00085807
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0007224
       label: smoothened signaling pathway
@@ -629,6 +754,10 @@ existing_annotations:
             17, 18).
       additional_reference_ids:
         - PMID:30139912
+    supporting_entities:
+      - ARBA:ARBA00084926
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0009949
       label: polarity specification of anterior/posterior axis
@@ -643,6 +772,9 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0010628
       label: positive regulation of gene expression
@@ -658,6 +790,9 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0010629
       label: negative regulation of gene expression
@@ -672,6 +807,9 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0021904
       label: dorsal/ventral neural tube patterning
@@ -686,6 +824,9 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0021930
       label: cerebellar granule cell precursor proliferation
@@ -707,6 +848,9 @@ existing_annotations:
             stimulated
       additional_reference_ids:
         - PMID:10226030
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0033077
       label: T cell differentiation in thymus
@@ -721,6 +865,9 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0033089
       label: positive regulation of T cell differentiation in thymus
@@ -736,6 +883,9 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0033092
       label: positive regulation of immature T cell proliferation in thymus
@@ -750,6 +900,9 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0042481
       label: regulation of odontogenesis
@@ -764,6 +917,9 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0042733
       label: embryonic digit morphogenesis
@@ -778,6 +934,9 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0043066
       label: negative regulation of apoptotic process
@@ -792,6 +951,9 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0043369
       label: CD4-positive or CD8-positive, alpha-beta T cell lineage commitment
@@ -806,6 +968,9 @@ existing_annotations:
         commitment annotation is biologically consistent with SHH evidence, but it describes a 
         biosynthetic location, structural cofactor, downstream effect, or tissue-specific 
         developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0045059
       label: positive thymic T cell selection
@@ -821,6 +986,9 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0045060
       label: negative thymic T cell selection
@@ -836,6 +1004,9 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0045893
       label: positive regulation of DNA-templated transcription
@@ -850,6 +1021,9 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0045944
       label: positive regulation of transcription by RNA polymerase II
@@ -864,6 +1038,9 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0046638
       label: positive regulation of alpha-beta T cell differentiation
@@ -878,6 +1055,9 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0048538
       label: thymus development
@@ -891,6 +1071,9 @@ existing_annotations:
       reason: Retained because the thymus development annotation is biologically consistent with SHH
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0048864
       label: stem cell development
@@ -905,6 +1088,9 @@ existing_annotations:
         SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream 
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0061053
       label: somite development
@@ -918,6 +1104,9 @@ existing_annotations:
       reason: Retained because the somite development annotation is biologically consistent with SHH
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0072136
       label: metanephric mesenchymal cell proliferation involved in metanephros development
@@ -932,6 +1121,9 @@ existing_annotations:
         metanephros development annotation is biologically consistent with SHH evidence, but it 
         describes a biosynthetic location, structural cofactor, downstream effect, or 
         tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0090370
       label: negative regulation of cholesterol efflux
@@ -947,6 +1139,9 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0097190
       label: apoptotic signaling pathway
@@ -961,6 +1156,9 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0140853
       label: cholesterol-protein transferase activity
@@ -982,6 +1180,9 @@ existing_annotations:
             autoprocessing domain endowed with autoproteolysis and cholesterol transferase activity.
       additional_reference_ids:
         - PMID:24342078
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:1904339
       label: negative regulation of dopaminergic neuron differentiation
@@ -997,6 +1198,9 @@ existing_annotations:
         transferred from another organism or high-throughput source, but its underlying source 
         experiment is not exposed in this GOA record and independent corroboration was not found. It
         is left undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:2000062
       label: negative regulation of ureter smooth muscle cell differentiation
@@ -1012,6 +1216,9 @@ existing_annotations:
         transferred from another organism or high-throughput source, but its underlying source 
         experiment is not exposed in this GOA record and independent corroboration was not found. It
         is left undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:2000063
       label: positive regulation of ureter smooth muscle cell differentiation
@@ -1027,6 +1234,9 @@ existing_annotations:
         transferred from another organism or high-throughput source, but its underlying source 
         experiment is not exposed in this GOA record and independent corroboration was not found. It
         is left undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:2000357
       label: negative regulation of kidney smooth muscle cell differentiation
@@ -1042,6 +1252,9 @@ existing_annotations:
         transferred from another organism or high-throughput source, but its underlying source 
         experiment is not exposed in this GOA record and independent corroboration was not found. It
         is left undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:2000358
       label: positive regulation of kidney smooth muscle cell differentiation
@@ -1057,6 +1270,9 @@ existing_annotations:
         transferred from another organism or high-throughput source, but its underlying source 
         experiment is not exposed in this GOA record and independent corroboration was not found. It
         is left undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:2000729
       label: positive regulation of mesenchymal cell proliferation involved in ureter development
@@ -1071,6 +1287,9 @@ existing_annotations:
         ureter development annotation is biologically consistent with SHH evidence, but it describes
         a biosynthetic location, structural cofactor, downstream effect, or tissue-specific 
         developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
+      - ensembl:ENSMUSP00000002708
   - term:
       id: GO:0004175
       label: endopeptidase activity
@@ -1094,6 +1313,8 @@ existing_annotations:
             autoprocessing domain endowed with autoproteolysis and cholesterol transferase activity.
       additional_reference_ids:
         - PMID:24342078
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0016540
       label: protein autoprocessing
@@ -1115,6 +1336,8 @@ existing_annotations:
             autoprocessing domain endowed with autoproteolysis and cholesterol transferase activity.
       additional_reference_ids:
         - PMID:24342078
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0005576
       label: extracellular region
@@ -1143,6 +1366,8 @@ existing_annotations:
       reason: Retained because the plasma membrane annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0140853
       label: cholesterol-protein transferase activity
@@ -1165,6 +1390,8 @@ existing_annotations:
             autoprocessing domain endowed with autoproteolysis and cholesterol transferase activity.
       additional_reference_ids:
         - PMID:24342078
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:1900107
       label: regulation of nodal signaling pathway
@@ -1203,6 +1430,8 @@ existing_annotations:
             17, 18).
       additional_reference_ids:
         - PMID:30139912
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0045944
       label: positive regulation of transcription by RNA polymerase II
@@ -1217,6 +1446,8 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0003140
       label: determination of left/right asymmetry in lateral mesoderm
@@ -1807,6 +2038,8 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0043066
       label: negative regulation of apoptotic process
@@ -1821,6 +2054,8 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0097190
       label: apoptotic signaling pathway
@@ -1836,6 +2071,8 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0005788
       label: endoplasmic reticulum lumen
@@ -1913,6 +2150,8 @@ existing_annotations:
             stimulated
       additional_reference_ids:
         - PMID:10226030
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0005576
       label: extracellular region
@@ -1956,6 +2195,8 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0042481
       label: regulation of odontogenesis
@@ -1970,6 +2211,8 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0045944
       label: positive regulation of transcription by RNA polymerase II
@@ -1984,6 +2227,8 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:1900180
       label: regulation of protein localization to nucleus
@@ -2027,6 +2272,8 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0007418
       label: ventral midline development
@@ -2124,6 +2371,8 @@ existing_annotations:
       reason: Retained because the heart looping annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0003140
       label: determination of left/right asymmetry in lateral mesoderm
@@ -2139,6 +2388,8 @@ existing_annotations:
         from mouse by curator judgment, but its underlying source experiment is not exposed in this
         GOA record and independent causal evidence was not available in the cached sources. It is
         left undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0007224
       label: smoothened signaling pathway
@@ -2175,6 +2426,8 @@ existing_annotations:
       reason: Retained because the somite development annotation is biologically consistent with SHH
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0005113
       label: patched binding
@@ -2213,6 +2466,8 @@ existing_annotations:
         ureter development annotation is biologically consistent with SHH evidence, but it describes
         a biosynthetic location, structural cofactor, downstream effect, or tissue-specific 
         developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0033089
       label: positive regulation of T cell differentiation in thymus
@@ -2228,6 +2483,8 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0045059
       label: positive thymic T cell selection
@@ -2243,6 +2500,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0045060
       label: negative thymic T cell selection
@@ -2258,6 +2517,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0046638
       label: positive regulation of alpha-beta T cell differentiation
@@ -2272,6 +2533,8 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0048538
       label: thymus development
@@ -2285,6 +2548,8 @@ existing_annotations:
       reason: Retained because the thymus development annotation is biologically consistent with SHH
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0048864
       label: stem cell development
@@ -2300,6 +2565,8 @@ existing_annotations:
         SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream 
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0072136
       label: metanephric mesenchymal cell proliferation involved in metanephros development
@@ -2315,6 +2582,8 @@ existing_annotations:
         metanephros development annotation is biologically consistent with SHH evidence, but it 
         describes a biosynthetic location, structural cofactor, downstream effect, or 
         tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:2000062
       label: negative regulation of ureter smooth muscle cell differentiation
@@ -2330,6 +2599,8 @@ existing_annotations:
         transferred from another organism or high-throughput source, but its underlying source 
         experiment is not exposed in this GOA record and independent corroboration was not found. It
         is left undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:2000063
       label: positive regulation of ureter smooth muscle cell differentiation
@@ -2345,6 +2616,8 @@ existing_annotations:
         transferred from another organism or high-throughput source, but its underlying source 
         experiment is not exposed in this GOA record and independent corroboration was not found. It
         is left undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:2000357
       label: negative regulation of kidney smooth muscle cell differentiation
@@ -2360,6 +2633,8 @@ existing_annotations:
         transferred from another organism or high-throughput source, but its underlying source 
         experiment is not exposed in this GOA record and independent corroboration was not found. It
         is left undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:2000358
       label: positive regulation of kidney smooth muscle cell differentiation
@@ -2375,6 +2650,8 @@ existing_annotations:
         transferred from another organism or high-throughput source, but its underlying source 
         experiment is not exposed in this GOA record and independent corroboration was not found. It
         is left undecided rather than overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0033077
       label: T cell differentiation in thymus
@@ -2390,6 +2667,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0033092
       label: positive regulation of immature T cell proliferation in thymus
@@ -2405,6 +2684,8 @@ existing_annotations:
         annotation is biologically consistent with SHH evidence, but it describes a biosynthetic 
         location, structural cofactor, downstream effect, or tissue-specific developmental context 
         rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0002320
       label: lymphoid progenitor cell differentiation
@@ -2506,6 +2787,8 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0001570
       label: vasculogenesis
@@ -2519,6 +2802,8 @@ existing_annotations:
       reason: Retained because the vasculogenesis annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0001656
       label: metanephros development
@@ -2534,6 +2819,8 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0001658
       label: branching involved in ureteric bud morphogenesis
@@ -2549,6 +2836,8 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0001708
       label: cell fate specification
@@ -2563,6 +2852,8 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0001755
       label: neural crest cell migration
@@ -2577,6 +2868,8 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0005576
       label: extracellular region
@@ -2591,6 +2884,8 @@ existing_annotations:
       reason: Retained as a defining SHH activity, pathway role, or active extracellular location. 
         The extracellular region annotation is consistent with the processed ligand's established 
         PTCH-SMO signaling mechanism or the precursor's intrinsic maturation chemistry.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0007267
       label: cell-cell signaling
@@ -2605,6 +2900,8 @@ existing_annotations:
       reason: Retained as a defining SHH activity, pathway role, or active extracellular location. 
         The cell-cell signaling annotation is consistent with the processed ligand's established 
         PTCH-SMO signaling mechanism or the precursor's intrinsic maturation chemistry.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0007389
       label: pattern specification process
@@ -2620,6 +2917,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0007405
       label: neuroblast proliferation
@@ -2635,6 +2934,8 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0007411
       label: axon guidance
@@ -2648,6 +2949,8 @@ existing_annotations:
       reason: Retained because the axon guidance annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0007417
       label: central nervous system development
@@ -2662,6 +2965,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0007507
       label: heart development
@@ -2675,6 +2980,8 @@ existing_annotations:
       reason: Retained because the heart development annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0008209
       label: androgen metabolic process
@@ -2690,6 +2997,8 @@ existing_annotations:
         high-throughput source, but its underlying source experiment is not exposed in this GOA 
         record and independent corroboration was not found. It is left undecided rather than 
         overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0008284
       label: positive regulation of cell population proliferation
@@ -2705,6 +3014,8 @@ existing_annotations:
         is biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0009953
       label: dorsal/ventral pattern formation
@@ -2720,6 +3031,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0009986
       label: cell surface
@@ -2734,6 +3047,8 @@ existing_annotations:
       reason: Retained because the cell surface annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0030162
       label: regulation of proteolysis
@@ -2749,6 +3064,8 @@ existing_annotations:
         high-throughput source, but its underlying source experiment is not exposed in this GOA 
         record and independent corroboration was not found. It is left undecided rather than 
         overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0030324
       label: lung development
@@ -2762,6 +3079,8 @@ existing_annotations:
       reason: Retained because the lung development annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0030326
       label: embryonic limb morphogenesis
@@ -2776,6 +3095,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0030336
       label: negative regulation of cell migration
@@ -2790,6 +3111,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0030539
       label: male genitalia development
@@ -2805,6 +3128,8 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0030850
       label: prostate gland development
@@ -2819,6 +3144,8 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0030900
       label: forebrain development
@@ -2834,6 +3161,8 @@ existing_annotations:
         SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream 
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0030901
       label: midbrain development
@@ -2848,6 +3177,8 @@ existing_annotations:
         SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream 
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0030902
       label: hindbrain development
@@ -2862,6 +3193,8 @@ existing_annotations:
         SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream 
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0042127
       label: regulation of cell population proliferation
@@ -2877,6 +3210,8 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0042733
       label: embryonic digit morphogenesis
@@ -2891,6 +3226,8 @@ existing_annotations:
         consistent with SHH evidence, but it describes a biosynthetic location, structural cofactor,
         downstream effect, or tissue-specific developmental context rather than the gene product's 
         defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0043237
       label: laminin-1 binding
@@ -2906,6 +3243,8 @@ existing_annotations:
         high-throughput source, but its underlying source experiment is not exposed in this GOA 
         record and independent corroboration was not found. It is left undecided rather than 
         overruled.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0045121
       label: membrane raft
@@ -2920,6 +3259,8 @@ existing_annotations:
       reason: Retained because the membrane raft annotation is biologically consistent with SHH 
         evidence, but it describes a biosynthetic location, structural cofactor, downstream effect, 
         or tissue-specific developmental context rather than the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0045596
       label: negative regulation of cell differentiation
@@ -2934,6 +3275,8 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0048468
       label: cell development
@@ -2948,6 +3291,8 @@ existing_annotations:
       reason: The cell development term is not false, but it is an uninformative umbrella 
         consequence of SHH signaling and is superseded by multiple more specific developmental 
         annotations.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0048663
       label: neuron fate commitment
@@ -2962,6 +3307,8 @@ existing_annotations:
         SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream 
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0048754
       label: branching morphogenesis of an epithelial tube
@@ -2976,6 +3323,8 @@ existing_annotations:
         biologically consistent with SHH evidence, but it describes a biosynthetic location, 
         structural cofactor, downstream effect, or tissue-specific developmental context rather than
         the gene product's defining activities.
+    supporting_entities:
+      - UniProtKB:Q62226
   - term:
       id: GO:0007418
       label: ventral midline development
@@ -2991,6 +3340,17 @@ existing_annotations:
         with SHH evidence, but it describes a biosynthetic location, structural cofactor, downstream
         effect, or tissue-specific developmental context rather than the gene product's defining 
         activities.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:19561609
+    qualifier: enables
+    supporting_entities:
+    - UniProtKB:Q13635
+    review:
+      summary: 'TODO: Review this GOA annotation'
+      action: PENDING
 references:
   - id: GO_REF:0000002
     title: Gene Ontology annotation through association of InterPro records with GO terms

--- a/history/genes/human/SHH/2026-09-05T033531Z-codex-43926e.yaml
+++ b/history/genes/human/SHH/2026-09-05T033531Z-codex-43926e.yaml
@@ -1,0 +1,27 @@
+history_version: 1
+target:
+  kind: gene
+  slug: SHH
+  organism: human
+  path: genes/human/SHH/SHH-ai-review.yaml
+session:
+  id: 2026-09-05T033531Z-codex-43926e
+  timestamp: '2026-09-05T03:35:31Z'
+  actors:
+  - type: ai_agent
+    name: codex
+    agent_tool: codex
+links:
+  issues: []
+  prs:
+  - https://github.com/ai4curation/ai-gene-review/pull/2926
+  urls: []
+events:
+- type: EDIT
+  outcome: changed
+  sections:
+  - existing_annotations.supporting_entities
+  - status
+  summary: Preserve GOA source identity and pending-review status during seeding
+  details: |
+    The supported seeder added the uncovered Q13635 source for GO:0005515 / IPI / PMID:19561609 as one PENDING row and backfilled 132 supporting-entity lists. All 194 prior review rows and judgments were preserved. Recomputed IN_PROGRESS through the fixed wrapper. Full per-gene validation passes with only the expected pending warning; the final corpus best-practices run reported 4539 valid and zero invalid. No biological judgment was copied from the Q96QV1 sibling.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ plugins:
 nav:
   - Home: index.md
   - Isoform Tracking: isoform_tracking.md
+  - Refreshing GOA Sources: goa_source_refresh.md
   - History Records: history.md
   - Evidence Subtraction Reports: subtraction_report.md
   - Automation (dismech migration, as built): automation-migration-to-dismech.md

--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import List, Optional
 
 import typer
@@ -1295,31 +1296,25 @@ def seed_goa(
     # Initialize validator
     validator = GOAValidator()
 
-    # First check what's missing
-    if yaml_file.exists():
-        typer.echo(f"Checking {yaml_file.name} for missing annotations...")
-        result = validator.validate_against_goa(yaml_file, goa_file)
-
-        if not result.missing_in_yaml:
-            typer.echo(
-                "✓ No missing annotations to seed - YAML already contains all GOA annotations"
-            )
-            return
-
-        typer.echo(f"Found {len(result.missing_in_yaml)} missing annotations to seed:")
-        for ann in result.missing_in_yaml[:5]:  # Show first 5
-            typer.echo(f"  - {ann.go_id} ({ann.go_term})")
-        if len(result.missing_in_yaml) > 5:
-            typer.echo(f"  ... and {len(result.missing_in_yaml) - 5} more")
-    else:
-        typer.echo("Creating new YAML file with all GOA annotations...")
-
-    if dry_run:
-        typer.echo("\n--dry-run specified, no changes will be made")
-        return
+    # Validation permits historical source collapse. Always ask the seeder what
+    # needs expansion/backfill instead of treating validation success as a no-op.
+    typer.echo(f"Checking {yaml_file.name} for missing annotations and source metadata...")
 
     # Perform the seeding
     try:
+        if dry_run:
+            with TemporaryDirectory(prefix="aigr-seed-preview-") as preview_dir:
+                added, _, refs, qualifiers, sources = validator.seed_missing_annotations(
+                    yaml_file, goa_file, Path(preview_dir) / "preview.yaml",
+                    fetch_titles=False,
+                )
+            typer.echo(
+                f"Would add {added} annotations and {refs} references; "
+                f"backfill {qualifiers} qualifiers and {sources} supporting-entity lists."
+            )
+            typer.echo("--dry-run specified, no changes will be made")
+            return
+
         (
             added_count,
             output_path,

--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -183,6 +183,7 @@ def fetch_gene(
                     result["annotations_added"] > 0
                     or result.get("references_added", 0) > 0
                     or result.get("qualifiers_backfilled", 0) > 0
+                    or result.get("supporting_entities_backfilled", 0) > 0
                 ):
                     parts = []
                     if result["annotations_added"] > 0:
@@ -192,6 +193,11 @@ def fetch_gene(
                     if result.get("qualifiers_backfilled", 0) > 0:
                         parts.append(
                             f"qualifiers on {result.get('qualifiers_backfilled', 0)} annotations"
+                        )
+                    if result.get("supporting_entities_backfilled", 0) > 0:
+                        parts.append(
+                            "supporting entities on "
+                            f"{result.get('supporting_entities_backfilled', 0)} annotations"
                         )
                     typer.echo(
                         f"  - {file_prefix}-ai-review.yaml (added {' and '.join(parts)})"
@@ -1314,13 +1320,24 @@ def seed_goa(
 
     # Perform the seeding
     try:
-        added_count, output_path, refs_added, qualifiers_backfilled = (
+        (
+            added_count,
+            output_path,
+            refs_added,
+            qualifiers_backfilled,
+            supporting_entities_backfilled,
+        ) = (
             validator.seed_missing_annotations(
                 yaml_file, goa_file, output, fetch_titles=fetch_titles
             )
         )
 
-        if added_count > 0 or refs_added > 0 or qualifiers_backfilled > 0:
+        if (
+            added_count > 0
+            or refs_added > 0
+            or qualifiers_backfilled > 0
+            or supporting_entities_backfilled > 0
+        ):
             parts = []
             if added_count > 0:
                 parts.append(f"{added_count} annotations")
@@ -1328,6 +1345,11 @@ def seed_goa(
                 parts.append(f"{refs_added} references")
             if qualifiers_backfilled > 0:
                 parts.append(f"qualifiers on {qualifiers_backfilled} annotations")
+            if supporting_entities_backfilled > 0:
+                parts.append(
+                    "supporting entities on "
+                    f"{supporting_entities_backfilled} annotations"
+                )
             typer.echo(f"\n✓ Successfully added {' and '.join(parts)} to {output_path}")
             typer.echo("\nNote: Review sections left empty for AI to complete")
         else:

--- a/src/ai_gene_review/etl/gene.py
+++ b/src/ai_gene_review/etl/gene.py
@@ -236,6 +236,7 @@ def _report_seed_updates(
     added_count: int,
     refs_added: int,
     qualifiers_backfilled: int,
+    supporting_entities_backfilled: int,
     yaml_existed: bool,
 ) -> None:
     """Report every mutation performed while seeding a gene review."""
@@ -249,10 +250,17 @@ def _report_seed_updates(
             f"  ✓ Backfilled qualifiers on {qualifiers_backfilled} annotations "
             f"in {file_prefix}-ai-review.yaml"
         )
+    if supporting_entities_backfilled > 0:
+        print(
+            "  ✓ Backfilled supporting entities on "
+            f"{supporting_entities_backfilled} annotations in "
+            f"{file_prefix}-ai-review.yaml"
+        )
     if (
         added_count == 0
         and refs_added == 0
         and qualifiers_backfilled == 0
+        and supporting_entities_backfilled == 0
         and yaml_existed
     ):
         print(
@@ -291,6 +299,8 @@ def fetch_gene_data(
             - annotations_added: int - Number of annotations added
             - references_added: int - Number of references added
             - qualifiers_backfilled: int - Number of existing annotations enriched
+            - supporting_entities_backfilled: int - Number of existing annotations
+              enriched with WITH/FROM entities
             - uniprot_updated: bool - True if UniProt file was updated
             - goa_updated: bool - True if GOA file was updated
             - uniprot_differences: bool - True if UniProt content differs from existing
@@ -391,6 +401,7 @@ def fetch_gene_data(
         "annotations_added": 0,
         "references_added": 0,
         "qualifiers_backfilled": 0,
+        "supporting_entities_backfilled": 0,
         "uniprot_updated": False,
         "goa_updated": False,
         "uniprot_differences": uniprot_differs,
@@ -496,7 +507,13 @@ def fetch_gene_data(
 
         # Now seed missing GOA annotations
         validator = GOAValidator()
-        added_count, _, refs_added, qualifiers_backfilled = (
+        (
+            added_count,
+            _,
+            refs_added,
+            qualifiers_backfilled,
+            supporting_entities_backfilled,
+        ) = (
             validator.seed_missing_annotations(
                 yaml_file, goa_file, fetch_titles=fetch_titles
             )
@@ -504,12 +521,14 @@ def fetch_gene_data(
         result["annotations_added"] = added_count
         result["references_added"] = refs_added
         result["qualifiers_backfilled"] = qualifiers_backfilled
+        result["supporting_entities_backfilled"] = supporting_entities_backfilled
 
         _report_seed_updates(
             file_prefix,
             added_count,
             refs_added,
             qualifiers_backfilled,
+            supporting_entities_backfilled,
             yaml_existed,
         )
 
@@ -1525,6 +1544,7 @@ def fetch_gene_data_ncRNA(
         "annotations_added": 0,
         "references_added": 0,
         "qualifiers_backfilled": 0,
+        "supporting_entities_backfilled": 0,
         "rnacentral_updated": False,
         "goa_updated": False,
         "rnacentral_differences": rnacentral_differs,
@@ -1621,7 +1641,13 @@ def fetch_gene_data_ncRNA(
         # Now seed missing GOA annotations (same as for protein-coding genes)
         from ai_gene_review.validation.goa_validator import GOAValidator
         validator = GOAValidator()
-        added_count, _, refs_added, qualifiers_backfilled = (
+        (
+            added_count,
+            _,
+            refs_added,
+            qualifiers_backfilled,
+            supporting_entities_backfilled,
+        ) = (
             validator.seed_missing_annotations(
                 yaml_file, goa_file, fetch_titles=True
             )
@@ -1629,12 +1655,14 @@ def fetch_gene_data_ncRNA(
         result["annotations_added"] = added_count
         result["references_added"] = refs_added
         result["qualifiers_backfilled"] = qualifiers_backfilled
+        result["supporting_entities_backfilled"] = supporting_entities_backfilled
 
         _report_seed_updates(
             file_prefix,
             added_count,
             refs_added,
             qualifiers_backfilled,
+            supporting_entities_backfilled,
             yaml_existed,
         )
 

--- a/src/ai_gene_review/validation/goa_validator.py
+++ b/src/ai_gene_review/validation/goa_validator.py
@@ -674,6 +674,10 @@ class GOAValidator:
         existing_by_tuple = {}
         existing_by_base: Dict[Tuple[str, str, str, bool], List[Dict[str, Any]]] = {}
         for ann in existing_annotations:
+            # Historical records must not suppress a fresh review if their GOA
+            # source reappears, or be enriched into a different current source.
+            if isinstance(ann, dict) and ann.get("retired", False):
+                continue
             if isinstance(ann, dict) and "term" in ann:
                 term = ann["term"]
                 if isinstance(term, dict) and "id" in term:

--- a/src/ai_gene_review/validation/goa_validator.py
+++ b/src/ai_gene_review/validation/goa_validator.py
@@ -291,10 +291,14 @@ class GOAValidator:
         result: GOAValidationResult,
     ) -> GOAValidationResult:
         """Validate using strict tuple matching (go_id, evidence_code, reference, negated)."""
-        # Create lookup structure for GOA using complete tuples
-        # Key: (go_id, evidence_code, reference, negated)
+        # Create lookup structure for GOA using complete tuples.
+        # WITH/FROM is part of annotation identity: otherwise distinct partner,
+        # donor, or inference-source rows collapse into one review entry.
+        # Key: (go_id, evidence_code, reference, negated, supporting_entities)
         goa_tuples = set()
-        goa_by_tuple: Dict[Tuple[str, str, str, bool], GOAAnnotation] = {}
+        goa_by_tuple: Dict[
+            Tuple[str, str, str, bool, Tuple[str, ...]], GOAAnnotation
+        ] = {}
         goa_by_go_id: Dict[str, List[GOAAnnotation]] = {}
         goa_by_annotation_identity: Dict[
             Tuple[str, str, bool], List[GOAAnnotation]
@@ -303,7 +307,14 @@ class GOAValidator:
             qualifier = getattr(ann, "qualifier", "")
             is_negated = self._qualifier_is_negated(qualifier)
             parsed_qualifier = self._parse_qualifier(qualifier) or ""
-            tuple_key = (ann.go_id, ann.evidence_code, ann.reference, is_negated)
+            supporting_entities = self._supporting_entities_key(ann.with_from)
+            tuple_key = (
+                ann.go_id,
+                ann.evidence_code,
+                ann.reference,
+                is_negated,
+                supporting_entities,
+            )
             goa_tuples.add(tuple_key)
             goa_by_tuple[tuple_key] = ann
             goa_by_go_id.setdefault(ann.go_id, []).append(ann)
@@ -387,12 +398,21 @@ class GOAValidator:
             evidence_type = yaml_ann.get("evidence_type", "")
             original_ref = yaml_ann.get("original_reference_id", "")
             negated = yaml_ann.get("negated", False)
+            supporting_entities = self._supporting_entities_key(
+                yaml_ann.get("supporting_entities")
+            )
 
             if not go_id:
                 continue
 
             # Create the tuple to check (includes negation)
-            yaml_tuple = (go_id, evidence_type, original_ref, negated)
+            yaml_tuple = (
+                go_id,
+                evidence_type,
+                original_ref,
+                negated,
+                supporting_entities,
+            )
 
             # Check if this exact tuple exists in GOA
             if yaml_tuple not in goa_tuples:
@@ -449,8 +469,19 @@ class GOAValidator:
                     evidence_type = yaml_ann.get("evidence_type", "")
                     original_ref = yaml_ann.get("original_reference_id", "")
                     negated = yaml_ann.get("negated", False)
+                    supporting_entities = self._supporting_entities_key(
+                        yaml_ann.get("supporting_entities")
+                    )
                     if go_id:
-                        yaml_tuples.add((go_id, evidence_type, original_ref, negated))
+                        yaml_tuples.add(
+                            (
+                                go_id,
+                                evidence_type,
+                                original_ref,
+                                negated,
+                                supporting_entities,
+                            )
+                        )
 
         for goa_tuple in goa_tuples:
             if goa_tuple not in yaml_tuples:
@@ -615,7 +646,7 @@ class GOAValidator:
         goa_file: Optional[Path] = None,
         output_file: Optional[Path] = None,
         fetch_titles: bool = False,
-    ) -> Tuple[int, Path, int, int]:
+    ) -> Tuple[int, Path, int, int, int]:
         """Seed missing annotations from GOA file into YAML.
 
         This function adds any annotations present in the GOA file but missing
@@ -630,7 +661,7 @@ class GOAValidator:
 
         Returns:
             Tuple of (annotations added, output file path, references added,
-            qualifiers backfilled)
+            qualifiers backfilled, supporting-entity lists backfilled)
         """
         # Derive GOA file path if not provided
         if goa_file is None:
@@ -666,12 +697,11 @@ class GOAValidator:
         existing_annotations = yaml_data.get("existing_annotations", [])
 
         # Build set of existing tuples (GO ID, evidence_type, reference, negated,
-        # qualifier). Older seeded files may lack qualifier, so keep a base-tuple
-        # index that lets us backfill the qualifier without adding duplicates.
+        # qualifier, supporting entities). Older seeded files may lack qualifier
+        # and/or supporting_entities, so keep a base-tuple index that lets us enrich
+        # one legacy annotation before adding rows that differ only by WITH/FROM.
         existing_tuples = set()
-        existing_missing_qualifier_by_base: Dict[
-            Tuple[str, str, str, bool], List[Dict[str, Any]]
-        ] = {}
+        existing_by_base: Dict[Tuple[str, str, str, bool], List[Dict[str, Any]]] = {}
         for ann in existing_annotations:
             if isinstance(ann, dict) and "term" in ann:
                 term = ann["term"]
@@ -681,14 +711,19 @@ class GOAValidator:
                     ref = ann.get("original_reference_id", "")
                     negated = ann.get("negated", False)
                     parsed_qualifier = self._parse_qualifier(ann.get("qualifier"))
+                    supporting_entities = self._supporting_entities_key(
+                        ann.get("supporting_entities")
+                    )
                     base_tuple = (go_id, evidence, ref, negated)
-                    existing_tuples.add((*base_tuple, parsed_qualifier or ""))
-                    if not parsed_qualifier:
-                        existing_missing_qualifier_by_base.setdefault(base_tuple, []).append(ann)
+                    existing_tuples.add(
+                        (*base_tuple, parsed_qualifier or "", supporting_entities)
+                    )
+                    existing_by_base.setdefault(base_tuple, []).append(ann)
 
         # Add missing annotations from GOA
         added_count = 0
         qualifiers_backfilled = 0
+        supporting_entities_backfilled = 0
         seen_tuples = set()  # Track which tuples we've already added
         pmids_to_add = set()  # Collect PMIDs and GO_REFs to add to references
 
@@ -711,28 +746,61 @@ class GOAValidator:
             qualifier = getattr(goa_ann, "qualifier", "")
             is_negated = self._qualifier_is_negated(qualifier)
             parsed_qualifier = self._parse_qualifier(qualifier)
+            supporting_entities = self._normalize_supporting_entities(
+                goa_ann.with_from
+            )
+            supporting_entities_key = self._supporting_entities_key(
+                supporting_entities
+            )
 
             # Include negation and qualifier in tuple key since NOT annotations and
             # relation-specific GOA assertions are distinct.
             base_tuple = (go_id, evidence, reference, is_negated)
-            tuple_key = (*base_tuple, parsed_qualifier or "")
+            tuple_key = (
+                *base_tuple,
+                parsed_qualifier or "",
+                supporting_entities_key,
+            )
 
             # Skip if this exact tuple already exists in YAML or was already added
             if tuple_key in existing_tuples or tuple_key in seen_tuples:
                 continue
 
-            # Backfill missing qualifiers on older seeded annotations instead of
-            # adding a duplicate annotation for the same GO/evidence/reference tuple.
-            if parsed_qualifier:
-                existing_without_qualifier = existing_missing_qualifier_by_base.get(
-                    base_tuple, []
+            # Enrich one compatible legacy annotation rather than duplicating it.
+            # A second GOA row with a different non-empty WITH/FROM value will no
+            # longer match the enriched annotation and will therefore be added.
+            enriched_existing = False
+            for existing_ann in existing_by_base.get(base_tuple, []):
+                existing_qualifier = self._parse_qualifier(
+                    existing_ann.get("qualifier")
                 )
-                if existing_without_qualifier:
-                    existing_ann = existing_without_qualifier.pop(0)
-                    existing_ann["qualifier"] = parsed_qualifier
-                    existing_tuples.add(tuple_key)
-                    qualifiers_backfilled += 1
+                existing_supporting_key = self._supporting_entities_key(
+                    existing_ann.get("supporting_entities")
+                )
+                qualifier_compatible = (
+                    existing_qualifier == parsed_qualifier
+                    or (not existing_qualifier and bool(parsed_qualifier))
+                )
+                supporting_compatible = (
+                    existing_supporting_key == supporting_entities_key
+                    or (not existing_supporting_key and bool(supporting_entities_key))
+                    or not supporting_entities_key
+                )
+                if not qualifier_compatible or not supporting_compatible:
                     continue
+
+                if parsed_qualifier and not existing_qualifier:
+                    existing_ann["qualifier"] = parsed_qualifier
+                    qualifiers_backfilled += 1
+                if supporting_entities and not existing_supporting_key:
+                    existing_ann["supporting_entities"] = supporting_entities
+                    supporting_entities_backfilled += 1
+                existing_tuples.add(tuple_key)
+                enriched_existing = True
+                break
+
+            if enriched_existing:
+                continue
 
             # Create new annotation entry (stub for review)
             new_annotation: Dict[str, Any] = {
@@ -747,6 +815,9 @@ class GOAValidator:
             # things biologically.
             if parsed_qualifier:
                 new_annotation["qualifier"] = parsed_qualifier
+
+            if supporting_entities:
+                new_annotation["supporting_entities"] = supporting_entities
 
             # Add negated field if this is a NOT annotation
             if is_negated:
@@ -858,6 +929,7 @@ class GOAValidator:
             or added_count > 0
             or refs_added > 0
             or qualifiers_backfilled > 0
+            or supporting_entities_backfilled > 0
         )
         if should_write:
             with open(output_file, "w") as f:
@@ -869,7 +941,13 @@ class GOAValidator:
                     allow_unicode=True,
                 )
 
-        return added_count, output_file, refs_added, qualifiers_backfilled
+        return (
+            added_count,
+            output_file,
+            refs_added,
+            qualifiers_backfilled,
+            supporting_entities_backfilled,
+        )
 
     def _get_go_ref_title(self, go_ref_id: str, cache: Dict[str, str]) -> str:
         """Fetch GO_REF title from GO site YAML file.
@@ -922,6 +1000,30 @@ class GOAValidator:
         if not isinstance(qualifier, str):
             return False
         return "NOT" in qualifier.upper()
+
+    @staticmethod
+    def _normalize_supporting_entities(value: Any) -> List[str]:
+        """Normalize GOA WITH/FROM or YAML supporting_entities to an ID list."""
+        if isinstance(value, str):
+            values = value.split("|")
+        elif isinstance(value, list):
+            values = value
+        else:
+            return []
+
+        normalized: List[str] = []
+        for item in values:
+            if not isinstance(item, str):
+                continue
+            item = item.strip()
+            if item and item not in normalized:
+                normalized.append(item)
+        return normalized
+
+    @classmethod
+    def _supporting_entities_key(cls, value: Any) -> Tuple[str, ...]:
+        """Return an order-insensitive identity key for supporting entities."""
+        return tuple(sorted(cls._normalize_supporting_entities(value)))
 
     # Valid GO annotation qualifiers from GAF/GPAD spec
     VALID_QUALIFIERS = {

--- a/src/ai_gene_review/validation/goa_validator.py
+++ b/src/ai_gene_review/validation/goa_validator.py
@@ -688,7 +688,10 @@ class GOAValidator:
         # and/or supporting_entities, so keep a base-tuple index that lets us enrich
         # one legacy annotation before adding rows that differ only by WITH/FROM.
         existing_tuples = set()
-        existing_by_tuple = {}
+        existing_by_tuple: Dict[
+            Tuple[str, str, str, bool, str, Tuple[str, ...]],
+            List[Dict[str, Any]],
+        ] = {}
         existing_by_base: Dict[Tuple[str, str, str, bool], List[Dict[str, Any]]] = {}
         for ann in existing_annotations:
             # Historical records must not suppress a fresh review if their GOA
@@ -703,15 +706,15 @@ class GOAValidator:
                     ref = ann.get("original_reference_id", "")
                     negated = ann.get("negated", False)
                     parsed_qualifier = self._parse_qualifier(ann.get("qualifier"))
-                    supporting_entities = self._supporting_entities_key(
+                    existing_sources_key = self._supporting_entities_key(
                         ann.get("supporting_entities")
                     )
                     base_tuple = (go_id, evidence, ref, negated)
                     existing_tuples.add(
-                        (*base_tuple, parsed_qualifier or "", supporting_entities)
+                        (*base_tuple, parsed_qualifier or "", existing_sources_key)
                     )
                     existing_by_tuple.setdefault(
-                        (*base_tuple, parsed_qualifier or "", supporting_entities), []
+                        (*base_tuple, parsed_qualifier or "", existing_sources_key), []
                     ).append(ann)
                     existing_by_base.setdefault(base_tuple, []).append(ann)
 

--- a/src/ai_gene_review/validation/goa_validator.py
+++ b/src/ai_gene_review/validation/goa_validator.py
@@ -929,6 +929,13 @@ class GOAValidator:
             yaml_data["references"] = existing_refs
             print(f"    Also seeded {refs_added} references from GOA")
 
+        if added_count > 0:
+            # New PENDING work invalidates an old completion status. Use the
+            # shared status rules rather than copying stale workflow metadata.
+            from ai_gene_review.status_manager import compute_status_from_data
+
+            yaml_data["status"] = compute_status_from_data(yaml_data)
+
         # Determine output path
         if output_file is None:
             output_file = yaml_file

--- a/src/ai_gene_review/validation/goa_validator.py
+++ b/src/ai_gene_review/validation/goa_validator.py
@@ -293,9 +293,9 @@ class GOAValidator:
         """Validate complete annotation tuples, preserving GOA WITH/FROM rows.
 
         ``supporting_entities`` was added after many reviews were seeded.  An
-        older YAML row without that field therefore acts as a wildcard for one
-        GOA row with the same term/evidence/reference/polarity.  It must not
-        hide a second GOA row with a different WITH/FROM value.  Explicitly
+        older YAML row without that field therefore acts as a wildcard for all
+        GOA rows with the same term/evidence/reference/polarity. Seeding expands
+        these legacy rows without requiring a corpus-wide migration. Explicitly
         populated YAML rows, by contrast, require an exact support match.
         """
         goa_keys: List[Tuple[str, str, str, bool, Tuple[str, ...]]] = []
@@ -333,7 +333,7 @@ class GOAValidator:
             Tuple[Dict, Tuple[str, str, str, bool], Tuple[str, ...]]
         ] = []
 
-        # Check NEW assertions first and collect ordinary rows for one-to-one
+        # Check NEW assertions first and collect ordinary rows for source-aware
         # matching below.
         for yaml_ann in yaml_annotations:
             if not isinstance(yaml_ann, dict):
@@ -423,38 +423,19 @@ class GOAValidator:
 
         unmatched_goa = set(range(len(goa_annotations)))
 
-        # Claim exact supported rows first.  This prevents a legacy wildcard
-        # from consuming a GOA row needed by an explicit YAML assertion.
-        explicit_yaml = [row for row in ordinary_yaml if row[2]]
-        legacy_yaml = [row for row in ordinary_yaml if not row[2]]
+        # Legacy reviews predate WITH/FROM identity and may intentionally contain
+        # one row for several sources. Preserve that validation compatibility;
+        # seeding still expands each distinct source into its own review row.
         unmatched_yaml: List[Dict] = []
-
-        for yaml_ann, base_key, support_key in explicit_yaml:
-            full_key = (*base_key, support_key)
-            match = next(
-                (index for index in unmatched_goa if goa_keys[index] == full_key),
-                None,
-            )
-            if match is None:
-                unmatched_yaml.append(yaml_ann)
+        for yaml_ann, base_key, support_key in ordinary_yaml:
+            matches = {
+                index for index, key in enumerate(goa_keys)
+                if key[:4] == base_key and (not support_key or key[4] == support_key)
+            }
+            if matches:
+                unmatched_goa.difference_update(matches)
             else:
-                unmatched_goa.remove(match)
-
-        # A support-less legacy row may represent exactly one remaining GOA row
-        # with the same base assertion.
-        for yaml_ann, base_key, _ in legacy_yaml:
-            match = next(
-                (
-                    index
-                    for index in unmatched_goa
-                    if goa_keys[index][:4] == base_key
-                ),
-                None,
-            )
-            if match is None:
                 unmatched_yaml.append(yaml_ann)
-            else:
-                unmatched_goa.remove(match)
 
         for yaml_ann in unmatched_yaml:
             result.missing_in_goa.append(yaml_ann)

--- a/src/ai_gene_review/validation/goa_validator.py
+++ b/src/ai_gene_review/validation/goa_validator.py
@@ -296,7 +296,9 @@ class GOAValidator:
         older YAML row without that field therefore acts as a wildcard for all
         GOA rows with the same term/evidence/reference/polarity. Seeding expands
         these legacy rows without requiring a corpus-wide migration. Explicitly
-        populated YAML rows, by contrast, require an exact support match.
+        populated YAML rows require an exact support match or an exact union
+        of complete GOA source lists for the same base tuple (older combined
+        reviews). Partial source lists and unsupported IDs remain errors.
         """
         goa_keys: List[Tuple[str, str, str, bool, Tuple[str, ...]]] = []
         goa_by_go_id: Dict[str, List[GOAAnnotation]] = {}
@@ -432,6 +434,21 @@ class GOAValidator:
                 index for index, key in enumerate(goa_keys)
                 if key[:4] == base_key and (not support_key or key[4] == support_key)
             }
+            if not matches and support_key:
+                # Older hand-authored reviews combined several source rows. Accept
+                # only a lossless union of whole matching lists, never a partial
+                # donor group or a list containing an unsupported entity.
+                support_set = set(support_key)
+                combined_matches = {
+                    index for index, key in enumerate(goa_keys)
+                    if key[:4] == base_key and key[4]
+                    and set(key[4]) <= support_set
+                }
+                combined_support = {
+                    entity for index in combined_matches for entity in goa_keys[index][4]
+                }
+                if combined_support == support_set:
+                    matches = combined_matches
             if matches:
                 unmatched_goa.difference_update(matches)
             else:

--- a/src/ai_gene_review/validation/goa_validator.py
+++ b/src/ai_gene_review/validation/goa_validator.py
@@ -290,15 +290,15 @@ class GOAValidator:
         yaml_annotations: List[Dict],
         result: GOAValidationResult,
     ) -> GOAValidationResult:
-        """Validate using strict tuple matching (go_id, evidence_code, reference, negated)."""
-        # Create lookup structure for GOA using complete tuples.
-        # WITH/FROM is part of annotation identity: otherwise distinct partner,
-        # donor, or inference-source rows collapse into one review entry.
-        # Key: (go_id, evidence_code, reference, negated, supporting_entities)
-        goa_tuples = set()
-        goa_by_tuple: Dict[
-            Tuple[str, str, str, bool, Tuple[str, ...]], GOAAnnotation
-        ] = {}
+        """Validate complete annotation tuples, preserving GOA WITH/FROM rows.
+
+        ``supporting_entities`` was added after many reviews were seeded.  An
+        older YAML row without that field therefore acts as a wildcard for one
+        GOA row with the same term/evidence/reference/polarity.  It must not
+        hide a second GOA row with a different WITH/FROM value.  Explicitly
+        populated YAML rows, by contrast, require an exact support match.
+        """
+        goa_keys: List[Tuple[str, str, str, bool, Tuple[str, ...]]] = []
         goa_by_go_id: Dict[str, List[GOAAnnotation]] = {}
         goa_by_annotation_identity: Dict[
             Tuple[str, str, bool], List[GOAAnnotation]
@@ -315,8 +315,7 @@ class GOAValidator:
                 is_negated,
                 supporting_entities,
             )
-            goa_tuples.add(tuple_key)
-            goa_by_tuple[tuple_key] = ann
+            goa_keys.append(tuple_key)
             goa_by_go_id.setdefault(ann.go_id, []).append(ann)
             identity = (ann.go_id, parsed_qualifier, is_negated)
             goa_by_annotation_identity.setdefault(identity, []).append(ann)
@@ -330,7 +329,12 @@ class GOAValidator:
             and isinstance((term := yaml_ann.get("term", {})), dict)
         }
 
-        # Check each YAML annotation against GOA
+        ordinary_yaml: List[
+            Tuple[Dict, Tuple[str, str, str, bool], Tuple[str, ...]]
+        ] = []
+
+        # Check NEW assertions first and collect ordinary rows for one-to-one
+        # matching below.
         for yaml_ann in yaml_annotations:
             if not isinstance(yaml_ann, dict):
                 continue
@@ -405,90 +409,75 @@ class GOAValidator:
             if not go_id:
                 continue
 
-            # Create the tuple to check (includes negation)
-            yaml_tuple = (
-                go_id,
-                evidence_type,
-                original_ref,
-                negated,
-                supporting_entities,
+            ordinary_yaml.append(
+                (
+                    yaml_ann,
+                    (go_id, evidence_type, original_ref, bool(negated)),
+                    supporting_entities,
+                )
             )
-
-            # Check if this exact tuple exists in GOA
-            if yaml_tuple not in goa_tuples:
-                # This exact annotation is not in GOA
-                result.missing_in_goa.append(yaml_ann)
-                result.is_valid = False
-
-                # Check if it's a partial match (same GO term but different evidence/ref)
-                partial_matches = [
-                    goa_ann for key, goa_ann in goa_by_tuple.items() if key[0] == go_id
-                ]
-
-                if partial_matches:
-                    # There are annotations for this GO term, but with different evidence/ref
-                    # Check for evidence mismatch
-                    goa_evidence_for_term = {
-                        ann.evidence_code for ann in partial_matches
-                    }
-                    if evidence_type and evidence_type not in goa_evidence_for_term:
-                        result.mismatched_evidence.append(
-                            (
-                                go_id,
-                                evidence_type,
-                                ", ".join(sorted(goa_evidence_for_term)),
-                            )
-                        )
-
-                    # Check for reference mismatch
-                    goa_refs_for_term = {ann.reference for ann in partial_matches}
-                    if original_ref and original_ref not in goa_refs_for_term:
-                        # This is a reference mismatch - add to result if we track it
-                        pass  # We could add a mismatched_references list if needed
 
             # Skip label consistency check - we validate against ontology, not GOA
             # GOA files may use synonyms instead of primary labels
             # Label validation is handled by term_validator.py against the ontology
 
-        # Check for annotations in GOA but not in YAML
-        # Build set of YAML annotations, excluding NEW and retired annotations
-        yaml_tuples = set()
-        for yaml_ann in yaml_annotations:
-            if isinstance(yaml_ann, dict):
-                # Skip retired annotations - they don't need to be in GOA
-                if yaml_ann.get("retired", False):
-                    continue
-                # Skip NEW annotations - they should NOT be in GOA
-                review = yaml_ann.get("review", {})
-                if isinstance(review, dict) and review.get("action") == "NEW":
-                    continue
+        unmatched_goa = set(range(len(goa_annotations)))
 
-                term = yaml_ann.get("term", {})
-                if isinstance(term, dict):
-                    go_id = term.get("id", "")
-                    evidence_type = yaml_ann.get("evidence_type", "")
-                    original_ref = yaml_ann.get("original_reference_id", "")
-                    negated = yaml_ann.get("negated", False)
-                    supporting_entities = self._supporting_entities_key(
-                        yaml_ann.get("supporting_entities")
-                    )
-                    if go_id:
-                        yaml_tuples.add(
-                            (
-                                go_id,
-                                evidence_type,
-                                original_ref,
-                                negated,
-                                supporting_entities,
-                            )
+        # Claim exact supported rows first.  This prevents a legacy wildcard
+        # from consuming a GOA row needed by an explicit YAML assertion.
+        explicit_yaml = [row for row in ordinary_yaml if row[2]]
+        legacy_yaml = [row for row in ordinary_yaml if not row[2]]
+        unmatched_yaml: List[Dict] = []
+
+        for yaml_ann, base_key, support_key in explicit_yaml:
+            full_key = (*base_key, support_key)
+            match = next(
+                (index for index in unmatched_goa if goa_keys[index] == full_key),
+                None,
+            )
+            if match is None:
+                unmatched_yaml.append(yaml_ann)
+            else:
+                unmatched_goa.remove(match)
+
+        # A support-less legacy row may represent exactly one remaining GOA row
+        # with the same base assertion.
+        for yaml_ann, base_key, _ in legacy_yaml:
+            match = next(
+                (
+                    index
+                    for index in unmatched_goa
+                    if goa_keys[index][:4] == base_key
+                ),
+                None,
+            )
+            if match is None:
+                unmatched_yaml.append(yaml_ann)
+            else:
+                unmatched_goa.remove(match)
+
+        for yaml_ann in unmatched_yaml:
+            result.missing_in_goa.append(yaml_ann)
+            result.is_valid = False
+            go_id = yaml_ann.get("term", {}).get("id", "")
+            evidence_type = yaml_ann.get("evidence_type", "")
+            partial_matches = goa_by_go_id.get(go_id, [])
+            if partial_matches:
+                goa_evidence_for_term = {
+                    ann.evidence_code for ann in partial_matches
+                }
+                if evidence_type and evidence_type not in goa_evidence_for_term:
+                    result.mismatched_evidence.append(
+                        (
+                            go_id,
+                            evidence_type,
+                            ", ".join(sorted(goa_evidence_for_term)),
                         )
+                    )
 
-        for goa_tuple in goa_tuples:
-            if goa_tuple not in yaml_tuples:
-                goa_ann = goa_by_tuple[goa_tuple]
-                result.missing_in_yaml.append(goa_ann)
-                # Missing GOA annotations in YAML is always a validation failure
-                result.is_valid = False
+        for index in sorted(unmatched_goa):
+            result.missing_in_yaml.append(goa_annotations[index])
+            result.is_valid = False
 
         return result
 
@@ -701,6 +690,7 @@ class GOAValidator:
         # and/or supporting_entities, so keep a base-tuple index that lets us enrich
         # one legacy annotation before adding rows that differ only by WITH/FROM.
         existing_tuples = set()
+        existing_by_tuple = {}
         existing_by_base: Dict[Tuple[str, str, str, bool], List[Dict[str, Any]]] = {}
         for ann in existing_annotations:
             if isinstance(ann, dict) and "term" in ann:
@@ -718,6 +708,9 @@ class GOAValidator:
                     existing_tuples.add(
                         (*base_tuple, parsed_qualifier or "", supporting_entities)
                     )
+                    existing_by_tuple.setdefault(
+                        (*base_tuple, parsed_qualifier or "", supporting_entities), []
+                    ).append(ann)
                     existing_by_base.setdefault(base_tuple, []).append(ann)
 
         # Add missing annotations from GOA
@@ -736,8 +729,24 @@ class GOAValidator:
             ):
                 pmids_to_add.add(goa_ann.reference)
 
-        # Second pass - add missing annotations based on complete tuple
-        for goa_ann in goa_annotations:
+        def seeding_key(ann: GOAAnnotation) -> tuple:
+            """Stable source order; reserve exact matches before legacy backfills."""
+            return (
+                ann.go_id, ann.evidence_code, ann.reference,
+                self._qualifier_is_negated(ann.qualifier),
+                self._parse_qualifier(ann.qualifier) or "",
+                self._supporting_entities_key(ann.with_from),
+            )
+
+        claimed_existing = {
+            id(ann)
+            for goa_ann in goa_annotations
+            for ann in existing_by_tuple.get(seeding_key(goa_ann), [])
+        }
+
+        # Stable ordering prevents a refresh from assigning a legacy review to a
+        # different donor merely because QuickGO changed its response order.
+        for goa_ann in sorted(goa_annotations, key=seeding_key):
             go_id = goa_ann.go_id
             evidence = goa_ann.evidence_code
             reference = goa_ann.reference
@@ -771,6 +780,8 @@ class GOAValidator:
             # longer match the enriched annotation and will therefore be added.
             enriched_existing = False
             for existing_ann in existing_by_base.get(base_tuple, []):
+                if id(existing_ann) in claimed_existing:
+                    continue
                 existing_qualifier = self._parse_qualifier(
                     existing_ann.get("qualifier")
                 )
@@ -784,7 +795,6 @@ class GOAValidator:
                 supporting_compatible = (
                     existing_supporting_key == supporting_entities_key
                     or (not existing_supporting_key and bool(supporting_entities_key))
-                    or not supporting_entities_key
                 )
                 if not qualifier_compatible or not supporting_compatible:
                     continue
@@ -796,6 +806,7 @@ class GOAValidator:
                     existing_ann["supporting_entities"] = supporting_entities
                     supporting_entities_backfilled += 1
                 existing_tuples.add(tuple_key)
+                claimed_existing.add(id(existing_ann))
                 enriched_existing = True
                 break
 

--- a/tests/test_goa_strict_validation.py
+++ b/tests/test_goa_strict_validation.py
@@ -13,7 +13,9 @@ def create_test_goa_file(annotations: list) -> Path:
     with tempfile.NamedTemporaryFile(mode="w", suffix="-goa.tsv", delete=False) as f:
         # Write header
         f.write(
-            "DB\tDB_Object_ID\tDB_Object_Symbol\tQualifier\tGO_ID\tGO_Term\tGO_Aspect\tEvidence_Type\tEvidence_Code\tReference\tDate\tAssignedBy\n"
+            "GENE PRODUCT DB\tGENE PRODUCT ID\tSYMBOL\tQUALIFIER\tGO TERM\t"
+            "GO NAME\tGO ASPECT\tECO ID\tGO EVIDENCE CODE\tREFERENCE\t"
+            "WITH/FROM\tTAXON ID\tTAXON NAME\tASSIGNED BY\tGENE NAME\tDATE\n"
         )
 
         # Write annotations
@@ -21,8 +23,9 @@ def create_test_goa_file(annotations: list) -> Path:
             f.write(
                 f"UniProtKB\t{ann['id']}\t{ann['symbol']}\t{ann.get('qualifier', '')}\t"
                 f"{ann['go_id']}\t{ann['go_term']}\t{ann.get('aspect', 'P')}\t"
-                f"{ann['evidence']}\t{ann['evidence']}\t{ann['reference']}\t"
-                f"20240101\tGOA\n"
+                f"ECO:0000000\t{ann['evidence']}\t{ann['reference']}\t"
+                f"{ann.get('with_from', '')}\tNCBITaxon:9606\tHomo sapiens\t"
+                f"GOA\tTest protein\t20240101\n"
             )
 
         return Path(f.name)

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -1606,13 +1606,14 @@ def test_seeding_preserves_combined_historical_review(tmp_path):
         'review': {'action': 'ACCEPT', 'summary': 'Combined historical judgment'},
     }
     yaml_path.write_text(yaml.safe_dump({
-        'id': 'Q12345', 'gene_symbol': 'TEST',
+        'id': 'Q12345', 'gene_symbol': 'TEST', 'status': 'COMPLETE',
         'existing_annotations': [historical],
         'references': [{'id': 'PMID:12345', 'title': 'Existing title'}],
     }))
     validator = GOAValidator()
     added, *_ = validator.seed_missing_annotations(yaml_path, goa_path, fetch_titles=False)
     assert added == 2
+    assert yaml.safe_load(yaml_path.read_text())['status'] == 'IN_PROGRESS'
     rows = yaml.safe_load(yaml_path.read_text())['existing_annotations']
     assert rows[0] == historical
     assert [row['review']['action'] for row in rows[1:]] == ['PENDING', 'PENDING']

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -676,7 +676,10 @@ def test_seed_missing_annotations_backfills_and_splits_supporting_entities(tmp_p
 
     before = validator.validate_against_goa(yaml_path, goa_path)
     assert not before.is_valid
-    assert len(before.missing_in_yaml) == 2
+    # The legacy support-less row represents one GOA assertion, but it cannot
+    # hide the second row with a distinct WITH/FROM value.
+    assert len(before.missing_in_yaml) == 1
+    assert not before.missing_in_goa
 
     added, _, references_added, qualifiers_backfilled, supporting_backfilled = (
         validator.seed_missing_annotations(yaml_path, goa_path)
@@ -1459,3 +1462,35 @@ UniProtKB	Q12345	TEST	enables	GO:0001234	test function	MF	ECO:0000353	IPI	PMID:1
         goa_path.unlink()
         if yaml_path.exists():
             yaml_path.unlink()
+
+
+@pytest.mark.parametrize('donors', [('', 'UniProtKB:P11111'), ('UniProtKB:P11111', '')])
+@pytest.mark.parametrize('qualifier', ['', 'enables'])
+def test_seed_mixed_empty_support_is_one_to_one(tmp_path, donors, qualifier):
+    """Empty support cannot steal a curated row already assigned to another source."""
+    goa_path = tmp_path / 'TEST-goa.tsv'
+    header = 'GENE PRODUCT DB\tGENE PRODUCT ID\tSYMBOL\tQUALIFIER\tGO TERM\tGO NAME\tGO ASPECT\tECO ID\tGO EVIDENCE CODE\tREFERENCE\tWITH/FROM\tTAXON ID\tTAXON NAME\tASSIGNED BY\tGENE NAME\tDATE\n'
+    goa_path.write_text(header + ''.join(
+        f'UniProtKB\tQ12345\tTEST\tenables\tGO:0001234\ttest function\tMF\tECO:0000266\tISO\tPMID:12345\t{donor}\tNCBITaxon:9606\tHomo sapiens\tUniProt\tTest\t20180515\n'
+        for donor in donors
+    ))
+    yaml_path = tmp_path / 'TEST-ai-review.yaml'
+    yaml_path.write_text(yaml.safe_dump({'existing_annotations': [{
+        'term': {'id': 'GO:0001234', 'label': 'test function'},
+        'evidence_type': 'ISO', 'original_reference_id': 'PMID:12345',
+        'qualifier': qualifier,
+        'review': {'summary': 'Curated legacy assertion', 'action': 'ACCEPT'},
+    }]}))
+    validator = GOAValidator()
+    added, *_ = validator.seed_missing_annotations(yaml_path, goa_path)
+    assert added == 1
+    rows = yaml.safe_load(yaml_path.read_text())['existing_annotations']
+    assert len(rows) == 2
+    assert {tuple(row.get('supporting_entities', [])) for row in rows} == {(), ('UniProtKB:P11111',)}
+    assert rows[0].get('supporting_entities', []) == []
+    assert rows[0]['review']['summary'] == 'Curated legacy assertion'
+    assert rows[1]['review']['action'] == 'PENDING'
+    assert validator.validate_against_goa(yaml_path, goa_path).is_valid
+    seeded = yaml_path.read_bytes()
+    assert validator.seed_missing_annotations(yaml_path, goa_path)[0] == 0
+    assert yaml_path.read_bytes() == seeded

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -38,6 +38,7 @@ def sample_yaml_matching():
                 "term": {"id": "GO:0005515", "label": "protein binding"},
                 "evidence_type": "IPI",
                 "original_reference_id": "PMID:29727692",
+                "supporting_entities": ["UniProtKB:Q9NVR5"],
             },
             {
                 "term": {"id": "GO:0005737", "label": "cytoplasm"},
@@ -80,6 +81,7 @@ def sample_yaml_missing():
                 "term": {"id": "GO:0005515", "label": "protein binding"},
                 "evidence_type": "IPI",
                 "original_reference_id": "PMID:29727692",
+                "supporting_entities": ["UniProtKB:Q9NVR5"],
             },
             {
                 "term": {"id": "GO:0005737", "label": "cytoplasm"},
@@ -108,6 +110,7 @@ def sample_yaml_extra():
                 "term": {"id": "GO:0005515", "label": "protein binding"},
                 "evidence_type": "IPI",
                 "original_reference_id": "PMID:29727692",
+                "supporting_entities": ["UniProtKB:Q9NVR5"],
             },
             {
                 "term": {"id": "GO:0005737", "label": "cytoplasm"},
@@ -158,6 +161,7 @@ def sample_yaml_label_mismatch():
                 },  # Should be 'protein binding'
                 "evidence_type": "IPI",
                 "original_reference_id": "PMID:29727692",
+                "supporting_entities": ["UniProtKB:Q9NVR5"],
             },
             {
                 "term": {"id": "GO:0005737", "label": "cytoplasm"},
@@ -546,7 +550,7 @@ UniProtKB	Q12345	TEST		GO:0009999	test location	CC	ECO:0007322	IEA	PMID:99999		N
 
     try:
         # Seed missing annotations
-        added_count, output_path, refs_added, _ = validator.seed_missing_annotations(
+        added_count, output_path, refs_added, _, _ = validator.seed_missing_annotations(
             yaml_path, goa_path
         )
 
@@ -613,7 +617,9 @@ UniProtKB	Q12345	TEST	part_of	GO:0008888	test complex	CC	ECO:0000314	IDA	PMID:88
         yaml_path = Path(yaml_file.name)
 
     try:
-        added_count, _, _, _ = validator.seed_missing_annotations(yaml_path, goa_path)
+        added_count, _, _, _, _ = validator.seed_missing_annotations(
+            yaml_path, goa_path
+        )
 
         assert added_count == 4
 
@@ -633,6 +639,66 @@ UniProtKB	Q12345	TEST	part_of	GO:0008888	test complex	CC	ECO:0000314	IDA	PMID:88
     finally:
         goa_path.unlink()
         yaml_path.unlink()
+
+
+def test_seed_missing_annotations_backfills_and_splits_supporting_entities(tmp_path):
+    """WITH/FROM-distinct rows must remain distinct in seeded review YAML."""
+    validator = GOAValidator()
+    goa_path = tmp_path / "TEST-goa.tsv"
+    goa_path.write_text(
+        "GENE PRODUCT DB\tGENE PRODUCT ID\tSYMBOL\tQUALIFIER\tGO TERM\tGO NAME\t"
+        "GO ASPECT\tECO ID\tGO EVIDENCE CODE\tREFERENCE\tWITH/FROM\tTAXON ID\t"
+        "TAXON NAME\tASSIGNED BY\tGENE NAME\tDATE\n"
+        "UniProtKB\tQ12345\tTEST\tenables\tGO:0001234\ttest function\tMF\t"
+        "ECO:0000266\tISO\tPMID:12345\tUniProtKB:P11111\tNCBITaxon:9606\t"
+        "Homo sapiens\tUniProt\tTest protein\t20180515\n"
+        "UniProtKB\tQ12345\tTEST\tenables\tGO:0001234\ttest function\tMF\t"
+        "ECO:0000266\tISO\tPMID:12345\tUniProtKB:P22222|UniProtKB:P33333\t"
+        "NCBITaxon:9606\tHomo sapiens\tUniProt\tTest protein\t20180515\n"
+    )
+    yaml_path = tmp_path / "TEST-ai-review.yaml"
+    yaml_path.write_text(
+        "id: Q12345\n"
+        "gene_symbol: TEST\n"
+        "taxon: {id: 'NCBITaxon:9606', label: Homo sapiens}\n"
+        "description: Test gene\n"
+        "existing_annotations:\n"
+        "- term: {id: 'GO:0001234', label: test function}\n"
+        "  evidence_type: ISO\n"
+        "  original_reference_id: PMID:12345\n"
+        "  qualifier: enables\n"
+        "  review: {summary: Already reviewed, action: ACCEPT}\n"
+        "references:\n"
+        "- id: PMID:12345\n"
+        "  title: Existing title\n"
+        "  findings: []\n"
+    )
+
+    before = validator.validate_against_goa(yaml_path, goa_path)
+    assert not before.is_valid
+    assert len(before.missing_in_yaml) == 2
+
+    added, _, references_added, qualifiers_backfilled, supporting_backfilled = (
+        validator.seed_missing_annotations(yaml_path, goa_path)
+    )
+
+    assert (
+        added,
+        references_added,
+        qualifiers_backfilled,
+        supporting_backfilled,
+    ) == (1, 0, 0, 1)
+    document = yaml.safe_load(yaml_path.read_text())
+    annotations = document["existing_annotations"]
+    assert len(annotations) == 2
+    assert annotations[0]["supporting_entities"] == ["UniProtKB:P11111"]
+    assert annotations[0]["review"]["summary"] == "Already reviewed"
+    assert annotations[1]["supporting_entities"] == [
+        "UniProtKB:P22222",
+        "UniProtKB:P33333",
+    ]
+    assert annotations[1]["review"]["action"] == "PENDING"
+    assert validator.validate_against_goa(yaml_path, goa_path).is_valid
 
 
 def test_seed_missing_annotations_reports_backfilled_qualifiers(tmp_path):
@@ -663,11 +729,16 @@ def test_seed_missing_annotations_reports_backfilled_qualifiers(tmp_path):
         "  original_reference_id: PMID:12345\n"
     )
 
-    added, _, references_added, qualifiers_backfilled = (
+    added, _, references_added, qualifiers_backfilled, supporting_backfilled = (
         validator.seed_missing_annotations(yaml_path, goa_path)
     )
 
-    assert (added, references_added, qualifiers_backfilled) == (0, 1, 1)
+    assert (
+        added,
+        references_added,
+        qualifiers_backfilled,
+        supporting_backfilled,
+    ) == (0, 1, 1, 0)
     document = yaml.safe_load(yaml_path.read_text())
     assert document["existing_annotations"][0]["qualifier"] == "enables"
 
@@ -703,11 +774,16 @@ def test_seed_missing_annotations_true_noop_preserves_yaml_bytes(tmp_path):
     )
     yaml_path.write_text(original)
 
-    added, _, references_added, qualifiers_backfilled = (
+    added, _, references_added, qualifiers_backfilled, supporting_backfilled = (
         validator.seed_missing_annotations(yaml_path, goa_path)
     )
 
-    assert (added, references_added, qualifiers_backfilled) == (0, 0, 0)
+    assert (
+        added,
+        references_added,
+        qualifiers_backfilled,
+        supporting_backfilled,
+    ) == (0, 0, 0, 0)
     assert yaml_path.read_text() == original
 
 
@@ -741,13 +817,24 @@ def test_seed_missing_annotations_noop_writes_requested_output(tmp_path):
     )
     output_path = tmp_path / "copy.yaml"
 
-    added, returned_path, references_added, qualifiers_backfilled = (
+    (
+        added,
+        returned_path,
+        references_added,
+        qualifiers_backfilled,
+        supporting_backfilled,
+    ) = (
         validator.seed_missing_annotations(
             yaml_path, goa_path, output_file=output_path
         )
     )
 
-    assert (added, references_added, qualifiers_backfilled) == (0, 0, 0)
+    assert (
+        added,
+        references_added,
+        qualifiers_backfilled,
+        supporting_backfilled,
+    ) == (0, 0, 0, 0)
     assert returned_path == output_path
     assert yaml.safe_load(output_path.read_text()) == yaml.safe_load(
         yaml_path.read_text()
@@ -1088,6 +1175,7 @@ UniProtKB\tQ12345\tTEST\tenables\tGO:0016491\toxidoreductase activity\tMF\tECO:0
                 "evidence_type": "IEA",
                 "original_reference_id": "GO_REF:0000002",
                 "qualifier": "enables",
+                "supporting_entities": ["InterPro:IPR000001"],
                 "review": {"summary": "The subunit does not enable the activity alone", "action": "REMOVE"},
             },
             {
@@ -1236,7 +1324,7 @@ UniProtKB	P19544-1	WT1		GO:0045892	negative regulation of DNA-templated transcri
 
     try:
         # Seed annotations
-        added_count, output_path, refs_added, _ = validator.seed_missing_annotations(
+        added_count, output_path, refs_added, _, _ = validator.seed_missing_annotations(
             yaml_path, goa_path
         )
 
@@ -1300,7 +1388,7 @@ UniProtKB	P19544-1	WT1	NOT|involved_in	GO:0045893	positive regulation of DNA-tem
 
     try:
         # Seed annotations
-        added_count, output_path, refs_added, _ = validator.seed_missing_annotations(
+        added_count, output_path, refs_added, _, _ = validator.seed_missing_annotations(
             yaml_path, goa_path
         )
 
@@ -1352,7 +1440,7 @@ UniProtKB	Q12345	TEST	enables	GO:0001234	test function	MF	ECO:0000353	IPI	PMID:1
 
     try:
         # Seed should create the file
-        added_count, output_path, refs_added, _ = validator.seed_missing_annotations(
+        added_count, output_path, refs_added, _, _ = validator.seed_missing_annotations(
             yaml_path, goa_path
         )
 

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -686,6 +686,23 @@ def test_seed_missing_annotations_backfills_and_splits_supporting_entities(tmp_p
     assert not before.missing_in_yaml
     assert not before.missing_in_goa
 
+    from typer.testing import CliRunner
+    from ai_gene_review.cli import app
+
+    original = yaml_path.read_bytes()
+    runner = CliRunner()
+    preview = runner.invoke(app, ["seed-goa", str(yaml_path), "--goa", str(goa_path), "--dry-run", "--no-fetch-titles"])
+    assert preview.exit_code == 0, preview.output
+    assert "Would add 1 annotations" in preview.output
+    assert "1 supporting-entity lists" in preview.output
+    assert yaml_path.read_bytes() == original
+    seeded_output = tmp_path / "cli-seeded.yaml"
+    seeded_cli = runner.invoke(app, ["seed-goa", str(yaml_path), "--goa", str(goa_path), "--output", str(seeded_output), "--no-fetch-titles"])
+    assert seeded_cli.exit_code == 0, seeded_cli.output
+    assert seeded_output.exists(), seeded_cli.output
+    assert len(yaml.safe_load(seeded_output.read_text())["existing_annotations"]) == 2
+    assert yaml_path.read_bytes() == original
+
     added, _, references_added, qualifiers_backfilled, supporting_backfilled = (
         validator.seed_missing_annotations(yaml_path, goa_path)
     )

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -748,6 +748,22 @@ def test_seed_missing_annotations_backfills_and_splits_supporting_entities(tmp_p
     assert len(wrong.missing_in_yaml) == 1
     assert len(wrong.missing_in_goa) == 1
 
+    # When a source changes, retain its historical review and explicitly retire
+    # it. The current source gets a fresh pending row rather than inheriting it.
+    annotations[0]["retired"] = True
+    yaml_path.write_text(yaml.safe_dump(document))
+    assert validator.seed_missing_annotations(yaml_path, goa_path)[0] == 1
+    refreshed = yaml.safe_load(yaml_path.read_text())
+    assert refreshed["existing_annotations"][0] == annotations[0]
+    assert refreshed["existing_annotations"][-1]["review"]["action"] == "PENDING"
+    assert validator.validate_against_goa(yaml_path, goa_path).is_valid
+
+    # Reappearance of a retired source must also seed a fresh active review.
+    refreshed["existing_annotations"][-1]["retired"] = True
+    yaml_path.write_text(yaml.safe_dump(refreshed))
+    assert validator.seed_missing_annotations(yaml_path, goa_path)[0] == 1
+    assert validator.validate_against_goa(yaml_path, goa_path).is_valid
+
 
 def test_seed_missing_annotations_reports_backfilled_qualifiers(tmp_path):
     """Report qualifier enrichments separately from newly seeded annotations."""

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -641,7 +641,8 @@ UniProtKB	Q12345	TEST	part_of	GO:0008888	test complex	CC	ECO:0000314	IDA	PMID:88
         yaml_path.unlink()
 
 
-def test_seed_missing_annotations_backfills_and_splits_supporting_entities(tmp_path):
+@pytest.mark.parametrize("reverse_sources", [False, True])
+def test_seed_missing_annotations_backfills_and_splits_supporting_entities(tmp_path, reverse_sources):
     """WITH/FROM-distinct rows must remain distinct in seeded review YAML."""
     validator = GOAValidator()
     goa_path = tmp_path / "TEST-goa.tsv"
@@ -674,6 +675,10 @@ def test_seed_missing_annotations_backfills_and_splits_supporting_entities(tmp_p
         "  findings: []\n"
     )
 
+    if reverse_sources:
+        header, *rows = goa_path.read_text().splitlines()
+        goa_path.write_text("\n".join([header, *reversed(rows)]) + "\n")
+
     before = validator.validate_against_goa(yaml_path, goa_path)
     # Validation preserves legacy collapsed-row compatibility. Seeding must
     # nevertheless expand every distinct source, even when validation passes.
@@ -702,6 +707,29 @@ def test_seed_missing_annotations_backfills_and_splits_supporting_entities(tmp_p
     ]
     assert annotations[1]["review"]["action"] == "PENDING"
     assert validator.validate_against_goa(yaml_path, goa_path).is_valid
+
+    seeded = yaml_path.read_bytes()
+    assert validator.seed_missing_annotations(yaml_path, goa_path)[::2] == (0, 0, 0)
+    assert yaml_path.read_bytes() == seeded
+
+    # Once sources are explicit, a missing source must be detected and seeded
+    # without changing the other source's curated review.
+    document["existing_annotations"] = annotations[:1]
+    yaml_path.write_text(yaml.safe_dump(document))
+    missing = validator.validate_against_goa(yaml_path, goa_path)
+    assert not missing.is_valid
+    assert len(missing.missing_in_yaml) == 1
+    assert validator.seed_missing_annotations(yaml_path, goa_path)[0] == 1
+    assert yaml.safe_load(yaml_path.read_text())["existing_annotations"][0] == annotations[0]
+
+    # A populated but incorrect source is never rescued by legacy compatibility.
+    annotations[0]["supporting_entities"] = ["UniProtKB:P99999"]
+    document["existing_annotations"] = annotations
+    yaml_path.write_text(yaml.safe_dump(document))
+    wrong = validator.validate_against_goa(yaml_path, goa_path)
+    assert not wrong.is_valid
+    assert len(wrong.missing_in_yaml) == 1
+    assert len(wrong.missing_in_goa) == 1
 
 
 def test_seed_missing_annotations_reports_backfilled_qualifiers(tmp_path):

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -675,10 +675,10 @@ def test_seed_missing_annotations_backfills_and_splits_supporting_entities(tmp_p
     )
 
     before = validator.validate_against_goa(yaml_path, goa_path)
-    assert not before.is_valid
-    # The legacy support-less row represents one GOA assertion, but it cannot
-    # hide the second row with a distinct WITH/FROM value.
-    assert len(before.missing_in_yaml) == 1
+    # Validation preserves legacy collapsed-row compatibility. Seeding must
+    # nevertheless expand every distinct source, even when validation passes.
+    assert before.is_valid
+    assert not before.missing_in_yaml
     assert not before.missing_in_goa
 
     added, _, references_added, qualifiers_backfilled, supporting_backfilled = (

--- a/tests/test_goa_validator.py
+++ b/tests/test_goa_validator.py
@@ -1555,3 +1555,67 @@ def test_seed_mixed_empty_support_is_one_to_one(tmp_path, donors, qualifier):
     seeded = yaml_path.read_bytes()
     assert validator.seed_missing_annotations(yaml_path, goa_path)[0] == 0
     assert yaml_path.read_bytes() == seeded
+
+@pytest.mark.parametrize(
+    'sources, valid, missing',
+    [
+        (['UniProtKB:P11111', 'UniProtKB:P22222', 'UniProtKB:P33333'], True, 0),
+        (['UniProtKB:P11111', 'UniProtKB:P22222'], False, 2),
+        (['UniProtKB:P11111', 'UniProtKB:P22222', 'UniProtKB:P33333', 'UniProtKB:P99999'], False, 2),
+        (['UniProtKB:P11111'], False, 1),
+    ],
+)
+def test_legacy_combined_support_requires_union_of_complete_sources(sources, valid, missing):
+    """Legacy unions are valid, but cannot invent IDs or truncate source groups."""
+    from ai_gene_review.validation.goa_validator import GOAValidationResult
+
+    goa = [GOAAnnotation.from_tsv_row([
+        'UniProtKB', 'Q12345', 'TEST', 'enables', 'GO:0005515',
+        'protein binding', 'MF', '', 'IPI', 'PMID:12345', support,
+    ]) for support in ['UniProtKB:P11111', 'UniProtKB:P22222|UniProtKB:P33333']]
+    annotations = [{
+        'term': {'id': 'GO:0005515', 'label': 'protein binding'},
+        'evidence_type': 'IPI', 'original_reference_id': 'PMID:12345',
+        'supporting_entities': sources, 'review': {'action': 'ACCEPT'},
+    }]
+    validator = GOAValidator()
+    result = validator._validate_strict_tuples(goa, annotations, GOAValidationResult(is_valid=True))
+    assert result.is_valid is valid
+    assert len(result.missing_in_yaml) == missing
+
+
+def test_seeding_preserves_combined_historical_review(tmp_path):
+    """Expanding combined support must not copy its judgment into each source."""
+    import csv
+
+    goa_path = tmp_path / 'TEST-goa.tsv'
+    with goa_path.open('w') as handle:
+        writer = csv.writer(handle, delimiter='\t')
+        writer.writerow(['GENE PRODUCT DB', 'GENE PRODUCT ID', 'SYMBOL', 'QUALIFIER',
+                         'GO TERM', 'GO NAME', 'GO ASPECT', 'ECO ID',
+                         'GO EVIDENCE CODE', 'REFERENCE', 'WITH/FROM'])
+        for source in ['UniProtKB:P11111', 'UniProtKB:P22222']:
+            writer.writerow(['UniProtKB', 'Q12345', 'TEST', 'enables', 'GO:0005515',
+                             'protein binding', 'MF', '', 'IPI', 'PMID:12345', source])
+    yaml_path = tmp_path / 'TEST-ai-review.yaml'
+    historical = {
+        'term': {'id': 'GO:0005515', 'label': 'protein binding'},
+        'evidence_type': 'IPI', 'original_reference_id': 'PMID:12345',
+        'qualifier': 'enables',
+        'supporting_entities': ['UniProtKB:P11111', 'UniProtKB:P22222'],
+        'review': {'action': 'ACCEPT', 'summary': 'Combined historical judgment'},
+    }
+    yaml_path.write_text(yaml.safe_dump({
+        'id': 'Q12345', 'gene_symbol': 'TEST',
+        'existing_annotations': [historical],
+        'references': [{'id': 'PMID:12345', 'title': 'Existing title'}],
+    }))
+    validator = GOAValidator()
+    added, *_ = validator.seed_missing_annotations(yaml_path, goa_path, fetch_titles=False)
+    assert added == 2
+    rows = yaml.safe_load(yaml_path.read_text())['existing_annotations']
+    assert rows[0] == historical
+    assert [row['review']['action'] for row in rows[1:]] == ['PENDING', 'PENDING']
+    assert validator.validate_against_goa(yaml_path, goa_path).is_valid
+    added, *_ = validator.seed_missing_annotations(yaml_path, goa_path, fetch_titles=False)
+    assert added == 0


### PR DESCRIPTION
Refreshing a review could report all GOA annotations present even when distinct WITH/FROM sources had collapsed into one YAML row. For SCHPO/sel0, two PMID:40849408 ISO records were represented by one row without supporting entities.

Seeding now includes normalized WITH/FROM in row identity. It reserves exact matches, backfills one compatible legacy row, and creates pending rows for additional sources in deterministic order. Empty and populated sources remain distinct. CLI/fetch wrappers report backfill counts; `seed-goa` always consults the seeder, and its dry-run previews changes in a temporary file.

Validation preserves both older formats: absent source metadata and lists that combine complete GOA source lists for the same term/evidence/reference/polarity. It rejects unsupported IDs and truncated source groups. Combined historical reviews remain intact; source-specific pending rows receive no copied judgment. Explicitly withdrawn sources use the documented manual `retired: true` workflow; retired records cannot suppress fresh seeding if a source reappears.

Validation:
- 50 GOA validator tests pass, including combined-source compatibility, incorrect/partial support rejection, mixed empty/nonempty ordering, CLI preview, historical-review preservation, and idempotency. Ruff passes.
- Full `just validate-all` passed schema, ontology and reference stages, but exposed 113 source errors across 57 files. Investigation identified 155 combined source lists; all are lossless unions of existing GOA sources. The compatibility fix addresses these.
- Rechecking all 4,539 reviews after the compatibility fix left one real missing-source case: human/SHH, GO:0005515 / IPI / PMID:19561609. Main's validator accepted it by collapsing the sources; this PR correctly detected the uncovered Q13635 source. `just seed-goa human SHH` now adds one PENDING row and backfills 132 source lists. All 194 prior review rows and judgments are preserved. File formatting was preserved after seeding, with parsed YAML equality to the wrapper output verified. `just validate human SHH` passes with only the expected pending-review warning; the final supported corpus best-practices rerun passes: **4,539 valid, 0 invalid**, no ERROR rows in the TSV (3,674 advisory warnings). The new source is deliberately not adjudicated by copying its sibling's judgment.

- Rebased onto main after the separate prediction-consistency prerequisites #2961 and #2963 merged. The full local pytest suite now passes: **2,045 tests**, with 63 integration tests deselected. The corpus result above and the new source/status regression remain valid.


Seeding new PENDING rows now recomputes workflow status through the shared status helper, so a completed review that gains a source becomes IN_PROGRESS. SHH was regenerated through the wrapper and has that status. The status regression was reproduced before the fix; all 58 focused GOA/status tests pass. Metadata-only backfills preserve existing status. The migration guide accurately notes that the separate `update-status` CLI fills missing status but only reports existing mismatches.

Final static checks found and fixed an untyped source index and a variable reused for both tuple keys and lists. The change adds the index type and renames the key variable; 50 focused GOA tests, mypy (179 source files), and repository Ruff all pass. Doctests also pass.
