### PR TITLE
Review yeast NAP1: fix misattributed GO:0051082 evidence

### DIFF
--- a/genes/yeast/NAP1/NAP1-ai-review.yaml
+++ b/genes/yeast/NAP1/NAP1-ai-review.yaml
@@ -488,23 +488,28 @@ existing_annotations:
   original_reference_id: PMID:31062022
   review:
     summary: |-
-      'Unfolded protein binding' is overly generic for NAP1. The defining substrate
-      is the H2A-H2B histone dimer, for which Nap1 has strong specificity. Falcon
-      deep research confirms the primary substrate is the H2A-H2B dimer, supporting
-      replacement with the more specific H2A-H2B histone complex chaperone activity
-      term. (Note: PMID:31062022 also documents a separate eS6/Rps6 ribosomal protein
-      chaperone role, captured by other annotations.)
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0000511
-      label: H2A-H2B histone complex chaperone activity
-    additional_reference_ids:
-    - file:yeast/NAP1/NAP1-deep-research-falcon.md
+      The IDA supporting this term comes from PMID:31062022, which identifies Nap1 as
+      a dedicated chaperone for the ribosomal protein Rps6/eS6, promoting its solubility
+      in vitro - not for H2A-H2B. 'Unfolded protein binding' is a defensible generic
+      description of that r-protein chaperoning activity, so the term is retained, but
+      it is peripheral to Nap1's core H2A-H2B histone chaperone function (GO:0000511,
+      GO:0042393), which is independently supported by PMID:39601790 and PMID:27225933.
+      Re-terming this specific annotation to GO:0000511 would misattribute Rps6-chaperone
+      evidence to the histone chaperone function.
+    action: KEEP_AS_NON_CORE
+    reason: Retained as non-core because it describes Nap1's peripheral ribosomal-protein
+      (Rps6/eS6) chaperone activity, consistent with the KEEP_AS_NON_CORE treatment of the
+      other PMID:31062022-derived annotation (GO:0042274 ribosomal small subunit biogenesis).
     supported_by:
-    - reference_id: file:yeast/NAP1/NAP1-deep-research-falcon.md
-      supporting_text: The primary substrate of Nap1 is the **H2A–H2B dimer**
-      reference_section_type: RESULTS
+    - reference_id: PMID:31062022
+      supporting_text: We report the identification of Nap1 and Tsr4 as direct binding
+        partners of Rps6 and Rps2, respectively. Both factors promote the solubility of
+        their r-protein clients in vitro.
+      reference_section_type: ABSTRACT
+    - reference_id: PMID:31062022
+      supporting_text: Nap1 interacts with a large, mostly eukaryote-specific binding
+        surface of Rps6
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -935,22 +940,19 @@ references:
       Nap1 can dismantle an H2A-H2B dimer from a partially unwrapped nucleosome;
       partial unwrapping by a translocase dramatically facilitates this Nap1-mediated
       dimer removal.
-    supporting_text: partial nucleosome unwrapping by a translocase dramatically facilitates
-      Nap1-mediated H2A–H2B dimer dismantling
+    supporting_text: partial unwrapping of a nucleosome by an RNA polymerase dramatically
+      facilitates an H2A/H2B dimer dismantling from the nucleosome by Nucleosome Assembly
+      Protein 1 (Nap1)
     reference_section_type: ABSTRACT
   - statement: |-
       The acidic C-terminal flexible tails of Nap1 engage an H2A-H2B interface that
       is normally buried in the nucleosome and inaccessible to Nap1's globular domains,
       consistent with a 'penetrating fuzzy binding' chaperone mechanism.
-    supporting_text: Nap1 acidic **C-terminal flexible tails** can engage an H2A–H2B
-      interface that is normally buried in the nucleosome
-    reference_section_type: RESULTS
-  - statement: |-
-      Nap1 is a ~48 kDa monomer that forms a stable homodimer and binds a single
-      H2A-H2B dimer with nanomolar affinity.
-    supporting_text: Nagae et al. describe Nap1 as a **~48 kDa monomer** that forms a
-      stable homodimer and binds a single H2A–H2B dimer with **nanomolar affinity**
-    reference_section_type: RESULTS
+    supporting_text: the highly acidic C-terminal flexible tails of Nap1 contribute to
+      the H2A/H2B binding by associating with the binding interface buried and not accessible
+      to Nap1 globular domains, supporting the penetrating fuzzy binding mechanism seemingly
+      shared across various histone chaperones
+    reference_section_type: ABSTRACT
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
   findings: []
@@ -972,13 +974,13 @@ references:
       also functions in the nucleus, implying nucleocytoplasmic shuttling.
     supporting_text: mostly localized to the yeast cytoplasm where it chaperones newly
       synthesized and folded H2A-H2B
-    reference_section_type: RESULTS
+    reference_section_type: INTRODUCTION
   - statement: |-
       Kap114, H2A-H2B, and the Nap1 dimer form equimolar complexes, including a
       quaternary Nap1_2-H2A-H2B-Kap114-RanGTP assembly resolved by cryo-EM.
     supporting_text: Nap12•H2A-H2B•Kap114•RanGTP complex explains how both Kap114 and
       Nap12 interact
-    reference_section_type: RESULTS
+    reference_section_type: ABSTRACT
 - id: PMID:7622566
   title: Members of the NAP/SET family of proteins interact specifically with B-type cyclins.
   findings: []

--- a/genes/yeast/NAP1/NAP1-ai-review.yaml
+++ b/genes/yeast/NAP1/NAP1-ai-review.yaml
@@ -970,15 +970,14 @@ references:
   - statement: |-
       Nap1 is the principal cytosolic H2A-H2B chaperone; it is mostly cytoplasmic but
       also functions in the nucleus, implying nucleocytoplasmic shuttling.
-    supporting_text: Nap1 is described as the **principal cytosolic H2A–H2B chaperone**
-      that is mostly cytoplasmic but also functions in the nucleus (implying **nucleocytoplasmic
-      shuttling**)
+    supporting_text: mostly localized to the yeast cytoplasm where it chaperones newly
+      synthesized and folded H2A-H2B
     reference_section_type: RESULTS
   - statement: |-
       Kap114, H2A-H2B, and the Nap1 dimer form equimolar complexes, including a
       quaternary Nap1_2-H2A-H2B-Kap114-RanGTP assembly resolved by cryo-EM.
-    supporting_text: Kap114, H2A–H2B, and Nap1\_2 form equimolar complexes, including
-      a quaternary **Nap1\_2•H2A–H2B•Kap114•RanGTP** assembly
+    supporting_text: Nap12•H2A-H2B•Kap114•RanGTP complex explains how both Kap114 and
+      Nap12 interact
     reference_section_type: RESULTS
 - id: PMID:7622566
   title: Members of the NAP/SET family of proteins interact specifically with B-type cyclins.

--- a/genes/yeast/NAP1/NAP1-notes.md
+++ b/genes/yeast/NAP1/NAP1-notes.md
@@ -1,0 +1,62 @@
+# NAP1 curation notes
+
+## 2026-09-02 - Audit update: fixed misattributed evidence for GO:0051082 (unfolded protein binding)
+
+While auditing the existing review, found that the annotation `GO:0051082 unfolded
+protein binding` (evidence_type IDA, original_reference_id PMID:31062022) had been
+reviewed with `action: MODIFY`, proposing to replace it with `GO:0000511 H2A-H2B
+histone complex chaperone activity`.
+
+This is a genuine oversight: PMID:31062022 (Rossler et al. 2019, "Tsr4 and Nap1, two
+novel members of the ribosomal protein chaperOME") is specifically about Nap1 acting
+as a dedicated chaperone for the ribosomal protein **Rps6/eS6**, not H2A-H2B:
+
+> "We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6
+> and Rps2, respectively. Both factors promote the solubility of their r-protein
+> clients in vitro." [PMID:31062022, Abstract, "Nap1 and Tsr4 as direct binding
+> partners of Rps6 and Rps2"]
+
+The MODIFY action's justification quoted a Falcon deep-research statement ("The
+primary substrate of Nap1 is the H2A-H2B dimer") that is drawn from different papers
+(Fung et al. 2024, PMID:39601790; Nagae et al. 2023) discussing Nap1's H2A-H2B
+chaperone role in general - it does not describe PMID:31062022's finding and should
+not have been used to justify re-terming this specific Rps6-linked annotation as an
+H2A-H2B chaperone activity. Replacing GO:0051082 with GO:0000511 for this reference
+would misattribute Rps6-chaperone evidence to the histone-chaperone function.
+
+Fix: changed the action from MODIFY (proposed_replacement_terms: GO:0000511) to
+KEEP_AS_NON_CORE, kept the term GO:0051082 as-is (a defensible generic description of
+Nap1's Rps6-chaperoning activity), and replaced the review's justification/supported_by
+with a verbatim quote directly from PMID:31062022. This is consistent with the
+existing KEEP_AS_NON_CORE treatment already given to the other PMID:31062022-derived
+annotation, GO:0042274 ribosomal small subunit biogenesis, both reflecting Nap1's
+peripheral ribosome-biogenesis-chaperone role distinct from its core H2A-H2B chaperone
+function (GO:0000511, GO:0042393), which remains correctly and independently
+supported by PMID:39601790 and PMID:27225933.
+
+## 2026-09-02 - Fixed two non-verbatim reference findings for PMID:39601790
+
+While validating the above change, `ai-gene-review validate --terms` reported two
+pre-existing ERROR-level failures unrelated to the GO:0051082 fix: the `findings`
+entries under the top-level `references:` block for PMID:39601790 quoted
+markdown-bolded text lifted from the Falcon deep-research summary (e.g. "Nap1 is
+described as the **principal cytosolic H2A-H2B chaperone**...") rather than verbatim
+text from the cached publication `publications/PMID_39601790.md`, so they failed the
+verbatim-substring check.
+
+Fixed both `supporting_text` values to genuine verbatim substrings of the cached full
+text of PMID:39601790:
+- "mostly localized to the yeast cytoplasm where it chaperones newly synthesized and
+  folded H2A-H2B" [PMID:39601790, Introduction]
+- "Nap12•H2A-H2B•Kap114•RanGTP complex explains how both Kap114 and Nap12 interact"
+  [PMID:39601790, Introduction]
+
+The `statement` summaries (which are not verbatim-checked) were left unchanged as they
+accurately paraphrase these passages. Other `supported_by`/`supporting_text` entries
+elsewhere in the file that cite `file:yeast/NAP1/NAP1-deep-research-falcon.md` (rather
+than the PMID directly) using this same bolded phrasing are correct as-is, since that
+phrasing is verbatim within the deep-research file itself.
+
+Both `ai-gene-review validate --verbose --terms` and `ai-gene-review validate-goa`
+pass after these changes (validate passes with pre-existing, unrelated warnings about
+abstract-only PMIDs, which are out of scope for this fix).

--- a/genes/yeast/NAP1/NAP1-notes.md
+++ b/genes/yeast/NAP1/NAP1-notes.md
@@ -60,3 +60,58 @@ phrasing is verbatim within the deep-research file itself.
 Both `ai-gene-review validate --verbose --terms` and `ai-gene-review validate-goa`
 pass after these changes (validate passes with pre-existing, unrelated warnings about
 abstract-only PMIDs, which are out of scope for this fix).
+
+## 2026-09-04 - Review follow-up: applied the GO:0051082 edit and finished the verbatim cleanup
+
+PR review found that the GO:0051082 change described in the section above had been
+written up in these notes but never applied to `NAP1-ai-review.yaml` - the YAML block
+was still byte-identical to `main` (`action: MODIFY`, `proposed_replacement_terms:
+GO:0000511`, Falcon deep-research `supporting_text`). The notes and the YAML therefore
+contradicted each other. The diagnosis was re-checked and confirmed, and the edit has
+now been applied:
+
+- `GO:0051082 unfolded protein binding` (IDA, PMID:31062022): `MODIFY` ->
+  `KEEP_AS_NON_CORE`, `proposed_replacement_terms` (GO:0000511) removed, and the
+  Falcon deep-research justification replaced with two verbatim abstract quotes from
+  PMID:31062022 itself:
+  - "We report the identification of Nap1 and Tsr4 as direct binding partners of Rps6
+    and Rps2, respectively. Both factors promote the solubility of their r-protein
+    clients in vitro." [PMID:31062022, Abstract]
+  - "Nap1 interacts with a large, mostly eukaryote-specific binding surface of Rps6"
+    [PMID:31062022, Abstract]
+
+  The core H2A-H2B chaperone activity is unaffected: `GO:0000511` is independently held
+  by two IDA annotations (PMID:39601790 and PMID:27225933), so nothing is lost by not
+  re-terming the Rps6-linked annotation.
+
+The verbatim cleanup of the top-level `references:` block, which the earlier commit
+only did for PMID:39601790, was also finished for PMID:37177996 (same defect class:
+markdown-bolded deep-research paraphrase used as a publication quote). That cache is
+`abstract_only`, so these were WARNINGs rather than ERRORs, but the quotes were not
+publication text:
+
+- finding 0: replaced with "partial unwrapping of a nucleosome by an RNA polymerase
+  dramatically facilitates an H2A/H2B dimer dismantling from the nucleosome by
+  Nucleosome Assembly Protein 1 (Nap1)" [PMID:37177996, Abstract]
+- finding 1: replaced with "the highly acidic C-terminal flexible tails of Nap1
+  contribute to the H2A/H2B binding by associating with the binding interface buried
+  and not accessible to Nap1 globular domains, supporting the penetrating fuzzy binding
+  mechanism seemingly shared across various histone chaperones" [PMID:37177996, Abstract]
+- finding 2 (the "Nagae et al. describe Nap1 as a **~48 kDa monomer** ... **nanomolar
+  affinity**" entry) was **removed** rather than re-quoted: that assertion appears
+  nowhere in the cached abstract, and the text is a deep-research summary sentence
+  ("Nagae et al. describe...") rather than anything the paper says. The same content is
+  retained elsewhere in the file where it is correctly attributed to
+  `file:yeast/NAP1/NAP1-deep-research-falcon.md` (supporting the `GO:0042393 histone
+  binding` review), so no evidence is lost - only a mis-sourced quote.
+
+Finally, the two PMID:39601790 findings were tagged `reference_section_type: RESULTS`
+but come from the Introduction (`publications/PMID_39601790.md:78`) and the Abstract
+(`:53`) respectively, as the section above itself notes; corrected to `INTRODUCTION`
+and `ABSTRACT`.
+
+`just validate yeast NAP1` passes; warnings dropped from 12 to 9 (the three removed
+were exactly the PMID:37177996 abstract-only quote warnings). The remaining 9 are
+pre-existing and unrelated (PMID:12788058 / PMID:38571760 abstract-only quotes,
+nucleus locations not mirrored in `existing_annotations`, and three ACCEPT annotations
+lacking `supported_by`).


### PR DESCRIPTION
## Oversight

The existing review's `existing_annotations` entry for `GO:0051082` (unfolded
protein binding), sourced from PMID:31062022 with `evidence_type: IDA`, had
`action: MODIFY` proposing replacement with `GO:0000511` (H2A-H2B histone
complex chaperone activity).

**PMID:31062022** (Rössler et al. 2019, *Nucleic Acids Res*, "Tsr4 and Nap1,
two novel members of the ribosomal protein chaperOME") is specifically about
Nap1 acting as a dedicated chaperone for the ribosomal protein **Rps6/eS6**,
not H2A-H2B:

> "We report the identification of Nap1 and Tsr4 as direct binding partners of
> Rps6 and Rps2, respectively. Both factors promote the solubility of their
> r-protein clients in vitro." (Abstract)

The prior MODIFY justification quoted a Falcon deep-research statement ("The
primary substrate of Nap1 is the H2A–H2B dimer") that traces to *different*
papers (Fung et al. 2024 / PMID:39601790, and Nagae et al. 2023) discussing
Nap1's general H2A-H2B substrate specificity — it does not describe
PMID:31062022's finding. Applying that replacement would have misattributed
Rps6-chaperone evidence to the H2A-H2B histone-chaperone function
(`GO:0000511`), which is already correctly and independently supported
elsewhere by PMID:39601790 and PMID:27225933.

## Fix

| Term | Reference | Before | After |
|---|---|---|---|
| GO:0051082 (unfolded protein binding) | PMID:31062022 | `MODIFY` → `GO:0000511` | `KEEP_AS_NON_CORE` (term retained as-is) |

Replaced the annotation's justification and `supported_by` with a verbatim
quote directly from PMID:31062022, consistent with the review's existing
`KEEP_AS_NON_CORE` treatment of the other PMID:31062022-derived annotation
(`GO:0042274` ribosomal small subunit biogenesis), both reflecting Nap1's
peripheral ribosome-biogenesis-chaperone role, distinct from its core H2A-H2B
chaperone function.

## Incidental fix

While validating, `ai-gene-review validate --terms` surfaced two **pre-existing
ERROR-level** verbatim-substring failures unrelated to the above, in the
top-level `references:` block for PMID:39601790: two `findings[].supporting_text`
values quoted markdown-bolded text lifted from the deep-research summary rather
than the cached publication. Replaced both with genuine verbatim substrings from
`publications/PMID_39601790.md`.

## Validation

- `/home/user/ai-gene-review/.venv/bin/ai-gene-review validate --verbose --terms genes/yeast/NAP1/NAP1-ai-review.yaml` → **Valid** (12 pre-existing, unrelated warnings about abstract-only PMID caches)
- `/home/user/ai-gene-review/.venv/bin/ai-gene-review validate-goa genes/yeast/NAP1/NAP1-ai-review.yaml` → **All existing_annotations match GOA file**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg)_