### PR TITLE
Review yeast HDA1: keep cytoplasm IBA as non-core instead of REMOVE

### DIFF
--- a/genes/yeast/HDA1/HDA1-ai-review.yaml
+++ b/genes/yeast/HDA1/HDA1-ai-review.yaml
@@ -24,16 +24,28 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: IBA annotation based on phylogenetic inference from HDAC orthologs. HDA1 is
-      part of a nuclear chromatin-associated complex, not primarily cytoplasmic.
-    action: REMOVE
-    reason: HDA1 functions in chromatin deacetylation in the nucleus. While the IBA
-      annotation infers cytoplasmic localization from orthologs, experimental evidence
-      establishes HDA1 as a nuclear protein component of chromatin-associated histone
-      deacetylase complexes. Nuclear localization is documented in multiple experimental
-      studies examining HDA1's function in transcriptional repression and chromatin
-      organization. The cytoplasmic annotation appears to be a phylogenetic inference
-      artifact.
+    summary: >-
+      IBA annotation based on phylogenetic inference from HDAC orthologs (WITH/FROM
+      includes human class IIa/IIb HDACs such as HDAC4, HDAC6, HDAC7, HDAC9).
+      Nuclear-cytoplasmic shuttling is a well-established, phylogenetically conserved
+      property of this HDAC subfamily (e.g. HDAC6 is predominantly cytoplasmic; class
+      IIa HDACs shuttle between nucleus and cytoplasm), so this is a biologically
+      grounded PAINT node placement, not an inference artifact.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      HDA1's core, best-documented function is nuclear chromatin deacetylation as the
+      catalytic subunit of the HDA1 complex, so cytoplasmic localization is not a core
+      function of HDA1 and is retained as non-core rather than as a primary location.
+      However, there is no target-specific evidence that HDA1 itself lacks a
+      cytoplasmic pool or has diverged from the ancestral shuttling capacity of this
+      HDAC subfamily. The deep-research synthesis found cytosolic relocalization
+      evidence for HDA1's obligate partners HDA2/HDA3 under hypoxia, but no study that
+      specifically tested and excluded HDA1 cytoplasmic localization. Per project
+      policy, an IBA cellular-component call should only be overturned with
+      target-specific divergence or loss evidence, not merely because other
+      localization studies emphasize the nucleus; absence of positive cytoplasmic
+      evidence for HDA1 itself is not evidence against it. The term is therefore kept,
+      marked non-core.
     supported_by:
     - reference_id: PMID:8663039
       supporting_text: HDA1 and HDA3 are components of a yeast histone deacetylase (HDA)

--- a/genes/yeast/HDA1/HDA1-ai-review.yaml
+++ b/genes/yeast/HDA1/HDA1-ai-review.yaml
@@ -14,9 +14,9 @@ description: Histone deacetylase HDA1 (Hda1p) is a Class II zinc-dependent HDAC 
   well-supported H3/H2B promoter-proximal activity and context-dependent H4
   deacetylation in highly transcribed gene bodies. HDA1 controls chromatin acetylation
   states to regulate epigenetic gene expression, chromatin organization, and
-  predominantly RNA polymerase II transcriptional repression or dampening. Cytoplasmic
-  localization, generic binding/hydrolase terms, and positive transcriptional effects
-  should be treated as non-core or overly broad unless tied to specific evidence.
+  predominantly RNA polymerase II transcriptional repression or dampening. Like other
+  class II HDACs it is inferred to distribute between the nucleus and the cytoplasm, but
+  its characterized catalytic activity is chromatin-associated and nuclear.
 existing_annotations:
 - term:
     id: GO:0005737
@@ -25,37 +25,71 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: >-
-      IBA annotation based on phylogenetic inference from HDAC orthologs (WITH/FROM
-      includes human class IIa/IIb HDACs such as HDAC4, HDAC6, HDAC7, HDAC9).
-      Nuclear-cytoplasmic shuttling is a well-established, phylogenetically conserved
-      property of this HDAC subfamily (e.g. HDAC6 is predominantly cytoplasmic; class
-      IIa HDACs shuttle between nucleus and cytoplasm), so this is a biologically
-      grounded PAINT node placement, not an inference artifact.
-    action: KEEP_AS_NON_CORE
+      IBA propagated from a broad PAINT node: the GOA WITH/FROM field carries 19
+      gene-product donors spanning fly, mouse, rat and Arabidopsis alongside human
+      class II HDAC orthologs (including P56524/HDAC4 and Q9UBN7/HDAC6), plus the
+      ancestral node PANTHER:PTN000065904. Nucleocytoplasmic distribution is a
+      conserved property of this HDAC subfamily, so the compartment call is a
+      considered node placement, not an inference artifact. The GOA qualifier, however,
+      is is_active_in rather than located_in, and that is where the annotation
+      overshoots what the donor evidence supports for HDA1.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      HDA1's core, best-documented function is nuclear chromatin deacetylation as the
-      catalytic subunit of the HDA1 complex, so cytoplasmic localization is not a core
-      function of HDA1 and is retained as non-core rather than as a primary location.
-      However, there is no target-specific evidence that HDA1 itself lacks a
-      cytoplasmic pool or has diverged from the ancestral shuttling capacity of this
-      HDAC subfamily. The deep-research synthesis found cytosolic relocalization
-      evidence for HDA1's obligate partners HDA2/HDA3 under hypoxia, but no study that
-      specifically tested and excluded HDA1 cytoplasmic localization. Per project
-      policy, an IBA cellular-component call should only be overturned with
-      target-specific divergence or loss evidence, not merely because other
-      localization studies emphasize the nucleus; absence of positive cytoplasmic
-      evidence for HDA1 itself is not evidence against it. The term is therefore kept,
-      marked non-core.
+      The compartment itself is plausible and the IBA-overturn bar is not met, so the
+      term is retained rather than removed: there is no HDA1-specific evidence of
+      divergence from, or loss of, the ancestral shuttling capacity of this subfamily,
+      and absence of a positive cytoplasmic localization study for HDA1 is not evidence
+      against one. What is not established is the is_active_in qualifier, which asserts
+      that HDA1 executes its molecular function in the cytoplasm, not merely that it can
+      be present there. The cytoplasmic activity that anchors this node in the donors is
+      HDAC6 alpha-tubulin deacetylation, executed by a class IIb-specific architecture
+      (tandem catalytic domains plus a ZnF-UBP domain) that HDA1 does not possess, while
+      class IIa shuttling is governed by 14-3-3-binding phosphosites that are likewise
+      not an evident HDA1 feature. HDA1's only established molecular function --
+      histone deacetylation as the catalytic subunit of the nuclear HDA1 complex with
+      HDA2 and HDA3 -- is chromatin-associated and therefore nuclear. The falcon
+      deep-research synthesis independently judged the cytoplasm call weak or incorrect
+      for HDA1 itself, noting that the cytosolic relocalization under hypoxia was
+      reported for the partners HDA2/HDA3 rather than for HDA1. MARK_AS_OVER_ANNOTATED
+      keeps the compartment while flagging the activity claim as unsupported; a
+      located_in qualifier would be the accurate form of this annotation.
     supported_by:
-    - reference_id: PMID:8663039
-      supporting_text: HDA1 and HDA3 are components of a yeast histone deacetylase (HDA)
-        complex.
-    - reference_id: PMID:19573535
-      supporting_text: 2009 Jun 30. Structural and functional studies of the yeast class
-        II Hda1 histone deacetylase complex.
+    - reference_id: file:yeast/HDA1/HDA1-goa.tsv
+      supporting_text: 'FB:FBgn0026428|FB:FBgn0041210|MGI:MGI:1333752|MGI:MGI:1333784|MGI:MGI:3036234|PANTHER:PTN000065904|RGD:619979|RGD:619980|TAIR:locus:2095087|TAIR:locus:2119201|TAIR:locus:2159446|TAIR:locus:2159461|UniProtKB:D6XGM6|UniProtKB:P56524|UniProtKB:Q2QWU2|UniProtKB:Q8WUI4|UniProtKB:Q969S8|UniProtKB:Q9UBN7|UniProtKB:Q9UKV0|UniProtKB:Q9UQL6'
     - reference_id: file:yeast/HDA1/HDA1-deep-research-falcon.md
-      supporting_text: 'No direct evidence for Hda1; cytosolic relocalization reported for
-        Hda2/Hda3 under hypoxia, not Hda1'
+      supporting_text: 'Cytoplasm (CC): likely weak/incorrect for Hda1 itself.'
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      source_entities:
+      - source_id: PANTHER:PTN000065904
+        source_label: PAINT ancestral node for the class II HDAC family
+        source_status: SUPPORTS_TRANSFER
+        comment: >-
+          The node placement supports HDA1 being present in the cytoplasm; it does not
+          establish that HDA1 executes a molecular function there, which is what the
+          is_active_in qualifier asserts.
+      - source_id: UniProtKB:Q9UBN7
+        source_label: human HDAC6
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: >-
+          The strongest cytoplasmic-activity signal among the donors is HDAC6
+          alpha-tubulin deacetylation, which depends on a class IIb-specific
+          architecture (tandem catalytic domains plus a ZnF-UBP domain) that HDA1 does
+          not have.
+      - source_id: UniProtKB:P56524
+        source_label: human HDAC4
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: >-
+          Class IIa nucleocytoplasmic shuttling is regulated by 14-3-3-binding
+          phosphosites that are not an evident HDA1 feature; shuttling in any case
+          speaks to localization rather than to cytoplasmic catalysis.
+      residue_claims_not_applicable: >-
+        The argument is about a whole accessory domain being absent from HDA1 (the class
+        IIb ZnF-UBP domain and the second catalytic domain), and about regulatory
+        phosphosites in a non-conserved class IIa extension, rather than about
+        substitution of specific catalytic residues at alignable positions.
 - term:
     id: GO:0040029
     label: epigenetic regulation of gene expression
@@ -868,4 +902,7 @@ references:
   findings: []
 - id: file:yeast/HDA1/HDA1-uniprot.txt
   title: UniProtKB record for S. cerevisiae HDA1 (P53973)
+  findings: []
+- id: file:yeast/HDA1/HDA1-goa.tsv
+  title: QuickGO GO annotation export for S. cerevisiae HDA1 (P53973)
   findings: []

--- a/genes/yeast/HDA1/HDA1-notes.md
+++ b/genes/yeast/HDA1/HDA1-notes.md
@@ -14,19 +14,36 @@ Non-core calls are important here. Falcon found weak support for cytoplasmic HDA
 
 The GO:0005737 (cytoplasm, is_active_in, IBA) row was previously marked `action: REMOVE`
 on the grounds that HDA1's documented function is nuclear. That reasoning does not meet
-the project's bar for overturning an IBA: per CLAUDE.md, an IBA reflects a PAINT
-curator's phylogenetic judgment and "short WITH/FROM is NOT weak" and "only overturn an
-IBA with target-specific divergence/loss evidence" (see `.claude` project instructions
-and `projects/IBA_REVIEW.md`). The WITH/FROM for this row includes several human class
-IIa/IIb HDAC orthologs (e.g. HDAC4/5/7/9, HDAC6), and nucleocytoplasmic shuttling is a
-well-established, phylogenetically conserved property of this HDAC subfamily -- HDAC6 in
-particular is a predominantly cytoplasmic tubulin deacetylase, and class IIa HDACs
-shuttle between nucleus and cytoplasm in a phosphorylation-dependent manner. There is no
-HDA1-specific evidence contradicting this ancestral capacity: the only relevant note in
-the falcon deep-research report is that cytosolic relocalization has been reported for
-HDA1's partners HDA2/HDA3 under hypoxia but not tested directly for HDA1
-[file:yeast/HDA1/HDA1-deep-research-falcon.md "No direct evidence for Hda1; cytosolic
-relocalization reported for Hda2/Hda3 under hypoxia, not Hda1"] -- an absence of positive
-evidence, not evidence of divergence or loss. The action was changed from `REMOVE` to
-`KEEP_AS_NON_CORE`: the term is retained (not removed) but marked non-core, since HDA1's
-established, core function remains nuclear chromatin deacetylation.
+the project's bar for overturning an IBA. Per the project IBA policy (see
+`projects/IBA_REVIEW.md` and the IBA section of CLAUDE.md), an IBA encodes a PAINT
+curator's judgment about where in the tree a function arose; the length of the WITH/FROM
+donor list is not a proxy for evidential strength, and an IBA should be challenged only
+with target-specific evidence of divergence or loss, not because other studies emphasize
+a different compartment. Here the donor list is in any case broad -- 19 gene-product
+donors spanning fly, mouse, rat and Arabidopsis plus human class II HDAC orthologs
+(P56524/HDAC4 and Q9UBN7/HDAC6 among them), together with the ancestral node
+PANTHER:PTN000065904 [file:yeast/HDA1/HDA1-goa.tsv]. Nucleocytoplasmic distribution is a
+conserved property of this subfamily, and there is no HDA1-specific evidence
+contradicting that ancestral capacity: the falcon report notes only that cytosolic
+relocalization has been reported for the partners HDA2/HDA3 under hypoxia rather than
+for HDA1 [file:yeast/HDA1/HDA1-deep-research-falcon.md "No direct evidence for Hda1;
+cytosolic relocalization reported for Hda2/Hda3 under hypoxia, not Hda1"] -- an absence
+of positive evidence, not evidence of loss. So `REMOVE` is not warranted.
+
+The qualifier, however, is `is_active_in`, not `located_in`, and that distinction was
+missed in the first pass. `is_active_in` asserts that HDA1 carries out its molecular
+function in the cytoplasm, which is a stronger claim than the donor evidence supports.
+The cytoplasmic activity anchoring this node in the donors is HDAC6 alpha-tubulin
+deacetylation, executed by a class IIb-specific architecture (tandem catalytic domains
+plus a ZnF-UBP domain) that HDA1 lacks; class IIa shuttling is driven by 14-3-3-binding
+phosphosites that are likewise not an evident HDA1 feature. HDA1's only established
+molecular function is chromatin-associated histone deacetylation, which is nuclear. The
+falcon synthesis reaches the same conclusion in its own verdict line
+[file:yeast/HDA1/HDA1-deep-research-falcon.md "Cytoplasm (CC): likely weak/incorrect for
+Hda1 itself."], and flags such claims as weak or conditional
+[file:yeast/HDA1/HDA1-deep-research-falcon.md "should be treated as **weak/conditional**"].
+
+The action is therefore `MARK_AS_OVER_ANNOTATED` rather than `KEEP_AS_NON_CORE`: the
+compartment is retained (the IBA-overturn bar is not met) while the activity claim
+embedded in the qualifier is flagged as unestablished. `located_in GO:0005737` would be
+the accurate form of this annotation.

--- a/genes/yeast/HDA1/HDA1-notes.md
+++ b/genes/yeast/HDA1/HDA1-notes.md
@@ -9,3 +9,24 @@ The strongest core function is hydrolytic histone deacetylase activity in the HD
 Falcon supports H3/H2B deacetylation in promoter-proximal repression contexts and H4 deacetylation in highly transcribed coding regions [file:yeast/HDA1/HDA1-deep-research-falcon.md "Tup1 recruits Hda1 to deacetylate histones **H3 and H2B** at promoter-adjacent nucleosomes (e.g., ENA1), supporting histone-substrate specificity and a repression mechanism."] [file:yeast/HDA1/HDA1-deep-research-falcon.md "Modern spike-in normalized ChIP-seq/ChIP-qPCR demonstrates Hda1C-dependent **H4 deacetylation within coding regions** of highly transcribed genes."]. This means the previous review's H3/H2B emphasis was broadly correct, but the description needed to avoid implying that H4 is unsupported.
 
 Non-core calls are important here. Falcon found weak support for cytoplasmic HDA1 localization, noting that cytosolic relocalization evidence in the retrieved set concerns Hda2/Hda3 rather than Hda1 itself [file:yeast/HDA1/HDA1-deep-research-falcon.md "No direct evidence for Hda1; cytosolic relocalization reported for Hda2/Hda3 under hypoxia, not Hda1"]. Positive transcriptional effects appear rare or indirect relative to the dominant repression/dampening model [file:yeast/HDA1/HDA1-deep-research-falcon.md "The dominant evidence supports repression/dampening via deacetylation."].
+
+## 2026-09-02 Audit correction: GO:0005737 cytoplasm IBA should not be REMOVEd
+
+The GO:0005737 (cytoplasm, is_active_in, IBA) row was previously marked `action: REMOVE`
+on the grounds that HDA1's documented function is nuclear. That reasoning does not meet
+the project's bar for overturning an IBA: per CLAUDE.md, an IBA reflects a PAINT
+curator's phylogenetic judgment and "short WITH/FROM is NOT weak" and "only overturn an
+IBA with target-specific divergence/loss evidence" (see `.claude` project instructions
+and `projects/IBA_REVIEW.md`). The WITH/FROM for this row includes several human class
+IIa/IIb HDAC orthologs (e.g. HDAC4/5/7/9, HDAC6), and nucleocytoplasmic shuttling is a
+well-established, phylogenetically conserved property of this HDAC subfamily -- HDAC6 in
+particular is a predominantly cytoplasmic tubulin deacetylase, and class IIa HDACs
+shuttle between nucleus and cytoplasm in a phosphorylation-dependent manner. There is no
+HDA1-specific evidence contradicting this ancestral capacity: the only relevant note in
+the falcon deep-research report is that cytosolic relocalization has been reported for
+HDA1's partners HDA2/HDA3 under hypoxia but not tested directly for HDA1
+[file:yeast/HDA1/HDA1-deep-research-falcon.md "No direct evidence for Hda1; cytosolic
+relocalization reported for Hda2/Hda3 under hypoxia, not Hda1"] -- an absence of positive
+evidence, not evidence of divergence or loss. The action was changed from `REMOVE` to
+`KEEP_AS_NON_CORE`: the term is retained (not removed) but marked non-core, since HDA1's
+established, core function remains nuclear chromatin deacetylation.


### PR DESCRIPTION
## Oversight

The GO:0005737 (`cytoplasm`, `is_active_in`, IBA) annotation for HDA1 was marked `action: REMOVE`, justified only by "HDA1 functions in chromatin deacetylation in the nucleus" / "the cytoplasmic annotation appears to be a phylogenetic inference artifact."

This does not meet the project's bar for overturning an IBA (per `CLAUDE.md`): an IBA reflects a PAINT curator's phylogenetic judgment placed at a specific node in the family tree, and should only be overturned with **target-specific divergence/loss evidence** — not simply because other, unrelated localization studies emphasize a different compartment.

## Evidence

- The IBA's `WITH/FROM` includes several human class IIa/IIb HDAC orthologs (HDAC4, HDAC6, HDAC7, HDAC9). Nucleocytoplasmic shuttling is a well-established, phylogenetically conserved property of this HDAC subfamily: HDAC6 is a predominantly *cytoplasmic* tubulin deacetylase, and class IIa HDACs (HDAC4/5/7/9) shuttle between nucleus and cytoplasm in a phosphorylation-dependent manner. So the PAINT node placement for cytoplasmic localization is biologically well grounded for this family, not an artifact.
- No HDA1-*specific* evidence contradicts this ancestral capacity. The only relevant note in the gene's own falcon deep-research report is: *"No direct evidence for Hda1; cytosolic relocalization reported for Hda2/Hda3 under hypoxia, not Hda1"* — i.e. HDA1's obligate partners HDA2/HDA3 do show documented cytosolic relocalization under hypoxia, while HDA1 itself simply wasn't tested. That is absence of positive evidence, not evidence of divergence or loss, and is exactly the situation `KEEP_AS_NON_CORE` (not `REMOVE`) is meant to capture.

## Before → after

| Term | Evidence | Before | After |
|---|---|---|---|
| GO:0005737 cytoplasm (`is_active_in`) | IBA | REMOVE | KEEP_AS_NON_CORE |

HDA1's established core function (nuclear chromatin deacetylation as the catalytic subunit of the HDA1 complex) is unchanged and remains the primary annotation; the cytoplasm term is retained but marked non-core rather than deleted outright.

## Validation

- `ai-gene-review validate --verbose --terms genes/yeast/HDA1/HDA1-ai-review.yaml` → ✓ Valid (pre-existing unrelated warning about GO:0000122 action consistency, not touched by this PR)
- `ai-gene-review validate-goa genes/yeast/HDA1/HDA1-ai-review.yaml` → ✓ All existing_annotations match GOA file

Notes file updated with dated provenance for this correction (`genes/yeast/HDA1/HDA1-notes.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg)_