### PR TITLE
Review yeast ESA1: fix miscited core_functions reference

### DIFF
--- a/genes/yeast/ESA1/ESA1-ai-review.yaml
+++ b/genes/yeast/ESA1/ESA1-ai-review.yaml
@@ -738,8 +738,8 @@ core_functions:
   - id: GO:0005634
     label: nucleus
   supported_by:
-  - reference_id: PMID:11742990
-    supporting_text: The Saccharomyces cerevisiae Set1 complex includes an Ash2 homologue and methylates histone 3 lysine 4
+  - reference_id: PMID:9520405
+    supporting_text: we express a yeast ORF with homology to MYST family members and show it possesses histone acetyltransferase activity
   - reference_id: PMID:31699900
     supporting_text: Gcn5 and Esa1 function as histone crotonyltransferases to regulate crotonylation-dependent transcription
 references:

--- a/genes/yeast/ESA1/ESA1-notes.md
+++ b/genes/yeast/ESA1/ESA1-notes.md
@@ -1,0 +1,35 @@
+# ESA1 curation notes
+
+## Update 2026-09-02
+
+Batch audit of the existing `ESA1-ai-review.yaml`. The review is otherwise thorough
+(63 GOA lines all reviewed, sound REMOVE/KEEP_AS_NON_CORE calls), but one citation in
+`core_functions[0].supported_by` was wrong:
+
+- The entry cited `PMID:11742990` ("The Saccharomyces cerevisiae Set1 complex includes
+  an Ash2 homologue and methylates histone 3 lysine 4", Roguev et al. 2001 EMBO J) with
+  `supporting_text` equal to that paper's own title, offered as support for ESA1's core
+  histone-acetyltransferase molecular function (GO:0004402) plus its involvement in
+  transcription regulation (GO:0006357) and DNA repair (GO:0006281).
+- `publications/PMID_11742990.md` (cached abstract) is about the **Set1/COMPASS**
+  H3K4-methyltransferase complex and does not mention ESA1/Esa1 anywhere
+  [PMID:11742990 "The Saccharomyces cerevisiae Set1 complex includes an Ash2 homologue
+  and methylates histone 3 lysine 4"] — an unrelated methyltransferase complex, not the
+  NuA4/Esa1 acetyltransferase this review is about. This is a genuine miscitation (right
+  format, wrong paper), not merely a weak citation.
+- Fixed by replacing it with `PMID:9520405` ("ESA1 is a histone acetyltransferase that
+  is essential for growth in yeast", Smith et al. 1998 PNAS), which is already used
+  elsewhere in this review's `existing_annotations` (GO:0004402 IMP evidence line) and
+  directly supports the claim: [PMID:9520405 "we express a yeast ORF with homology to
+  MYST family members and show it possesses histone acetyltransferase activity"].
+- No other content, actions, or GO terms were changed. `PMID:31699900` (crotonylation)
+  remains as the second `supported_by` entry, unchanged.
+
+Everything else reviewed (all `existing_annotations`, the `description`, and the rest of
+`core_functions`) was judged sound and evidence-backed; no further changes made in this
+pass. Note: this gene directory also carries several non-standard files
+(`ESA1-CURATION-ANALYSIS.md`, `ESA1-CURATION-SUMMARY.md`, `ESA1-ai-review-CURATED.yaml`,
+`ESA1-ANNOTATION-TRIAGE.tsv`, `README-CURATION.md`, `FILES-INDEX.md`,
+`ESA1-DECISIONS-OVERVIEW.txt`, `ESA1-CURATION-COMPLETE.md`) left over from an earlier
+curation pass; left untouched here since removing/consolidating them is outside the
+scope of this citation fix.


### PR DESCRIPTION
## Oversight

`core_functions[0].supported_by` in `genes/yeast/ESA1/ESA1-ai-review.yaml` cited
**PMID:11742990** ("The Saccharomyces cerevisiae Set1 complex includes an Ash2
homologue and methylates histone 3 lysine 4", Roguev et al. 2001, EMBO J) as support
for ESA1's core histone-acetyltransferase molecular function (GO:0004402) and its
involvement in transcription regulation (GO:0006357) / DNA repair (GO:0006281).

That paper is about the unrelated **Set1/COMPASS H3K4-methyltransferase complex** —
the cached abstract (`publications/PMID_11742990.md`) never mentions ESA1/Esa1 at all.
It's a right-format, wrong-paper miscitation (the `supporting_text` was just that
paper's own title, so it passes the mechanical verbatim-substring check but doesn't
actually support the claim being made).

## Evidence

- `publications/PMID_11742990.md`: title/abstract entirely about Set1 complex /
  H3K4me, no mention of ESA1, Esa1, NuA4, or histone acetylation.
- `publications/PMID_9520405.md` ("ESA1 is a histone acetyltransferase that is
  essential for growth in yeast", Smith et al. 1998 PNAS) directly supports the claim:
  "we express a yeast ORF with homology to MYST family members and show it possesses
  histone acetyltransferase activity." This PMID is already used elsewhere in the same
  review (as IMP evidence for GO:0004402), so it was already vetted as on-target for
  ESA1.

## Change

| Field | Before | After |
|---|---|---|
| `core_functions[0].supported_by[0].reference_id` | PMID:11742990 (wrong paper — Set1/COMPASS) | PMID:9520405 (ESA1 HAT activity, PNAS 1998) |
| `core_functions[0].supported_by[0].supporting_text` | Set1-complex paper title | verbatim quote from PMID:9520405 abstract establishing ESA1 HAT activity |

Everything else in the review (all `existing_annotations`, `description`, remaining
`core_functions` content, actions) was audited and found sound/evidence-backed — no
other changes made. Added `ESA1-notes.md` documenting the fix with provenance.

## Validation

Both pass from `/home/user/ai-gene-review/.venv/bin/ai-gene-review`:
- `validate --verbose --terms genes/yeast/ESA1/ESA1-ai-review.yaml` → ✓ Valid
- `validate-goa genes/yeast/ESA1/ESA1-ai-review.yaml` → ✓ All existing_annotations match GOA file

## Note

This gene directory also carries several non-standard leftover files from an earlier
curation pass (`ESA1-CURATION-ANALYSIS.md`, `ESA1-ai-review-CURATED.yaml`,
`ESA1-ANNOTATION-TRIAGE.tsv`, `README-CURATION.md`, `FILES-INDEX.md`, etc.). These are
untouched here — out of scope for this citation fix — but may be worth a separate
cleanup pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg)_