### PR TITLE
Review yeast IRE1: fix UNDECIDED nuclear-localization annotation

### DIFF
--- a/genes/yeast/IRE1/IRE1-ai-review.yaml
+++ b/genes/yeast/IRE1/IRE1-ai-review.yaml
@@ -575,13 +575,40 @@ existing_annotations:
   original_reference_id: PMID:17035634
   review:
     summary: >-
-      IDA annotation for nuclear localization. This may reflect a minor
-      population of IRE1 or a specific experimental condition.
-    action: UNDECIDED
+      IDA annotation for nuclear localization. PMID:17035634 (Goffin et al.
+      2006) directly demonstrates that Ire1p contains a functional 18-residue
+      nuclear localization sequence (NLS) in its cytoplasmic linker region,
+      recognized by both importin alpha (Kap60p) and multiple importin beta
+      homologues, and that this NLS targets Ire1p (or an NLS-GFP fusion) to
+      the yeast nucleus in a Ran-GTPase-dependent process in vivo.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Unable to access PMID:17035634 to verify the nuclear localization claim.
-      IRE1 is primarily an ER membrane protein, so nuclear localization would
-      be unusual and requires verification.
+      The cached abstract for PMID:17035634 is available in this repository
+      and directly supports nuclear localization: it reports a validated NLS
+      that targets Ire1p to the nucleus, and shows that point mutations
+      disrupting this NLS impair ER-stress-induced HAC1 mRNA splicing and UPR
+      signaling. This is genuine experimental (IDA) evidence for a nuclear
+      pool of Ire1p, not an artifact, so the annotation should not be left
+      UNDECIDED. It is kept as non-core because IRE1's core, best-established
+      catalytic functions (kinase trans-autophosphorylation and HAC1 RNase
+      splicing) occur at the ER membrane; the nuclear-import step described
+      here is a regulatory/signaling-trafficking aspect rather than the site
+      of the defining enzymatic activities.
+    supported_by:
+    - reference_id: PMID:17035634
+      supporting_text: >-
+        The Ire1p transmembrane receptor kinase/endonuclease transduces the
+        unfolded protein response (UPR) from the endoplasmic reticulum (ER) to
+        the nucleus in Saccharomyces cerevisiae.
+    - reference_id: PMID:17035634
+      supporting_text: >-
+        This 18-residue sequence is capable of targeting green fluorescent
+        protein to the nucleus of yeast cells in a process requiring proteins
+        involved in the Ran GTPase cycle that facilitates nuclear import.
+    - reference_id: PMID:17035634
+      supporting_text: >-
+        The NLS-dependent nuclear localization of Ire1p would thus seem to be
+        central to its role in UPR signaling.
 - term:
     id: GO:0006020
     label: inositol metabolic process

--- a/genes/yeast/IRE1/IRE1-notes.md
+++ b/genes/yeast/IRE1/IRE1-notes.md
@@ -1,0 +1,37 @@
+# IRE1 review notes
+
+## 2026-09-02 Update: nuclear-localization annotation (GO:0005634, IDA, PMID:17035634)
+
+Audited the existing review for oversights. The IDA annotation of GO:0005634 (nucleus)
+from PMID:17035634 had been marked `UNDECIDED` with the stated reason "Unable to access
+PMID:17035634 to verify the nuclear localization claim." This was incorrect: the
+publication is cached in this repository (`publications/PMID_17035634.md`) and its
+abstract directly and unambiguously supports the annotation.
+
+Goffin et al. 2006 (Mol Biol Cell) show that Ire1p's cytoplasmic linker region contains
+an 18-residue nuclear localization sequence (NLS) recognized by both importin alpha
+(Kap60p) and multiple importin beta homologues, that this NLS drives Ran-GTPase-dependent
+nuclear import of Ire1p (or an NLS-GFP reporter) in vivo, and that NLS-disrupting point
+mutations impair ER-stress-induced HAC1 mRNA splicing:
+
+[PMID:17035634 "The Ire1p transmembrane receptor kinase/endonuclease transduces the
+unfolded protein response (UPR) from the endoplasmic reticulum (ER) to the nucleus in
+Saccharomyces cerevisiae."]
+
+[PMID:17035634 "This 18-residue sequence is capable of targeting green fluorescent
+protein to the nucleus of yeast cells in a process requiring proteins involved in the
+Ran GTPase cycle that facilitates nuclear import."]
+
+[PMID:17035634 "The NLS-dependent nuclear localization of Ire1p would thus seem to be
+central to its role in UPR signaling."]
+
+Changed the annotation's `action` from `UNDECIDED` to `KEEP_AS_NON_CORE`: the nuclear
+pool and NLS-dependent import are real and evidence-backed (so UNDECIDED, reserved for
+cases where the evidence genuinely cannot be assessed, was not appropriate), but IRE1's
+best-established, defining catalytic activities (kinase trans-autophosphorylation and
+HAC1 pre-mRNA endoribonuclease splicing) are ER-membrane events, so nuclear import is
+kept as a non-core regulatory/trafficking aspect rather than promoted into
+`core_functions`.
+
+All other existing annotations, `core_functions`, and the top-level `description` were
+reviewed and found sound and well-supported; no other changes made.


### PR DESCRIPTION
## Oversight found

The `GO:0005634` (nucleus) `IDA` annotation from `PMID:17035634` was marked `UNDECIDED`
with the stated reason "Unable to access PMID:17035634 to verify the nuclear
localization claim."

This was factually wrong: the publication **is** cached in this repository
(`publications/PMID_17035634.md`), and its abstract directly and unambiguously
supports the annotation. Goffin et al. 2006 (*Mol Biol Cell*, PMID:17035634) show:

- Ire1p's cytoplasmic linker region contains a functional 18-residue nuclear
  localization sequence (NLS), recognized by both importin alpha (Kap60p) and
  multiple importin beta homologues.
- The NLS drives Ran-GTPase-dependent nuclear import of Ire1p (and an NLS-GFP
  reporter) in vivo.
- NLS-disrupting point mutations impair ER-stress-induced HAC1 mRNA splicing and UPR
  signaling — i.e. the nuclear-import step is functionally consequential, not an
  artifact.

Quotes used (verbatim from the cached abstract):
- "The Ire1p transmembrane receptor kinase/endonuclease transduces the unfolded
  protein response (UPR) from the endoplasmic reticulum (ER) to the nucleus in
  Saccharomyces cerevisiae."
- "This 18-residue sequence is capable of targeting green fluorescent protein to the
  nucleus of yeast cells in a process requiring proteins involved in the Ran GTPase
  cycle that facilitates nuclear import."
- "The NLS-dependent nuclear localization of Ire1p would thus seem to be central to
  its role in UPR signaling."

## Before → after

| Field | Before | After |
|---|---|---|
| `existing_annotations[GO:0005634, IDA, PMID:17035634].review.action` | `UNDECIDED` | `KEEP_AS_NON_CORE` |
| `review.reason` | "Unable to access PMID:17035634 to verify..." | Cites the cached abstract; nuclear pool is real/evidence-backed but IRE1's defining kinase/RNase catalytic activities remain ER-membrane events, so kept non-core rather than promoted to `core_functions` |
| `review.supported_by` | (none) | 3 verbatim quotes from PMID:17035634 |

All other existing annotations, `core_functions`, and the top-level `description` were
reviewed and found sound and well-supported (extensive, careful IBA/IEA/IDA coverage of
IRE1's kinase, RNase, and UPR functions) — no other changes made.

## Validation

Both required checks pass on the worktree:
```
.venv/bin/ai-gene-review validate --verbose --terms genes/yeast/IRE1/IRE1-ai-review.yaml
✓ Valid (5 pre-existing warnings, unrelated to this change)

.venv/bin/ai-gene-review validate-goa genes/yeast/IRE1/IRE1-ai-review.yaml
✓ All existing_annotations match GOA file
```

Also created `genes/yeast/IRE1/IRE1-notes.md` (did not previously exist) recording this
update with inline PMID-quoted provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg)_