### PR TITLE
Stop timed-out research clients before starting fallbacks

### DIFF
--- a/scripts/deep_research_wrapper.py
+++ b/scripts/deep_research_wrapper.py
@@ -19,6 +19,8 @@ from pathlib import Path
 import re
 from typing import Any
 
+from ai_gene_review.utils.research_process import run_research_process
+
 # Default timeout for deep research subprocess (seconds)
 DEFAULT_TIMEOUT = 600
 DEFAULT_OPENSCIENTIST_TIMEOUT = 7200
@@ -320,7 +322,7 @@ def run_deep_research(
         print(f"{label}Timeout: {timeout}s")
 
         try:
-            result = subprocess.run(cmd, timeout=timeout)
+            result = run_research_process(cmd, timeout=timeout)
             if result.returncode == 0:
                 return 0
             print(f"Provider {prov} exited with code {result.returncode}", file=sys.stderr)

--- a/scripts/gene_hypothesis_deep_research.py
+++ b/scripts/gene_hypothesis_deep_research.py
@@ -15,6 +15,8 @@ from typing import Any, Mapping, Sequence
 
 import yaml
 
+from ai_gene_review.utils.research_process import run_research_process
+
 
 DEFAULT_GENES_ROOT = Path("genes")
 DEFAULT_TEMPLATE = Path("templates/gene_hypothesis_deep_research.md")
@@ -1294,11 +1296,9 @@ def run_record(
     output_file.parent.mkdir(parents=True, exist_ok=True)
     started = time.monotonic()
     try:
-        result = subprocess.run(
+        result = run_research_process(
             command,
-            check=False,
             capture_output=True,
-            text=True,
             timeout=timeout_seconds,
         )
         duration = time.monotonic() - started

--- a/scripts/module_deep_research_wrapper.py
+++ b/scripts/module_deep_research_wrapper.py
@@ -22,6 +22,8 @@ from typing import Any
 
 import yaml
 
+from ai_gene_review.utils.research_process import run_research_process
+
 
 PROVIDERS = (
     "openai",
@@ -430,7 +432,7 @@ def run_deep_research(
         return 0
     output_path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        result = subprocess.run(cmd, timeout=timeout)
+        result = run_research_process(cmd, timeout=timeout)
     except subprocess.TimeoutExpired:
         print(f"Error: deep-research-client timed out after {timeout}s", file=sys.stderr)
         return 124

--- a/scripts/module_pathway_taxon_deep_research_wrapper.py
+++ b/scripts/module_pathway_taxon_deep_research_wrapper.py
@@ -15,6 +15,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from ai_gene_review.utils.research_process import run_research_process
+
 from module_deep_research_wrapper import (
     command_for_log,
     deep_research_client_command,
@@ -458,7 +460,7 @@ def main() -> int:
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        result = subprocess.run(cmd, timeout=effective_timeout)
+        result = run_research_process(cmd, timeout=effective_timeout)
     except subprocess.TimeoutExpired:
         print(
             f"Error: deep-research-client timed out after {effective_timeout}s",

--- a/src/ai_gene_review/utils/research_process.py
+++ b/src/ai_gene_review/utils/research_process.py
@@ -1,0 +1,51 @@
+"""Run research clients without leaving local descendants after a timeout."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from collections.abc import Sequence
+
+
+def run_research_process(
+    command: Sequence[str],
+    *,
+    timeout: float | None = None,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Run a client, cleaning up its local process group on timeout or interruption.
+
+    On POSIX, launchers such as ``uv`` and their client descendants share a new
+    session. Kill that entire process group before returning control to a caller
+    that may start a fallback. This also handles an exited launcher whose child
+    still holds captured output pipes open. Other platforms retain direct-child
+    cleanup. This does not promise cancellation of remote provider jobs.
+
+    Output is text when captured; otherwise stdout and stderr are inherited.
+    Nonzero exit codes are returned for the wrapper to interpret.
+    """
+    args = list(command)
+    process = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE if capture_output else None,
+        stderr=subprocess.PIPE if capture_output else None,
+        text=True,
+        start_new_session=os.name == "posix",
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except BaseException:
+        # Unlike subprocess.run(), clean up descendants of uv/uvx as well as
+        # the immediate launcher. Kill even if the launcher has already exited.
+        if os.name == "posix":
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        else:
+            process.kill()
+        process.communicate()
+        raise
+    assert process.returncode is not None
+    return subprocess.CompletedProcess(args, process.returncode, stdout, stderr)

--- a/tests/test_deep_research_provider_selection.py
+++ b/tests/test_deep_research_provider_selection.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -114,13 +115,21 @@ def test_fallback_after_hyphenated_provider_uses_canonical_output_path(
 ) -> None:
     wrapper = load_wrapper()
     gene_dir = tmp_path / "TP53"
-    calls: list[list[str]] = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, returncode=1 if len(calls) == 1 else 0)
-
-    monkeypatch.setattr(wrapper.subprocess, "run", fake_run)
+    command_log = tmp_path / "calls.jsonl"
+    client = tmp_path / "client.py"
+    client.write_text(
+        "import json, pathlib, sys\n"
+        f"with open({str(command_log)!r}, 'a') as log:\n"
+        "    log.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+        "if sys.argv[sys.argv.index('--provider') + 1] != 'falcon':\n"
+        "    sys.exit(1)\n"
+        "output = pathlib.Path(sys.argv[sys.argv.index('--output') + 1])\n"
+        "output.parent.mkdir(parents=True, exist_ok=True)\n"
+        "output.write_text('research report')\n"
+    )
+    monkeypatch.setenv(
+        "DEEP_RESEARCH_CLIENT_CMD", shlex.join([sys.executable, str(client)])
+    )
 
     result = wrapper.run_deep_research(
         organism="human",
@@ -132,7 +141,9 @@ def test_fallback_after_hyphenated_provider_uses_canonical_output_path(
         fallback_providers=["falcon"],
     )
 
+    calls = [json.loads(line) for line in command_log.read_text().splitlines()]
     assert result == 0
+    assert (gene_dir / "TP53-deep-research-falcon.md").read_text() == "research report"
     assert len(calls) == 2
     assert calls[0][calls[0].index("--output") + 1] == str(
         gene_dir / "TP53-deep-research-perplexity-lite.md"

--- a/tests/test_research_process_cleanup.py
+++ b/tests/test_research_process_cleanup.py
@@ -1,0 +1,96 @@
+"""Exercise research timeout cleanup with real parent and child processes."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import deep_research_wrapper
+
+
+@pytest.mark.skipif(os.name != "posix", reason="Process-group cleanup is POSIX-specific")
+def test_gene_timeout_stops_child_before_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A timed-out launcher must not leave a client writing during fallback."""
+    late_output = tmp_path / "late-primary.md"
+    child_started = tmp_path / "child-started"
+    client = tmp_path / "client.py"
+    client.write_text(
+        "import pathlib, subprocess, sys, time\n"
+        f"late = pathlib.Path({str(late_output)!r})\n"
+        f"started = pathlib.Path({str(child_started)!r})\n"
+        "provider = sys.argv[sys.argv.index('--provider') + 1]\n"
+        "if provider == 'falcon':\n"
+        "    code = 'import pathlib,time; pathlib.Path(' + repr(str(started)) + ').touch(); time.sleep(2.5); pathlib.Path(' + repr(str(late)) + ').write_text(\"late report\")'\n"
+        "    subprocess.Popen([sys.executable, '-c', code])\n"
+        "    time.sleep(60)\n"
+        "else:\n"
+        "    time.sleep(1)\n"
+        "    sys.exit(17 if late.exists() else 0)\n"
+    )
+    monkeypatch.setenv("DEEP_RESEARCH_CLIENT_CMD", shlex.join([sys.executable, str(client)]))
+
+    result = deep_research_wrapper.run_deep_research(
+        organism="SCHPO",
+        gene_id="TEST",
+        gene_symbol="TEST",
+        provider="falcon",
+        output_path=tmp_path / "TEST-deep-research-falcon.md",
+        timeout=2,
+        fallback_providers=["perplexity-lite"],
+    )
+
+    assert child_started.exists(), "The real descendant must start to exercise cleanup"
+    assert not late_output.exists(), "Timed-out client wrote after the wrapper moved on"
+    assert result == 0
+
+
+@pytest.mark.skipif(os.name != "posix", reason="Process-group cleanup is POSIX-specific")
+@pytest.mark.parametrize("capture_output,launcher_exits", [(False, False), (True, False), (True, True)])
+def test_timeout_kills_descendant_with_inherited_pipes(
+    tmp_path: Path, capture_output: bool, launcher_exits: bool
+) -> None:
+    """Captured pipes must not keep a timed-out client's descendants alive."""
+    import subprocess
+    import time
+
+    from ai_gene_review.utils.research_process import run_research_process
+
+    late_output = tmp_path / "late.md"
+    started = tmp_path / "started"
+    child_code = (
+        "import pathlib,time; "
+        f"pathlib.Path({str(started)!r}).touch(); "
+        "time.sleep(2); "
+        f"pathlib.Path({str(late_output)!r}).write_text('late')"
+    )
+    parent_code = (
+        "import subprocess,sys,time; "
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}]); "
+        "print('client started', flush=True); "
+        + ("sys.exit(0)" if launcher_exits else "time.sleep(60)")
+    )
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_research_process(
+            [sys.executable, "-c", parent_code], timeout=1, capture_output=capture_output
+        )
+    assert started.exists()
+    # Wait past the child's real write deadline; this detects surviving clients.
+    time.sleep(1.2)
+    assert not late_output.exists()
+
+
+def test_research_process_returns_captured_output_and_exit_code() -> None:
+    from ai_gene_review.utils.research_process import run_research_process
+
+    result = run_research_process(
+        [sys.executable, "-c", "import sys; print('report'); print('diagnostic', file=sys.stderr); sys.exit(7)"],
+        capture_output=True,
+        timeout=5,
+    )
+    assert result.returncode == 7
+    assert result.stdout == "report\n"
+    assert result.stderr == "diagnostic\n"


### PR DESCRIPTION
A Falcon request timed out at 600 seconds, but its child process kept running and wrote the report at 651 seconds while the wrapper had already attempted fallback. The timeout killed the launcher without stopping its local client descendants.

Run the four timeout-enabled research wrappers through a shared process runner that starts a separate POSIX session and kills its process group on timeout or interruption before returning control. This also handles an exited launcher whose descendant still holds captured output pipes. Captured text, inherited output, and nonzero exit codes retain their existing behavior. Non-POSIX cleanup remains limited to the direct child; this does not promise cancellation of remote provider jobs.

Validation: reproduced the late write with a failing real-process regression before the fix; five new real-process tests now pass, including inherited pipes and an exited launcher. Also checked an actual `uv run --no-project` launcher. Full `just test` passed: 2,050 tests, 156 doctests, mypy, and Ruff.
