### PR TITLE
Review yeast RIM15: fix wrong proposed_replacement_terms id (GO:0045959)

### DIFF
--- a/genes/yeast/RIM15/RIM15-ai-review.yaml
+++ b/genes/yeast/RIM15/RIM15-ai-review.yaml
@@ -272,13 +272,17 @@ existing_annotations:
         inferred from UniProtKB keyword "Meiosis" rather than direct meiotic 
         cell cycle involvement.
       action: MODIFY
-      reason: RIM15's role is in meiotic gene expression (stimulation of early 
-        meiotic genes via interaction with Ime1p/Ume6p), not cell cycle 
-        progression per se. GO:0045944 (positive regulation of transcription of 
-        genes involved in meiosis) would be more accurate.
+      reason: RIM15's role is in meiotic gene expression (stimulation of early
+        meiotic genes via interaction with Ime1p/Ume6p), not cell cycle
+        progression per se. GO:0045944 (positive regulation of transcription by
+        RNA polymerase II) would be more accurate, since Rim15-dependent early
+        meiotic genes such as IME2 are Pol II transcribed. The previously
+        proposed id GO:0045959 was incorrect; that id actually denotes negative
+        regulation of complement activation, classical pathway, which is
+        unrelated to meiosis and was likely a mislookup.
       proposed_replacement_terms:
-        - id: GO:0045959
-          label: positive regulation of mitotic gene expression
+        - id: GO:0045944
+          label: positive regulation of transcription by RNA polymerase II
   - term:
       id: GO:0106310
       label: protein serine kinase activity
@@ -442,11 +446,14 @@ existing_annotations:
         cycle progression.
       action: MODIFY
       reason: RIM15's role is in meiotic gene expression/transcription, not cell
-        cycle progression per se. GO:0045959 (positive regulation of meiotic 
-        gene expression) is more mechanistically accurate.
+        cycle progression per se. GO:0045944 (positive regulation of
+        transcription by RNA polymerase II) is more mechanistically accurate.
+        Note that GO:0045959, previously proposed here, is an incorrect id --
+        it actually denotes negative regulation of complement activation,
+        classical pathway, and is not a meiotic gene expression term.
       proposed_replacement_terms:
-        - id: GO:0045959
-          label: positive regulation of meiotic gene expression
+        - id: GO:0045944
+          label: positive regulation of transcription by RNA polymerase II
       supported_by:
         - reference_id: PMID:9111339
           supporting_text: Stimulation of yeast meiotic gene expression by the

--- a/genes/yeast/RIM15/RIM15-ai-review.yaml
+++ b/genes/yeast/RIM15/RIM15-ai-review.yaml
@@ -268,21 +268,23 @@ existing_annotations:
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: RIM15 is involved in meiotic gene expression, but this is 
-        inferred from UniProtKB keyword "Meiosis" rather than direct meiotic 
-        cell cycle involvement.
-      action: MODIFY
-      reason: RIM15's role is in meiotic gene expression (stimulation of early
-        meiotic genes via interaction with Ime1p/Ume6p), not cell cycle
-        progression per se. GO:0045944 (positive regulation of transcription by
-        RNA polymerase II) would be more accurate, since Rim15-dependent early
-        meiotic genes such as IME2 are Pol II transcribed. The previously
-        proposed id GO:0045959 was incorrect; that id actually denotes negative
-        regulation of complement activation, classical pathway, which is
-        unrelated to meiosis and was likely a mislookup.
-      proposed_replacement_terms:
-        - id: GO:0045944
-          label: positive regulation of transcription by RNA polymerase II
+      summary: RIM15 is involved in meiosis, stimulating expression of early
+        meiotic genes on glucose depletion. This IEA is inferred from the
+        UniProtKB keyword "Meiosis" and is corroborated by the independent SGD
+        IMP for the same term on PMID:9111339.
+      action: KEEP_AS_NON_CORE
+      reason: The meiotic involvement is real but is one of several downstream
+        outputs of RIM15's core nutrient-signalling kinase activity (quiescence
+        entry, stress-response gene induction, autophagy, chronological
+        lifespan), so it is retained as non-core rather than as a core function.
+        No replacement term is proposed, because GO has deliberately obsoleted
+        the meiosis-scoped transcription-regulation terms (GO:0051039 and
+        GO:0010673) as GO-CAM-shaped, and both carry "consider" pointers to
+        GO:0045944 and GO:0051321 used together rather than merged. The
+        transcriptional mechanism is therefore already captured additively by
+        the separate GO:0045944 IMP annotation on this same paper, and swapping
+        this term for GO:0045944 would discard the meiotic context rather than
+        refine it.
   - term:
       id: GO:0106310
       label: protein serine kinase activity
@@ -441,23 +443,26 @@ existing_annotations:
     evidence_type: IMP
     original_reference_id: PMID:9111339
     review:
-      summary: RIM15 was originally identified as a stimulator of meiotic gene 
-        expression, but the term conflates transcriptional activation with cell 
-        cycle progression.
-      action: MODIFY
-      reason: RIM15's role is in meiotic gene expression/transcription, not cell
-        cycle progression per se. GO:0045944 (positive regulation of
-        transcription by RNA polymerase II) is more mechanistically accurate.
-        Note that GO:0045959, previously proposed here, is an incorrect id --
-        it actually denotes negative regulation of complement activation,
-        classical pathway, and is not a meiotic gene expression term.
-      proposed_replacement_terms:
-        - id: GO:0045944
-          label: positive regulation of transcription by RNA polymerase II
+      summary: RIM15 was originally identified through a mutation causing
+        reduced ability to undergo meiosis, and its deletion reduces expression
+        of the early meiotic genes IME2, SPO13 and HOP1 as well as of IME1.
+      action: KEEP_AS_NON_CORE
+      reason: The mutant phenotype reported in this paper is direct IMP support
+        for meiotic involvement, so the SGD curator's term stands (full text is
+        not available to us, per CLAUDE.md we do not overrule an experimental
+        annotation we cannot fully inspect). It is marked non-core because
+        RIM15's core function is nutrient-responsive serine/threonine kinase
+        activity, of which meiotic entry is one downstream output alongside
+        quiescence, stress response and autophagy. The transcriptional mechanism
+        is expressed additively rather than as a swap, via the separate
+        GO:0045944 IMP annotation on this same reference; this matches GO's own
+        guidance, since the merged terms (GO:0051039, GO:0010673) are obsolete
+        and direct users to GO:0045944 and GO:0051321 together.
       supported_by:
         - reference_id: PMID:9111339
-          supporting_text: Stimulation of yeast meiotic gene expression by the
-            glucose-repressible protein kinase Rim15p.
+          supporting_text: The Saccharomyces cerevisiae RIM15 gene was
+            identified previously through a mutation that caused reduced
+            ability to undergo meiosis.
         - reference_id: file:yeast/RIM15/RIM15-deep-research-falcon.md
           supporting_text: |-
             Igo1/2 are required for **pre-meiotic autophagy**, and the

--- a/genes/yeast/RIM15/RIM15-notes.md
+++ b/genes/yeast/RIM15/RIM15-notes.md
@@ -29,6 +29,62 @@ promoter indicates that activation through Ume6p is defective"]. No exact
 term was used instead, with a note in `reason` flagging the prior id as wrong
 rather than silently swapping it.
 
-No other issues found in this review during this audit pass -- the IBA,
-IEA, and experimental annotation calls elsewhere in the file are
-well-supported and consistent with the cited literature.
+Scope of this audit pass: it was a targeted `proposed_replacement_terms` id
+audit. The other three proposed ids in the file (`GO:1903452` x3) were checked
+and resolve with correct labels. The IBA, IEA and experimental annotation
+*actions* elsewhere in the file were not systematically re-adjudicated in this
+pass, so no claim is made about them.
+
+## 2026-09-04 Update: dropped the replacement entirely -- the meiotic context stays
+
+Follow-up to review feedback on PR #2941, which flagged that swapping the
+meiosis-specific GOA term `GO:0051321` for `GO:0045944` (positive regulation of
+transcription by RNA polymerase II) trades a specific term for a strictly less
+informative one, and that the `MODIFY` on the SGD IMP was weakly justified.
+
+Looked up whether GO has a meiosis-scoped regulation-of-transcription term, as
+the review asked. It does not, and the reason is decisive: GO has **obsoleted**
+that entire region of the ontology.
+
+```
+GO:0051039  obsolete positive regulation of transcription involved in meiotic cell cycle
+GO:0010673  obsolete positive regulation of transcription from RNA polymerase II
+            promoter involved in meiotic cell cycle
+GO:0051037, GO:0051038, GO:0010672, GO:0010674, GO:0100023, GO:0100051  (also obsolete)
+```
+
+Both of the positive-regulation terms carry the same obsoletion comment --
+"This term was obsoleted because it represents a GO-CAM model" -- and, crucially,
+both carry these replacement pointers:
+
+```
+consider: GO:0045944
+consider: GO:0051321
+```
+
+That is GO explicitly instructing curators to use the two terms **together**
+rather than merged into one. So the additive shape the reviewer suggested is not
+just a preference here, it is the ontology's own documented guidance, and adding
+a `proposed_new_terms` entry for a meiosis-scoped transcription term would mean
+proposing the re-creation of a deliberately obsoleted class.
+
+Actions taken:
+
+- Both `GO:0051321` entries (IEA `GO_REF:0000043` and IMP `PMID:9111339`)
+  changed from `MODIFY` to `KEEP_AS_NON_CORE`, and `proposed_replacement_terms`
+  removed from both. Non-core rather than `ACCEPT` because RIM15's core function
+  is nutrient-responsive Ser/Thr kinase activity, with meiotic entry one
+  downstream output alongside quiescence entry, stress-response induction and
+  autophagy.
+- The transcriptional mechanism is already captured additively by the separate
+  `GO:0045944` IMP annotation on the same reference, which the review accepts --
+  no new term is needed to express it.
+- The IMP's `supporting_text` was changed from the paper title to the abstract
+  sentence that actually evidences the term
+  [PMID:9111339 "The Saccharomyces cerevisiae RIM15 gene was identified
+  previously through a mutation that caused reduced ability to undergo meiosis."].
+  `full_text_available: false` for this paper, so per CLAUDE.md the SGD curator's
+  experimental call is not second-guessed.
+- The duplicated `GO:0045959` errata prose was dropped from both `reason` fields.
+  The correction is recorded above and in git history; with the replacement gone
+  the erroneous id no longer appears anywhere in the file.

--- a/genes/yeast/RIM15/RIM15-notes.md
+++ b/genes/yeast/RIM15/RIM15-notes.md
@@ -1,0 +1,34 @@
+# RIM15 curation notes
+
+## 2026-09-02 Update: fixed incorrect proposed_replacement_terms id
+
+While auditing the existing review, found that two `existing_annotations` entries
+for `GO:0051321` (meiotic cell cycle, IEA and IMP evidence) proposed
+`GO:0045959` as a replacement term, with two different (and both incorrect)
+labels attached in different places ("positive regulation of mitotic gene
+expression" in one entry, "positive regulation of meiotic gene expression" in
+the other).
+
+Verified via QuickGO
+(https://www.ebi.ac.uk/QuickGO/services/ontology/go/terms/GO:0045959) that
+`GO:0045959` actually denotes "negative regulation of complement activation,
+classical pathway" -- a term with no relationship to meiosis, gene expression,
+or cell-cycle regulation. Neither proposed label matches the real term, and a
+web search confirms there is no GO term literally named "positive regulation
+of meiotic gene expression" or "... mitotic gene expression".
+
+Replaced the erroneous id in both entries with `GO:0045944` (positive
+regulation of transcription by RNA polymerase II, verified via QuickGO:
+https://www.ebi.ac.uk/QuickGO/services/ontology/go/terms/GO:0045944), which
+matches the review's own stated rationale that RIM15 stimulates transcription
+of early meiotic genes (e.g. IME2, a Pol II gene) via Ime1p/Ume6p
+[PMID:9111339 "Ime1p activates early meiotic genes through its interaction
+with Ume6p, and analysis of Rim15p-dependent regulatory sites at the IME2
+promoter indicates that activation through Ume6p is defective"]. No exact
+"meiotic gene expression" GO term exists, so the closest verifiably-correct
+term was used instead, with a note in `reason` flagging the prior id as wrong
+rather than silently swapping it.
+
+No other issues found in this review during this audit pass -- the IBA,
+IEA, and experimental annotation calls elsewhere in the file are
+well-supported and consistent with the cited literature.


### PR DESCRIPTION
## Oversight found

Two `existing_annotations` entries for `GO:0051321` (meiotic cell cycle, one IEA
from GO_REF:0000043, one IMP from PMID:9111339) proposed `GO:0045959` as the
`proposed_replacement_terms` id — but with **two different, mutually
inconsistent labels** attached in the two places:

- "positive regulation of mitotic gene expression" (IEA entry)
- "positive regulation of meiotic gene expression" (IMP entry)

## Evidence

Verified via QuickGO that `GO:0045959` actually denotes **"negative regulation
of complement activation, classical pathway"**
(https://www.ebi.ac.uk/QuickGO/services/ontology/go/terms/GO:0045959) — a term
with no relationship to meiosis, transcription, or the cell cycle. A web search
also confirms no GO term literally named "positive regulation of meiotic (or
mitotic) gene expression" exists. This is a hallucinated/incorrect term id
that would have propagated a false replacement recommendation.

The review's own reasoning already correctly points at RIM15's real mechanism:
RIM15 stimulates meiotic gene transcription via Ime1p/Ume6p
[PMID:9111339, "Ime1p activates early meiotic genes through its interaction
with Ume6p, and analysis of Rim15p-dependent regulatory sites at the IME2
promoter indicates that activation through Ume6p is defective"]. `GO:0045944`
("positive regulation of transcription by RNA polymerase II", verified via
QuickGO: https://www.ebi.ac.uk/QuickGO/services/ontology/go/terms/GO:0045944)
is the closest verifiably-correct term for this mechanism (IME2 is a Pol II
gene), so both entries now propose that id instead, with a note flagging the
prior id as wrong so the correction is traceable.

## Before → after

| Entry (evidence) | proposed_replacement_terms before | after |
|---|---|---|
| GO:0051321 IEA (GO_REF:0000043) | GO:0045959 "positive regulation of mitotic gene expression" (wrong id/label) | GO:0045944 "positive regulation of transcription by RNA polymerase II" |
| GO:0051321 IMP (PMID:9111339) | GO:0045959 "positive regulation of meiotic gene expression" (wrong id/label) | GO:0045944 "positive regulation of transcription by RNA polymerase II" |

No `action` values changed (both remain `MODIFY`); no experimental annotations
were second-guessed; `existing_annotations[].term.id` (the GOA-sourced ids)
were left untouched per repo convention.

## Validation

Both required checks pass:
```
$ .venv/bin/ai-gene-review validate --verbose --terms genes/yeast/RIM15/RIM15-ai-review.yaml
✓ Valid (with 1 warnings)   # pre-existing, unrelated warning about propagation_review metadata

$ .venv/bin/ai-gene-review validate-goa genes/yeast/RIM15/RIM15-ai-review.yaml
✓ All existing_annotations match GOA file
```

Notes appended to `genes/yeast/RIM15/RIM15-notes.md` (new file) with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg)_