### PR TITLE
Review yeast PHD1: fix fabricated citation quote

### DIFF
--- a/genes/yeast/PHD1/PHD1-ai-review.yaml
+++ b/genes/yeast/PHD1/PHD1-ai-review.yaml
@@ -580,10 +580,11 @@ references:
     colony morphology.
   findings:
   - statement: |
-      In structured-colony strain F13, PHD1/YKL043W clusters with genes whose expression
-      correlates positively with colony structure, but phd1-delta had little effect on
-      colony morphology at day 5, unlike flo11-delta or msb2-delta which abolished
-      structure, indicating PHD1 redundancy in loss-of-function in this background.
+      In structured-colony strain F13, deletion of PHD1 (with SIM1, SRL1 and SVS1)
+      had little effect on colony morphology at day 5, unlike deletion of FLO11 or
+      MSB2 which abolished the structured phenotype, indicating PHD1 is
+      dispensable/redundant for loss-of-function in this genetic background despite
+      its strong gain-of-function phenotype.
     supporting_text: |
-      **PHD1 (YKL043W)** is in a gene-expression cluster whose expression correlates positively with colony structure. Yet, **phd1Δ** had little effect** on colony morphology at day 5
+      Deletion of other I9 genes tested (PHD1, SIM1, SRL1 and SVS1) had little effect on F13 colony morphology, retaining a central smooth and outer structured zone at day-5.
     reference_section_type: RESULTS


### PR DESCRIPTION
## Oversight

The top-level `references` entry for PMID:39637084 (Cromie et al. 2024, "Spatiotemporal patterns of gene expression during development of a complex colony morphology", `full_text_available: true`) quoted a fabricated/composite `supporting_text` with fictional markdown emphasis that is **not** a verbatim substring of the cached full text. Since this paper's full text is cached, `ai-gene-review validate --terms` flags this as a blocking `ERROR` (not just a warning), which is the citation-accuracy problem this repo's reference validator is specifically designed to catch.

## Evidence

The actual sentence in the cached Results section (`publications/PMID_39637084.md`) reads:

> "Deletion of other I9 genes tested (PHD1, SIM1, SRL1 and SVS1) had little effect on F13 colony morphology, retaining a central smooth and outer structured zone at day-5."

This differs from the previously-recorded quote, which invented bold-emphasis markup and paraphrased wording not present in the source text.

## Fix

- Replaced `references[].findings[].supporting_text` for PMID:39637084 with the exact verbatim sentence above.
- Reworded the accompanying `statement` field slightly for clarity, without changing its meaning (PHD1 deletion is dispensable/redundant for F13 colony structure at day 5, unlike FLO11/MSB2 deletion).
- No `existing_annotations` actions were changed — this finding is background/contextual support, not the basis for any curation decision.

## Before → after

| Field | Before | After |
|---|---|---|
| `references[PMID:39637084].findings[0].supporting_text` | Fabricated composite quote (not a substring of cached text) | Verbatim substring of cached Results text |
| Annotation actions | unchanged | unchanged |

## Validation

Both required checks pass on the updated file:
```
ai-gene-review validate --verbose --terms genes/yeast/PHD1/PHD1-ai-review.yaml   # ✓ Valid (1 pre-existing tolerated warning on an abstract-only paper)
ai-gene-review validate-goa genes/yeast/PHD1/PHD1-ai-review.yaml                 # ✓ All existing_annotations match GOA file
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg)_