### PR TITLE
Run Pages generation once daily

### DIFF
--- a/.github/cron-profiles.yaml
+++ b/.github/cron-profiles.yaml
@@ -33,9 +33,9 @@
 # Feb 30: GitHub can ignore invalid cron updates and leave the previous valid
 # schedule registered.
 #
-# Note: .github/workflows/main.yaml also has a weekly `schedule:` (the full
-# re-validation safety net). It is ordinary CI, not an agent, so it is not
-# managed here and `off` will not disable it.
+# Exempt schedules: main.yaml runs weekly full re-validation, and
+# generate-pages.yaml runs daily site generation. These are CI/publication,
+# not agents, so profiles do not manage them and `off` will not disable them.
 
 active: "medium"
 

--- a/.github/workflows/generate-pages.yaml
+++ b/.github/workflows/generate-pages.yaml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: generate-pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   generate-pages:
@@ -55,37 +55,9 @@ jobs:
       - name: Install project
         run: uv sync --dev
 
-      - name: Get changed files
-        id: changed
-        run: |
-          # Get YAML files changed in the triggering commit(s)
-          CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'genes/**/*-ai-review.yaml' 'rules/**/*-review.yaml' 2>/dev/null || echo "")
-          echo "files<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGED" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "Changed YAML files: $(echo "$CHANGED" | grep -c '.' || echo 0)"
-
-      - name: Validate changed gene reviews
-        run: |
-          ERRORS=0
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            [ ! -f "$f" ] && continue
-            if [[ "$f" == genes/*/*/*-ai-review.yaml ]]; then
-              ORG=$(echo "$f" | cut -d/ -f2)
-              GENE=$(echo "$f" | cut -d/ -f3)
-              echo "=== Validating $ORG/$GENE ==="
-              if ! just validate "$ORG" "$GENE"; then
-                ERRORS=$((ERRORS + 1))
-              fi
-            fi
-          done <<< "${{ steps.changed.outputs.files }}"
-          if [ $ERRORS -gt 0 ]; then
-            echo "❌ $ERRORS validation errors"
-            exit 1
-          fi
-          echo "✅ All changed files valid"
-
+      # Gene review validation belongs to main.yaml: changed reviews are checked
+      # on PRs, with a weekly full validate-all safety net. A last-commit diff
+      # here would miss most merges included in the daily regeneration.
       - name: Render all gene review HTML pages
         run: just render-all
 

--- a/.github/workflows/generate-pages.yaml
+++ b/.github/workflows/generate-pages.yaml
@@ -2,32 +2,10 @@
 name: Generate Pages
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'genes/**/*.yaml'
-      - 'src/ai_gene_review/schema/**'
-      - 'src/ai_gene_review/templates/**'
-      - 'src/ai_gene_review/render.py'
-      - 'src/ai_gene_review/render_projects.py'
-      - 'src/ai_gene_review/render_modules.py'
-      - 'src/ai_gene_review/export/**'
-      - 'src/ai_gene_review/browser/**'
-      - 'src/ai_gene_review/tools/minify_linkml_browser_data.py'
-      - 'src/ai_gene_review/tools/stage_pages.py'
-      - 'projects/*.md'
-      - 'projects/**/*.md'
-      - 'projects/**/*.csv'
-      - 'projects/**/*.json'
-      - 'modules/**/*.yaml'
-      - 'project.justfile'
-      - '.github/workflows/generate-pages.yaml'
+  # Batch the full build once per day; manual dispatch remains available.
+  schedule:
+    - cron: '23 8 * * *'  # Daily at 08:23 UTC.
   workflow_dispatch:
-    inputs:
-      force:
-        description: 'Force run even if already ran today'
-        type: boolean
-        default: false
 
 concurrency:
   group: generate-pages
@@ -306,19 +284,7 @@ jobs:
             echo
             echo "## Trigger"
             echo
-            echo "This PR was triggered by changes to:"
-            echo "- genes/**/*.yaml - gene review data files"
-            echo "- src/ai_gene_review/schema/** - LinkML schema files"
-            echo "- src/ai_gene_review/templates/** - Jinja2 templates"
-            echo "- src/ai_gene_review/render.py - rendering code"
-            echo "- src/ai_gene_review/render_modules.py - module rendering code"
-            echo "- src/ai_gene_review/export/** - export code"
-            echo "- src/ai_gene_review/browser/** - browser app assets"
-            echo "- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction"
-            echo "- projects/*.md - project definitions"
-            echo "- modules/**/*.yaml - module definitions"
-            echo "- project.justfile - just recipes used by CI"
-            echo "- .github/workflows/generate-pages.yaml - workflow definition"
+            echo "Daily scheduled or manually requested regeneration."
             echo
             echo "## Review"
             echo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,7 +530,11 @@ just deploy-browser    # update data.js + index.html for the interactive browser
 Output: `app/`
 
 ### CI automation
-The `generate-pages` workflow runs on push to main when gene YAMLs, schema, templates, or project markdown change. It renders everything and creates a PR. Pages deploy directly from main — no gh-pages branch needed for the static content.
+The `generate-pages` workflow runs daily at 08:23 UTC, with manual runs available
+through GitHub Actions. It renders everything and creates a PR. Its publication
+schedule is exempt from agent cron profiles. Gene reviews are validated in PR CI
+and by the weekly full validation workflow. Pages deploy directly from main — no
+gh-pages branch needed for the static content.
 
 ## General guidelines
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,9 @@ from `main:/` until the shadow artifact has been verified.
 The Generate Pages workflow runs daily at 08:23 UTC and can also be started with
 GitHub Actions' **Run workflow** button. Each run rebuilds the full site, so merged
 content normally appears after the next daily regeneration PR is merged.
+Agent cron profiles do not control this publication schedule. Manual runs wait for
+an active build to finish instead of cancelling it. Gene review validation remains
+in PR CI and the weekly full validation workflow.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,10 @@ uses `<repo-root>/_site`. Shadow build failures warn
 without blocking regeneration PRs. The live site continues to publish
 from `main:/` until the shadow artifact has been verified.
 
+The Generate Pages workflow runs daily at 08:23 UTC and can also be started with
+GitHub Actions' **Run workflow** button. Each run rebuilds the full site, so merged
+content normally appears after the next daily regeneration PR is merged.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed contribution guidelines including:

--- a/tests/test_apply_cron_profile.py
+++ b/tests/test_apply_cron_profile.py
@@ -138,13 +138,13 @@ def test_off_profile_removes_every_schedule():
         assert "workflow_dispatch" in triggers
 
 
-def test_main_ci_workflow_is_not_managed():
-    """main.yaml's weekly re-validation is CI, not an agent; `off` must not
-    disable it."""
+@pytest.mark.parametrize("workflow", ["main", "generate-pages"])
+def test_ci_and_publication_workflows_are_not_managed(workflow):
+    """Agent profiles must not disable validation or publication schedules."""
     config = load_config(DEFAULT_CONFIG)
     for profile in config["profiles"].values():
-        assert "main" not in profile["workflows"]
-    assert "cron:" in (Path(".github/workflows/main.yaml")).read_text()
+        assert workflow not in profile["workflows"]
+    assert "cron:" in Path(f".github/workflows/{workflow}.yaml").read_text()
 
 
 def test_off_then_back_round_trips_every_managed_workflow():

--- a/tests/test_pr_shepherd_workflow.py
+++ b/tests/test_pr_shepherd_workflow.py
@@ -122,6 +122,20 @@ def test_generated_pages_runs_daily_or_manually():
     assert set(triggers) == {"schedule", "workflow_dispatch"}
     assert triggers["schedule"] == [{"cron": "23 8 * * *"}]
     assert triggers["workflow_dispatch"] is None
+    assert workflow["concurrency"]["cancel-in-progress"] is False
+
+
+def test_daily_generation_relies_on_main_validation_workflow():
+    """A last-commit diff cannot validate a day's merges; main CI owns validation."""
+    generation = GENERATE_PAGES.read_text()
+    assert "HEAD~1" not in generation
+    assert "steps.changed.outputs.files" not in generation
+    main_ci = _workflow(ROOT / ".github/workflows/main.yaml")
+    assert "pull_request" in main_ci[True]
+    assert "schedule" in main_ci[True]
+    validation = _step(main_ci["jobs"]["test"], "Validate gene reviews (scoped)")
+    assert "just validate-changed" in validation["run"]
+    assert "just validate-all" in validation["run"]
 
 
 def test_shadow_pages_failures_do_not_block_regeneration():

--- a/tests/test_pr_shepherd_workflow.py
+++ b/tests/test_pr_shepherd_workflow.py
@@ -115,12 +115,13 @@ def test_reviewer_app_token_cannot_write_pr_contents():
     assert permissions == {"permission-pull-requests": "write"}
 
 
-def test_generated_pages_triggers_on_project_data_files():
-    """Published project data must trigger regeneration of its pages copies."""
+def test_generated_pages_runs_daily_or_manually():
+    """Batch regeneration daily instead of rebuilding on every merge."""
     workflow = _workflow(GENERATE_PAGES)
-    paths = workflow[True]["push"]["paths"]
-    assert "projects/**/*.csv" in paths
-    assert "projects/**/*.json" in paths
+    triggers = workflow[True]
+    assert set(triggers) == {"schedule", "workflow_dispatch"}
+    assert triggers["schedule"] == [{"cron": "23 8 * * *"}]
+    assert triggers["workflow_dispatch"] is None
 
 
 def test_shadow_pages_failures_do_not_block_regeneration():


### PR DESCRIPTION
The full Pages regeneration takes about an hour and currently restarts after each matching merge. Run it once daily at 08:23 UTC, with manual dispatch available for earlier updates. Active builds finish before another run starts.

Publication is explicitly exempt from agent cron profiles, alongside the weekly validation workflow. Remove the obsolete last-commit gene-validation gate: main.yaml validates changed reviews on PRs and runs full validation weekly. Update README, CLAUDE.md, and the generated PR text to describe the new behavior; remove the unused force input.

Incremental rendering remains deferred. This branch started from current main and contains only publication workflow, documentation, and associated test changes.

Validation: 20 workflow and cron-profile tests passed; Ruff and git diff --check passed.
