### PR TITLE
Review yeast ZNG1: remove fabricated PMID citations from notes.md

### DIFF
--- a/genes/yeast/ZNG1/ZNG1-ai-review.html
+++ b/genes/yeast/ZNG1/ZNG1-ai-review.html
@@ -2848,16 +2848,23 @@ this with annotations you find in gene/protein databases, but these can be outda
             </summary>
             <div class="markdown-content">
                 <h1 id="zng1-gene-review-notes">ZNG1 Gene Review Notes</h1>
-<h2 id="colleague-question">Colleague Question</h2>
-<p><strong>Contact</strong>: sgd@stanford.edu<br />
-<strong>Key Issue</strong>: COG0523 family misannotated - NOT metal-binding transcription factors!</p>
+<h2 id="scope-of-these-notes">Scope of these notes</h2>
+<p>Working notes for the yeast ZNG1 (YNR029C; UniProt P53729) review. Provenance for<br />
+every substantive claim is given inline; see "Update 2026-09-06" at the end of this<br />
+file for a record of uncited/incorrect material that was removed.</p>
 <h2 id="key-findings">Key Findings</h2>
-<h3 id="the-misannotation-problem">The Misannotation Problem</h3>
+<h3 id="family-placement">Family placement</h3>
 <ul>
-<li><strong>Incorrect</strong>: COG0523 proteins annotated as "metal-binding transcription factors"</li>
-<li><strong>Correct</strong>: They are metallochaperones (G3E P-loop GTPases)</li>
-<li>Widespread error affects hundreds of genome annotations</li>
-<li>No DNA-binding domains present in any family member</li>
+<li>ZNG1 is a member of the <strong>COG0523 / G3E subfamily of P-loop GTPases</strong>, whose<br />
+  members couple nucleotide hydrolysis to metal delivery<br />
+  [<code>ZNG1-deep-research-falcon.md</code>, "ZNG1-family proteins belong to the <strong>G3E<br />
+  subfamily of P-loop GTPases</strong> (COG0523 family) whose members use nucleotide<br />
+  hydrolysis to power metal delivery/insertions"].</li>
+<li>InterPro domain assignments for P53729 are CobW-like C-terminal<br />
+  (IPR036627/IPR011629), CobW/HypB/UreG nucleotide-binding (IPR003495), P-loop<br />
+  NTPase (IPR027417) and Zinc-regulated GTPase activator (IPR051316)<br />
+  [<code>ZNG1-deep-research-falcon.md</code> line 45] — i.e. metallochaperone/GTPase<br />
+  architecture, with no DNA-binding domain assigned.</li>
 </ul>
 <h3 id="true-function-zinc-chaperone">True Function: Zinc Chaperone</h3>
 <ol>
@@ -2878,45 +2885,61 @@ this with annotations you find in gene/protein databases, but these can be outda
 <li>
 <p><strong>Regulatory mechanism</strong>:</p>
 </li>
-<li>Zinc availability controls GTPase activity</li>
-<li>CxxC motif coordinates zinc</li>
-<li>Conformational changes upon GTP binding</li>
+<li>The zinc-coordinating motif is <strong>CXCC</strong>, not CxxC: UniProt P53729 annotates a<br />
+<code>CXCC motif</code> feature and states that "zinc is transferred from the CXCC motif<br />
+     in the GTPase domain of ZNG1" to MAP1 (<code>ZNG1-uniprot.txt:71,160</code>).</li>
+<li>GTP hydrolysis drives the transfer, and GTP/GDP exchange is required to<br />
+     release active MAP1 (<code>ZNG1-uniprot.txt</code>, PMID:35584675).</li>
 </ol>
-<h3 id="cog0523-family-diversity">COG0523 Family Diversity</h3>
-<ul>
-<li><strong>YeiR/CobW subfamily</strong>: Cobalt/zinc chaperones</li>
-<li><strong>YciC subfamily</strong>: Iron-sulfur cluster assembly</li>
-<li><strong>ZigA/YeaZ subfamily</strong>: Zinc homeostasis</li>
-<li>All share G3E GTPase domain, NOT transcription factor domains</li>
-</ul>
 <h2 id="go-annotation-review">GO Annotation Review</h2>
+<p>What this review actually does to the 22 GOA rows (18 <code>existing_annotations</code><br />
+entries after folding duplicate <code>protein binding</code> WITH-entries into<br />
+<code>supporting_entities</code>):</p>
 <ul>
-<li><strong>Removed</strong>: All transcription factor annotations</li>
-<li><strong>Added</strong>: GO:0140827 (zinc chaperone activity)</li>
-<li><strong>Confirmed</strong>: GTPase activity annotations</li>
-<li><strong>Clarified</strong>: Metal ion binding specificity</li>
+<li><strong>ACCEPT (11)</strong>: <code>GO:0140827</code> zinc chaperone activity (IBA + IDA),<br />
+<code>GO:0003924</code> GTPase activity (IDA), <code>GO:0005525</code> GTP binding (IEA),<br />
+<code>GO:0008270</code> zinc ion binding (IBA), <code>GO:0008047</code> enzyme activator activity<br />
+  (IDA), <code>GO:0051604</code> protein maturation (IBA, IMP, IGI), <code>GO:0005737</code> cytoplasm<br />
+  (IBA, HDA).</li>
+<li><strong>MODIFY (2)</strong>: <code>GO:0016787</code> hydrolase activity → <code>GO:0003924</code> GTPase activity;<br />
+<code>GO:0046872</code> metal ion binding → <code>GO:0008270</code> zinc ion binding. Both are<br />
+  IEA-level generalisations that the experimental evidence lets us make specific.</li>
+<li><strong>MARK_AS_OVER_ANNOTATED (3)</strong>: both <code>GO:0005515</code> protein binding IPIs (per the<br />
+  project rule against uninformative <code>protein binding</code>) and <code>GO:0000166</code><br />
+  nucleotide binding.</li>
+<li><strong>KEEP_AS_NON_CORE (2)</strong>: <code>GO:0034224</code> cellular response to zinc ion starvation<br />
+  (IMP, IGI) — a real phenotype, but downstream of the molecular function.</li>
+<li><strong>REMOVE: none.</strong> No transcription-factor or DNA-binding term appears anywhere in<br />
+<code>ZNG1-goa.tsv</code>, so there was nothing of that kind to remove.</li>
+<li><strong>Proposed new terms: none.</strong> <code>GO:0140827</code> was already present in GOA (IBA and<br />
+  IDA) and was accepted, not added; <code>proposed_new_terms</code> is empty.</li>
+<li>Single <code>core_functions</code> molecular function: <code>GO:0140827</code> zinc chaperone activity.</li>
 </ul>
 <h2 id="experimental-evidence">Experimental Evidence</h2>
 <ul>
-<li><a href="https://pubmed.ncbi.nlm.nih.gov/31992591">PMID:31992591</a> - Crystal structure with zinc bound</li>
-<li><a href="https://pubmed.ncbi.nlm.nih.gov/29695862">PMID:29695862</a> - MAP1 activation mechanism</li>
-<li><a href="https://pubmed.ncbi.nlm.nih.gov/23595998">PMID:23595998</a> - GTPase cycle and zinc transfer</li>
-<li><a href="https://pubmed.ncbi.nlm.nih.gov/26369868">PMID:26369868</a> - Family-wide functional analysis</li>
+<li>The core experimental evidence for yeast Zng1p (GTP-dependent zinc transfer to<br />
+  apo-Map1p, GTP-hydrolysis dependence, Zn-deficiency growth/genetic-interaction<br />
+  phenotypes) is PMID:35584675 [Pasquini et al., "Zng1 is a GTP-dependent zinc<br />
+  transferase needed for activation of methionine aminopeptidase"], already cited<br />
+  throughout <code>ZNG1-ai-review.yaml</code>.</li>
+<li>See Update 2026-09-02 below: four previously listed PMIDs in this section<br />
+  (31992591, 29695862, 23595998, 26369868) were checked against PubMed and found<br />
+  to be unrelated papers (glycine riboswitch structure, acupuncture analgesia<br />
+  mechanism, an E. coli nitrile reductase enzyme-engineering study, and a growth<br />
+  hormone receptor antibody study, respectively). They did not describe COG0523,<br />
+  ZNG1, zinc chaperones, or Map1/MetAP1, and have been removed as incorrect<br />
+  citations. None of them were used as <code>original_reference_id</code> or<br />
+<code>supported_by.reference_id</code> anywhere in the ai-review.yaml, so no annotation<br />
+  action changes as a result of this correction.</li>
 </ul>
 <h2 id="bioinformatics-analysis">Bioinformatics Analysis</h2>
-<ul>
-<li>BLAST revealed &gt;1000 misannotated COG0523 proteins</li>
-<li>No DNA-binding domains in any family member</li>
-<li>Conserved G3E GTPase architecture</li>
-<li>Metal-binding CxxC motif universal</li>
-</ul>
-<h2 id="impact-of-correction">Impact of Correction</h2>
-<ul>
-<li>Affects genome annotations across all kingdoms</li>
-<li>Changes understanding of metal homeostasis</li>
-<li>Reveals new drug targets (metal delivery)</li>
-<li>Corrects metabolic pathway reconstructions</li>
-</ul>
+<p><strong>None was performed for this review.</strong> There is no <code>genes/yeast/ZNG1/ZNG1-bioinformatics/</code><br />
+folder, no script and no <code>RESULTS.md</code>. The domain/family statements under "Family<br />
+placement" above come from the InterPro assignments recorded in<br />
+<code>ZNG1-deep-research-falcon.md</code>, not from any analysis run here.</p>
+<p>If a family-wide misannotation survey is wanted, it needs to be done properly under<br />
+<code>ZNG1-bioinformatics/</code> with a reproducible script, per CLAUDE.md ("Never hardcode the<br />
+results of the script... Never ever make up results").</p>
 <h2 id="remaining-questions">Remaining Questions</h2>
 <ul>
 <li>How specific is zinc vs cobalt delivery?</li>
@@ -2931,6 +2954,75 @@ this with annotations you find in gene/protein databases, but these can be outda
 <li>Highlights need for family-wide curation</li>
 <li>Example for teaching annotation best practices</li>
 </ul>
+<h2 id="update-2026-09-02">Update 2026-09-02</h2>
+<p>Audited this file as part of a batch oversight review. <code>ZNG1-ai-review.yaml</code><br />
+itself (existing_annotations, core_functions, description) is well-supported:<br />
+its cited PMIDs (35584675, 14562095, 16429126, 19536198) all resolve to the<br />
+correct papers and every <code>supporting_text</code> verified as a verbatim substring of<br />
+the cached publication (confirmed via<br />
+<code>ai-gene-review validate --verbose --terms</code> and <code>validate-goa</code>, both pass with<br />
+no changes). No action changes were made to any GO annotation.</p>
+<p>The previous "Experimental Evidence" section of this notes file, however,<br />
+listed four PMIDs (31992591, 29695862, 23595998, 26369868) that do not<br />
+correspond to the claims made next to them. Direct lookup confirms:<br />
+- PMID:31992591 = "The asymmetry and cooperativity of tandem glycine<br />
+  riboswitch aptamers" (Torgerson et al., RNA, 2020) — glycine riboswitch<br />
+  structural biology, unrelated to ZNG1/COG0523.<br />
+- PMID:29695862 = "Critical roles of TRPV2 channels, histamine H1 and<br />
+  adenosine A1 receptors in the initiation of acupoint signals for<br />
+  acupuncture analgesia" (Sci Rep, 2018) — acupuncture pharmacology,<br />
+  unrelated.<br />
+- PMID:23595998 = "Targeting the substrate binding site of E. coli nitrile<br />
+  reductase QueF by modeling, substrate and enzyme engineering" (Wilding et<br />
+  al., Chemistry, 2013) — a QueF nitrile reductase enzyme-engineering study,<br />
+  unrelated.<br />
+- PMID:26369868 = an anti-idiotypic-antibody growth-hormone-receptor<br />
+  antagonist study — unrelated.</p>
+<p>These citations were fabricated/mis-attributed and have been removed (see the<br />
+"Experimental Evidence" section above) per the project rule to never fabricate<br />
+identifiers or provenance. They were not used anywhere in the ai-review.yaml,<br />
+so this is a notes-file-only correction with no effect on any curated<br />
+annotation action.</p>
+<h2 id="update-2026-09-06">Update 2026-09-06</h2>
+<p>Follow-up to the PR review on #2947, completing the cleanup that the 2026-09-02<br />
+pass started. The 2026-09-02 commit removed the four fabricated PMIDs from the<br />
+"Experimental Evidence" section but left three further problems in this file, all<br />
+of which are fixed here:</p>
+<ol>
+<li>
+<p><strong><code>## GO Annotation Review</code> described work that was never done.</strong> It claimed<br />
+<em>"Removed: All transcription factor annotations"</em> and <em>"Added: GO:0140827"</em>.<br />
+   Neither is true: <code>ZNG1-goa.tsv</code> contains no transcription-factor or DNA-binding<br />
+   term, <code>ZNG1-ai-review.yaml</code> contains zero <code>REMOVE</code> actions (18 entries: 11<br />
+   ACCEPT, 3 MARK_AS_OVER_ANNOTATED, 2 MODIFY, 2 KEEP_AS_NON_CORE), <code>GO:0140827</code><br />
+   is already in GOA twice (IBA + IDA) and was accepted rather than added, and<br />
+<code>proposed_new_terms</code> is empty. The section now enumerates the actions the YAML<br />
+   actually records.</p>
+</li>
+<li>
+<p><strong><code>## Bioinformatics Analysis</code> asserted a result that does not exist.</strong> The<br />
+   claim <em>"BLAST revealed &gt;1000 misannotated COG0523 proteins"</em> had no<br />
+<code>ZNG1-bioinformatics/</code> folder, no script and no citation behind it — the same<br />
+   class of fabrication as the four PMIDs. Removed and replaced with an explicit<br />
+   statement that no analysis was run.</p>
+</li>
+<li>
+<p><strong>The COG0523 subfamily list and the "misannotation problem" framing were<br />
+   uncited and partly wrong.</strong> <em>"YciC subfamily: Iron-sulfur cluster assembly"</em><br />
+   and <em>"ZigA/YeaZ subfamily"</em> were incorrect (YeaZ is TsaB, a t6A<br />
+   tRNA-modification protein, not a COG0523 member), and <em>"Widespread error<br />
+   affects hundreds of genome annotations"</em>, the <code>## Impact of Correction</code><br />
+   section, and the <code>## Colleague Question</code> header were unsourced boilerplate<br />
+   that had never been reconciled against this gene. All removed in favour of the<br />
+   family placement that the deep-research file and UniProt actually support.</p>
+</li>
+</ol>
+<p>Also corrected the metal-binding motif from <code>CxxC</code> to <strong><code>CXCC</code></strong>, which is what<br />
+UniProt P53729 annotates (<code>ZNG1-uniprot.txt:71,160</code>).</p>
+<p><code>ZNG1-ai-review.yaml</code> is again untouched by this commit; the only other change is<br />
+the regenerated <code>ZNG1-ai-review.html</code>, which had been publishing the four<br />
+fabricated PMIDs as live PubMed links because <code>generate-pages.yaml</code> triggers only<br />
+on <code>genes/**/*.yaml</code> and so never re-renders on a notes-only change.</p>
             </div>
         </details>
 

--- a/genes/yeast/ZNG1/ZNG1-notes.md
+++ b/genes/yeast/ZNG1/ZNG1-notes.md
@@ -41,10 +41,20 @@
 - **Clarified**: Metal ion binding specificity
 
 ## Experimental Evidence
-- [PMID:31992591] - Crystal structure with zinc bound
-- [PMID:29695862] - MAP1 activation mechanism
-- [PMID:23595998] - GTPase cycle and zinc transfer
-- [PMID:26369868] - Family-wide functional analysis
+- The core experimental evidence for yeast Zng1p (GTP-dependent zinc transfer to
+  apo-Map1p, GTP-hydrolysis dependence, Zn-deficiency growth/genetic-interaction
+  phenotypes) is PMID:35584675 [Pasquini et al., "Zng1 is a GTP-dependent zinc
+  transferase needed for activation of methionine aminopeptidase"], already cited
+  throughout `ZNG1-ai-review.yaml`.
+- See Update 2026-09-02 below: four previously listed PMIDs in this section
+  (31992591, 29695862, 23595998, 26369868) were checked against PubMed and found
+  to be unrelated papers (glycine riboswitch structure, acupuncture analgesia
+  mechanism, an E. coli nitrile reductase enzyme-engineering study, and a growth
+  hormone receptor antibody study, respectively). They did not describe COG0523,
+  ZNG1, zinc chaperones, or Map1/MetAP1, and have been removed as incorrect
+  citations. None of them were used as `original_reference_id` or
+  `supported_by.reference_id` anywhere in the ai-review.yaml, so no annotation
+  action changes as a result of this correction.
 
 ## Bioinformatics Analysis
 - BLAST revealed >1000 misannotated COG0523 proteins
@@ -69,3 +79,36 @@
 - Shows importance of experimental validation
 - Highlights need for family-wide curation
 - Example for teaching annotation best practices
+
+## Update 2026-09-02
+
+Audited this file as part of a batch oversight review. `ZNG1-ai-review.yaml`
+itself (existing_annotations, core_functions, description) is well-supported:
+its cited PMIDs (35584675, 14562095, 16429126, 19536198) all resolve to the
+correct papers and every `supporting_text` verified as a verbatim substring of
+the cached publication (confirmed via
+`ai-gene-review validate --verbose --terms` and `validate-goa`, both pass with
+no changes). No action changes were made to any GO annotation.
+
+The previous "Experimental Evidence" section of this notes file, however,
+listed four PMIDs (31992591, 29695862, 23595998, 26369868) that do not
+correspond to the claims made next to them. Direct lookup confirms:
+- PMID:31992591 = "The asymmetry and cooperativity of tandem glycine
+  riboswitch aptamers" (Torgerson et al., RNA, 2020) — glycine riboswitch
+  structural biology, unrelated to ZNG1/COG0523.
+- PMID:29695862 = "Critical roles of TRPV2 channels, histamine H1 and
+  adenosine A1 receptors in the initiation of acupoint signals for
+  acupuncture analgesia" (Sci Rep, 2018) — acupuncture pharmacology,
+  unrelated.
+- PMID:23595998 = "Targeting the substrate binding site of E. coli nitrile
+  reductase QueF by modeling, substrate and enzyme engineering" (Wilding et
+  al., Chemistry, 2013) — a QueF nitrile reductase enzyme-engineering study,
+  unrelated.
+- PMID:26369868 = an anti-idiotypic-antibody growth-hormone-receptor
+  antagonist study — unrelated.
+
+These citations were fabricated/mis-attributed and have been removed (see the
+"Experimental Evidence" section above) per the project rule to never fabricate
+identifiers or provenance. They were not used anywhere in the ai-review.yaml,
+so this is a notes-file-only correction with no effect on any curated
+annotation action.

--- a/genes/yeast/ZNG1/ZNG1-notes.md
+++ b/genes/yeast/ZNG1/ZNG1-notes.md
@@ -1,16 +1,24 @@
 # ZNG1 Gene Review Notes
 
-## Colleague Question
-**Contact**: sgd@stanford.edu
-**Key Issue**: COG0523 family misannotated - NOT metal-binding transcription factors!
+## Scope of these notes
+
+Working notes for the yeast ZNG1 (YNR029C; UniProt P53729) review. Provenance for
+every substantive claim is given inline; see "Update 2026-09-06" at the end of this
+file for a record of uncited/incorrect material that was removed.
 
 ## Key Findings
 
-### The Misannotation Problem
-- **Incorrect**: COG0523 proteins annotated as "metal-binding transcription factors"
-- **Correct**: They are metallochaperones (G3E P-loop GTPases)
-- Widespread error affects hundreds of genome annotations
-- No DNA-binding domains present in any family member
+### Family placement
+- ZNG1 is a member of the **COG0523 / G3E subfamily of P-loop GTPases**, whose
+  members couple nucleotide hydrolysis to metal delivery
+  [`ZNG1-deep-research-falcon.md`, "ZNG1-family proteins belong to the **G3E
+  subfamily of P-loop GTPases** (COG0523 family) whose members use nucleotide
+  hydrolysis to power metal delivery/insertions"].
+- InterPro domain assignments for P53729 are CobW-like C-terminal
+  (IPR036627/IPR011629), CobW/HypB/UreG nucleotide-binding (IPR003495), P-loop
+  NTPase (IPR027417) and Zinc-regulated GTPase activator (IPR051316)
+  [`ZNG1-deep-research-falcon.md` line 45] — i.e. metallochaperone/GTPase
+  architecture, with no DNA-binding domain assigned.
 
 ### True Function: Zinc Chaperone
 1. **GTPase activity**:
@@ -24,21 +32,36 @@
    - Protects zinc from chelation/oxidation during transfer
 
 3. **Regulatory mechanism**:
-   - Zinc availability controls GTPase activity
-   - CxxC motif coordinates zinc
-   - Conformational changes upon GTP binding
-
-### COG0523 Family Diversity
-- **YeiR/CobW subfamily**: Cobalt/zinc chaperones
-- **YciC subfamily**: Iron-sulfur cluster assembly
-- **ZigA/YeaZ subfamily**: Zinc homeostasis
-- All share G3E GTPase domain, NOT transcription factor domains
+   - The zinc-coordinating motif is **CXCC**, not CxxC: UniProt P53729 annotates a
+     `CXCC motif` feature and states that "zinc is transferred from the CXCC motif
+     in the GTPase domain of ZNG1" to MAP1 (`ZNG1-uniprot.txt:71,160`).
+   - GTP hydrolysis drives the transfer, and GTP/GDP exchange is required to
+     release active MAP1 (`ZNG1-uniprot.txt`, PMID:35584675).
 
 ## GO Annotation Review
-- **Removed**: All transcription factor annotations
-- **Added**: GO:0140827 (zinc chaperone activity)
-- **Confirmed**: GTPase activity annotations
-- **Clarified**: Metal ion binding specificity
+
+What this review actually does to the 22 GOA rows (18 `existing_annotations`
+entries after folding duplicate `protein binding` WITH-entries into
+`supporting_entities`):
+
+- **ACCEPT (11)**: `GO:0140827` zinc chaperone activity (IBA + IDA),
+  `GO:0003924` GTPase activity (IDA), `GO:0005525` GTP binding (IEA),
+  `GO:0008270` zinc ion binding (IBA), `GO:0008047` enzyme activator activity
+  (IDA), `GO:0051604` protein maturation (IBA, IMP, IGI), `GO:0005737` cytoplasm
+  (IBA, HDA).
+- **MODIFY (2)**: `GO:0016787` hydrolase activity → `GO:0003924` GTPase activity;
+  `GO:0046872` metal ion binding → `GO:0008270` zinc ion binding. Both are
+  IEA-level generalisations that the experimental evidence lets us make specific.
+- **MARK_AS_OVER_ANNOTATED (3)**: both `GO:0005515` protein binding IPIs (per the
+  project rule against uninformative `protein binding`) and `GO:0000166`
+  nucleotide binding.
+- **KEEP_AS_NON_CORE (2)**: `GO:0034224` cellular response to zinc ion starvation
+  (IMP, IGI) — a real phenotype, but downstream of the molecular function.
+- **REMOVE: none.** No transcription-factor or DNA-binding term appears anywhere in
+  `ZNG1-goa.tsv`, so there was nothing of that kind to remove.
+- **Proposed new terms: none.** `GO:0140827` was already present in GOA (IBA and
+  IDA) and was accepted, not added; `proposed_new_terms` is empty.
+- Single `core_functions` molecular function: `GO:0140827` zinc chaperone activity.
 
 ## Experimental Evidence
 - The core experimental evidence for yeast Zng1p (GTP-dependent zinc transfer to
@@ -57,16 +80,15 @@
   action changes as a result of this correction.
 
 ## Bioinformatics Analysis
-- BLAST revealed >1000 misannotated COG0523 proteins
-- No DNA-binding domains in any family member
-- Conserved G3E GTPase architecture
-- Metal-binding CxxC motif universal
 
-## Impact of Correction
-- Affects genome annotations across all kingdoms
-- Changes understanding of metal homeostasis
-- Reveals new drug targets (metal delivery)
-- Corrects metabolic pathway reconstructions
+**None was performed for this review.** There is no `genes/yeast/ZNG1/ZNG1-bioinformatics/`
+folder, no script and no `RESULTS.md`. The domain/family statements under "Family
+placement" above come from the InterPro assignments recorded in
+`ZNG1-deep-research-falcon.md`, not from any analysis run here.
+
+If a family-wide misannotation survey is wanted, it needs to be done properly under
+`ZNG1-bioinformatics/` with a reproducible script, per CLAUDE.md ("Never hardcode the
+results of the script... Never ever make up results").
 
 ## Remaining Questions
 - How specific is zinc vs cobalt delivery?
@@ -112,3 +134,41 @@ These citations were fabricated/mis-attributed and have been removed (see the
 identifiers or provenance. They were not used anywhere in the ai-review.yaml,
 so this is a notes-file-only correction with no effect on any curated
 annotation action.
+## Update 2026-09-06
+
+Follow-up to the PR review on #2947, completing the cleanup that the 2026-09-02
+pass started. The 2026-09-02 commit removed the four fabricated PMIDs from the
+"Experimental Evidence" section but left three further problems in this file, all
+of which are fixed here:
+
+1. **`## GO Annotation Review` described work that was never done.** It claimed
+   *"Removed: All transcription factor annotations"* and *"Added: GO:0140827"*.
+   Neither is true: `ZNG1-goa.tsv` contains no transcription-factor or DNA-binding
+   term, `ZNG1-ai-review.yaml` contains zero `REMOVE` actions (18 entries: 11
+   ACCEPT, 3 MARK_AS_OVER_ANNOTATED, 2 MODIFY, 2 KEEP_AS_NON_CORE), `GO:0140827`
+   is already in GOA twice (IBA + IDA) and was accepted rather than added, and
+   `proposed_new_terms` is empty. The section now enumerates the actions the YAML
+   actually records.
+
+2. **`## Bioinformatics Analysis` asserted a result that does not exist.** The
+   claim *"BLAST revealed >1000 misannotated COG0523 proteins"* had no
+   `ZNG1-bioinformatics/` folder, no script and no citation behind it — the same
+   class of fabrication as the four PMIDs. Removed and replaced with an explicit
+   statement that no analysis was run.
+
+3. **The COG0523 subfamily list and the "misannotation problem" framing were
+   uncited and partly wrong.** *"YciC subfamily: Iron-sulfur cluster assembly"*
+   and *"ZigA/YeaZ subfamily"* were incorrect (YeaZ is TsaB, a t6A
+   tRNA-modification protein, not a COG0523 member), and *"Widespread error
+   affects hundreds of genome annotations"*, the `## Impact of Correction`
+   section, and the `## Colleague Question` header were unsourced boilerplate
+   that had never been reconciled against this gene. All removed in favour of the
+   family placement that the deep-research file and UniProt actually support.
+
+Also corrected the metal-binding motif from `CxxC` to **`CXCC`**, which is what
+UniProt P53729 annotates (`ZNG1-uniprot.txt:71,160`).
+
+`ZNG1-ai-review.yaml` is again untouched by this commit; the only other change is
+the regenerated `ZNG1-ai-review.html`, which had been publishing the four
+fabricated PMIDs as live PubMed links because `generate-pages.yaml` triggers only
+on `genes/**/*.yaml` and so never re-renders on a notes-only change.


### PR DESCRIPTION
## Oversight

`ZNG1-notes.md`'s "Experimental Evidence" section cited four PMIDs as direct support for specific claims about ZNG1/COG0523 (crystal structure with zinc bound, Map1 activation mechanism, GTPase cycle/zinc transfer, family-wide functional analysis). Direct PubMed lookup shows **all four resolve to entirely unrelated papers**:

| PMID cited | Claimed topic | Actual paper |
|---|---|---|
| 31992591 | Crystal structure with zinc bound | "The asymmetry and cooperativity of tandem glycine riboswitch aptamers" (Torgerson et al., *RNA*, 2020) |
| 29695862 | MAP1 activation mechanism | "Critical roles of TRPV2 channels, histamine H1 and adenosine A1 receptors in the initiation of acupoint signals for acupuncture analgesia" (*Sci Rep*, 2018) |
| 23595998 | GTPase cycle and zinc transfer | "Targeting the substrate binding site of *E. coli* nitrile reductase QueF by modeling, substrate and enzyme engineering" (Wilding et al., *Chemistry*, 2013) |
| 26369868 | Family-wide functional analysis | Anti-idiotypic-antibody growth-hormone-receptor antagonist study |

None of these have anything to do with COG0523, zinc chaperones, GTPases, or Map1/MetAP1 — they were fabricated/mis-attributed citations, which violates this project's explicit rule to never fabricate identifiers or provenance for assertions.

## Scope of fix

Critically, **none of these four PMIDs were ever used** as `original_reference_id` or `supported_by.reference_id` anywhere in `ZNG1-ai-review.yaml` — the actual curated review draws its evidence entirely and correctly from PMID:35584675 (Pasquini et al., "Zng1 is a GTP-dependent zinc transferase needed for activation of methionine aminopeptidase") plus PMID:14562095, PMID:16429126, PMID:19536198, all of which I verified resolve to the correct papers with verbatim `supporting_text`.

So this is a **notes-file-only correction**: the fabricated citations are removed from the "Experimental Evidence" list and replaced with a pointer to the real, correctly-used PMID:35584675, plus a dated Update section documenting the verification. **No `existing_annotations`, `core_functions`, or `description` content changed, and no annotation action changed.**

## Before → after

| File | Before | After |
|---|---|---|
| `ZNG1-notes.md` § Experimental Evidence | 4 fabricated PMIDs | Removed; points to the real, already-cited PMID:35584675 |
| `ZNG1-ai-review.yaml` | unchanged | unchanged |

## Validation

Both required checks pass (unchanged, since the YAML itself was not modified — it was already sound):

```
$ ai-gene-review validate --verbose --terms genes/yeast/ZNG1/ZNG1-ai-review.yaml
✓ Valid

$ ai-gene-review validate-goa genes/yeast/ZNG1/ZNG1-ai-review.yaml
✓ All existing_annotations match GOA file
```

## Note on ZDS1 (same batch)

ZDS1 was also audited in this batch. Its review is comprehensive, already validates cleanly, and its notes file documents a prior correction round — no genuine oversight found, so no PR was opened for it (recorded as NO CHANGE).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg)_