### PR TITLE
Review yeast UBP3: fix REMOVE misapplied to genuine-but-generic annotations

### DIFF
--- a/genes/yeast/UBP3/UBP3-ai-review.yaml
+++ b/genes/yeast/UBP3/UBP3-ai-review.yaml
@@ -699,29 +699,37 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Proteolysis is too broad for UBP3 and obscures its specific 
+    summary: Proteolysis is chemically correct (Ubp3 is a cysteine-type
+      peptidase that hydrolyzes the isopeptide bond linking ubiquitin to
+      substrates) but too broad for UBP3 and obscures its specific
       deubiquitination-focused biology.
-    action: REMOVE
-    reason: Changed from MODIFY to REMOVE because the review already concluded 
-      this term should be removed in favor of specific deubiquitination process 
-      annotations.
+    action: KEEP_AS_NON_CORE
+    reason: REMOVE is defined for annotations unlikely to be correct. Ubp3
+      genuinely performs proteolysis (isopeptide-bond hydrolysis via its
+      cysteine-protease mechanism), so the term is true, just uninformatively
+      general; it should be retained as a non-core broad parent of the more
+      specific protein deubiquitination (GO:0016579) process annotation
+      rather than removed.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16429126
   review:
-    summary: Generic protein binding annotation from interaction database 
-      (IntAct). IPI from binary interaction data (Bre5 interaction, based on 
+    summary: Generic protein binding annotation from interaction database
+      (IntAct). IPI from binary interaction data (Bre5 interaction, based on
       PMID:16429126 - proteome survey). Non-specific and uninformative.
-    action: REMOVE
-    reason: GO:0005515 protein binding is overly generic and uninformative 
-      annotation. Ubp3 is an enzyme that catalyzes a specific reaction on 
-      specific substrates. Catalytic activity (GO:0004843) is already annotated 
-      and is far more informative. Protein binding does not distinguish between 
-      substrate recognition and non-specific protein aggregation. The catalytic 
-      function completely supersedes generic binding annotation. Interaction 
-      with BRE5 is better captured by GO:1990861 (Ubp3-Bre5 complex membership).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: GO:0005515 protein binding is a genuine, correctly evidenced
+      interaction, not an incorrect one, so REMOVE (defined for annotations
+      unlikely to be correct) is the wrong action; it is overly generic and
+      uninformative rather than wrong. Ubp3 is an enzyme that catalyzes a
+      specific reaction on specific substrates. Catalytic activity
+      (GO:0004843) is already annotated and is far more informative. Protein
+      binding does not distinguish between substrate recognition and
+      non-specific protein aggregation. The catalytic function completely
+      supersedes generic binding annotation. Interaction with BRE5 is better
+      captured by GO:1990861 (Ubp3-Bre5 complex membership).
     supported_by:
     - reference_id: PMID:16429126
       supporting_text: Proteome survey reveals modularity of the yeast cell 
@@ -732,16 +740,18 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:16554755
   review:
-    summary: Generic protein binding from binary interaction database. Multiple 
-      proteins detected binding to Ubp3 (O94742, P39015, P53141, P53741) from 
+    summary: Generic protein binding from binary interaction database. Multiple
+      proteins detected binding to Ubp3 (O94742, P39015, P53141, P53741) from
       high-throughput interaction study.
-    action: REMOVE
-    reason: Generic protein binding annotation. These binary interactions do not
-      indicate catalytic substrates or functional complexes. The meaningful 
-      interaction (Bre5) is captured by complex membership term GO:1990861. 
-      Other interactions without functional characterization should not be 
-      annotated. Following GO curation guidelines that recommend avoiding 
-      protein binding in favor of more specific molecular function terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The physical interactions are genuinely evidenced (IPI), so
+      REMOVE, which is defined for annotations unlikely to be correct, is not
+      the right action; the issue is that these binary interactions do not
+      indicate catalytic substrates or functional complexes, making the
+      generic term over-annotation rather than error. The meaningful
+      interaction (Bre5) is captured by complex membership term GO:1990861.
+      Following GO curation guidelines that recommend avoiding protein
+      binding in favor of more specific molecular function terms.
     supported_by:
     - reference_id: PMID:16554755
       supporting_text: Global landscape of protein complexes in the yeast 
@@ -753,9 +763,11 @@ existing_annotations:
   original_reference_id: PMID:16554755
   review:
     summary: Interaction database annotation for O94742 interaction with Ubp3.
-    action: REMOVE
-    reason: Generic protein binding. No mechanistic role known. Should be 
-      removed.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is genuinely evidenced (IPI), so REMOVE is not
+      warranted; no mechanistic role is known and generic protein binding is
+      uninformative given the specific catalytic annotation already present,
+      so it is marked as over-annotated rather than incorrect.
     supported_by:
     - reference_id: PMID:16554755
       supporting_text: Global landscape of protein complexes in the yeast 
@@ -767,8 +779,11 @@ existing_annotations:
   original_reference_id: PMID:16554755
   review:
     summary: Interaction database annotation for P53141 interaction with Ubp3.
-    action: REMOVE
-    reason: Generic protein binding. Should be removed per GO best practices.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is genuinely evidenced (IPI), so REMOVE is not
+      warranted; generic protein binding is uninformative given the specific
+      catalytic annotation already present, so it is marked as
+      over-annotated rather than incorrect.
     supported_by:
     - reference_id: PMID:16554755
       supporting_text: Global landscape of protein complexes in the yeast 
@@ -779,13 +794,14 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:17632125
   review:
-    summary: Protein binding with Bre5 from structural study (PMID:17632125 - 
+    summary: Protein binding with Bre5 from structural study (PMID:17632125 -
       Ubp3-Bre5 crystal structure).
-    action: REMOVE
-    reason: While this interaction (Ubp3-Bre5) is functionally important and 
-      well-characterized, it should be annotated as GO:1990861 (Ubp3-Bre5 
-      complex membership) rather than generic protein binding. The complex term 
-      is far more informative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: This interaction (Ubp3-Bre5) is functionally important,
+      well-characterized, and genuinely evidenced, so REMOVE is the wrong
+      action; it should instead be treated as over-annotation, since
+      GO:1990861 (Ubp3-Bre5 complex membership) already captures it far more
+      informatively than generic protein binding.
     supported_by:
     - reference_id: PMID:17632125
       supporting_text: Molecular basis for bre5 cofactor recognition by the ubp3
@@ -796,11 +812,13 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:18719252
   review:
-    summary: Interaction database annotation for Bre5 from large-scale 
+    summary: Interaction database annotation for Bre5 from large-scale
       interaction screen.
-    action: REMOVE
-    reason: Generic protein binding. Complex membership (GO:1990861) already 
-      captures this functionally significant interaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is genuinely evidenced (IPI), so REMOVE is not
+      warranted; complex membership (GO:1990861) already captures this
+      functionally significant interaction more informatively than generic
+      protein binding.
     supported_by:
     - reference_id: PMID:18719252
       supporting_text: High-quality binary protein interaction map of the yeast 
@@ -811,16 +829,15 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:20508643
   review:
-    summary: Protein binding with CDC48 and/or Ufd3 and/or DOA1 from ribophagy 
-      complex identification study. IPI indicates these proteins interact with 
+    summary: Protein binding with CDC48 and/or Ufd3 and/or DOA1 from ribophagy
+      complex identification study. IPI indicates these proteins interact with
       Ubp3.
-    action: REMOVE
-    reason: These are functionally meaningful interactions in the ribophagy 
-      pathway, but generic protein binding term is not appropriate. Recommend 
-      replacing with GO term for ubiquitin proteasome system components or 
-      ribophagy complex if available, or documenting in process terms 
-      (GO:0034517 ribophagy) already annotated. Generic binding annotation is 
-      uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: These are functionally meaningful, genuinely evidenced
+      interactions in the ribophagy pathway, so REMOVE is not appropriate;
+      the generic protein binding term is uninformative given the more
+      specific process term already annotated (GO:0034517 ribophagy), so it
+      is marked as over-annotation rather than incorrect.
     supported_by:
     - reference_id: PMID:20508643
       supporting_text: Cdc48 and Ufd3, new partners of the ubiquitin protease 
@@ -831,11 +848,12 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:21179020
   review:
-    summary: Protein binding with Bre5 from chromatin-associated protein 
+    summary: Protein binding with Bre5 from chromatin-associated protein
       interaction study.
-    action: REMOVE
-    reason: Generic protein binding. This is part of Ubp3-Bre5 complex (already 
-      captured by GO:1990861).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is genuinely evidenced (IPI), so REMOVE is not
+      warranted; it is part of the Ubp3-Bre5 complex (already captured by
+      GO:1990861), so the generic term is over-annotation, not error.
     supported_by:
     - reference_id: PMID:21179020
       supporting_text: Defining the budding yeast chromatin-associated 
@@ -846,16 +864,17 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:21743437
   review:
-    summary: Protein binding with Hog1 from osmotic stress signaling study. IPI 
-      demonstrates direct interaction between Ubp3 and osmotic stress-response 
+    summary: Protein binding with Hog1 from osmotic stress signaling study. IPI
+      demonstrates direct interaction between Ubp3 and osmotic stress-response
       kinase.
-    action: REMOVE
-    reason: While this interaction is functionally important for osmotic stress 
-      response (regulation of Ubp3 activity by Hog1 phosphorylation), the 
-      relationship should be captured through process annotation (GO:0047484 
-      regulation of response to osmotic stress) rather than generic protein 
-      binding. Recommend alternative term if available for kinase-substrate 
-      regulator interaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: This interaction is genuinely evidenced and functionally
+      important for osmotic stress response (regulation of Ubp3 activity by
+      Hog1 phosphorylation), so REMOVE is the wrong action; the relationship
+      is already captured through the more informative process annotation
+      (GO:0047484 regulation of response to osmotic stress) and the
+      corresponding IPI row for that term, so generic protein binding is
+      over-annotation here rather than incorrect.
     supported_by:
     - reference_id: PMID:21743437
       supporting_text: Control of Ubp3 ubiquitin protease activity by the Hog1 
@@ -866,11 +885,13 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:37968396
   review:
-    summary: Generic protein binding from recent large-scale interaction study 
+    summary: Generic protein binding from recent large-scale interaction study
       (2023). Interactions with P39015 and/or P53741.
-    action: REMOVE
-    reason: Generic protein binding from interaction database. No functional 
-      characterization. Should be removed.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is genuinely evidenced (IPI), so REMOVE is not
+      warranted; no functional characterization is given and it is redundant
+      with the more informative annotations already present, so it is marked
+      as over-annotation rather than incorrect.
     supported_by:
     - reference_id: PMID:37968396
       supporting_text: The social and structural architecture of the yeast 
@@ -885,16 +906,17 @@ existing_annotations:
       stability. This is an indirect consequence of deubiquitination (removing 
       ubiquitin signals targeting proteins for degradation), not a direct 
       catalytic function.
-    action: REMOVE
-    reason: GO:0031647 regulation of protein stability is too indirect and 
-      non-specific. It is a downstream consequence of deubiquitination, not a 
-      direct molecular function. The deubiquitinase activity (GO:0004843) is the
-      direct function. Protein stability is affected through deubiquitination 
-      because ubiquitin modifications target proteins for proteasomal 
-      degradation. However, multiple substrate-specific deubiquitination 
-      annotations (SEC23, RNAP II, Ste7, ribophagy targets) are more informative
-      than this generic stability regulation term. Recommend removing in favor 
-      of substrate-specific process annotations already present.
+    action: KEEP_AS_NON_CORE
+    reason: This is an IBA (phylogenetic) call, and no target-specific
+      divergence or loss evidence for UBP3 was found, so REMOVE is not
+      warranted. The claim itself is also true, not merely generic - Ubp3
+      demonstrably reverses degradative ubiquitination of specific substrates
+      (Sec23, RNAP II), which is a form of protein-stability regulation. The
+      deubiquitinase activity (GO:0004843) is the direct molecular function,
+      and the multiple substrate-specific deubiquitination process
+      annotations (SEC23 transport, RNAP II regulation, Ste7/MAPK signaling,
+      ribophagy) are more informative than this generic term, so it is
+      retained as non-core rather than removed.
 core_functions:
 - molecular_function:
     id: GO:0004843

--- a/genes/yeast/UBP3/UBP3-ai-review.yaml
+++ b/genes/yeast/UBP3/UBP3-ai-review.yaml
@@ -8,9 +8,10 @@ taxon:
 description: Ubiquitin carboxyl-terminal hydrolase 3 (EC 3.4.19.12), a 
   deubiquitinating enzyme critical for protein quality control, selective 
   autophagy (ribophagy), and transcriptional regulation. Functions as a 
-  cysteine-type serine/threonine protease that cleaves ubiquitin from target 
-  proteins in a cofactor-dependent manner, primarily in complex with regulatory 
-  protein BRE5. Core functions include removal of ubiquitin conjugates from 
+  papain-fold cysteine protease of the peptidase C19 (USP) family that cleaves
+  ubiquitin from target proteins in a cofactor-dependent manner, primarily in
+  complex with regulatory protein BRE5. Core functions include removal of
+  ubiquitin conjugates from
   COPII pathway proteins (SEC23), ribosomal proteins during starvation-induced 
   autophagy, and chromatin-associated proteins (H2B).
 existing_annotations:
@@ -699,17 +700,20 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Proteolysis is chemically correct (Ubp3 is a cysteine-type
+    summary: Proteolysis is chemically defensible (Ubp3 is a cysteine-type
       peptidase that hydrolyzes the isopeptide bond linking ubiquitin to
       substrates) but too broad for UBP3 and obscures its specific
       deubiquitination-focused biology.
-    action: KEEP_AS_NON_CORE
-    reason: REMOVE is defined for annotations unlikely to be correct. Ubp3
-      genuinely performs proteolysis (isopeptide-bond hydrolysis via its
-      cysteine-protease mechanism), so the term is true, just uninformatively
-      general; it should be retained as a non-core broad parent of the more
-      specific protein deubiquitination (GO:0016579) process annotation
-      rather than removed.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Not entirely wrong — Ubp3 does hydrolyze an isopeptide bond via a
+      cysteine-protease mechanism, and the corresponding MF term GO:0004843 is
+      indeed classified under peptidase activity — but generic proteolysis is
+      an over-annotation for a deubiquitinase. Note that GO deliberately does
+      not classify GO:0016579 protein deubiquitination under GO:0006508; the
+      BP is under GO:0070646 protein modification by small protein removal, so
+      the broad term is not a parent of the specific process already annotated
+      here. This matches the treatment of the same IEA/TAS proteolysis term on
+      the USP-family DUB USP25.
 - term:
     id: GO:0005515
     label: protein binding

--- a/genes/yeast/UBP3/UBP3-notes.md
+++ b/genes/yeast/UBP3/UBP3-notes.md
@@ -1,0 +1,49 @@
+# UBP3 curation notes
+
+## 2026-09-02 Update: fixed REMOVE misapplication for genuine-but-generic annotations
+
+Audited the existing review for action-enum misuse against the project's own
+`ActionEnum` definitions (`REMOVE` = "unlikely to be correct based on combined
+evidence"; `MARK_AS_OVER_ANNOTATED` = "not entirely wrong, but likely
+represents an over-annotation"; `KEEP_AS_NON_CORE` = correct but not core).
+
+Found 11 rows where `REMOVE` had been applied to annotations whose underlying
+evidence the review itself acknowledged as genuine and correct — the review's
+own `reason` text argued only that the term was too generic/broad, not that
+it was factually wrong. This misapplies `REMOVE`'s semantics (which signals
+"this annotation is unlikely to be correct") to cases that are really
+over-annotation or over-general-but-true annotation:
+
+- **9x `GO:0005515` protein binding (IPI)**, one per cited PMID
+  (PMID:16429126, PMID:16554755 x3, PMID:17632125, PMID:18719252,
+  PMID:20508643, PMID:21179020, PMID:21743437, PMID:37968396). Every one of
+  these rows is a genuinely evidenced physical interaction (IntAct IPI
+  evidence); the review's own reasoning in each case was "generic/
+  uninformative", which is exactly the definition of `MARK_AS_OVER_ANNOTATED`,
+  not `REMOVE`. Changed action to `MARK_AS_OVER_ANNOTATED` for all 9 rows;
+  reasons were left substantively intact but reworded to reflect that the
+  interaction itself is real and correctly cited, with the more informative
+  replacement terms (GO:1990861 Ubp3-Bre5 complex, GO:0047484 regulation of
+  response to osmotic stress, GO:0034517 ribophagy) noted as already covering
+  the same evidence.
+
+- **`GO:0031647` regulation of protein stability (IBA)**: this is a
+  phylogenetic (IBA) annotation, and per project policy an IBA should only be
+  overturned with target-specific divergence/loss evidence, not because the
+  term is broad. No such evidence was offered (or exists) here — indeed the
+  claim is directly true for UBP3, which reverses degradative ubiquitination
+  of Sec23 and RNAP II [PMID:12778054, PMID:18498751]. Changed action from
+  `REMOVE` to `KEEP_AS_NON_CORE`, matching how comparably broad-but-true IBA
+  terms are treated elsewhere in this project (e.g. TSA1's `response to
+  oxidative stress`).
+
+- **`GO:0006508` proteolysis (IEA)**: Ubp3 is a bona fide cysteine-type
+  peptidase (peptidase C19/USP family, EC 3.4.19.12) that hydrolyzes the
+  isopeptide bond linking ubiquitin to substrate lysines — this literally is
+  proteolysis, just described at a very general level. Changed action from
+  `REMOVE` to `KEEP_AS_NON_CORE` as a correct, non-core parent of the more
+  specific `GO:0016579` protein deubiquitination process annotation.
+
+No changes were made to any `ACCEPT` rows, to the `description`, or to
+`core_functions`; those were sound. `validate --terms` and `validate-goa`
+both pass after the edit.

--- a/genes/yeast/UBP3/UBP3-notes.md
+++ b/genes/yeast/UBP3/UBP3-notes.md
@@ -47,3 +47,47 @@ over-annotation or over-general-but-true annotation:
 No changes were made to any `ACCEPT` rows, to the `description`, or to
 `core_functions`; those were sound. `validate --terms` and `validate-goa`
 both pass after the edit.
+
+## Review follow-up (PR #2948, 2026-09-06)
+
+Two blocking items from the `ai4c-reviewer` CHANGES_REQUESTED review were
+addressed.
+
+- **`description` stated the wrong catalytic class.** It read "cysteine-type
+  serine/threonine protease", which is self-contradictory. UniProt records only
+  the C19 family assignment [file:yeast/UBP3/UBP3-uniprot.txt line 121,
+  "SIMILARITY: Belongs to the peptidase C19 family."] — no serine/threonine
+  protease claim. Corrected to "papain-fold cysteine protease of the peptidase
+  C19 (USP) family". This matters here because the `GO:0006508` rationale rests
+  on Ubp3 being a cysteine peptidase.
+
+- **`GO:0006508` proteolysis rationale asserted a parent-child relation that
+  does not hold.** The earlier note above (and the YAML `reason`) described
+  proteolysis as a "parent of the more specific `GO:0016579` protein
+  deubiquitination". That is wrong, and the reviewer was right to flag it.
+  Verified against the QuickGO ontology service: the `is_a`/`part_of` ancestor
+  closure of `GO:0016579` is `GO:0016579`, `GO:0070646`, `GO:0070647`,
+  `GO:0043412`, `GO:0043687`, `GO:0036211`, `GO:0019538`, `GO:0043170`,
+  `GO:0044238`, `GO:0009987`, `GO:0008152`, `GO:0008150` — `GO:0006508` is
+  **not** among them. GO deliberately keeps the asymmetry: the MF
+  `GO:0004843` *is* under peptidase activity, but the BP for deubiquitination
+  sits under `GO:0070646` protein modification by small protein removal, not
+  under proteolysis.
+
+  Because the broad term is therefore not a true parent of the specific process
+  already annotated, `KEEP_AS_NON_CORE` (which frames it as a correct
+  general parent) is the wrong encoding. Changed to `MARK_AS_OVER_ANNOTATED`
+  — "not entirely wrong, but likely represents an over-annotation" fits
+  exactly, and it matches the in-project precedent for the same term on a
+  USP-family DUB (`genes/human/USP25/USP25-ai-review.yaml`, `GO:0006508`,
+  `MARK_AS_OVER_ANNOTATED`). This is still not a `REMOVE`, so it does not
+  reintroduce the error this PR set out to fix.
+
+The three non-blocking suggestions in the review (MODIFY-with-replacement for
+the Hog1 protein-binding row, adding `in_complex: GO:1990861` to
+`core_functions`, and removing the stale `UBP3-CURATION-*` /
+`UBP3-ai-review-CURATED.yaml` sidecars) are left for the PR author — the first
+two are curation judgment calls beyond the requested fixes, and the third
+deletes files outside this PR's diff.
+
+`just validate yeast UBP3` passes after the edit.


### PR DESCRIPTION
## Oversight

`genes/yeast/UBP3/UBP3-ai-review.yaml` used `action: REMOVE` on 11 annotations whose evidence the review's own `reason` text described as genuine and correctly cited — the stated problem in every case was that the term was *too generic/broad*, not that it was factually wrong. Per the schema's own `ActionEnum`, `REMOVE` means "unlikely to be correct based on combined evidence," which is a different (and stronger) claim than "correct but uninformative" (`MARK_AS_OVER_ANNOTATED`) or "correct but not core" (`KEEP_AS_NON_CORE`). This repo's own convention (e.g. the TSA1 review, which uses `MARK_AS_OVER_ANNOTATED` for the identical `GO:0005515 protein binding` situation, and `KEEP_AS_NON_CORE` for broad-but-true IBA/IEA terms) makes the intended usage clear.

## Evidence and fixes

**9x `GO:0005515` protein binding (IPI)** — one row per cited PMID (16429126, 16554755 ×3, 17632125, 18719252, 20508643, 21179020, 21743437, 37968396). Each is a genuinely evidenced, correctly cited IntAct physical interaction (confirmed against `UBP3-goa.tsv`). The review's stated rationale in every case was genericity/redundancy with a more specific term already annotated (GO:1990861 Ubp3-Bre5 complex, GO:0047484 osmotic-stress regulation, GO:0034517 ribophagy) — textbook `MARK_AS_OVER_ANNOTATED`, not `REMOVE`.

**`GO:0031647` regulation of protein stability (IBA)** — this is a phylogenetic call, and per project policy (`CLAUDE.md`) an IBA should be overturned only with target-specific divergence/loss evidence, never removed merely for being general. No such evidence exists, and the claim is directly true: Ubp3 reverses degradative ubiquitination of Sec23 [PMID:12778054] and RNA Pol II [PMID:18498751]. Changed to `KEEP_AS_NON_CORE`.

**`GO:0006508` proteolysis (IEA)** — Ubp3 is a bona fide cysteine-type peptidase (peptidase C19/USP family, EC 3.4.19.12) that hydrolyzes the isopeptide bond linking ubiquitin to substrate lysines; this literally is proteolysis, just stated very generally. Changed to `KEEP_AS_NON_CORE` as a correct, non-core parent of the more specific `GO:0016579 protein deubiquitination` process annotation already present.

## Before → after

| Term | Evidence | Before | After |
|---|---|---|---|
| GO:0005515 protein binding × 9 rows | IPI | REMOVE | MARK_AS_OVER_ANNOTATED |
| GO:0031647 regulation of protein stability | IBA | REMOVE | KEEP_AS_NON_CORE |
| GO:0006508 proteolysis | IEA | REMOVE | KEEP_AS_NON_CORE |

No `ACCEPT` rows, `description`, or `core_functions` were touched; those were already sound. Rationale is also recorded in a new `UBP3-notes.md`.

## Validation

Both required checks pass:
```
.venv/bin/ai-gene-review validate --verbose --terms genes/yeast/UBP3/UBP3-ai-review.yaml   # ✓ Valid
.venv/bin/ai-gene-review validate-goa genes/yeast/UBP3/UBP3-ai-review.yaml                   # ✓ All existing_annotations match GOA file
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaijmXnUswFxVML64ru2Zg)_