### PR TITLE
Support curated reference replacements and cross-paper finding evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,16 @@ reference has not been manually adjudicated. **Verify, don't trust**: confirm a 
 anchor a claim to a checkable fact such as the GOA evidence code) before marking it `VERIFIED` — an
 LLM-generated deep-research summary asserting a citation is not sufficient.
 
+**Deleted duplicate PMIDs and conflicting findings:** Keep GOA's
+`original_reference_id`. Record a verified canonical identifier in
+`reference_review.replacement` with `reference_id`, `reason`, and verification
+notes; fetch failure alone does not establish a remapping or retraction. Quote
+the canonical paper using its own `reference_id` in `review.supported_by`.
+For a statement from P1 contradicted by P2, use P1's
+`findings[].finding_review` with `finding_status`, `superseded_by`, and
+`supported_by` containing P2's exact snippet. See
+[Reference Curation](docs/reference_curation.md) for examples and validation rules.
+
 ## Tools
 
 Use the OLS MCP to find relevant ontology terms, if the terms you need are not in existing_annotations.

--- a/docs/reference_curation.md
+++ b/docs/reference_curation.md
@@ -1,0 +1,102 @@
+# Curating reference identifiers and conflicting evidence
+
+Keep `existing_annotations[].original_reference_id` as supplied by GOA/UniProt.
+The annotation's `review.supported_by` can cite a different publication, whether
+it is a canonical replacement record or a paper that changes the interpretation.
+Declare both references in the top-level `references` list.
+
+## Deleted or incorrect identifiers
+
+Record an established mapping on the original reference:
+
+```yaml
+references:
+  - id: PMID:34521819
+    title: Deleted duplicate record of PMID:32953130
+    reference_review:
+      replacement:
+        reference_id: PMID:32953130
+        reason: DUPLICATE_RECORD
+        review_notes: >-
+          PubMed's redirection notice identifies this as a duplicate of
+          PMID:32953130. The original PMID is retained for source provenance.
+  - id: PMID:32953130
+    title: >-
+      SARS-CoV-2 N protein antagonizes type I interferon signaling by suppressing
+      phosphorylation and nuclear translocation of STAT1 and STAT2.
+```
+
+`replacement.reason` is one of:
+
+- `DUPLICATE_RECORD`: the authority deleted or merged a duplicate record.
+- `REPLACED_RECORD`: the authority explicitly replaced the source record.
+- `WRONG_IDENTIFIER`: the citation used the wrong identifier; the target identifies
+  the intended paper. Record the evidence establishing that intent.
+
+The target and reason are required. The target must be declared in `references`;
+self-replacements and replacement cycles fail best-practice validation. Existing
+reviews without this optional metadata remain valid. Record the mapping's source
+and verification in `replacement.review_notes`.
+
+When a PMID fetch fails, inspect the PubMed web page for an explicit redirection
+notice. E-utilities may return an empty result or error for a deleted duplicate
+without identifying the retained record. A fetch failure alone establishes
+neither replacement nor retraction. Do not guess a target from similar titles.
+
+Quote the canonical paper under its own identifier:
+
+```yaml
+original_reference_id: PMID:34521819
+review:
+  action: KEEP_AS_NON_CORE
+  supported_by:
+    - reference_id: PMID:32953130
+      supporting_text: >-
+        Moreover, our result showed that SARS-CoV-2 N interfered with the
+        interactions of STAT1 with JAK1 and STAT2 with TYK2
+```
+
+This metadata does **not** silently redirect validation or fetches. LRV checks
+each snippet against its explicit `reference_id`. The old reference may still
+produce an advisory fetch warning until upstream LRV supports curated mappings.
+Do not copy canonical publication text into the old PMID's cache or rewrite the
+GOA-derived identifier to silence that warning. Duplicate-record deletion does
+not imply that the paper or its findings were retracted.
+
+## A finding from P1 contradicted by P2
+
+Use the existing per-finding `finding_review`, with `finding_status: DISPUTED`
+(contested) or `OVERTURNED` (refuted). `superseded_by` identifies the relevant
+papers; `finding_review.supported_by` now holds their exact quoted evidence.
+This assesses a particular statement rather than declaring the entire P1 paper
+invalid. `CORROBORATED` can similarly carry corroborating evidence.
+
+The following is a **synthetic** example; replace all example identifiers and
+sentences with verified sources when curating:
+
+```yaml
+references:
+  - id: PMID:1
+    title: Original study
+    findings:
+      - statement: Activity occurs without a cofactor.
+        supporting_text: Activity occurs without a cofactor.
+        finding_review:
+          finding_status: DISPUTED
+          superseded_by: [PMID:2]
+          review_notes: The follow-up reports a cofactor requirement.
+          supported_by:
+            - reference_id: PMID:2
+              supporting_text: A cofactor was required.
+  - id: PMID:2
+    title: Follow-up study
+```
+
+The finding's direct `supporting_text` belongs to P1. The assessment's nested
+snippet explicitly belongs to P2. Never place P2's text directly on P1's finding
+and rely on `superseded_by` or `replacement` to change its attribution. When
+revisiting an annotation, cite P2 in `review.supported_by` and explain the curation
+decision in `review.reason`, retaining P1 as `original_reference_id`.
+
+Validate with `just validate <organism> <gene>` and add a curation history record
+as described in [History Records](history.md).

--- a/docs/reference_curation.md
+++ b/docs/reference_curation.md
@@ -12,7 +12,10 @@ Record an established mapping on the original reference:
 ```yaml
 references:
   - id: PMID:34521819
-    title: Deleted duplicate record of PMID:32953130
+    title: >-
+      SARS-CoV-2 N protein antagonizes type I interferon signaling by suppressing
+      phosphorylation and nuclear translocation of STAT1 and STAT2.
+    is_invalid: true
     reference_review:
       replacement:
         reference_id: PMID:32953130
@@ -38,6 +41,20 @@ self-replacements and replacement cycles fail best-practice validation. Existing
 reviews without this optional metadata remain valid. Record the mapping's source
 and verification in `replacement.review_notes`.
 
+For a deleted duplicate, retain `is_invalid: true` on the old reference alongside
+`replacement`. The flag describes the replaced record; it does not invalidate the
+canonical paper or establish that its findings were retracted. This is consistent
+with `mark_invalid_pmids()`, which otherwise re-adds the flag. Keep the publication
+title in `title` (for a verified duplicate, use the cached canonical title), and put
+the deletion explanation and the title's provenance in `replacement.review_notes`.
+Do not mark the canonical reference invalid merely because an obsolete ID points
+to it.
+
+`replacement.reason` explains the identifier mapping; `reference_review.correctness`
+assesses citation correctness and scientific soundness. A `DUPLICATE_RECORD`
+mapping does not imply `correctness: WRONG_IDENTIFIER`, because both records
+identify the same paper. Leave correctness unset until separately assessed.
+
 When a PMID fetch fails, inspect the PubMed web page for an explicit redirection
 notice. E-utilities may return an empty result or error for a deleted duplicate
 without identifying the retained record. A fetch failure alone establishes
@@ -58,7 +75,8 @@ review:
 
 This metadata does **not** silently redirect validation or fetches. LRV checks
 each snippet against its explicit `reference_id`. The old reference may still
-produce an advisory fetch warning until upstream LRV supports curated mappings.
+produce an advisory fetch warning until upstream LRV supports curated mappings;
+`is_invalid: true` is not currently guaranteed to suppress LRV's fetch warning.
 Do not copy canonical publication text into the old PMID's cache or rewrite the
 GOA-derived identifier to silence that warning. Duplicate-record deletion does
 not imply that the paper or its findings were retracted.

--- a/genes/human/JAK1/JAK1-ai-review.yaml
+++ b/genes/human/JAK1/JAK1-ai-review.yaml
@@ -304,8 +304,10 @@ references:
     subunit leads to STAT activation and prevention of apoptosis.
   findings: []
 - id: PMID:34521819
-  title: Deleted duplicate record of PMID:32953130
+  title: SARS-CoV-2 N protein antagonizes type I interferon signaling by suppressing
+    phosphorylation and nuclear translocation of STAT1 and STAT2.
   findings: []
+  is_invalid: true
   reference_review:
     replacement:
       reference_id: PMID:32953130
@@ -315,7 +317,9 @@ references:
         because it duplicates PMID:32953130. The canonical publication is cached
         with full text. E-utilities retrieval of the old PMID does not expose this
         mapping. Preserve the original GOA PMID and cite the canonical record for
-        supporting text; duplicate-record deletion does not imply retraction.
+        supporting text. is_invalid marks the old record as replaced, not the
+        canonical paper as retracted. The title is taken from the cached canonical
+        record rather than using the title field for a curation note.
 - id: Reactome:R-HSA-1112602
   title: Tyrosine phosphorylation of STAT1, STAT3 by IL6 receptor
   findings: []

--- a/genes/human/JAK1/JAK1-ai-review.yaml
+++ b/genes/human/JAK1/JAK1-ai-review.yaml
@@ -1633,13 +1633,21 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:34950606
   review:
-    summary: SARS-CoV-2 protein interactions
-    action: REMOVE
-    reason: Duplicate viral antagonism study, already covered by PMID:32953130.
+    summary: Independent co-IP evidence for STAT1-JAK1 binding and its inhibition
+      by SARS-CoV-2 spike protein.
+    action: KEEP_AS_NON_CORE
+    reason: Zhang et al. examine membrane and spike proteins in this independent
+      study, whereas Mu et al. (PMID:32953130) examine nucleocapsid protein.
+      Figure 5D-E reports co-IP assays of STAT1-JAK1 binding and its inhibition
+      by spike protein, consistent with the GOA interaction partner STAT1
+      (UniProtKB:P42224). Retain this experimental evidence as non-core because
+      generic protein binding is less informative than JAK1's specific tyrosine
+      kinase function. An independent paper supporting the same interaction is
+      not a duplicate PubMed record or a reason to remove the annotation.
     supported_by:
     - reference_id: PMID:34950606
-      supporting_text: Severe Acute Respiratory Syndrome Coronavirus 2 (SARS-CoV-2)
-        Membrane (M) and Spike (S) Proteins Antagonize Host Type I Interferon Response.
+      supporting_text: Co-IP assays indicated that the S protein inhibited the
+        binding of JAK1 to STAT1 and subsequently suppressed its phosphorylation
   qualifier: enables
 - term:
     id: GO:0005515

--- a/genes/human/JAK1/JAK1-ai-review.yaml
+++ b/genes/human/JAK1/JAK1-ai-review.yaml
@@ -304,9 +304,18 @@ references:
     subunit leads to STAT activation and prevention of apoptosis.
   findings: []
 - id: PMID:34521819
-  title: 'INVALID: Cannot retrieve from PubMed (possibly replaced or retracted)'
+  title: Deleted duplicate record of PMID:32953130
   findings: []
-  is_invalid: true
+  reference_review:
+    replacement:
+      reference_id: PMID:32953130
+      reason: DUPLICATE_RECORD
+      review_notes: The reviewer supplied the PubMed redirection notice at
+        https://pubmed.ncbi.nlm.nih.gov/34521819/ stating that this PMID was deleted
+        because it duplicates PMID:32953130. The canonical publication is cached
+        with full text. E-utilities retrieval of the old PMID does not expose this
+        mapping. Preserve the original GOA PMID and cite the canonical record for
+        supporting text; duplicate-record deletion does not imply retraction.
 - id: Reactome:R-HSA-1112602
   title: Tyrosine phosphorylation of STAT1, STAT3 by IL6 receptor
   findings: []
@@ -1570,20 +1579,17 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:32953130
   review:
-    summary: SARS-CoV-2 N protein interaction - viral immune evasion mechanism
-    action: REMOVE
-    reason: While PMID:32953130 demonstrates that SARS-CoV-2 N protein antagonizes
-      JAK1 function by suppressing STAT1/STAT2 phosphorylation and nuclear translocation,
-      this represents a pathological interaction during viral infection rather than
-      normal JAK1 function. Generic protein binding annotations are removed per GO
-      curation guidelines, and this specific viral interaction is not representative
-      of JAK1's core cellular functions.
-    additional_reference_ids:
-    - file:human/JAK1/JAK1-deep-research.md
+    summary: STAT1-JAK1 interaction examined in a study of viral interferon antagonism.
+    action: KEEP_AS_NON_CORE
+    reason: The full text reports interference with the STAT1-JAK1 interaction by
+      SARS-CoV-2 N protein (Supplementary Fig. S1d, e). Retain this experimental
+      binding evidence as non-core because the generic protein binding term does
+      not describe JAK1's specific tyrosine kinase function. Viral perturbation of
+      the interaction is not a reason to remove the underlying binding evidence.
     supported_by:
     - reference_id: PMID:32953130
-      supporting_text: SARS-CoV-2 N protein antagonizes type I interferon signaling
-        by suppressing phosphorylation and nuclear translocation of STAT1 and STAT2
+      supporting_text: Moreover, our result showed that SARS-CoV-2 N interfered with
+        the interactions of STAT1 with JAK1 and STAT2 with TYK2
   qualifier: enables
 - term:
     id: GO:0005515
@@ -1605,9 +1611,17 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:34521819
   review:
-    summary: Invalid PMID - cannot retrieve
-    action: REMOVE
-    reason: PMID appears to be invalid or retracted, cannot verify interaction.
+    summary: STAT1-JAK1 interaction cited through a deleted duplicate PubMed record.
+    action: KEEP_AS_NON_CORE
+    reason: PMID:34521819 redirects to PMID:32953130, whose cached full text reports
+      the STAT1-JAK1 interaction and its perturbation by SARS-CoV-2 N protein.
+      Retain the source PMID for GOA provenance and assess the canonical paper.
+      The experimental interaction is supported, but generic protein binding is
+      less informative than JAK1's specific tyrosine kinase function and is non-core.
+    supported_by:
+    - reference_id: PMID:32953130
+      supporting_text: Moreover, our result showed that SARS-CoV-2 N interfered with
+        the interactions of STAT1 with JAK1 and STAT2 with TYK2
   qualifier: enables
 - term:
     id: GO:0005515

--- a/history/genes/human/JAK1/2026-09-12T194408Z-claude-code-ddd5b9.yaml
+++ b/history/genes/human/JAK1/2026-09-12T194408Z-claude-code-ddd5b9.yaml
@@ -1,0 +1,27 @@
+history_version: 1
+target:
+  kind: gene
+  slug: JAK1
+  organism: human
+  path: genes/human/JAK1/JAK1-ai-review.yaml
+session:
+  id: 2026-09-12T194408Z-claude-code-ddd5b9
+  timestamp: '2026-09-12T19:44:08Z'
+  actors:
+  - type: ai_agent
+    name: codex
+    model: gpt-6
+    agent_tool: codex
+links:
+  issues: []
+  prs: []
+  urls: []
+events:
+- type: EDIT
+  outcome: changed
+  sections:
+  - existing_annotations
+  - references
+  summary: Defer JAK1 interaction decision for inaccessible reference
+  details: |
+    Changed the IPI protein-binding annotation citing PMID:34521819 from REMOVE to UNDECIDED because the supporting publication could not be retrieved. Removed the unsupported invalid/retracted/replaced characterization from the reference, recorded its correctness as UNVERIFIED, and retained the GOA identifier. Validation: just validate human JAK1 passed with one advisory warning for the inaccessible PMID:34521819; its pathway PMID check passed. After rebasing onto origin/main at 78ce621267, just validate yeast CMC2 also passed without curation warnings.

--- a/history/genes/human/JAK1/2026-09-12T220118Z-codex-1040e7.yaml
+++ b/history/genes/human/JAK1/2026-09-12T220118Z-codex-1040e7.yaml
@@ -1,0 +1,27 @@
+history_version: 1
+target:
+  kind: gene
+  slug: JAK1
+  organism: human
+  path: genes/human/JAK1/JAK1-ai-review.yaml
+session:
+  id: 2026-09-12T220118Z-codex-1040e7
+  timestamp: '2026-09-12T22:01:18Z'
+  actors:
+  - type: ai_agent
+    name: codex
+    model: gpt-6
+    agent_tool: codex
+links:
+  issues: []
+  prs: []
+  urls: []
+events:
+- type: EDIT
+  outcome: changed
+  sections:
+  - references
+  - existing_annotations
+  summary: Resolve duplicate PMID and reassess JAK1 interaction evidence
+  details: |
+    Following the reviewer-supplied PubMed duplicate notice, recorded PMID:34521819 as a duplicate of PMID:32953130 without altering the original GOA identifier. Read the canonical cached full text, which reports STAT1-JAK1 interaction perturbation by SARS-CoV-2 N. Reassessed both original and canonical IPI rows as KEEP_AS_NON_CORE with an exact snippet from PMID:32953130; the prior inaccessible-reference rationale and removal based solely on viral context are superseded. This session follows the earlier UNDECIDED edit with new identifier evidence. Validation: just validate human JAK1 passed, including schema, terms, snippet/reference, best-practice, and pathway PMID checks. One expected advisory remains because current LRV does not resolve the old deleted PMID from the curated mapping.

--- a/history/genes/human/JAK1/2026-09-13T012023Z-codex-629e31.yaml
+++ b/history/genes/human/JAK1/2026-09-13T012023Z-codex-629e31.yaml
@@ -1,0 +1,27 @@
+history_version: 1
+target:
+  kind: gene
+  slug: JAK1
+  organism: human
+  path: genes/human/JAK1/JAK1-ai-review.yaml
+session:
+  id: 2026-09-13T012023Z-codex-629e31
+  timestamp: '2026-09-13T01:20:23Z'
+  actors:
+  - type: ai_agent
+    name: codex
+    model: gpt-6
+    agent_tool: codex
+links:
+  issues: []
+  prs:
+  - https://github.com/ai4curation/ai-gene-review/pull/3033
+  urls: []
+events:
+- type: EDIT
+  outcome: changed
+  sections:
+  - references
+  summary: Retain invalid flag on replaced PubMed record
+  details: |
+    Addressed reviewer concern that dropping is_invalid from deleted duplicate PMID:34521819 conflicts with mark_invalid_pmids(). Restored is_invalid: true alongside the curated replacement mapping to PMID:32953130. Replaced the hand-authored deletion placeholder title with the title from the canonical publication cache, and documented title provenance and the distinction between an invalid/replaced record and a retracted paper in replacement.review_notes. Canonical evidence snippets and original GOA identifiers are unchanged. Added a regression check that the invalid-PMID utility leaves this combined metadata semantically unchanged. Validation: all 11 reference-curation tests passed, including the metadata-preservation regression. just validate human JAK1 passed with one expected advisory for retrieval of the obsolete PMID; restoring is_invalid does not suppress that LRV warning. Ruff passed.

--- a/history/genes/human/JAK1/2026-09-13T015802Z-codex-ae25d3.yaml
+++ b/history/genes/human/JAK1/2026-09-13T015802Z-codex-ae25d3.yaml
@@ -1,0 +1,27 @@
+history_version: 1
+target:
+  kind: gene
+  slug: JAK1
+  organism: human
+  path: genes/human/JAK1/JAK1-ai-review.yaml
+session:
+  id: 2026-09-13T015802Z-codex-ae25d3
+  timestamp: '2026-09-13T01:58:02Z'
+  actors:
+  - type: ai_agent
+    name: codex
+    model: gpt-6
+    agent_tool: codex
+links:
+  issues: []
+  prs:
+  - https://github.com/ai4curation/ai-gene-review/pull/3033
+  urls: []
+events:
+- type: EDIT
+  outcome: changed
+  sections:
+  - existing_annotations
+  summary: Retain independent Zhang et al. STAT1-JAK1 interaction evidence
+  details: |
+    Corrected the false duplicate-study rationale for PMID:34950606. The cached full text identifies Zhang et al. studying SARS-CoV-2 M and S proteins, distinct from Mu et al. PMID:32953130 on N protein. Figure 5D-E describes co-IP of STAT1 and JAK1 with and without spike protein; the GOA WITH/FROM partner is UniProtKB:P42224 (STAT1). Changed REMOVE to KEEP_AS_NON_CORE and replaced the title-only supporting text with the verbatim co-IP result. Independent experimental support for the same interaction is not grounds for removal. Validation: just validate human JAK1 passed, including the new verbatim snippet and pathway PMID checks, with only the existing advisory for deleted PMID:34521819. git diff --check passed.

--- a/history/genes/human/JAK1/2026-09-13T021542Z-codex-b91496.yaml
+++ b/history/genes/human/JAK1/2026-09-13T021542Z-codex-b91496.yaml
@@ -5,8 +5,8 @@ target:
   organism: human
   path: genes/human/JAK1/JAK1-ai-review.yaml
 session:
-  id: 2026-09-12T194408Z-claude-code-ddd5b9
-  timestamp: '2026-09-12T19:44:08Z'
+  id: 2026-09-13T021542Z-codex-b91496
+  timestamp: '2026-09-13T02:15:42Z'
   actors:
   - type: ai_agent
     name: codex
@@ -14,7 +14,8 @@ session:
     agent_tool: codex
 links:
   issues: []
-  prs: []
+  prs:
+  - https://github.com/ai4curation/ai-gene-review/pull/3033
   urls: []
 events:
 - type: EDIT
@@ -25,3 +26,5 @@ events:
   summary: Defer JAK1 interaction decision for inaccessible reference
   details: |
     Changed the IPI protein-binding annotation citing PMID:34521819 from REMOVE to UNDECIDED because the supporting publication could not be retrieved. Removed the unsupported invalid/retracted/replaced characterization from the reference, recorded its correctness as UNVERIFIED, and retained the GOA identifier. Validation: just validate human JAK1 passed with one advisory warning for the inaccessible PMID:34521819; its pathway PMID check passed. After rebasing onto origin/main at 78ce621267, just validate yeast CMC2 also passed without curation warnings.
+
+    Regenerated during PR #3033 review to correct the filename/session actor mismatch. The curation described above occurred at 2026-09-12T19:44:08Z; the new session timestamp records regeneration of this provenance file, not a new curation decision. Original record: history/genes/human/JAK1/2026-09-12T194408Z-claude-code-ddd5b9.yaml.

--- a/history/schema/gene_review/2026-09-12T220118Z-codex-e04cb9.yaml
+++ b/history/schema/gene_review/2026-09-12T220118Z-codex-e04cb9.yaml
@@ -1,0 +1,27 @@
+history_version: 1
+target:
+  kind: schema
+  slug: gene_review
+  path: src/ai_gene_review/schema/gene_review.yaml
+session:
+  id: 2026-09-12T220118Z-codex-e04cb9
+  timestamp: '2026-09-12T22:01:18Z'
+  actors:
+  - type: ai_agent
+    name: codex
+    model: gpt-6
+    agent_tool: codex
+links:
+  issues: []
+  prs: []
+  urls: []
+events:
+- type: EDIT
+  outcome: changed
+  sections:
+  - ReferenceReview
+  - ReferenceReplacement
+  - FindingReview
+  summary: Add curated reference replacements and cross-paper finding evidence
+  details: |
+    Added optional reference_review.replacement metadata with a required target reference and controlled reason, preserving source identifiers. Extended FindingReview with supported_by evidence so a disputed or overturned finding can cite an exact snippet from a different publication. Regenerated the Pydantic model, added target/self/cycle integrity checks, and documented both workflows. Tests exercise source-preserving round trips, schema constraints, replacement integrity, and real offline LRV validation including rejection of a quote from the wrong paper.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
   - Isoform Tracking: isoform_tracking.md
   - Refreshing GOA Sources: goa_source_refresh.md
   - History Records: history.md
+  - Reference Curation: reference_curation.md
   - Evidence Subtraction Reports: subtraction_report.md
   - Automation (dismech migration, as built): automation-migration-to-dismech.md
 

--- a/reports/validation-triage.md
+++ b/reports/validation-triage.md
@@ -1,0 +1,89 @@
+# Gene validation triage
+
+Latest follow-up: added structured reference replacement metadata to the schema and JAK1. PMID:34521819 is recorded as a duplicate of PMID:32953130, based on the reviewer-supplied PubMed notice. The canonical full text was reviewed; both matching IPI rows now use KEEP_AS_NON_CORE and cite a verbatim canonical-PMID snippet. JAK1 passes validation with the expected legacy-PMID retrieval advisory. Earlier run results and intermediate decisions below are historical.
+
+Follow-up: rebased onto `78ce621267`. CMC2 now passes `just validate yeast CMC2`. JAK1 was corrected to UNDECIDED for PMID:34521819, with the reference marked UNVERIFIED and the unsupported invalid/retracted claim removed. `just validate human JAK1` passes with one advisory warning for that inaccessible reference. The full-batch counts below describe the earlier run; the full batch was not rerun after this follow-up.
+
+Validated after rebase onto origin/main at `0d925a0696`.
+
+`just validate-all` exited 1: 4,796 reviews checked; 4,795 passed, one failed. Schema passed; term checks had no blocking errors (10 label warnings in 9 files); reference checks had 53 advisory warnings in 30 files; best-practice checks had 2 errors and 3,659 warnings in 1,805 files. All 54 pathway markdown files containing PMID references passed.
+
+## Blocking failure
+
+[yeast/CMC2](../genes/yeast/CMC2/CMC2-ai-review.yaml): the GO:0033617 / IMP / PMID:20220131 row includes `supporting_entities: [SGD:S000001620]` at lines 77–78, but the cached GOA WITH/FROM field is empty. This causes the same annotation to be reported as both missing and extra. Reconcile this metadata with its source; the term ID itself is not the mismatch.
+
+## Priorities
+
+- Inspect inconsistent annotation decisions and core-function/annotation discrepancies first. These warnings identify possible curation inconsistencies, not proven biological errors; evidence-specific differences can be valid.
+- Resolve malformed or unsupported reference identifiers so citations can be checked. See the per-gene list below.
+- In human/JAK1, the experimental protein-binding row for PMID:34521819 is REMOVE solely because its reference cannot be retrieved (lines 1603–1610). The repository instructs reviewers to use UNDECIDED for inaccessible evidence; missing access alone does not justify REMOVE or a retraction claim.
+- Complete unfinished reviews (PENDING annotations, TODO descriptions, missing core functions) according to project priority.
+- Missing structured propagation reviews are a large provenance backlog. Do not mechanically invent phylogenetic claims to silence them.
+- Uncited deep research and term-label mismatches are lower priority than evidence and decision problems.
+
+## Best-practice warning counts
+
+| Warning | Instances | Genes |
+|---|---:|---:|
+| Missing structured propagation reviews | 1186 | 496 |
+| Available deep research not cited | 804 | 804 |
+| Core molecular function absent from annotation block | 356 | 306 |
+| Core process absent from annotation block | 349 | 294 |
+| Core location absent from annotation block | 246 | 202 |
+| Inconsistent actions for the same GO term | 260 | 154 |
+| Missing core functions | 177 | 177 |
+| PENDING annotations | 52 | 52 |
+| Missing references | 3 | 3 |
+| TODO description | 58 | 58 |
+| Core complex absent from annotation block | 103 | 103 |
+| Accepted annotation lacks supported_by | 65 | 20 |
+
+## Unresolved reference warnings
+
+These are fetch/identifier warnings, not findings that the cited biology is false. PMID:34521819 is already documented as unresolvable in the reviews. Some unsupported source types may need validator support rather than curation changes.
+
+| Gene | Warning | Occurrences |
+|---|---|---:|
+| [9POAL/psbA](../genes/9POAL/psbA/psbA-ai-review.yaml) | Could not fetch reference: HAMAP-Rule:MF_01379 | 1 |
+| [ACET2/cipA](../genes/ACET2/cipA/cipA-ai-review.yaml) | Could not fetch reference: cipA-deep-research-falcon.md | 1 |
+| [ANOGA/CLIPB4](../genes/ANOGA/CLIPB4/CLIPB4-ai-review.yaml) | Could not fetch reference: saab2024insightintothe | 1 |
+| [ANOGA/CLIPB4](../genes/ANOGA/CLIPB4/CLIPB4-ai-review.yaml) | Could not fetch reference: vandana2024wolbachiainfectionresponsiveimmune | 1 |
+| [ARATH/AT5G05410](../genes/ARATH/AT5G05410/AT5G05410-ai-review.yaml) | Could not fetch reference: AT5G05410-notes.md | 1 |
+| [ARATH/AT5G05410](../genes/ARATH/AT5G05410/AT5G05410-ai-review.yaml) | Could not fetch reference: AT5G05410-deep-research-perplexity.md | 1 |
+| [ARATH/AT5G05410](../genes/ARATH/AT5G05410/AT5G05410-ai-review.yaml) | Could not fetch reference: AT5G05410-uniprot.txt | 1 |
+| [ARATH/FLS2](../genes/ARATH/FLS2/FLS2-ai-review.yaml) | Could not fetch reference: PANTHER:PTHR48056 | 1 |
+| [ARATH/PAL1](../genes/ARATH/PAL1/PAL1-ai-review.yaml) | Could not fetch reference: P35510 | 9 |
+| [CUPNH/glcE](../genes/CUPNH/glcE/glcE-ai-review.yaml) | Could not fetch reference: UniProtKB-EC | 1 |
+| [CUPNH/glcE](../genes/CUPNH/glcE/glcE-ai-review.yaml) | Could not fetch reference: InterPro | 1 |
+| [CUPNH/glcE](../genes/CUPNH/glcE/glcE-ai-review.yaml) | Could not fetch reference: curator_inference | 1 |
+| [CUPNH/glcE](../genes/CUPNH/glcE/glcE-ai-review.yaml) | Could not fetch reference: glcE-falcon-research | 1 |
+| [DROME/CG6051](../genes/DROME/CG6051/CG6051-ai-review.yaml) | Could not fetch reference: Q9VB70 | 1 |
+| [DROME/Ced-12](../genes/DROME/Ced-12/Ced-12-ai-review.yaml) | Could not fetch reference: deep-research | 1 |
+| [ECOLI/yrhB](../genes/ECOLI/yrhB/yrhB-ai-review.yaml) | Could not fetch reference: DOI:10.1007/978-0-8176-4747-1 | 1 |
+| [PSEPK/pvdS](../genes/PSEPK/pvdS/pvdS-ai-review.yaml) | Could not fetch reference: curator_inference | 1 |
+| [WHEAT/RHT1](../genes/WHEAT/RHT1/RHT1-ai-review.yaml) | Could not fetch reference: Q9ST59 | 1 |
+| [human/ANKFY1](../genes/human/ANKFY1/ANKFY1-ai-review.yaml) | Could not fetch reference: projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv | 1 |
+| [human/BCL2](../genes/human/BCL2/BCL2-ai-review.yaml) | Could not fetch reference: croce2025thebcl2protein | 1 |
+| [human/C1QBP](../genes/human/C1QBP/C1QBP-ai-review.yaml) | Could not fetch reference: deep-research | 1 |
+| [human/CKAP2](../genes/human/CKAP2/CKAP2-ai-review.yaml) | Could not fetch reference: CKAP2-deep-research.md | 1 |
+| [human/FOXO1](../genes/human/FOXO1/FOXO1-ai-review.yaml) | Could not fetch reference: santos2023foxofamilyisoforms | 1 |
+| [human/FOXO1](../genes/human/FOXO1/FOXO1-ai-review.yaml) | Could not fetch reference: cheng2024forkheadboxo | 1 |
+| [human/FOXO1](../genes/human/FOXO1/FOXO1-ai-review.yaml) | Could not fetch reference: rodriguezcolman2024foxotranscriptionfactors | 1 |
+| [human/GGCT](../genes/human/GGCT/GGCT-ai-review.yaml) | Could not fetch reference: reactome/R-HSA-1247922.md | 1 |
+| [human/GSS](../genes/human/GSS/GSS-ai-review.yaml) | Could not fetch reference: GSS-deep-research-falcon.md | 1 |
+| [human/JAK1](../genes/human/JAK1/JAK1-ai-review.yaml) | Could not fetch reference: PMID:34521819 | 1 |
+| [human/PARD6G](../genes/human/PARD6G/PARD6G-ai-review.yaml) | Could not fetch reference: earl2025capturemutualinhibition | 1 |
+| [human/PCSK1N](../genes/human/PCSK1N/PCSK1N-ai-review.yaml) | Could not fetch reference: geneontology/go-annotation#6407 | 1 |
+| [human/PEMT](../genes/human/PEMT/PEMT-ai-review.yaml) | Could not fetch reference: reactome/R-HSA-1483191.md | 1 |
+| [human/PEMT](../genes/human/PEMT/PEMT-ai-review.yaml) | Could not fetch reference: reactome/R-HSA-1483174.md | 4 |
+| [human/SCN1A](../genes/human/SCN1A/SCN1A-ai-review.yaml) | Could not fetch reference: clinical_literature | 1 |
+| [human/STAT1](../genes/human/STAT1/STAT1-ai-review.yaml) | Could not fetch reference: PMID:34521819 | 1 |
+| [human/STAT2](../genes/human/STAT2/STAT2-ai-review.yaml) | Could not fetch reference: PMID:34521819 | 1 |
+| [worm/hsp-4](../genes/worm/hsp-4/hsp-4-ai-review.yaml) | Could not fetch reference: urban2025functionallydiversifiedcaenorhabditis | 1 |
+| [worm/hsp-4](../genes/worm/hsp-4/hsp-4-ai-review.yaml) | Could not fetch reference: waldherr2024endoplasmicreticulumunfolded | 1 |
+| [worm/hsp-4](../genes/worm/hsp-4/hsp-4-ai-review.yaml) | Could not fetch reference: xu2024theunfoldedprotein | 1 |
+| [worm/ire-1](../genes/worm/ire-1/ire-1-ai-review.yaml) | Could not fetch reference: ire-1-deep-research-falcon.md | 1 |
+| [worm/lrx-1](../genes/worm/lrx-1/lrx-1-ai-review.yaml) | Could not fetch reference: BioGRID | 1 |
+| [yeast/THI22](../genes/yeast/THI22/THI22-ai-review.yaml) | Could not fetch reference: SGD:S000006325 | 2 |
+
+Full logs: [all stages](validation-all.log). Detailed best-practice issues: [TSV](validation-all.tsv). Individual CMC2 check: [log](validation-CMC2.log).

--- a/src/ai_gene_review/datamodel/gene_review_model.py
+++ b/src/ai_gene_review/datamodel/gene_review_model.py
@@ -1374,6 +1374,24 @@ class PredictionErrorTypeEnum(str, Enum):
     """
 
 
+class ReferenceReplacementReasonEnum(str, Enum):
+    """
+    Reason for a manually verified identifier replacement, distinct from the empirical standing of a publication's findings.
+    """
+    DUPLICATE_RECORD = "DUPLICATE_RECORD"
+    """
+    Source record was deleted or merged as a duplicate of the target record.
+    """
+    REPLACED_RECORD = "REPLACED_RECORD"
+    """
+    The source authority explicitly replaced this record with the target record.
+    """
+    WRONG_IDENTIFIER = "WRONG_IDENTIFIER"
+    """
+    The original citation used the wrong identifier; the target identifies the intended paper.
+    """
+
+
 class ReferenceRelevanceEnum(str, Enum):
     """
     Reviewer's assessment of how relevant a reference is to the gene's function and review.
@@ -1977,7 +1995,20 @@ class ReferenceReview(ConfiguredBaseModel):
 
     relevance: Optional[ReferenceRelevanceEnum] = Field(default=None, description="""Reviewer judgment of how relevant the reference is to the gene's function and this review.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReview']} })
     correctness: Optional[ReferenceCorrectnessEnum] = Field(default=None, description="""Reviewer's overall assessment of a reference's trustworthiness - both citation correctness (the identifier resolves to the intended paper that supports its use) and scientific soundness of that paper's claim.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReview']} })
-    review_notes: Optional[str] = Field(default=None, description="""Free-text note explaining the relevance/correctness judgment (e.g. what was verified, or why a citation is wrong, disputed, or low quality).""", json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReview', 'FindingReview']} })
+    review_notes: Optional[str] = Field(default=None, description="""Free-text note explaining the relevance/correctness judgment (e.g. what was verified, or why a citation is wrong, disputed, or low quality).""", json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReview', 'ReferenceReplacement', 'FindingReview']} })
+    replacement: Optional[ReferenceReplacement] = Field(default=None, description="""Manually established replacement for this reference identifier. This records identifier provenance, not a biological contradiction or retraction, and does not implicitly redirect supporting_text to another publication.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReview']} })
+
+
+class ReferenceReplacement(ConfiguredBaseModel):
+    """
+    A curated identifier remapping. Keep the original Reference.id and original_reference_id; declare the target in references and explicitly cite it in supported_by when quoting its text. Record how the mapping was established in review_notes. A duplicate-record deletion is not a retraction of the paper.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ai4curation.io/ai-gene-review'})
+
+    reference_id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReplacement', 'SupportingTextInReference'],
+         'implements': ['dcterms:references']} })
+    review_notes: Optional[str] = Field(default=None, description="""Free-text note explaining the relevance/correctness judgment (e.g. what was verified, or why a citation is wrong, disputed, or low quality).""", json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReview', 'ReferenceReplacement', 'FindingReview']} })
+    reason: ReferenceReplacementReasonEnum = Field(default=..., description="""Why the source identifier should resolve to the target reference.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReplacement', 'Review']} })
 
 
 class Finding(ConfiguredBaseModel):
@@ -2002,11 +2033,33 @@ class FindingReview(ConfiguredBaseModel):
     """
     Manual reviewer assessment of a specific finding within a reference - in particular whether it remains current, is disputed, or has been overturned/superseded by later evidence. This is finer-grained than reference_review (which assesses the whole reference); a paper may contain some findings that stand and others that are overturned. All fields optional and reviewer-supplied.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ai4curation.io/ai-gene-review'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ai4curation.io/ai-gene-review',
+         'slot_usage': {'supported_by': {'description': 'Evidence for this assessment, '
+                                                        'including exact snippets from '
+                                                        'the papers that contradict, '
+                                                        'overturn, or corroborate the '
+                                                        'original finding. Each '
+                                                        'snippet is attributed to its '
+                                                        'explicit reference_id, not '
+                                                        "the parent finding's "
+                                                        'publication.',
+                                         'name': 'supported_by'}}})
 
     finding_status: Optional[FindingReviewStatusEnum] = Field(default=None, description="""Reviewer's assessment of the empirical standing of a specific finding in light of other evidence (e.g. whether it has been disputed or overturned).""", json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview']} })
     superseded_by: Optional[list[str]] = Field(default=None, description="""Reference(s) that dispute, correct, or overturn this finding. Used together with finding_status DISPUTED or OVERTURNED.""", json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview']} })
-    review_notes: Optional[str] = Field(default=None, description="""Free-text note explaining the relevance/correctness judgment (e.g. what was verified, or why a citation is wrong, disputed, or low quality).""", json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReview', 'FindingReview']} })
+    review_notes: Optional[str] = Field(default=None, description="""Free-text note explaining the relevance/correctness judgment (e.g. what was verified, or why a citation is wrong, disputed, or low quality).""", json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReview', 'ReferenceReplacement', 'FindingReview']} })
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Evidence for this assessment, including exact snippets from the papers that contradict, overturn, or corroborate the original finding. Each snippet is attributed to its explicit reference_id, not the parent finding's publication.""", json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
+                       'CoreFunction',
+                       'ProposedOntologyTerm',
+                       'RuleReview',
+                       'ParsimonyAssessment',
+                       'LiteratureSupportAssessment',
+                       'ConditionOverlapAssessment',
+                       'GOSpecificityAssessment',
+                       'TaxonomicScopeAssessment',
+                       'PredictionAssessment'],
+         'recommended': True} })
 
 
 class SupportingTextInReference(ConfiguredBaseModel):
@@ -2015,7 +2068,7 @@ class SupportingTextInReference(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ai4curation.io/ai-gene-review'})
 
-    reference_id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'domain_of': ['SupportingTextInReference'],
+    reference_id: str = Field(default=..., json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReplacement', 'SupportingTextInReference'],
          'implements': ['dcterms:references']} })
     supporting_text: Optional[str] = Field(default=None, description="""Supporting text from the publication. This should be exact substrings. Different substrings can be broken up by '...'s. These substrings will be checked against the actual text of the paper. If editorialization is necessary, put this in square brackets (this is not checked). For example, you can say '...[CFAP300 shows] transport within cilia is IFT dependent...'""", json_schema_extra = { "linkml_meta": {'domain_of': ['Finding',
                        'SupportingTextInReference',
@@ -3858,7 +3911,7 @@ class ExistingAnnotation(ConfiguredBaseModel):
     extensions: Optional[list[AnnotationExtension]] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ExistingAnnotation']} })
     negated: Optional[bool] = Field(default=None, description="""Whether the term is negated""", json_schema_extra = { "linkml_meta": {'domain_of': ['ExistingAnnotation', 'RuleCondition']} })
     evidence_type: EvidenceType = Field(default=..., description="""Evidence code (e.g., IDA, IBA, ISS, TAS)""", json_schema_extra = { "linkml_meta": {'domain_of': ['ExistingAnnotation']} })
-    original_reference_id: Optional[str] = Field(default=None, description="""ID of the original reference""", json_schema_extra = { "linkml_meta": {'domain_of': ['ExistingAnnotation']} })
+    original_reference_id: Optional[str] = Field(default=None, description="""ID of the original source reference, preserved as supplied by GOA/UniProt. Curate identifier replacements in references.reference_review.replacement and cite the actual evidence source in review.supported_by; do not rewrite this provenance.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ExistingAnnotation']} })
     retired: Optional[bool] = Field(default=None, description="""Whether the annotation is retired or replaced""", json_schema_extra = { "linkml_meta": {'domain_of': ['ExistingAnnotation']} })
     isoform: Optional[str] = Field(default=None, description="""UniProt isoform identifier (e.g., \"P19544-1\" for WT1 isoform 1). Only populated when the annotation is specific to a particular isoform rather than the canonical protein sequence. Note that just because an experiment used a particular isoform doesn't mean the annotation is isoform-specific - it may apply to all isoforms. Use this field only when there is clear evidence the annotation is isoform-specific.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ExistingAnnotation']} })
     supporting_entities: Optional[list[str]] = Field(default=None, description="""IDs of the supporting entities""", json_schema_extra = { "linkml_meta": {'domain_of': ['ExistingAnnotation']} })
@@ -3882,12 +3935,13 @@ class Review(ConfiguredBaseModel):
                        'PredictionAssessment'],
          'recommended': True} })
     action: ActionEnum = Field(default=..., description="""Action to be taken""", json_schema_extra = { "linkml_meta": {'domain_of': ['Review', 'RuleReview']} })
-    reason: Optional[str] = Field(default=None, description="""Reason for the action""", json_schema_extra = { "linkml_meta": {'domain_of': ['Review'], 'recommended': True} })
+    reason: Optional[str] = Field(default=None, description="""Reason for the action""", json_schema_extra = { "linkml_meta": {'domain_of': ['ReferenceReplacement', 'Review'], 'recommended': True} })
     proposed_replacement_terms: Optional[list[Term]] = Field(default=None, description="""If the action is MODIFY, then this is a list of proposed replacement terms""", json_schema_extra = { "linkml_meta": {'comments': ['note there is a separate rule that this is required IF the '
                       'action is MODIFY'],
          'domain_of': ['Review']} })
     additional_reference_ids: Optional[list[str]] = Field(default=None, description="""IDs of the references""", json_schema_extra = { "linkml_meta": {'domain_of': ['Review']} })
-    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Review',
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
                        'CoreFunction',
                        'ProposedOntologyTerm',
                        'RuleReview',
@@ -4018,7 +4072,8 @@ class CoreFunction(ConfiguredBaseModel):
                        'RuleReview',
                        'PredictionReview'],
          'recommended': True} })
-    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Review',
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
                        'CoreFunction',
                        'ProposedOntologyTerm',
                        'RuleReview',
@@ -4088,7 +4143,8 @@ class ProposedOntologyTerm(ConfiguredBaseModel):
     justification: Optional[str] = Field(default=None, description="""Justification for why this term is needed""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProposedOntologyTerm']} })
     proposed_parent: Optional[Term] = Field(default=None, description="""Proposed parent term in the ontology hierarchy""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProposedOntologyTerm']} })
     proposed_mappings: Optional[list[TermMapping]] = Field(default=None, description="""Proposed mappings to equivalent terms in other ontologies""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProposedOntologyTerm']} })
-    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Review',
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
                        'CoreFunction',
                        'ProposedOntologyTerm',
                        'RuleReview',
@@ -4220,7 +4276,8 @@ class RuleReview(ConfiguredBaseModel):
     go_specificity: Optional[GOSpecificityAssessment] = Field(default=None, description="""Assessment of GO term specificity""", json_schema_extra = { "linkml_meta": {'domain_of': ['RuleReview']} })
     taxonomic_scope: Optional[TaxonomicScopeAssessment] = Field(default=None, description="""Assessment of taxonomic restriction appropriateness""", json_schema_extra = { "linkml_meta": {'domain_of': ['RuleReview']} })
     confidence: Optional[float] = Field(default=None, description="""Overall confidence in the rule (0.0 to 1.0)""", ge=0.0, le=1.0, json_schema_extra = { "linkml_meta": {'domain_of': ['RuleReview']} })
-    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this review""", json_schema_extra = { "linkml_meta": {'domain_of': ['Review',
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this review""", json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
                        'CoreFunction',
                        'ProposedOntologyTerm',
                        'RuleReview',
@@ -4449,7 +4506,8 @@ class ParsimonyAssessment(ConfiguredBaseModel):
                        'ConditionOverlapAssessment',
                        'GOSpecificityAssessment',
                        'TaxonomicScopeAssessment']} })
-    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['Review',
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
                        'CoreFunction',
                        'ProposedOntologyTerm',
                        'RuleReview',
@@ -4494,7 +4552,8 @@ class LiteratureSupportAssessment(ConfiguredBaseModel):
                        'ConditionOverlapAssessment',
                        'GOSpecificityAssessment',
                        'TaxonomicScopeAssessment']} })
-    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['Review',
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
                        'CoreFunction',
                        'ProposedOntologyTerm',
                        'RuleReview',
@@ -4539,7 +4598,8 @@ class ConditionOverlapAssessment(ConfiguredBaseModel):
                        'ConditionOverlapAssessment',
                        'GOSpecificityAssessment',
                        'TaxonomicScopeAssessment']} })
-    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['Review',
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
                        'CoreFunction',
                        'ProposedOntologyTerm',
                        'RuleReview',
@@ -4584,7 +4644,8 @@ class GOSpecificityAssessment(ConfiguredBaseModel):
                        'ConditionOverlapAssessment',
                        'GOSpecificityAssessment',
                        'TaxonomicScopeAssessment']} })
-    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['Review',
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
                        'CoreFunction',
                        'ProposedOntologyTerm',
                        'RuleReview',
@@ -4629,7 +4690,8 @@ class TaxonomicScopeAssessment(ConfiguredBaseModel):
                        'ConditionOverlapAssessment',
                        'GOSpecificityAssessment',
                        'TaxonomicScopeAssessment']} })
-    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['Review',
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting text from literature for this assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
                        'CoreFunction',
                        'ProposedOntologyTerm',
                        'RuleReview',
@@ -4738,7 +4800,8 @@ class PredictionAssessment(ConfiguredBaseModel):
                        'Review',
                        'InterPro2GORedundancy',
                        'PredictionAssessment']} })
-    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting evidence for the assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['Review',
+    supported_by: Optional[list[SupportingTextInReference]] = Field(default=None, description="""Supporting evidence for the assessment""", json_schema_extra = { "linkml_meta": {'domain_of': ['FindingReview',
+                       'Review',
                        'CoreFunction',
                        'ProposedOntologyTerm',
                        'RuleReview',
@@ -4759,6 +4822,7 @@ FunctionalIsoformMapping.model_rebuild()
 Term.model_rebuild()
 Reference.model_rebuild()
 ReferenceReview.model_rebuild()
+ReferenceReplacement.model_rebuild()
 Finding.model_rebuild()
 FindingReview.model_rebuild()
 SupportingTextInReference.model_rebuild()

--- a/src/ai_gene_review/schema/gene_review.yaml
+++ b/src/ai_gene_review/schema/gene_review.yaml
@@ -189,7 +189,9 @@ slots:
   original_reference_id:
     range: Reference
     inlined: false
-    description: ID of the original reference
+    description: ID of the original source reference, preserved as supplied by GOA/UniProt.
+      Curate identifier replacements in references.reference_review.replacement and cite
+      the actual evidence source in review.supported_by; do not rewrite this provenance.
   retired:
     range: boolean
     description: Whether the annotation is retired or replaced
@@ -211,6 +213,12 @@ slots:
     description: Manual reviewer assessment of this reference (relevance, and citation
       correctness / scientific soundness). Reviewer-supplied, distinct from the
       machine-fetched id/title.
+  replacement:
+    range: ReferenceReplacement
+    inlined: true
+    description: Manually established replacement for this reference identifier. This records
+      identifier provenance, not a biological contradiction or retraction, and does not
+      implicitly redirect supporting_text to another publication.
   relevance:
     range: ReferenceRelevanceEnum
     description: Reviewer judgment of how relevant the reference is to the gene's function
@@ -474,6 +482,21 @@ classes:
       - relevance
       - correctness
       - review_notes
+      - replacement
+
+  ReferenceReplacement:
+    description: A curated identifier remapping. Keep the original Reference.id and
+      original_reference_id; declare the target in references and explicitly cite it in
+      supported_by when quoting its text. Record how the mapping was established in
+      review_notes. A duplicate-record deletion is not a retraction of the paper.
+    slots:
+      - reference_id
+      - review_notes
+    attributes:
+      reason:
+        range: ReferenceReplacementReasonEnum
+        required: true
+        description: Why the source identifier should resolve to the target reference.
 
   Finding:
     description: A finding is a statement about a gene, which is supported by a reference.
@@ -495,6 +518,12 @@ classes:
       - finding_status
       - superseded_by
       - review_notes
+      - supported_by
+    slot_usage:
+      supported_by:
+        description: Evidence for this assessment, including exact snippets from the papers
+          that contradict, overturn, or corroborate the original finding. Each snippet is
+          attributed to its explicit reference_id, not the parent finding's publication.
 
   SupportingTextInReference:
     description: A supporting text in a reference.
@@ -3300,6 +3329,17 @@ enums:
           noncatalytic accessory subunit. Participation in the complex or its
           biological process does not establish that the subunit catalyzes the reaction.
 
+
+  ReferenceReplacementReasonEnum:
+    description: Reason for a manually verified identifier replacement, distinct from
+      the empirical standing of a publication's findings.
+    permissible_values:
+      DUPLICATE_RECORD:
+        description: Source record was deleted or merged as a duplicate of the target record.
+      REPLACED_RECORD:
+        description: The source authority explicitly replaced this record with the target record.
+      WRONG_IDENTIFIER:
+        description: The original citation used the wrong identifier; the target identifies the intended paper.
 
   ReferenceRelevanceEnum:
     description: Reviewer's assessment of how relevant a reference is to the gene's function and review.

--- a/src/ai_gene_review/validation/validator.py
+++ b/src/ai_gene_review/validation/validator.py
@@ -179,6 +179,58 @@ def validate_reference_finding_supporting_text(
             )
 
 
+def validate_reference_replacements(
+    data: Dict[str, Any], report: ValidationReport,
+) -> None:
+    """Require declared replacement targets and reject self-links and cycles.
+
+    This checks curated metadata only; it never rewrites a source identifier or
+    changes the publication against which a snippet is validated.
+    """
+    references = [r for r in data.get("references", []) if isinstance(r, dict)]
+    reference_ids = {r.get("id") for r in references}
+    replacements = {}
+    paths = {}
+    for i, reference in enumerate(references):
+        review = reference.get("reference_review") or {}
+        replacement = review.get("replacement") or {}
+        target = replacement.get("reference_id")
+        if not target:
+            continue
+        source = reference.get("id")
+        path = f"references[{i}].reference_review.replacement.reference_id"
+        message = None
+        if target == source:
+            message = f"Reference {source} cannot replace itself"
+        elif target not in reference_ids:
+            message = f"Replacement references non-existent reference ID: {target}"
+        if message:
+            report.add_issue(
+                ValidationSeverity.ERROR, message, path=path,
+                validation_category="BestPractices", check_type="reference_replacement",
+            )
+        else:
+            replacements[source] = target
+            paths[source] = path
+
+    checked = set()
+    for source in replacements:
+        trail = set()
+        current = source
+        while current in replacements and current not in checked:
+            if current in trail:
+                report.add_issue(
+                    ValidationSeverity.ERROR,
+                    f"Reference replacement cycle includes {current}",
+                    path=paths[current], validation_category="BestPractices",
+                    check_type="reference_replacement",
+                )
+                break
+            trail.add(current)
+            current = replacements[current]
+        checked.update(trail)
+
+
 def load_schema() -> SchemaView:
     """Load the LinkML schema.
 
@@ -306,6 +358,7 @@ def check_best_practices_rules(
 
     if check_supporting_text:
         validate_reference_finding_supporting_text(data, report, publications_dir)
+    validate_reference_replacements(data, report)
 
     # Check for TODO in description
     if "description" in data and "TODO" in str(data["description"]):

--- a/tests/test_reference_curation_metadata.py
+++ b/tests/test_reference_curation_metadata.py
@@ -1,0 +1,127 @@
+"""Reference remapping and cross-paper finding evidence preserve source identity."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+from pydantic import ValidationError
+from linkml_runtime.utils.schemaview import SchemaView
+
+from ai_gene_review.datamodel.gene_review_model import GeneReview, ReferenceReview
+from ai_gene_review.validation import validate_gene_review
+import yaml
+
+
+SCHEMA = Path(__file__).parents[1] / "src/ai_gene_review/schema/gene_review.yaml"
+
+
+def review_data():
+    """Synthetic records distinguish original, canonical, and contradicting sources."""
+    return {
+        "id": "TEST", "gene_symbol": "TEST",
+        "taxon": {"id": "NCBITaxon:9606", "label": "Homo sapiens"},
+        "description": "Synthetic fixture for reference metadata.",
+        "references": [
+            {"id": "PMID:1", "title": "Deleted duplicate", "reference_review": {
+                "replacement": {"reference_id": "PMID:2", "reason": "DUPLICATE_RECORD"},
+                "review_notes": "Synthetic verified duplicate mapping.",
+            }},
+            {"id": "PMID:2", "title": "Original study", "findings": [{
+                "statement": "Activity occurs without a cofactor.",
+                "finding_review": {
+                    "finding_status": "DISPUTED", "superseded_by": ["PMID:3"],
+                    "supported_by": [{"reference_id": "PMID:3", "supporting_text": "A cofactor was required."}],
+                },
+            }]},
+            {"id": "PMID:3", "title": "Follow-up study"},
+        ],
+        "existing_annotations": [{
+            "term": {"id": "GO:0005515", "label": "protein binding"},
+            "evidence_type": "IPI", "original_reference_id": "PMID:1",
+            "review": {"action": "UNDECIDED", "supported_by": [
+                {"reference_id": "PMID:2", "supporting_text": "An interaction was observed."},
+            ]},
+        }],
+    }
+
+
+def test_metadata_roundtrip_preserves_each_source():
+    data = GeneReview.model_validate(review_data()).model_dump(mode="json", exclude_none=True)
+    assert data["existing_annotations"][0]["original_reference_id"] == "PMID:1"
+    assert data["existing_annotations"][0]["review"]["supported_by"][0]["reference_id"] == "PMID:2"
+    assert data["references"][0]["reference_review"]["replacement"]["reference_id"] == "PMID:2"
+    evidence = data["references"][1]["findings"][0]["finding_review"]["supported_by"][0]
+    assert evidence == {"reference_id": "PMID:3", "supporting_text": "A cofactor was required."}
+
+
+@pytest.mark.parametrize("replacement", [
+    {"reason": "DUPLICATE_RECORD"},
+    {"reference_id": "PMID:2"},
+    {"reference_id": "PMID:2", "reason": "RETRACTED"},
+])
+def test_incomplete_or_invalid_replacement_rejected(replacement):
+    with pytest.raises(ValidationError):
+        ReferenceReview(replacement=replacement)
+
+
+def test_schema_exposes_cross_paper_evidence_to_lrv():
+    sv = SchemaView(str(SCHEMA))
+    assert sv.induced_slot("replacement", "ReferenceReview").range == "ReferenceReplacement"
+    assert sv.induced_slot("reference_id", "ReferenceReplacement").required
+    assert sv.induced_slot("supported_by", "FindingReview").range == "SupportingTextInReference"
+    assert sv.induced_slot("supported_by", "FindingReview").multivalued
+
+
+@pytest.mark.parametrize("target,expected", [("PMID:1", "itself"), ("PMID:9", "non-existent")])
+def test_replacement_target_integrity(tmp_path, target, expected):
+    data = review_data()
+    data["references"][0]["reference_review"]["replacement"]["reference_id"] = target
+    path = tmp_path / "review.yaml"
+    path.write_text(yaml.safe_dump(data))
+    report = validate_gene_review(path, check_goa=False, check_supporting_text=False)
+    assert any(i.is_error() and expected in i.message for i in report.issues)
+
+
+def test_replacement_cycle_rejected(tmp_path):
+    data = review_data()
+    data["references"][1]["reference_review"] = {
+        "replacement": {"reference_id": "PMID:1", "reason": "DUPLICATE_RECORD"},
+    }
+    path = tmp_path / "review.yaml"
+    path.write_text(yaml.safe_dump(data))
+    report = validate_gene_review(path, check_goa=False, check_supporting_text=False)
+    assert any(i.is_error() and "cycle" in i.message for i in report.issues)
+
+
+@pytest.mark.parametrize("quote,valid", [
+    ("A cofactor was required.", True),
+    ("An interaction was observed.", False),
+])
+def test_lrv_checks_finding_review_quote_against_explicit_source(tmp_path, quote, valid):
+    """Run real LRV offline: a quote from P2 must not pass when attributed to P3."""
+    data = review_data()
+    data["references"][1]["findings"][0]["finding_review"]["supported_by"][0]["supporting_text"] = quote
+    cache = tmp_path / "publications"
+    cache.mkdir()
+    texts = ["Duplicate record.", "An interaction was observed.", "A cofactor was required."]
+    for ref, text in zip(data["references"], texts):
+        metadata = {"pmid": ref["id"].split(":")[1], "title": ref["title"], "full_text_available": True}
+        (cache / (ref["id"].replace(":", "_") + ".md")).write_text(
+            "---\n" + yaml.safe_dump(metadata) + "---\n\n" + text + "\n"
+        )
+    path = tmp_path / "review.yaml"
+    path.write_text(yaml.safe_dump(data))
+    config = tmp_path / "config.yaml"
+    config.write_text(yaml.safe_dump({"cache_dir": str(cache)}))
+    result = subprocess.run(
+        [str(Path(sys.executable).with_name("linkml-reference-validator")),
+         "validate", "data", str(path), "--schema", str(SCHEMA),
+         "--target-class", "GeneReview", "--config", str(config)],
+        capture_output=True, text=True, check=False,
+    )
+    output = result.stdout + result.stderr
+    assert (result.returncode == 0) == valid, output
+    if not valid:
+        assert "finding_review.supported_by" in output
+        assert "PMID:3" in output

--- a/tests/test_reference_curation_metadata.py
+++ b/tests/test_reference_curation_metadata.py
@@ -6,10 +6,11 @@ import sys
 
 import pytest
 from pydantic import ValidationError
-from linkml_runtime.utils.schemaview import SchemaView
+from linkml_runtime.utils.schemaview import SchemaView  # type: ignore[import-untyped]
 
 from ai_gene_review.datamodel.gene_review_model import GeneReview, ReferenceReview
 from ai_gene_review.validation import validate_gene_review
+from ai_gene_review.utils.pmid_utils import mark_invalid_pmids
 import yaml
 
 
@@ -23,7 +24,7 @@ def review_data():
         "taxon": {"id": "NCBITaxon:9606", "label": "Homo sapiens"},
         "description": "Synthetic fixture for reference metadata.",
         "references": [
-            {"id": "PMID:1", "title": "Deleted duplicate", "reference_review": {
+            {"id": "PMID:1", "title": "Deleted duplicate", "is_invalid": True, "reference_review": {
                 "replacement": {"reference_id": "PMID:2", "reason": "DUPLICATE_RECORD"},
                 "review_notes": "Synthetic verified duplicate mapping.",
             }},
@@ -53,6 +54,16 @@ def test_metadata_roundtrip_preserves_each_source():
     assert data["references"][0]["reference_review"]["replacement"]["reference_id"] == "PMID:2"
     evidence = data["references"][1]["findings"][0]["finding_review"]["supported_by"][0]
     assert evidence == {"reference_id": "PMID:3", "supporting_text": "A cofactor was required."}
+    assert data["references"][0]["is_invalid"] is True
+
+
+def test_invalid_pmid_tool_preserves_curated_replacement(tmp_path):
+    """An invalid source record and its valid replacement coexist without churn."""
+    data = review_data()
+    path = tmp_path / "review.yaml"
+    path.write_text(yaml.safe_dump(data))
+    assert mark_invalid_pmids(path, ["PMID:1"]) == 0
+    assert yaml.safe_load(path.read_text()) == data
 
 
 @pytest.mark.parametrize("replacement", [


### PR DESCRIPTION
## Summary

- Preserve GOA/UniProt citation identifiers while curating a replacement in `reference_review.replacement`, with a required target and reason. Reject undeclared targets, self-links, and cycles; regenerate the Pydantic model and document the workflow.
- Extend `FindingReview` with `supported_by` so assessments of disputed, overturned, or corroborated findings can quote another paper explicitly. LRV validates each snippet against its own reference identifier.
- Record JAK1's PMID:34521819 → PMID:32953130 duplicate mapping. Reassess both matching IPI annotations as `KEEP_AS_NON_CORE` using the canonical paper's full-text STAT1–JAK1 interaction evidence, retaining original source PMIDs. Include curation history and the earlier all-gene validation triage.

## Validation

- 69 targeted tests passed, including real offline LRV checks that reject a quotation attributed to the wrong paper.
- `just validate human JAK1` passed; one expected advisory remains for fetching the deleted PMID. Curated replacement metadata does not yet cause LRV to redirect fetches automatically.
- `just validate yeast CMC2` passed after rebasing onto the upstream fix.
- New schema and JAK1 history records validated; Ruff and `git diff --check` passed.
- The earlier `just validate-all` run checked 4,796 reviews and found only CMC2 blocking, plus advisory warnings detailed in `reports/validation-triage.md`. The full batch was not rerun after these changes.

## Test plan

- [x] Verify schema/model round trips preserve original, replacement, and contradicting reference identifiers.
- [x] Reject incomplete replacement metadata, invalid reasons, missing targets, self-links, and cycles.
- [x] Verify LRV accepts a finding-review snippet from its explicit source and rejects a snippet from another paper.
- [x] Validate JAK1 with the canonical-PMID snippet and unchanged original GOA identifiers.
