### PR TITLE
Remove PR Shepherd file-path veto and recover failed reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,9 @@
 name: Claude Code Review
+run-name: 'Review PR #${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}'
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -13,7 +14,14 @@ on:
         type: number
 
 concurrency:
-  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
+  # All actual review triggers share a PR lane. An ordinary issue comment must
+  # not cancel that PR's running review before the job-level filter skips it.
+  group: >-
+    claude-review-${{ github.event_name == 'issue_comment' &&
+      !(github.event.issue.pull_request != null && github.event.comment.body == '/review' &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) &&
+      format('ignored-{0}', github.run_id) ||
+      github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -23,7 +31,7 @@ jobs:
         (
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
-          github.event.pull_request.head.ref != 'auto/generate-pages' &&
+          !startsWith(github.event.pull_request.head.ref, 'auto/generate-') &&
           github.actor != 'dependabot[bot]'
         ) ||
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,6 +72,7 @@ jobs:
               - '.github/agent-config.yaml'
               - '.github/cron-profiles.yaml'
               - 'scripts/auto_merge_ready_prs.py'
+              - 'scripts/retry_failed_reviews.py'
               - 'scripts/apply_cron_profile.py'
               - 'tests/js/**'
             genes:
@@ -316,7 +317,8 @@ jobs:
         run: |
           uv run pytest tests/test_agent_config.py tests/test_agent_run_summary.py \
             tests/test_apply_cron_profile.py tests/test_auto_merge_ready_prs.py \
-            tests/test_pr_shepherd_workflow.py -q
+            tests/test_pr_shepherd_workflow.py tests/test_retry_failed_reviews.py -q
           uv run ruff check --no-force-exclude scripts/auto_merge_ready_prs.py \
-            tests/test_auto_merge_ready_prs.py tests/test_pr_shepherd_workflow.py
+            scripts/retry_failed_reviews.py tests/test_auto_merge_ready_prs.py \
+            tests/test_pr_shepherd_workflow.py tests/test_retry_failed_reviews.py
           just test-js

--- a/.github/workflows/pr-shepherd.yml
+++ b/.github/workflows/pr-shepherd.yml
@@ -22,6 +22,23 @@ on:
         required: true
         default: true
         type: boolean
+      review_retry_mode:
+        description: "Independent failed-review recovery (scheduled runs execute)"
+        required: true
+        default: audit
+        type: choice
+        options:
+          - audit
+          - execute
+          - "off"
+      review_retry_delay_hours:
+        description: "Minimum hours after a failed review attempt (0 bypasses backoff)"
+        default: "1"
+        type: string
+      max_review_retries:
+        description: "Maximum failed review runs to retry (0 disables retries)"
+        default: "5"
+        type: string
       merge_mode:
         description: "Deterministic closing pass (execute requires the protected-main feature flag)"
         required: true
@@ -48,23 +65,75 @@ on:
         default: ""
         type: string
 
-concurrency:
-  group: pr-shepherd
-  cancel-in-progress: false
-
 permissions:
-  # Keep the built-in token read-only. The two jobs mint separate, short-lived
-  # App tokens for their own writes; the deterministic job receives no writer
-  # credential at all in audit mode.
+  # Keep the built-in token read-only. Each job mints a separate, short-lived
+  # App token for its writes; deterministic audit jobs receive no writer token.
   contents: read
   pull-requests: read
   checks: read
   statuses: read
 
 jobs:
+  retry-reviews:
+    # Recovery must not compete with the LLM shortlist or wait for its runner.
+    if: >-
+      ${{ github.event_name == 'schedule' ||
+          (github.event_name == 'workflow_dispatch' && inputs.review_retry_mode != 'off') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: pr-shepherd-review-retries
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+    env:
+      RETRY_MODE: ${{ github.event_name == 'schedule' && 'execute' || inputs.review_retry_mode || 'audit' }}
+      RETRY_DELAY: ${{ inputs.review_retry_delay_hours || '1' }}
+      RETRY_LIMIT: ${{ inputs.max_review_retries || '5' }}
+      SPECIFIC_PR: ${{ inputs.pr_number || '' }}
+    steps:
+      - name: Checkout trusted default branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ github.token }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Generate scoped retry token
+        id: retry-token
+        if: ${{ env.RETRY_MODE == 'execute' && env.RETRY_LIMIT != '0' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+          permission-actions: write
+
+      - name: Retry failed reviews (deterministic)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_RETRY_TOKEN: ${{ steps.retry-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          args=(--repo "$GITHUB_REPOSITORY" --min-delay-hours "$RETRY_DELAY" --max-retries "$RETRY_LIMIT")
+          if [ "$RETRY_MODE" = "execute" ] && [ "$RETRY_LIMIT" != "0" ]; then
+            args+=(--execute)
+          else
+            args+=(--dry-run)
+          fi
+          if [ -n "$SPECIFIC_PR" ]; then args+=(--specific-pr "$SPECIFIC_PR"); fi
+          uv run --python 3.12 --no-project python scripts/retry_failed_reviews.py "${args[@]}"
+
   shepherd:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_agent }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: pr-shepherd-agent
+      cancel-in-progress: false
     # A GitHub App installation token expires 60 minutes after it is minted and
     # does not refresh. Keep the job inside that window so a long run cannot
     # finish its analysis and then 401 on every push.
@@ -149,6 +218,13 @@ jobs:
             after pushing a fix commit you do NOT need to (and should NOT) manually re-trigger
             review; the push itself is enough.
 
+            Failed/timed-out review runs belong to the independent deterministic retry-reviews
+            job while GitHub permits rerunning them (created less than 30 days ago and fewer
+            than 50 attempts). Do not rerun them or dispatch replacements here during that
+            window. Failed runs outside the 30-day window or at the 50-attempt limit need a
+            new dispatch and remain in your recovery scope, alongside missing/cancelled
+            reviews and successful runs that posted no formal verdict.
+
             Start by reading the full contents of CLAUDE.md. Follow all repository conventions.
             In particular:
             - Never edit derived files: *-uniprot.txt, *-goa.tsv, *-deep-research*.md,
@@ -160,16 +236,19 @@ jobs:
 
             Candidate PRs:
             - If SPECIFIC_PR is set, inspect only that PR.
-            - Otherwise list open PRs in REPO and consider PRs that match EITHER criterion:
+            - Otherwise list open PRs in REPO with `gh pr list --limit 1000` (the default
+              first page hides older PRs) and consider PRs that match EITHER criterion:
               (a) authored by: `ai4c-agent`, `app/claude`, `app/github-actions`,
                   `github-actions[bot]`, or any bot/app author, OR
               (b) the head branch name starts with `feat/review-`, `chore/`, `claude/`,
-                  `auto/`, or `curation/` (these are agent-created branches).
+                  `auto/`, `codex/`, or `curation/` (these are agent-created branches,
+                  including when a maintainer is the recorded author).
             - A PR matching either (a) or (b) is a candidate. Do not act on PRs that match
               neither criterion.
             - EXCLUDE every PR whose head starts with `auto/generate-`, even when it matches
               the author rule or SPECIFIC_PR. Generated artifacts have a separate deterministic
               lifecycle; do not edit, review, dispatch, comment on, mark ready, or merge them.
+            - Exclude assigned PRs, PRs labeled `shepherd:hold`, and fork PRs from tending.
 
             Gather enough context for each candidate before choosing:
             - PR metadata: author, draft state, base/head refs, head SHA, updated/created time,
@@ -183,7 +262,7 @@ jobs:
               CHANGES_REQUESTED, REVIEW_REQUIRED, or a comment's prose as approval.
             - Read review bodies only to understand and repair requested changes.
             - Only the deterministic controller below may decide that a PR is merge-ready; it
-              separately verifies reviewer identity, reviewed head SHA, base freshness, holds,
+              separately verifies reviewed head SHA, merge state, holds,
               and required checks.
 
             Classify each candidate into one of these states:
@@ -191,21 +270,23 @@ jobs:
             - APPROVED + DIRTY: formal reviewDecision is approval but branch is behind or
               conflicted.
             - CHANGES_REQUESTED: latest effective review has genuinely blocking issues.
-            - REVIEW_REQUIRED + cancelled review: the PR still requires review and the current
-              or latest Claude review run was cancelled or never completed after the latest
-              head SHA.
+            - REVIEW_REQUIRED + review gap: no formal verdict exists for the current head,
+              and the latest review was cancelled, is missing, or succeeded without posting
+              a verdict, or failed but is too old/exhausted for GitHub to rerun it.
+              Retryable failed/timed-out runs belong to retry-reviews; queued/running
+              reviews need no duplicate dispatch.
 
             Prioritize the most stuck PRs in this order:
             1. APPROVED + DIRTY PRs that can be updated without a rebase or force-push.
             2. Stale CHANGES_REQUESTED PRs, oldest updated first.
-            3. REVIEW_REQUIRED PRs whose review was cancelled or missing after the latest push.
+            3. REVIEW_REQUIRED PRs with a review gap, oldest updated first.
 
             Then process only the highest-ranked PRs up to MAX_PRS.
 
             Allowed actions by state:
             - APPROVED + CLEAN:
               - Take no action. Do not mark a draft ready, merge, or enable auto-merge. The
-                deterministic controller owns this state and is currently report-only.
+                deterministic controller owns this state and enforces its own rollout flag.
             - APPROVED + DIRTY:
               - First try GitHub's update-branch API with the current head SHA.
               - If update-branch reports conflicts, you may attempt a local merge from the base
@@ -230,7 +311,7 @@ jobs:
                 committing and pushing.
               - Commit a small fix on top of the PR branch and push normally. Do not rebase,
                 reset, or force-push.
-            - REVIEW_REQUIRED + cancelled review:
+            - REVIEW_REQUIRED + review gap:
               - This state has no new push to auto-trigger review, so explicitly re-trigger it:
                 `gh workflow run claude-code-review.yml --repo "$REPO" --ref main -f pr_number=PR_NUMBER`
               - Leave a short comment only if useful to explain the re-trigger.
@@ -247,7 +328,8 @@ jobs:
             - NEVER merge a PR, enable auto-merge, approve a review, close a PR, or mark a draft
               ready. Those transitions belong to deterministic policy or a human maintainer.
             - Never force-push, rebase, reset, or rewrite PR history.
-            - Never modify human-authored PRs.
+            - Never modify human-authored PRs outside the recognized agent branch prefixes
+              above. SPECIFIC_PR does not bypass these candidate rules or exclusions.
             - If you are unsure about a biological, ontological, or evidence fix, post a
               clarifying comment on the PR instead of guessing.
             - Spend this run on the selected PRs only.
@@ -298,6 +380,9 @@ jobs:
       ${{ github.event_name == 'schedule' ||
           (github.event_name == 'workflow_dispatch' && inputs.merge_mode != 'off') }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: pr-shepherd-merge-ready
+      cancel-in-progress: false
     timeout-minutes: 15
     env:
       # Scheduled execution remains feature-gated even with strict main

--- a/.github/workflows/pr-shepherd.yml
+++ b/.github/workflows/pr-shepherd.yml
@@ -89,7 +89,12 @@ jobs:
       actions: read
       pull-requests: read
     env:
-      RETRY_MODE: ${{ github.event_name == 'schedule' && 'execute' || inputs.review_retry_mode || 'audit' }}
+      # Explicit false audits scheduled passes without minting a writer token.
+      # Unset preserves the intended live schedule; manual mode stays explicit.
+      RETRY_MODE: >-
+        ${{ github.event_name == 'schedule' &&
+            (vars.PR_SHEPHERD_RETRY_ENABLED == 'false' && 'audit' || 'execute') ||
+            inputs.review_retry_mode || 'audit' }}
       RETRY_DELAY: ${{ inputs.review_retry_delay_hours || '1' }}
       RETRY_LIMIT: ${{ inputs.max_review_retries || '5' }}
       SPECIFIC_PR: ${{ inputs.pr_number || '' }}
@@ -447,6 +452,9 @@ jobs:
           # remains best-effort and does not justify a wider merge credential.
           permission-contents: write
           permission-pull-requests: write
+          # The same merge policy applies to reviewed workflow changes. The
+          # App registration and installation must grant this before rollout.
+          permission-workflows: write
 
       - name: Audit merge-ready PRs (deterministic)
         if: ${{ env.MERGE_MODE == 'audit' }}

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -380,7 +380,7 @@ assignment, or `shepherd:hold` when fresh content needs additional observation
 time.
 
 Reads use the built-in read-only token. A separately scoped ai4c-agent token
-(Contents write + pull-request write) is supplied only to the head-pinned merge
+(Contents write + pull-request write + Workflows write) is supplied only to the head-pinned merge
 and best-effort courtesy-comment subprocesses. API uncertainty fails an execute
 run red. A positively observed head movement is instead a benign skip:
 concurrent automation changed the candidate, so its new state must pass a later
@@ -405,6 +405,16 @@ rule in repository settings or with
   Actions App (`app_id: 15368`);
 - one approving review is required and stale approvals are dismissed; requiring
   a separate approval for the latest push is disabled, matching DisMech;
+- the approval policy intentionally accepts bot-only approval on infrastructure
+  paths as well as curation paths, per the maintainer's direction for PR #3041.
+  An AI-approved PR may therefore update the automation's own merge policy.
+  There is no additional human or CODEOWNERS gate for `.github/`, `scripts/`,
+  or `src/`; do not infer one from `.protected`. The same current-head approval,
+  CI, conflict, hold, and age checks apply to all files;
+- the ai4c-agent App registration and installation grant **Workflows: write**, in
+  addition to Contents and Pull requests write, so the merge token can support
+  workflow-changing PRs without a file-path exception. The separate reviewer
+  token remains scoped to Pull requests write only;
 - unresolved review conversations block merging;
 - the ai4c-agent and ai4c-reviewer Apps have no pull-request bypass allowance,
   while force pushes and branch deletion remain disabled;
@@ -417,6 +427,16 @@ rule in repository settings or with
 
 If any setting is weakened later, set the flag false and cancel any in-flight
 Shepherd run.
+
+During the PR #3041 review, the live merge flag was already `true` (set August
+10), and `main` required one review with stale-review dismissal and no CODEOWNERS
+requirement. The ai4c-agent App and its ai4curation installation both lacked
+Workflows write. Before merging the token-permission change in #3041, add that
+permission in the [App registration](https://github.com/settings/apps/ai4c-agent/permissions)
+and approve it for the [ai4curation installation](https://github.com/organizations/ai4curation/settings/installations/130616615).
+Requesting it in YAML cannot expand the installation's grant; token minting will
+fail until the grant is approved. GitHub documents this two-step process in
+[Changing App permissions](https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app-registration#changing-the-permissions-of-a-github-app).
 
 Generated-page PRs use a separate lane. Their workflow's staged-file allowlist
 proves the commit contains derived artifacts only and always builds from the
@@ -500,6 +520,10 @@ token. `review_retry_delay_hours` defaults to one; successive attempts back off
 to six and then 24 hours. `pr_number` narrows recovery to a specific PR.
 Standalone script invocations also default to audit; live operation requires
 both `--execute` and `GH_RETRY_TOKEN`.
+Set the repository variable `PR_SHEPHERD_RETRY_ENABLED=false` to switch scheduled
+recovery to audit without minting a writer token; an unset or other value keeps
+the live schedule. Manual `review_retry_mode` remains independent. This switch
+does not cancel requests accepted by previous sweeps.
 
 The retry sweep checks the current PR and attempt again before acting, skips
 superseded commits, completed formal verdicts, generated-page branches, and
@@ -540,3 +564,9 @@ closing predicate, including its 41 paths, formal approval, current head,
 mergeability, and CI. A one-day retry audit with a two-PR budget selected #3006
 and #3005, deferred #3008 and #3007 at the budget, and reported no errors. Neither
 audit issued GitHub writes.
+
+Per-PR API errors deliberately make the retry job red after it writes its full
+summary and processes the other candidates. This keeps failures visible while
+isolating malformed payloads and transient errors to the affected PR. Red does
+not mean that earlier retry requests were rolled back; the summary identifies
+the accepted requests and failures separately.

--- a/docs/automation-migration-to-dismech.md
+++ b/docs/automation-migration-to-dismech.md
@@ -343,21 +343,14 @@ through `--trusted-reviewer`, but the production workflow does not enable it.
 The exact-head binding itself is always enforced: at least one approval must
 refer to the precise PR commit that the controller is about to merge.
 
-Broad author/head ingress does not mean broad file scope. The controller also
-requires every changed path to sit under one of these conservative curation and
-data prefixes by default: `genes/`, `genesets/`, `gocams/`, `interpro/`,
-`modules/`, `pages/`, `projects/`, `publications/`, `reactome/`, `rules/`,
-`terms/`, `families/`, or `research/`. A PR that mixes an allowed data change
-with even one path outside that set is ineligible. Repeatable CLI additions can
-expand the prefix set through `--allowed-path-prefix` for a deliberate one-off
-policy; each addition must be a normalized directory prefix ending in `/`, so
-`src/` cannot accidentally authorize a sibling such as `src_generated/`. The
-production workflow passes none. Every path outside the thirteen listed
-prefixes is therefore out of scope and requires a manual merge. Examples
-include
-infrastructure and self-modifying automation under `.github/`, `scripts/`,
-`src/`, and `tests/`, as well as `docs/`, `reports/`, and top-level
-build/configuration files.
+The production closing pass has no file-path allowlist. An approved, green,
+conflict-free PR is not blocked because it changes caches, history, code,
+workflows, or documentation. Regenerating a cache during conflict repair is a
+separate concern from deciding whether a conflict-free PR can merge.
+The optional `--allowed-path-prefix` argument restricts an explicitly scoped
+manual invocation; it is not enabled by the production workflow. Each prefix
+must be a normalized directory ending in `/`, so `src/` cannot accidentally
+authorize a sibling such as `src_generated/`.
 
 The controller requires all of these at fresh reads immediately before merge:
 
@@ -366,7 +359,6 @@ The controller requires all of these at fresh reads immediately before merge:
 - no `shepherd:hold` label and no `auto/generate-*` head branch;
 - GitHub's aggregate review decision is `APPROVED`;
 - at least one approval is bound to the exact current PR head;
-- every changed file is inside the conservative path-prefix policy above;
 - GitHub reports mergeable and clean;
 - all reported checks are complete/non-failing, and `test (3.12)` is explicitly
   successful.
@@ -480,3 +472,71 @@ synthetic record for every existing review, and do not make history coverage a
 merge requirement until normal human and agent curation paths reliably emit
 records. Rendering per-gene history on the site can follow once real records
 exist.
+
+## September 2026: stalled PRs and independent review recovery
+
+[PR #2804](https://github.com/ai4curation/ai-gene-review/pull/2804) was formally
+approved on August 31 against its current head, `80209fb14c296fba3484e600c6bced5f91a00e9a`.
+Its September 12 stall was after review: the
+[closing pass](https://github.com/ai4curation/ai-gene-review/actions/runs/34724996466/job/103637476941)
+reported `changed files outside the allowed path scope: cache/go/terms.csv`.
+Six other PRs had the same cache-file exclusion, and two were excluded for
+curation history. The default file-path veto is removed entirely: a conflict-free
+PR does not need a filename exception once review and checks pass. An explicit
+manual `--allowed-path-prefix` restriction remains available. Approval,
+current-head binding, CI, and branch-protection requirements still apply.
+
+DisMech's separate `retry-reviews` job is ported here as
+`scripts/retry_failed_reviews.py`. It retries existing failed or timed-out review
+jobs without waiting for the agent's shortlist or the merge controller. Each
+job has its own concurrency group. The retry job uses a read token for discovery
+and a separate App token with only Actions write permission for rerun requests;
+it never pushes, merges, or posts PR comments.
+
+Scheduled retry passes execute with a default budget of five PRs. Manual runs
+default to `review_retry_mode=audit`; `execute` enables reruns and `off` disables
+the lane. `max_review_retries=0` also disables recovery without minting a writer
+token. `review_retry_delay_hours` defaults to one; successive attempts back off
+to six and then 24 hours. `pr_number` narrows recovery to a specific PR.
+Standalone script invocations also default to audit; live operation requires
+both `--execute` and `GH_RETRY_TOKEN`.
+
+The retry sweep checks the current PR and attempt again before acting, skips
+superseded commits, completed formal verdicts, generated-page branches, and
+already running or newer reviews, and reports actions and deferrals in the
+Actions summary. Draft state, author identity, assignment, PR age, and merge
+eligibility do not suppress recovery of an already-triggered review. GitHub's
+[rerun limits](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs)
+restrict this lane to runs less than 30 days old and below the attempt limit.
+Missing/cancelled reviews, successful runs without a verdict, and expired or
+exhausted failures still need a new dispatch from the tending agent.
+
+A live dry run exposed an additional global stall in the copied recovery logic:
+[run 32212423440](https://github.com/ai4curation/ai-gene-review/actions/runs/32212423440)
+had been marked queued since August 19, with no jobs and no API PR association.
+The original unresolved-active-run guard made that one record veto every retry.
+Recovery now reports an unassociated queue record as a diagnostic when a fresh
+read confirms it is still queued, has no jobs, and has had no updates for at
+least 24 hours. It does not cancel or restart that record. Fresh queues, other
+active states, nonempty job lists, and uncertain reads still defer recovery.
+This is a liveness policy for duplicate-review prevention, not a claim that the
+old run is terminal; a dormant run could theoretically start later.
+
+The tending prompt now recognizes maintainer-created `codex/` branches and
+requests an explicit large PR inventory instead of the CLI's first page. It
+respects assignments and holds. Review runs have a numeric PR run name for
+recovery, and real review triggers share one concurrency lane per PR. Ordinary
+comments use a separate lane so a skipped comment event cannot cancel a review.
+Reopening a PR or marking it ready also triggers review.
+
+These changes do not require merge queues. DisMech's queue enqueueing and
+deterministic candidate-selection policy have not been ported: AIGR retains its
+protected direct-merge policy. The LLM still selects which branches to tend;
+this port makes failed review recovery independent, rather than replacing all
+tending with a deterministic shortlist.
+
+Read-only verification after these changes found #2804 eligible under the full
+closing predicate, including its 41 paths, formal approval, current head,
+mergeability, and CI. A one-day retry audit with a two-PR budget selected #3006
+and #3005, deferred #3008 and #3007 at the budget, and reported no errors. Neither
+audit issued GitHub writes.

--- a/scripts/auto_merge_ready_prs.py
+++ b/scripts/auto_merge_ready_prs.py
@@ -10,7 +10,8 @@ merges when every mechanical guard passes:
 * the aggregate review decision is APPROVED;
 * at least one approval is bound to the exact current PR head;
 * the PR is old enough, conflict-free, and GitHub reports a CLEAN merge state;
-* every changed file is under a conservative content-path allowlist;
+* the changed-file inventory is complete and valid, and any explicitly requested
+  path restriction is satisfied (all paths are eligible by default);
 * every reported check is complete and non-failing, with at least one SUCCESS;
 * every optionally named required check has an explicit SUCCESS result.
 
@@ -73,21 +74,6 @@ VIEW_FIELDS = (
 
 DEFAULT_TRUSTED_REVIEWERS: tuple[str, ...] = ()
 DEFAULT_EXCLUDED_HEAD_PREFIXES = ("auto/generate-",)
-DEFAULT_ALLOWED_PATH_PREFIXES = (
-    "genes/",
-    "genesets/",
-    "gocams/",
-    "interpro/",
-    "modules/",
-    "pages/",
-    "projects/",
-    "publications/",
-    "reactome/",
-    "rules/",
-    "terms/",
-    "families/",
-    "research/",
-)
 MAX_REST_CHANGED_FILES = 3_000
 PASSING_CONCLUSIONS = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
 PASSING_STATES = frozenset({"SUCCESS", "NEUTRAL"})
@@ -364,7 +350,11 @@ def changed_files_decision(
     previous_filenames: list[str] | None = None,
     allowed_path_prefixes: Iterable[str] = (),
 ) -> Decision:
-    """Require every changed file to stay within a conservative content scope."""
+    """Validate the inventory and optionally restrict both sides of renames.
+
+    File paths do not veto approved, green PRs by default. Callers can explicitly
+    opt into a restricted sweep by supplying the complete allowed prefix list.
+    """
     if (
         isinstance(expected_file_count, bool)
         or not isinstance(expected_file_count, int)
@@ -384,12 +374,7 @@ def changed_files_decision(
     previous_filenames = previous_filenames or []
 
     prefixes = tuple(
-        dict.fromkeys(
-            (
-                *DEFAULT_ALLOWED_PATH_PREFIXES,
-                *(prefix.strip() for prefix in allowed_path_prefixes if prefix.strip()),
-            )
-        )
+        dict.fromkeys(prefix.strip() for prefix in allowed_path_prefixes if prefix.strip())
     )
     malformed = [
         path
@@ -427,14 +412,14 @@ def changed_files_decision(
     disallowed = sorted(
         path
         for path in (*changed_files, *previous_filenames)
-        if not any(path.startswith(prefix) for prefix in prefixes)
+        if prefixes and not any(path.startswith(prefix) for prefix in prefixes)
     )
     if disallowed:
         return Decision(
             False,
             "changed files outside the allowed path scope: " + ", ".join(disallowed),
         )
-    return Decision(True, f"{len(changed_files)} changed file(s) in allowed paths")
+    return Decision(True, f"{len(changed_files)} changed file(s) verified")
 
 
 def evaluate(
@@ -884,8 +869,8 @@ def main(argv: list[str] | None = None) -> int:
         type=directory_path_prefix,
         default=[],
         help=(
-            "additional normalized directory prefix allowed by the merge controller; "
-            "must end with '/', repeatable (the conservative defaults always remain)"
+            "restrict merging to this normalized directory prefix; must end with '/', "
+            "repeatable (default: all paths; supplied prefixes define the entire scope)"
         ),
     )
     parser.add_argument(

--- a/scripts/retry_failed_reviews.py
+++ b/scripts/retry_failed_reviews.py
@@ -21,6 +21,14 @@ RETRYABLE = {"failure", "timed_out"}
 REVIEWERS = {"ai4c-reviewer[bot]", "github-actions[bot]"}
 RERUN_WINDOW_DAYS = 30
 STALE_JOBLESS_QUEUE_HOURS = 24
+LOOKUP_ERRORS = (
+    subprocess.SubprocessError,
+    ValueError,
+    KeyError,
+    TypeError,
+    AttributeError,
+    RuntimeError,
+)
 
 
 def timestamp(value):
@@ -49,11 +57,18 @@ def api(path):
     return json.loads(gh("api", path))
 
 
+def object_rows(value):
+    """Reject malformed API collections instead of treating them as empty."""
+    if not isinstance(value, list) or any(not isinstance(row, dict) for row in value):
+        raise TypeError("Expected an API list of objects")
+    return value
+
+
 def pages(path, key=None):
     result = []
     for page in range(1, 1001):
         data = api(f"{path}{'&' if '?' in path else '?'}per_page=100&page={page}")
-        rows = data[key] if key else data
+        rows = object_rows(data[key] if key else data)
         result.extend(rows)
         if len(rows) < 100:
             return result
@@ -98,9 +113,9 @@ def workflow_runs(repo, since, until, status=None, event=None):
         return workflow_runs(repo, since, middle, status, event) + workflow_runs(
             repo, middle, until, status, event
         )
-    rows = first["workflow_runs"]
+    rows = object_rows(first["workflow_runs"])
     for page in range(2, (first["total_count"] + 99) // 100 + 1):
-        rows.extend(api(path + f"&per_page=100&page={page}")["workflow_runs"])
+        rows.extend(object_rows(api(path + f"&per_page=100&page={page}")["workflow_runs"]))
     return rows
 
 
@@ -155,7 +170,7 @@ def resolve_run(run, repo):
     """Bounded, read-only metadata lookup; retain deterministic report order."""
     try:
         return run, run_pr(run, repo), None
-    except (subprocess.SubprocessError, ValueError, KeyError, RuntimeError) as exc:
+    except LOOKUP_ERRORS as exc:
         return run, None, type(exc).__name__
 
 
@@ -191,7 +206,7 @@ def unassociated_active_disposition(run, repo, now):
             f"has no jobs or PR association and no updates for at least "
             f"{STALE_JOBLESS_QUEUE_HOURS} hours. No run was cancelled or retried."
         )
-    except (subprocess.SubprocessError, ValueError, KeyError, TypeError, RuntimeError) as exc:
+    except LOOKUP_ERRORS as exc:
         return False, (
             f"{prefix}: deferred; cannot verify an unassociated active review "
             f"({type(exc).__name__})."
@@ -338,7 +353,7 @@ def sweep(
                     datetime.now(UTC),
                     state,
                 )
-            peers = list(fresh["workflow_runs"])
+            peers = object_rows(fresh["workflow_runs"]).copy()
             blocked_by_unassociated = False
             for peer in {r["id"]: r for r in recent}.values():
                 if peer.get("conclusion") == "skipped":
@@ -381,7 +396,7 @@ def sweep(
                 f"{prefix}: {'would retry' if dry_run else 'retried'} failed jobs "
                 f"(attempt {current.get('run_attempt', 1) + 1})."
             )
-        except (subprocess.SubprocessError, ValueError, KeyError, RuntimeError) as exc:
+        except LOOKUP_ERRORS as exc:
             errors += 1
             rows.append(
                 f"{prefix}: error ({type(exc).__name__}); no further action on this PR."
@@ -501,7 +516,7 @@ def main(argv=None):
             dry_run,
             args.specific_pr,
         )
-    except (subprocess.SubprocessError, ValueError, KeyError, RuntimeError) as exc:
+    except LOOKUP_ERRORS as exc:
         rows, errors = (
             [f"Discovery failed ({type(exc).__name__}); no retries issued."],
             1,

--- a/scripts/retry_failed_reviews.py
+++ b/scripts/retry_failed_reviews.py
@@ -1,0 +1,518 @@
+"""Retry failed review Actions independently of model and merge eligibility.
+
+Only reruns existing failed jobs; never dispatches a new workflow, edits a PR,
+or changes reviews. Uses Actions attempts for persistent backoff. Ported from
+DisMech's independent review recovery controller; no merge-queue dependency.
+The CLI is read-only unless --execute and GH_RETRY_TOKEN are both supplied.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from urllib.parse import urlencode
+
+WORKFLOW = "claude-code-review.yml"
+RETRYABLE = {"failure", "timed_out"}
+REVIEWERS = {"ai4c-reviewer[bot]", "github-actions[bot]"}
+RERUN_WINDOW_DAYS = 30
+STALE_JOBLESS_QUEUE_HOURS = 24
+
+
+def timestamp(value):
+    return datetime.fromisoformat(value)
+
+
+def gh(*args, write=False):
+    env = os.environ.copy()
+    writer = env.pop("GH_RETRY_TOKEN", None)
+    if write and not writer:
+        raise RuntimeError("GH_RETRY_TOKEN is required for review retry writes")
+    if write:
+        env["GH_TOKEN"] = writer
+    result = subprocess.run(
+        ["gh", *args],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=120,
+    )
+    return result.stdout
+
+
+def api(path):
+    return json.loads(gh("api", path))
+
+
+def pages(path, key=None):
+    result = []
+    for page in range(1, 1001):
+        data = api(f"{path}{'&' if '?' in path else '?'}per_page=100&page={page}")
+        rows = data[key] if key else data
+        result.extend(rows)
+        if len(rows) < 100:
+            return result
+    raise RuntimeError("API pagination exceeded 1000 pages")
+
+
+def workflow_runs(repo, since, until, status=None, event=None):
+    """Split search windows to avoid Actions' 1000-result filtered-query cap."""
+    if status is None:
+        # Avoid thousands of skipped comments and successful PR runs. Success
+        # on a PR branch is checked just before retry; manual successes must be
+        # indexed here because their Actions branch is main, not the PR branch.
+        return [
+            run
+            for state in (
+                "failure",
+                "timed_out",
+                "queued",
+                "in_progress",
+                "waiting",
+                "pending",
+                "requested",
+                "cancelled",
+                "action_required",
+            )
+            for run in workflow_runs(repo, since, until, state)
+        ] + [
+            run
+            for trigger in ("workflow_dispatch", "issue_comment")
+            for run in workflow_runs(repo, since, until, "success", trigger)
+        ]
+    params = {"created": f"{since.isoformat()}..{until.isoformat()}", "status": status}
+    if event:
+        params["event"] = event
+    query = urlencode(params)
+    path = f"repos/{repo}/actions/workflows/{WORKFLOW}/runs?{query}"
+    first = api(path + "&per_page=100&page=1")
+    if first["total_count"] > 1000:
+        if (until - since).total_seconds() <= 1:
+            raise RuntimeError("Too many review runs in a one-second window")
+        middle = since + (until - since) / 2
+        return workflow_runs(repo, since, middle, status, event) + workflow_runs(
+            repo, middle, until, status, event
+        )
+    rows = first["workflow_runs"]
+    for page in range(2, (first["total_count"] + 99) // 100 + 1):
+        rows.extend(api(path + f"&per_page=100&page={page}")["workflow_runs"])
+    return rows
+
+
+def run_pr(run, repo):
+    """Use API association or our run-name; recover legacy dispatches from logs.
+
+    Never match PR titles. Legacy manual runs have no PR association in the
+    Actions API, but their trusted guard prints the numeric dispatch input.
+    """
+    prs = run.get("pull_requests", [])
+    if len(prs) == 1:
+        return prs[0]["number"]
+    if run["event"] == "pull_request":
+        # Actions can return an empty association even for PR-triggered runs
+        # (observed after merges). Resolve by commit/ref, never by title.
+        linked = pages(f"repos/{repo}/commits/{run['head_sha']}/pulls")
+        numbers = {
+            p["number"] for p in linked if p["head"]["ref"] == run["head_branch"]
+        }
+        return numbers.pop() if len(numbers) == 1 else None
+    if run["event"] not in {"workflow_dispatch", "issue_comment"}:
+        return None
+    # Legacy PR-event and issue-comment display titles can be arbitrary
+    # contributor text, even if they resemble our new run-name. Dispatches
+    # previously used the fixed workflow name; only they may trust this shape.
+    if run["event"] == "workflow_dispatch":
+        match = re.fullmatch(r"Review PR #(\d+)", run.get("display_title") or "")
+        if match:
+            return int(match[1])
+    jobs = pages(f"repos/{repo}/actions/runs/{run['id']}/jobs", "jobs")
+    for job in jobs:
+        if job["status"] != "completed":
+            continue
+        if job["name"] not in {"dispatch-guard", "claude-review"}:
+            continue
+        log = gh("api", f"repos/{repo}/actions/jobs/{job['id']}/logs")
+        # Match the workflow's env/guard output, not arbitrary agent prose.
+        found = re.findall(r"(?:Dispatched PR #|\bPR_NUMBER: )([0-9]+)", log)
+        numbers = {int(number) for number in found}
+        if len(numbers) == 1:
+            return numbers.pop()
+    return None
+
+
+def delay_hours(attempt, minimum):
+    if minimum == 0:
+        return 0
+    return max(minimum, (1, 6, 24)[min(max(attempt - 1, 0), 2)])
+
+
+def resolve_run(run, repo):
+    """Bounded, read-only metadata lookup; retain deterministic report order."""
+    try:
+        return run, run_pr(run, repo), None
+    except (subprocess.SubprocessError, ValueError, KeyError, RuntimeError) as exc:
+        return run, None, type(exc).__name__
+
+
+def unassociated_active_disposition(run, repo, now):
+    """Return whether an unresolved active record may be ignored, with a reason.
+
+    GitHub can retain old queued issue-comment records with no jobs at all.
+    They must not veto every other PR indefinitely. This exception is only for
+    a queued record with no updates for 24 hours whose exact refreshed record
+    is still unassociated and whose fresh job list is empty. Never cancel or
+    rerun it. Any evidence of actual activity, or any failed lookup, still
+    blocks recovery because we cannot establish which PR is being reviewed.
+    """
+    prefix = f"Run {run['id']}"
+    blocked = f"{prefix}: deferred; active review has no trusted PR association."
+    stale = timedelta(hours=STALE_JOBLESS_QUEUE_HOURS)
+    try:
+        if run["status"] != "queued" or now - timestamp(run["updated_at"]) < stale:
+            return False, blocked
+        current = api(f"repos/{repo}/actions/runs/{run['id']}")
+        if (
+            current["id"] != run["id"]
+            or current["status"] != "queued"
+            or now - timestamp(current["updated_at"]) < stale
+            or current.get("pull_requests") != []
+        ):
+            return False, blocked
+        jobs = pages(f"repos/{repo}/actions/runs/{run['id']}/jobs", "jobs")
+        if jobs:
+            return False, blocked
+        return True, (
+            f"{prefix}: ignored for duplicate suppression; refreshed queued record "
+            f"has no jobs or PR association and no updates for at least "
+            f"{STALE_JOBLESS_QUEUE_HOURS} hours. No run was cancelled or retried."
+        )
+    except (subprocess.SubprocessError, ValueError, KeyError, TypeError, RuntimeError) as exc:
+        return False, (
+            f"{prefix}: deferred; cannot verify an unassociated active review "
+            f"({type(exc).__name__})."
+        )
+
+
+def skip_reason(run, pr, peers, reviews, now, minimum, repo):
+    if run["status"] != "completed" or run["conclusion"] not in RETRYABLE:
+        return "latest attempt is not a failed or timed-out run"
+    if now - timestamp(run["created_at"]) >= timedelta(days=RERUN_WINDOW_DAYS):
+        return "outside GitHub's 30-day rerun window"
+    if run.get("run_attempt", 1) >= 50:
+        return "GitHub's 50-attempt limit reached"
+    if pr["state"] != "open":
+        return "PR is closed"
+    if (pr.get("base", {}).get("repo") or {}).get("full_name", "").casefold() != repo.casefold():
+        return "PR base repository does not match the review repository"
+    if pr["head"]["ref"].startswith("auto/generate-"):
+        return "generated artifacts have a separate review lifecycle"
+    if run["event"] not in {"pull_request", "workflow_dispatch", "issue_comment"}:
+        return "review trigger is outside the supported recovery scope"
+    if run["event"] == "pull_request" and (
+        (pr["head"].get("repo") or {}).get("full_name", "").casefold() != repo.casefold()
+    ):
+        return "automatic review does not support fork PRs"
+    # Existing manual review runs already passed their workflow's dispatch or
+    # trusted-comment gate. Retrying one preserves that authorization, including
+    # the documented workflow_dispatch path for fork PRs.
+    if run["event"] == "pull_request" and run["head_sha"] != pr["head"]["sha"]:
+        return "superseded by a new PR commit"
+    for peer in peers:
+        if peer["id"] == run["id"] or peer.get("conclusion") == "skipped":
+            continue
+        if peer["status"] != "completed":
+            return "another review is queued or running"
+        if peer["event"] == "pull_request" and peer["head_sha"] != pr["head"]["sha"]:
+            continue
+        if timestamp(peer["created_at"]) > timestamp(run["created_at"]):
+            return "a newer review run exists"
+        if peer.get("conclusion") == "success" and timestamp(
+            peer["updated_at"]
+        ) > timestamp(run["updated_at"]):
+            return "another review succeeded after this failure"
+    latest = {}
+    for review in sorted(reviews, key=lambda row: row["id"]):
+        login = (review.get("user") or {}).get("login")
+        if login in REVIEWERS and review["state"] != "COMMENTED":
+            latest[login] = review
+    if any(
+        r["commit_id"] == pr["head"]["sha"]
+        and r["state"] in {"APPROVED", "CHANGES_REQUESTED"}
+        for r in latest.values()
+    ):
+        return "reviewer already submitted a verdict for the current commit"
+    wait = delay_hours(run.get("run_attempt", 1), minimum)
+    if now - timestamp(run["updated_at"]) < timedelta(hours=wait):
+        return f"waiting {wait:g} hours after latest failure"
+    return None
+
+
+def sweep(
+    repo,
+    now,
+    minimum=1,
+    limit=5,
+    lookback=RERUN_WINDOW_DAYS,
+    dry_run=True,
+    specific_pr=None,
+):
+    if limit == 0:
+        return ["Review retries disabled (budget 0)."], 0
+    if not dry_run and not os.environ.get("GH_RETRY_TOKEN"):
+        raise RuntimeError("GH_RETRY_TOKEN is required for --execute")
+    runs = {
+        r["id"]: r for r in workflow_runs(repo, now - timedelta(days=lookback), now)
+    }
+    runs = [r for r in runs.values() if r.get("conclusion") != "skipped"]
+    rows, errors, indexed, unknown_active = [], 0, {}, False
+    # Historic manual runs require separate jobs/log requests. Bound lookup
+    # concurrency so the 30-day census fits the job lifetime. Writes stay serial.
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        resolved = list(pool.map(lambda run: resolve_run(run, repo), runs))
+    for run, number, error in resolved:
+        if error:
+            rows.append(f"Run {run['id']}: cannot resolve PR ({error}).")
+        if number:
+            indexed.setdefault(number, []).append(run)
+        elif run["status"] != "completed":
+            ignored, diagnostic = unassociated_active_disposition(run, repo, now)
+            rows.append(diagnostic)
+            unknown_active = unknown_active or not ignored
+        elif run.get("conclusion") in RETRYABLE:
+            rows.append(f"Run {run['id']}: deferred; PR association unavailable.")
+    if unknown_active:
+        return [
+            *rows,
+            "Retries deferred: an active legacy review cannot yet be associated with a PR.",
+        ], 0
+
+    candidates = sorted(
+        [
+            (r, n)
+            for n, group in indexed.items()
+            for r in [max(group, key=lambda item: item["created_at"])]
+            if r.get("conclusion") in RETRYABLE
+            and (specific_pr is None or n == specific_pr)
+        ],
+        key=lambda pair: pair[0]["updated_at"],
+    )
+    retried = set()
+    for run, number in candidates:
+        if number in retried:
+            continue
+        prefix = f"PR #{number}, run {run['id']}"
+        try:
+            # Refresh the exact attempt and PR before any write. A manual rerun
+            # may already have changed this run to queued since discovery.
+            current = api(f"repos/{repo}/actions/runs/{run['id']}")
+            pr = api(f"repos/{repo}/pulls/{number}")
+            reviews = pages(f"repos/{repo}/pulls/{number}/reviews")
+            reason = skip_reason(current, pr, indexed[number], reviews, now, minimum, repo)
+            if reason:
+                rows.append(f"{prefix}: skipped; {reason}.")
+                continue
+            if len(retried) >= limit:
+                rows.append(f"{prefix}: deferred; retry budget reached.")
+                continue
+            # Recheck branch-triggered runs for pushes/reviews arriving during
+            # this sweep, plus manual runs created since discovery began.
+            # Manual runs execute on the default branch; a fork PR can itself
+            # have a head named main. Only PR events associate by head branch.
+            # Manual peers are associated separately below, never by branch.
+            query = urlencode({
+                "branch": pr["head"]["ref"], "event": "pull_request", "per_page": 100,
+            })
+            fresh = api(f"repos/{repo}/actions/workflows/{WORKFLOW}/runs?{query}")
+            recent = workflow_runs(repo, now, datetime.now(UTC))
+            # An old manual run can be rerun during discovery without changing
+            # created_at. Include active attempts across the full rerun window.
+            for state in ("queued", "in_progress", "waiting", "pending", "requested"):
+                recent += workflow_runs(
+                    repo,
+                    now - timedelta(days=RERUN_WINDOW_DAYS),
+                    datetime.now(UTC),
+                    state,
+                )
+            peers = list(fresh["workflow_runs"])
+            blocked_by_unassociated = False
+            for peer in {r["id"]: r for r in recent}.values():
+                if peer.get("conclusion") == "skipped":
+                    continue
+                peer_number = run_pr(peer, repo)
+                if peer_number == number:
+                    peers.append(peer)
+                elif peer_number is None and peer["status"] != "completed":
+                    ignored, diagnostic = unassociated_active_disposition(peer, repo, now)
+                    if diagnostic not in rows:
+                        rows.append(diagnostic)
+                    if not ignored:
+                        rows.append(
+                            f"{prefix}: deferred; unassociated active review run "
+                            f"{peer['id']} prevents checking for a duplicate review."
+                        )
+                        blocked_by_unassociated = True
+                        break
+            if blocked_by_unassociated:
+                continue
+            current = api(f"repos/{repo}/actions/runs/{run['id']}")
+            pr = api(f"repos/{repo}/pulls/{number}")
+            reviews = pages(f"repos/{repo}/pulls/{number}/reviews")
+            reason = skip_reason(current, pr, peers, reviews, now, minimum, repo)
+            if reason:
+                rows.append(f"{prefix}: skipped; {reason}.")
+                continue
+            if not dry_run:
+                gh(
+                    "run",
+                    "rerun",
+                    str(run["id"]),
+                    "--failed",
+                    "--repo",
+                    repo,
+                    write=True,
+                )
+            retried.add(number)
+            rows.append(
+                f"{prefix}: {'would retry' if dry_run else 'retried'} failed jobs "
+                f"(attempt {current.get('run_attempt', 1) + 1})."
+            )
+        except (subprocess.SubprocessError, ValueError, KeyError, RuntimeError) as exc:
+            errors += 1
+            rows.append(
+                f"{prefix}: error ({type(exc).__name__}); no further action on this PR."
+            )
+    return rows or ["No failed review runs need recovery."], errors
+
+
+def nonnegative(value):
+    number = int(value)
+    if number < 0:
+        raise argparse.ArgumentTypeError("must be nonnegative")
+    return number
+
+
+def render_summary(repo, rows, dry_run, limit):
+    """Make actions prominent without changing sweep decisions."""
+    groups = {
+        "Restarted reviews": [],
+        "Would restart (dry run)": [],
+        "Deferred at retry limit": [],
+        "Errors": [],
+        "Notices": [],
+        "Skipped": [],
+        "PR lookup diagnostics": [],
+    }
+    for row in rows:
+        if ": retried failed jobs" in row:
+            group = "Restarted reviews"
+        elif ": would retry failed jobs" in row:
+            group = "Would restart (dry run)"
+        elif ": deferred; retry budget reached" in row:
+            group = "Deferred at retry limit"
+        elif row.startswith("Run "):
+            group = "PR lookup diagnostics"
+        elif ": skipped;" in row:
+            group = "Skipped"
+        elif ": error (" in row or row.startswith("Discovery failed"):
+            group = "Errors"
+        else:
+            group = "Notices"
+        linked = re.sub(
+            r"\bPR #(\d+)",
+            lambda m: f"[{m[0]}](https://github.com/{repo}/pull/{m[1]})",
+            row,
+        )
+        linked = re.sub(
+            r"\b([Rr]un) (\d+)",
+            lambda m: f"[{m[0]}](https://github.com/{repo}/actions/runs/{m[2]})",
+            linked,
+        )
+        groups[group].append(linked)
+    restarted = len(groups["Restarted reviews"])
+    preview = len(groups["Would restart (dry run)"])
+    if dry_run:
+        lead = f"Dry run: no rerun requests issued; {preview} would restart (limit: {limit})."
+    else:
+        lead = f"Live run: {restarted} rerun requests accepted (limit: {limit})."
+    parts = [
+        "## Review retry sweep",
+        lead,
+        (
+            "Accepted requests restart failed jobs on existing workflow runs; they do not "
+            "mean the reviews have completed or passed."
+        ),
+        (
+            f"{len(groups['Deferred at retry limit'])} PRs deferred at the retry limit. "
+            "They are reconsidered on the next sweep, subject to fresh eligibility checks; "
+            "they have not been queued by this sweep."
+        ),
+    ]
+    for title, items in groups.items():
+        if not items:
+            continue
+        listing = "\n".join(f"- {item}" for item in items)
+        if title == "PR lookup diagnostics":
+            # One unresolved run can produce both an error and a deferral row.
+            listing = (
+                "Messages, not unique PRs or runs; no retry issued for these entries.\n\n"
+                + listing
+            )
+        if title in {"Skipped", "PR lookup diagnostics"}:
+            parts.append(
+                f"<details>\n<summary>{title} ({len(items)} messages)</summary>\n\n"
+                f"{listing}\n\n</details>"
+            )
+        else:
+            parts.append(f"### {title} ({len(items)})\n\n{listing}")
+    return "\n\n".join(parts) + "\n"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--min-delay-hours", type=nonnegative, default=1)
+    parser.add_argument("--max-retries", type=nonnegative, default=5)
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        choices=range(1, RERUN_WINDOW_DAYS + 1),
+        default=RERUN_WINDOW_DAYS,
+    )
+    parser.add_argument("--specific-pr", type=int)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="report only (the default)")
+    mode.add_argument("--execute", action="store_true", help="rerun eligible failed jobs")
+    args = parser.parse_args(argv)
+    dry_run = not args.execute
+    if args.execute and not os.environ.get("GH_RETRY_TOKEN"):
+        parser.error("--execute requires GH_RETRY_TOKEN; refusing to use discovery credentials")
+    try:
+        rows, errors = sweep(
+            args.repo,
+            datetime.now(UTC),
+            args.min_delay_hours,
+            args.max_retries,
+            args.lookback_days,
+            dry_run,
+            args.specific_pr,
+        )
+    except (subprocess.SubprocessError, ValueError, KeyError, RuntimeError) as exc:
+        rows, errors = (
+            [f"Discovery failed ({type(exc).__name__}); no retries issued."],
+            1,
+        )
+    summary = render_summary(args.repo, rows, dry_run, args.max_retries)
+    print(summary)
+    if os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as stream:
+            stream.write(summary)
+    return int(bool(errors))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_auto_merge_ready_prs.py
+++ b/tests/test_auto_merge_ready_prs.py
@@ -373,54 +373,69 @@ def test_recorded_stale_base_does_not_block_an_independent_pr():
 # Changed-file path scope
 
 
-def test_default_allowed_path_prefixes_are_the_conservative_content_set():
-    assert auto_merge.DEFAULT_ALLOWED_PATH_PREFIXES == (
-        "genes/",
-        "genesets/",
-        "gocams/",
-        "interpro/",
-        "modules/",
-        "pages/",
-        "projects/",
-        "publications/",
-        "reactome/",
-        "rules/",
-        "terms/",
-        "families/",
-        "research/",
-    )
-
-
-def test_allowed_path_canary_mix_is_eligible():
-    canaries = [
-        f"{prefix}path-canary.yaml"
-        for prefix in auto_merge.DEFAULT_ALLOWED_PATH_PREFIXES
+def test_pr_2804_style_curation_with_shared_go_cache_is_eligible():
+    # Representative paths from PR #2804: its cache update was the sole scope veto.
+    files = [
+        "cache/go/terms.csv",
+        "genes/PSEPK/PP_0075/PP_0075-ai-review.yaml",
+        "genes/PSEPK/PP_0076/PP_0076-ai-review.html",
+        "genes/PSEPK/betC/betC-notes.md",
+        "modules/bacterial_choline_o_sulfate_uptake_and_desulfation.yaml",
+        "pages/modules/bacterial_choline_o_sulfate_uptake_and_desulfation.html",
+        "projects/P_PUTIDA/batches/choline_o_sulfate_uptake_desulfation.md",
+        "publications/PMID_17116241.md",
     ]
-    assert decide(make_pr(changedFiles=len(canaries), changed_files=canaries)).eligible
+    assert decide(
+        make_pr(number=2804, changedFiles=len(files), changed_files=files),
+        required_checks=[REQUIRED_CHECK],
+    ).eligible
+
+
+def test_curation_history_is_eligible_with_its_curated_content():
+    files = [
+        "genes/human/EXAMPLE/EXAMPLE-ai-review.yaml",
+        "history/genes/human/EXAMPLE/session.yaml",
+        "modules/example.yaml",
+        "history/modules/example/session.yaml",
+        "gocams/example/example-review.yaml",
+        "history/gocams/example/session.yaml",
+        "projects/EXAMPLE.md",
+        "history/projects/EXAMPLE/session.yaml",
+    ]
+    assert decide(make_pr(changedFiles=len(files), changed_files=files)).eligible
 
 
 @pytest.mark.parametrize(
-    "disallowed",
+    "path",
     [
         ".github/workflows/main.yaml",
         "scripts/release.py",
         "src/ai_gene_review/cli.py",
+        "docs/policy.md",
         "pyproject.toml",
+        "cache/go/terms.csv",
+        "cache/go/other.csv",
+        "cache/go/terms.csv.bak",
+        "cache/go/terms.csv/nested.yaml",
+        "cache/go/terms.csv-malicious",
+        "cache/other/terms.csv",
+        "history/schema/session.yaml",
+        "history/other/session.yaml",
+        "history/session.yaml",
+        "history/genes-other/session.yaml",
     ],
 )
-def test_one_disallowed_path_vetoes_otherwise_allowed_changes(disallowed):
+def test_default_scope_accepts_all_normalized_repo_paths(path):
     decision = decide(
         make_pr(
             changedFiles=2,
             changed_files=[
                 "genes/human/EXAMPLE/EXAMPLE-ai-review.yaml",
-                disallowed,
+                path,
             ],
         )
     )
-    assert not decision.eligible
-    assert "outside the allowed path scope" in decision.reason
-    assert disallowed in decision.reason
+    assert decision.eligible
 
 
 @pytest.mark.parametrize("changed_files", [None, [], [None], [""], [{}]])
@@ -431,13 +446,24 @@ def test_missing_empty_or_malformed_changed_files_fail_closed(changed_files):
     assert "file" in decision.reason
 
 
-def test_additional_path_prefix_expands_without_replacing_defaults():
+def test_explicit_path_prefixes_define_the_entire_optional_scope():
     pr = make_pr(
         changedFiles=2,
         changed_files=["genes/human/EXAMPLE/review.yaml", "docs/policy.md"],
     )
-    assert not decide(pr).eligible
-    assert decide(pr, allowed_path_prefixes=["docs/"]).eligible
+    assert decide(pr).eligible
+    restricted = decide(pr, allowed_path_prefixes=["docs/"])
+    assert not restricted.eligible
+    assert "outside the allowed path scope" in restricted.reason
+    assert "genes/human/EXAMPLE/review.yaml" in restricted.reason
+    assert decide(pr, allowed_path_prefixes=["docs/", "genes/"]).eligible
+
+
+@pytest.mark.parametrize("path", ["genes-other/review.yaml", "genes.md"])
+def test_explicit_path_prefix_requires_a_directory_boundary(path):
+    decision = decide(make_pr(changed_files=[path]), allowed_path_prefixes=["genes/"])
+    assert not decision.eligible
+    assert path in decision.reason
 
 
 @pytest.mark.parametrize("count", [None, True, 0, -1, "1"])
@@ -483,6 +509,9 @@ def test_duplicate_rest_filenames_fail_closed():
         "genes\\human\\review.yaml",
         "genes/human/review.yaml\n.github/workflows/main.yaml",
         " genes/human/review.yaml",
+        "cache/go/./terms.csv",
+        "cache/go/terms.csv ",
+        "history/genes/../../schema/session.yaml",
     ],
 )
 def test_non_normalized_repo_paths_fail_closed(path):
@@ -491,18 +520,47 @@ def test_non_normalized_repo_paths_fail_closed(path):
     assert "non-normalized changed-file path" in decision.reason
 
 
-def test_rename_source_path_is_also_within_the_perimeter():
+def test_default_scope_accepts_renames_across_repo_directories():
     moved_from_infrastructure = make_pr(
         changed_files=["genes/human/EXAMPLE/moved.yaml"],
         previous_changed_filenames=[".github/workflows/main.yaml"],
     )
-    assert not decide(moved_from_infrastructure).eligible
+    assert decide(moved_from_infrastructure).eligible
+    assert not decide(
+        moved_from_infrastructure, allowed_path_prefixes=["genes/"]
+    ).eligible
     assert decide(
         make_pr(
             changed_files=["genes/human/EXAMPLE/new.yaml"],
             previous_changed_filenames=["genes/human/EXAMPLE/old.yaml"],
-        )
+        ),
+        allowed_path_prefixes=["genes/"],
     ).eligible
+
+
+@pytest.mark.parametrize(
+    ("prefix", "allowed", "disallowed"),
+    [
+        ("cache/go/", "cache/go/terms.csv", "cache/other/terms.csv"),
+        (
+            "history/genes/",
+            "history/genes/human/EXAMPLE/session.yaml",
+            "history/schema/session.yaml",
+        ),
+        ("genes/", "genes/human/EXAMPLE/review.yaml", ".github/workflows/main.yaml"),
+    ],
+)
+@pytest.mark.parametrize("rename_into_allowed_scope", [False, True])
+def test_explicit_scope_checks_both_rename_paths(
+    prefix, allowed, disallowed, rename_into_allowed_scope
+):
+    old, new = (disallowed, allowed) if rename_into_allowed_scope else (allowed, disallowed)
+    decision = decide(
+        make_pr(changed_files=[new], previous_changed_filenames=[old]),
+        allowed_path_prefixes=[prefix],
+    )
+    assert not decision.eligible
+    assert disallowed in decision.reason
 
 
 # Check rollup and named required checks
@@ -1084,14 +1142,20 @@ def test_hold_added_after_verification_blocks_execute(monkeypatch, tmp_path):
     assert "state changed after verification: held by label" in summary
 
 
-def test_disallowed_path_added_on_second_read_blocks_execute(monkeypatch, tmp_path):
+def test_explicit_path_scope_is_enforced_again_on_second_read(monkeypatch, tmp_path):
     initial = make_pr(number=42)
     changed = make_pr(number=42, changed_files=["scripts/new_release.py"])
     code, merges, summary = _run_main(
         monkeypatch,
         tmp_path,
         views=[initial, changed],
-        args=("--execute", "--required-check", REQUIRED_CHECK),
+        args=(
+            "--execute",
+            "--required-check",
+            REQUIRED_CHECK,
+            "--allowed-path-prefix",
+            "genes/",
+        ),
     )
     assert code == 0
     assert merges == []
@@ -1156,7 +1220,17 @@ def test_head_movement_during_final_file_read_is_a_benign_skip(monkeypatch, tmp_
     assert "head moved during the file-list read" in summary
 
 
-def test_allowed_path_cli_extension_preserves_default_paths(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("path_args", "eligible"),
+    [
+        ((), True),
+        (("--allowed-path-prefix", "docs/"), False),
+        (("--allowed-path-prefix", "docs/", "--allowed-path-prefix", "genes/"), True),
+    ],
+)
+def test_allowed_path_cli_is_an_optional_restriction(
+    monkeypatch, tmp_path, path_args, eligible
+):
     view = make_pr(
         number=42,
         changedFiles=2,
@@ -1166,11 +1240,14 @@ def test_allowed_path_cli_extension_preserves_default_paths(monkeypatch, tmp_pat
         monkeypatch,
         tmp_path,
         view=view,
-        args=("--dry-run", "--allowed-path-prefix", "docs/"),
+        args=("--dry-run", *path_args),
     )
     assert code == 0
     assert merges == []
-    assert "Would merge 1" in summary
+    assert ("Would merge 1" in summary) is eligible
+    if not eligible:
+        assert "outside the allowed path scope" in summary
+        assert "genes/human/EXAMPLE/review.yaml" in summary
 
 
 def test_execute_and_dry_run_are_mutually_exclusive(monkeypatch):

--- a/tests/test_pr_shepherd_workflow.py
+++ b/tests/test_pr_shepherd_workflow.py
@@ -1,10 +1,12 @@
 """Security contracts for the deterministic PR Shepherd closing pass."""
 
 import re
+import os
 import subprocess
 from pathlib import Path
 
 import yaml
+import pytest
 
 
 ROOT = Path(__file__).parents[1]
@@ -49,6 +51,101 @@ def test_merge_controller_is_a_separate_job_with_trusted_checkout():
     assert checkout["with"]["ref"] == "${{ github.event.repository.default_branch }}"
     assert checkout["with"]["token"] == "${{ github.token }}"
     assert checkout["with"]["persist-credentials"] is False
+
+
+def test_review_recovery_has_an_independent_runner_budget_and_credential():
+    workflow = _workflow(SHEPHERD)
+    jobs = workflow["jobs"]
+    assert "concurrency" not in workflow
+    assert len({job["concurrency"]["group"] for job in jobs.values()}) == len(jobs)
+    retry = jobs["retry-reviews"]
+    assert "needs" not in retry
+    assert "run_agent" not in retry["if"]
+    assert "merge_mode" not in retry["if"]
+    assert retry["permissions"] == {
+        "contents": "read",
+        "actions": "read",
+        "pull-requests": "read",
+    }
+    assert retry["env"]["RETRY_LIMIT"] == "${{ inputs.max_review_retries || '5' }}"
+    checkout = _step(retry, "Checkout trusted default branch")
+    assert checkout["with"]["ref"] == "${{ github.event.repository.default_branch }}"
+    assert checkout["with"]["persist-credentials"] is False
+    assert not any("claude-code-action" in use for use in _action_uses(retry))
+    token = _step(retry, "Generate scoped retry token")
+    assert "env.RETRY_MODE == 'execute'" in token["if"]
+    assert "env.RETRY_LIMIT != '0'" in token["if"]
+    assert {k: v for k, v in token["with"].items() if k.startswith("permission-")} == {
+        "permission-actions": "write"
+    }
+    run = _step(retry, "Retry failed reviews (deterministic)")
+    assert run["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert run["env"]["GH_RETRY_TOKEN"] == "${{ steps.retry-token.outputs.token }}"
+    inputs = workflow[True]["workflow_dispatch"]["inputs"]
+    assert inputs["review_retry_mode"]["default"] == "audit"
+
+
+@pytest.mark.parametrize(
+    ("mode", "limit", "pr", "expected_mode"),
+    [
+        ("audit", "5", "2804", "--dry-run"),
+        ("execute", "5", "", "--execute"),
+        ("execute", "0", "", "--dry-run"),
+    ],
+)
+def test_retry_workflow_invokes_explicit_modes(
+    tmp_path, mode, limit, pr, expected_mode
+):
+    """Exercise the actual shell so zero budgets and audit cannot issue writes."""
+    retry = _workflow(SHEPHERD)["jobs"]["retry-reviews"]
+    script = _step(retry, "Retry failed reviews (deterministic)")["run"]
+    uv = tmp_path / "uv"
+    uv.write_text('#!/bin/sh\nprintf "%s\\n" "$@"\n')
+    uv.chmod(0o755)
+    env = dict(
+        os.environ,
+        PATH=f"{tmp_path}:{os.environ['PATH']}",
+        RETRY_MODE=mode,
+        RETRY_LIMIT=limit,
+        RETRY_DELAY="1",
+        SPECIFIC_PR=pr,
+        GITHUB_REPOSITORY="ai4curation/ai-gene-review",
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], env=env, text=True, capture_output=True, check=True
+    )
+    args = result.stdout.splitlines()
+    assert expected_mode in args
+    assert ("--execute" in args) != ("--dry-run" in args)
+    assert args[args.index("--max-retries") + 1] == limit
+    assert ("--specific-pr" in args) == bool(pr)
+
+
+def test_review_triggers_share_one_lane_without_comment_cancellation():
+    workflow = _workflow(CLAUDE_REVIEW)
+    assert workflow["run-name"].startswith("Review PR #")
+    assert {"opened", "synchronize", "reopened", "ready_for_review"} <= set(
+        workflow[True]["pull_request"]["types"]
+    )
+    group = workflow["concurrency"]["group"]
+    assert "claude-review-${{ github.event_name }}" not in group
+    assert "github.event.comment.body == '/review'" in group
+    assert "github.event.comment.author_association" in group
+    assert "format('ignored-{0}', github.run_id)" in group
+    assert workflow["concurrency"]["cancel-in-progress"] is True
+
+
+def test_agent_scope_includes_maintainer_codex_branches_without_retry_overlap():
+    prompt = _step(_workflow(SHEPHERD)["jobs"]["shepherd"], "Run PR Shepherd")["with"][
+        "prompt"
+    ]
+    assert "`codex/`" in prompt
+    assert "gh pr list --limit 1000" in prompt
+    assert "Never modify human-authored PRs." not in prompt
+    assert "SPECIFIC_PR does not bypass" in prompt
+    assert "independent deterministic retry-reviews" in prompt
+    assert "Do not rerun them or dispatch replacements here" in prompt
+    assert "Failed runs outside the 30-day window or at the 50-attempt limit" in prompt
 
 
 def test_audit_and_execute_have_literal_modes_and_distinct_tokens():

--- a/tests/test_pr_shepherd_workflow.py
+++ b/tests/test_pr_shepherd_workflow.py
@@ -83,6 +83,12 @@ def test_review_recovery_has_an_independent_runner_budget_and_credential():
     assert run["env"]["GH_RETRY_TOKEN"] == "${{ steps.retry-token.outputs.token }}"
     inputs = workflow[True]["workflow_dispatch"]["inputs"]
     assert inputs["review_retry_mode"]["default"] == "audit"
+    retry_mode = retry["env"]["RETRY_MODE"]
+    assert (
+        "vars.PR_SHEPHERD_RETRY_ENABLED == 'false' && 'audit' || 'execute'"
+        in retry_mode
+    )
+    assert "inputs.review_retry_mode || 'audit'" in retry_mode
 
 
 @pytest.mark.parametrize(
@@ -133,6 +139,26 @@ def test_review_triggers_share_one_lane_without_comment_cancellation():
     assert "github.event.comment.author_association" in group
     assert "format('ignored-{0}', github.run_id)" in group
     assert workflow["concurrency"]["cancel-in-progress"] is True
+
+
+def test_review_comment_authorization_matches_the_concurrency_lane():
+    """Changing comment authorization must also change its cancellation lane."""
+    workflow = _workflow(CLAUDE_REVIEW)
+    predicate = """github.event.issue.pull_request != null &&
+        github.event.comment.body == '/review' &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                 github.event.comment.author_association)"""
+
+    # Compare normalized tokens, including the entire role list and exact
+    # comment match, so neither predicate can acquire an extra/missing guard.
+    def tokens(value):
+        return re.sub(r"\s+", "", value)
+
+    concurrency = tokens(workflow["concurrency"]["group"])
+    job_condition = tokens(workflow["jobs"]["claude-review"]["if"])
+    shared = tokens(predicate)
+    assert f"!({shared})" in concurrency
+    assert f"github.event_name=='issue_comment'&&{shared})" in job_condition
 
 
 def test_agent_scope_includes_maintainer_codex_branches_without_retry_overlap():
@@ -196,6 +222,7 @@ def test_execute_is_feature_gated_main_only_and_narrowly_scoped():
     assert permissions == {
         "permission-contents": "write",
         "permission-pull-requests": "write",
+        "permission-workflows": "write",
     }
     assert "permission-issues" not in token["with"]
     assert "|| github.token" not in str(token)

--- a/tests/test_retry_failed_reviews.py
+++ b/tests/test_retry_failed_reviews.py
@@ -1,0 +1,602 @@
+"""Exercise retry writes, backoff, supersession and workflow isolation."""
+
+import importlib.util
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "retry_reviews", ROOT / "scripts/retry_failed_reviews.py"
+)
+retry = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(retry)
+NOW = datetime(2026, 9, 6, 12, tzinfo=UTC)
+
+
+def run(**overrides):
+    row = {
+        "id": 20,
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "failure",
+        "head_sha": "abc",
+        "run_attempt": 1,
+        "pull_requests": [{"number": 7}],
+        "created_at": (NOW - timedelta(hours=5)).isoformat(),
+        "updated_at": (NOW - timedelta(hours=2)).isoformat(),
+    }
+    return row | overrides
+
+
+def pr(**overrides):
+    # These are deliberately the opposite of merge eligibility.
+    return {
+        "state": "open",
+        "draft": True,
+        "user": {"login": "human"},
+        "assignees": [{"login": "human"}],
+        "base": {"repo": {"full_name": "owner/repo"}},
+        "head": {"sha": "abc", "ref": "feature", "repo": {"full_name": "owner/repo"}},
+    } | overrides
+
+
+def reason(row=None, pull=None, peers=(), reviews=()):
+    return retry.skip_reason(row or run(), pull or pr(), peers, reviews, NOW, 1, "owner/repo")
+
+
+def test_human_owned_assigned_draft_can_be_retried():
+    assert reason() is None
+
+
+@pytest.mark.parametrize(
+    "attempt,hours,eligible",
+    [
+        (1, 0.5, False),
+        (1, 1, True),
+        (2, 5, False),
+        (2, 6, True),
+        (3, 23, False),
+        (3, 24, True),
+        (8, 24, True),
+    ],
+)
+def test_backoff_uses_latest_attempt_completion(attempt, hours, eligible):
+    row = run(
+        run_attempt=attempt, updated_at=(NOW - timedelta(hours=hours)).isoformat()
+    )
+    assert (reason(row) is None) == eligible
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"status": "queued", "conclusion": None},
+        {"status": "in_progress", "conclusion": None},
+        {"conclusion": "success"},
+        {"conclusion": "cancelled"},
+        {"conclusion": "skipped"},
+        {"run_attempt": 50},
+        {"created_at": (NOW - timedelta(days=30)).isoformat()},
+        {"head_sha": "old"},
+    ],
+)
+def test_ineligible_attempts_are_not_retried(changes):
+    assert reason(run(**changes))
+
+
+def test_closed_pr_and_superseding_reviews():
+    assert reason(pull=pr(state="closed"))
+    assert reason(peers=[run(id=21, status="in_progress", conclusion=None)])
+    assert reason(peers=[run(id=21, created_at=(NOW - timedelta(hours=1)).isoformat())])
+    assert reason(peers=[run(id=21, conclusion="success", updated_at=NOW.isoformat())])
+    assert reason(peers=[run(id=21, conclusion="skipped")]) is None
+
+
+@pytest.mark.parametrize("state", ["APPROVED", "CHANGES_REQUESTED"])
+def test_current_bot_verdict_stops_retry_but_old_verdict_does_not(state):
+    review = {
+        "id": 1,
+        "user": {"login": "ai4c-reviewer[bot]"},
+        "state": state,
+        "commit_id": "abc",
+    }
+    assert reason(reviews=[review])
+    assert reason(reviews=[review | {"commit_id": "old"}]) is None
+    assert reason(reviews=[review | {"state": "DISMISSED"}]) is None
+
+
+def test_manual_run_is_rerunnable_despite_main_sha():
+    assert reason(run(event="workflow_dispatch", head_sha="main-sha")) is None
+
+
+@pytest.mark.parametrize("event", ["pull_request", "workflow_dispatch", "issue_comment"])
+def test_generated_artifacts_are_not_retried(event):
+    generated = pr(head=pr()["head"] | {"ref": "auto/generate-project-pages"})
+    assert "generated artifacts" in reason(run(event=event), generated)
+
+
+def test_automatic_fork_review_is_excluded_but_existing_manual_review_is_authorized():
+    fork = pr(head=pr()["head"] | {"repo": {"full_name": "contributor/fork"}})
+    assert "fork PRs" in reason(pull=fork)
+    assert reason(run(event="workflow_dispatch", head_sha="main-sha"), fork) is None
+    assert reason(run(event="issue_comment", head_sha="main-sha"), fork) is None
+
+
+def test_missing_or_wrong_repository_metadata_fails_closed():
+    assert reason(pull=pr(base={"repo": {"full_name": "other/repo"}}))
+    assert reason(pull=pr(base={}))
+    assert reason(pull=pr(head=pr()["head"] | {"repo": None}))
+
+
+def harness(monkeypatch, rows=None, current=None, reviews=None, fresh=None):
+    rows = rows or [run()]
+    writes = []
+    monkeypatch.setenv("GH_RETRY_TOKEN", "writer")
+    monkeypatch.setattr(retry, "workflow_runs", lambda *args: list(rows))
+    monkeypatch.setattr(retry, "pages", lambda *args: reviews or [])
+
+    def read(path):
+        if "/actions/runs/" in path:
+            return current or next(r for r in rows if path.endswith(str(r["id"])))
+        if "/pulls/" in path:
+            repo = path.split("/pulls/")[0].removeprefix("repos/")
+            return pr(
+                base={"repo": {"full_name": repo}},
+                head={"sha": "abc", "ref": "feature", "repo": {"full_name": repo}},
+            )
+        if "/workflows/" in path:
+            return {"workflow_runs": fresh or rows}
+        raise AssertionError(path)
+
+    monkeypatch.setattr(retry, "api", read)
+    monkeypatch.setattr(
+        retry, "gh", lambda *args, **kwargs: writes.append((args, kwargs))
+    )
+    return writes
+
+
+def test_sweep_issues_exact_failed_job_rerun(monkeypatch):
+    writes = harness(monkeypatch)
+    rows, errors = retry.sweep("owner/repo", NOW, dry_run=False)
+    assert errors == 0
+    assert writes == [
+        (("run", "rerun", "20", "--failed", "--repo", "owner/repo"), {"write": True})
+    ]
+    assert "retried failed jobs" in rows[0]
+
+
+@pytest.mark.parametrize(
+    "kwargs", [{"dry_run": True}, {"limit": 0}, {"specific_pr": 8}]
+)
+def test_dry_run_zero_budget_and_specific_pr_never_write(monkeypatch, kwargs):
+    writes = harness(monkeypatch)
+    retry.sweep("owner/repo", NOW, **({"dry_run": False} | kwargs))
+    assert not writes
+
+
+def test_manual_retry_started_since_discovery_is_left_alone(monkeypatch):
+    writes = harness(
+        monkeypatch, current=run(status="queued", conclusion=None, run_attempt=2)
+    )
+    retry.sweep("owner/repo", NOW, dry_run=False)
+    assert not writes
+
+
+def test_new_review_arriving_during_sweep_prevents_retry(monkeypatch):
+    writes = harness(
+        monkeypatch, fresh=[run(id=30, status="in_progress", conclusion=None)]
+    )
+    retry.sweep("owner/repo", NOW, dry_run=False)
+    assert not writes
+
+
+def test_only_latest_failure_retried_once_per_pr(monkeypatch):
+    old = run(
+        id=10,
+        created_at=(NOW - timedelta(days=1)).isoformat(),
+        updated_at=(NOW - timedelta(hours=8)).isoformat(),
+    )
+    writes = harness(monkeypatch, rows=[old, run()])
+    retry.sweep("owner/repo", NOW, dry_run=False)
+    assert len(writes) == 1
+    assert writes[0][0][2] == "20"
+
+
+def test_read_failure_does_not_retry(monkeypatch):
+    writes = harness(monkeypatch)
+
+    def fail(path):
+        raise subprocess.CalledProcessError(1, ["gh"])
+
+    monkeypatch.setattr(retry, "api", fail)
+    rows, errors = retry.sweep("owner/repo", NOW, dry_run=False)
+    assert not writes and errors == 1
+    assert "error" in rows[0]
+
+
+def test_exhausted_run_does_not_spend_retry_budget(monkeypatch):
+    exhausted = run(
+        id=10,
+        pull_requests=[{"number": 8}],
+        run_attempt=50,
+        updated_at=(NOW - timedelta(days=2)).isoformat(),
+    )
+    writes = harness(monkeypatch, rows=[exhausted, run()])
+    rows, errors = retry.sweep("owner/repo", NOW, limit=1, dry_run=False)
+    assert errors == 0
+    assert "50-attempt limit" in rows[0]
+    assert len(writes) == 1 and writes[0][0][2] == "20"
+
+
+def test_failed_rerun_request_does_not_spend_successful_retry_capacity(monkeypatch):
+    older = run(
+        id=10,
+        pull_requests=[{"number": 8}],
+        updated_at=(NOW - timedelta(hours=8)).isoformat(),
+    )
+    harness(monkeypatch, rows=[older, run()])
+    attempted = []
+
+    def rerun(*args, **kwargs):
+        attempted.append(args[2])
+        if args[2] == "10":
+            raise subprocess.CalledProcessError(1, ["gh"])
+
+    monkeypatch.setattr(retry, "gh", rerun)
+    rows, errors = retry.sweep("owner/repo", NOW, limit=1, dry_run=False)
+    assert errors == 1
+    assert attempted == ["10", "20"]
+    assert any("PR #7, run 20: retried" in row for row in rows)
+
+
+def test_resolve_dispatch_and_legacy_dispatch(monkeypatch):
+    assert (
+        retry.run_pr(
+            run(event="workflow_dispatch", pull_requests=[], display_title="Review PR #42"),
+            "o/r",
+        ) == 42
+    )
+    monkeypatch.setattr(
+        retry,
+        "pages",
+        lambda *args: [{"id": 99, "name": "dispatch-guard", "status": "completed"}],
+    )
+    monkeypatch.setattr(
+        retry,
+        "gh",
+        lambda *args: "2026-09-06 Dispatched PR #7: head_ref='feature' author='human'",
+    )
+    assert retry.run_pr(run(event="workflow_dispatch", pull_requests=[]), "o/r") == 7
+
+
+def test_legacy_aigr_dispatch_resolves_from_pr_number_environment(monkeypatch):
+    monkeypatch.setattr(
+        retry, "pages",
+        lambda *args: [{"id": 99, "name": "claude-review", "status": "completed"}],
+    )
+    monkeypatch.setattr(retry, "gh", lambda *args: "2026-09-06T12:00:00Z   PR_NUMBER: 2804")
+    assert retry.run_pr(run(event="workflow_dispatch", pull_requests=[]), "o/r") == 2804
+
+
+def test_legacy_comment_title_cannot_override_numeric_workflow_input(monkeypatch):
+    monkeypatch.setattr(
+        retry, "pages",
+        lambda *args: [{"id": 99, "name": "claude-review", "status": "completed"}],
+    )
+    monkeypatch.setattr(retry, "gh", lambda *args: "2026-09-06T12:00:00Z   PR_NUMBER: 2804")
+    row = run(event="issue_comment", pull_requests=[], display_title="Review PR #999")
+    assert retry.run_pr(row, "o/r") == 2804
+    monkeypatch.setattr(retry, "gh", lambda *args: "no trustworthy association")
+    assert retry.run_pr(row, "o/r") is None
+
+
+def test_unresolved_active_legacy_run_defers_without_duplicate_writes(monkeypatch):
+    writes = harness(
+        monkeypatch,
+        rows=[run(), run(id=30, pull_requests=[], status="queued", conclusion=None)],
+    )
+    rows, _ = retry.sweep("o/r", NOW, dry_run=False)
+    assert not writes
+    assert "active legacy review" in rows[-1]
+
+
+def stale_queue(**overrides):
+    return run(
+        id=30,
+        event="issue_comment",
+        status="queued",
+        conclusion=None,
+        pull_requests=[],
+        updated_at=(NOW - timedelta(days=2)).isoformat(),
+    ) | overrides
+
+
+@pytest.mark.parametrize("during_discovery", [False, True])
+def test_stale_jobless_unassociated_queue_does_not_starve_known_pr(monkeypatch, during_discovery):
+    queued = stale_queue()
+    writes = harness(monkeypatch, rows=[run(), queued], fresh=[run()])
+    if during_discovery:
+        calls = []
+
+        def discovered(*args):
+            calls.append(args)
+            return [run()] if len(calls) == 1 else [queued]
+
+        monkeypatch.setattr(retry, "workflow_runs", discovered)
+    rows, errors = retry.sweep("owner/repo", NOW, dry_run=False)
+    assert errors == 0
+    assert len(writes) == 1 and writes[0][0][2] == "20"
+    assert sum("ignored for duplicate suppression" in row for row in rows) == 1
+    assert any("No run was cancelled or retried" in row for row in rows)
+
+
+@pytest.mark.parametrize(
+    "changes,jobs",
+    [
+        ({"updated_at": (NOW - timedelta(hours=23)).isoformat()}, []),
+        ({"status": "in_progress"}, []),
+        ({"status": "waiting"}, []),
+        ({"status": "pending"}, []),
+        ({"pull_requests": [{"number": 7}]}, []),
+        ({}, [{"id": 50, "status": "queued"}]),
+        ({}, [{"id": 50, "status": "completed"}]),
+    ],
+)
+def test_stale_queue_refresh_activity_still_blocks(monkeypatch, changes, jobs):
+    calls = []
+
+    def current(path):
+        calls.append(path)
+        return stale_queue(**changes)
+
+    monkeypatch.setattr(retry, "api", current)
+    monkeypatch.setattr(retry, "pages", lambda *args: jobs)
+    ignored, diagnostic = retry.unassociated_active_disposition(stale_queue(), "owner/repo", NOW)
+    assert not ignored and "deferred" in diagnostic
+    assert calls == ["repos/owner/repo/actions/runs/30"]
+
+
+@pytest.mark.parametrize("lookup", ["api", "pages"])
+def test_stale_queue_refresh_read_failure_still_blocks(monkeypatch, lookup):
+    monkeypatch.setattr(retry, "api", lambda *args: stale_queue())
+    monkeypatch.setattr(retry, "pages", lambda *args: [])
+
+    def fail(*args):
+        raise subprocess.CalledProcessError(1, ["gh"])
+
+    monkeypatch.setattr(retry, lookup, fail)
+    ignored, diagnostic = retry.unassociated_active_disposition(stale_queue(), "owner/repo", NOW)
+    assert not ignored and "cannot verify" in diagnostic
+
+
+def test_recent_unassociated_queue_during_final_scan_has_explicit_deferral(monkeypatch):
+    queued = stale_queue(updated_at=NOW.isoformat())
+    writes = harness(monkeypatch, rows=[run(), queued], fresh=[run()])
+    calls = []
+
+    def discovered(*args):
+        calls.append(args)
+        return [run()] if len(calls) == 1 else [queued]
+
+    monkeypatch.setattr(retry, "workflow_runs", discovered)
+    rows, errors = retry.sweep("owner/repo", NOW, dry_run=False)
+    assert not writes and errors == 0
+    assert any("unassociated active review run 30" in row for row in rows)
+    assert not any("RuntimeError" in row for row in rows)
+
+
+def test_writer_token_only_reaches_rerun(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "reader")
+    monkeypatch.setenv("GH_RETRY_TOKEN", "writer")
+    environments = []
+
+    def execute(args, **kwargs):
+        environments.append(kwargs["env"])
+        return subprocess.CompletedProcess(args, 0, stdout="{}")
+
+    monkeypatch.setattr(retry.subprocess, "run", execute)
+    retry.gh("api", "some/path")
+    retry.gh("run", "rerun", "20", "--failed", write=True)
+    assert [env["GH_TOKEN"] for env in environments] == ["reader", "writer"]
+    assert all("GH_RETRY_TOKEN" not in env for env in environments)
+
+
+def test_write_never_falls_back_to_discovery_credentials(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "reader")
+    monkeypatch.delenv("GH_RETRY_TOKEN", raising=False)
+    monkeypatch.setattr(retry.subprocess, "run", lambda *args, **kwargs: pytest.fail("subprocess ran"))
+    with pytest.raises(RuntimeError, match="GH_RETRY_TOKEN"):
+        retry.gh("run", "rerun", "20", "--failed", write=True)
+
+
+def test_pr_event_with_empty_association_resolves_by_commit_and_branch(monkeypatch):
+    monkeypatch.setattr(
+        retry,
+        "pages",
+        lambda path: [
+            {"number": 7, "head": {"ref": "feature"}},
+            {"number": 8, "head": {"ref": "different"}},
+        ],
+    )
+    assert retry.run_pr(run(pull_requests=[], head_branch="feature"), "o/r") == 7
+    assert retry.run_pr(
+        run(pull_requests=[], head_branch="feature", display_title="Review PR #999"), "o/r"
+    ) == 7
+
+
+def test_discovery_splits_above_github_search_limit(monkeypatch):
+    calls = []
+
+    def read(path):
+        calls.append(path)
+        if len(calls) == 1:
+            return {"total_count": 1001, "workflow_runs": []}
+        return {"total_count": 1, "workflow_runs": [run(id=len(calls))]}
+
+    monkeypatch.setattr(retry, "api", read)
+    found = retry.workflow_runs("o/r", NOW - timedelta(days=1), NOW, "failure")
+    assert len(calls) == 3
+    assert {r["id"] for r in found} == {2, 3}
+    assert all("status=failure" in path for path in calls)
+
+
+def test_discovery_reads_later_pages(monkeypatch):
+    def read(path):
+        rows = (
+            [run(id=i) for i in range(100)]
+            if path.endswith("&page=1")
+            else [run(id=101)]
+        )
+        return {"total_count": 101, "workflow_runs": rows}
+
+    monkeypatch.setattr(retry, "api", read)
+    assert (
+        len(retry.workflow_runs("o/r", NOW - timedelta(days=1), NOW, "failure")) == 101
+    )
+
+
+def test_operator_minimum_delay_can_increase_backoff():
+    assert retry.delay_hours(1, 12) == 12
+    assert retry.delay_hours(2, 12) == 12
+    assert retry.delay_hours(3, 12) == 24
+
+
+def test_newer_manual_review_prevents_write(monkeypatch):
+    manual = run(
+        id=30,
+        event="workflow_dispatch",
+        head_sha="main",
+        pull_requests=[],
+        display_title="Review PR #7",
+        status="in_progress",
+        conclusion=None,
+    )
+    writes = harness(monkeypatch, rows=[run(), manual])
+    retry.sweep("o/r", NOW, dry_run=False)
+    assert not writes
+
+
+def test_manual_fork_branch_main_does_not_match_unrelated_manual_reviews(monkeypatch):
+    manual = run(event="workflow_dispatch", head_sha="default-branch-sha")
+    unrelated = run(
+        id=30,
+        event="issue_comment",
+        pull_requests=[{"number": 99}],
+        conclusion="success",
+        created_at=(NOW - timedelta(hours=1)).isoformat(),
+    )
+    writes = harness(monkeypatch, rows=[manual])
+    original = retry.api
+
+    def read(path):
+        if "/workflows/" in path:
+            assert "branch=main" in path
+            return {"workflow_runs": [] if "event=pull_request" in path else [unrelated]}
+        if "/pulls/" in path:
+            return pr(head={"sha": "abc", "ref": "main", "repo": {"full_name": "contributor/fork"}})
+        return original(path)
+
+    monkeypatch.setattr(retry, "api", read)
+    rows, errors = retry.sweep("owner/repo", NOW, dry_run=False)
+    assert errors == 0
+    assert len(writes) == 1 and writes[0][0][2] == "20"
+
+
+def test_late_success_on_old_commit_does_not_hide_current_failure():
+    old = run(id=15, head_sha="old", conclusion="success", updated_at=NOW.isoformat())
+    assert reason(peers=[old]) is None
+
+
+def test_deleted_reviewer_does_not_crash_recovery():
+    assert reason(reviews=[{"id": 1, "user": None, "state": "APPROVED"}]) is None
+
+
+def test_zero_delay_explicitly_bypasses_backoff():
+    assert retry.delay_hours(1, 0) == 0
+    assert retry.delay_hours(5, 0) == 0
+
+
+def test_summary_links_actions_first_and_keeps_diagnostics():
+    rows = [
+        "Run 30: cannot resolve PR (CalledProcessError).",
+        "Run 30: deferred; PR association unavailable.",
+        "PR #9, run 29: skipped; PR is closed.",
+        "PR #7, run 20: retried failed jobs (attempt 2).",
+        "PR #8, run 21: deferred; retry budget reached.",
+    ]
+    summary = retry.render_summary("owner/repo", rows, False, 1)
+    assert "Live run: 1 rerun requests accepted (limit: 1)." in summary
+    assert "1 PRs deferred at the retry limit" in summary
+    assert "[PR #7](https://github.com/owner/repo/pull/7)" in summary
+    assert "[run 20](https://github.com/owner/repo/actions/runs/20)" in summary
+    assert "[Run 30](https://github.com/owner/repo/actions/runs/30)" in summary
+    assert summary.index("### Restarted reviews") < summary.index("<details>")
+    assert "PR lookup diagnostics (2 messages)" in summary
+    assert "Messages, not unique PRs or runs" in summary
+    assert "they have not been queued" in summary
+    for row in rows:
+        assert row.split(": ", 1)[1] in summary
+
+
+def test_summary_dry_run_does_not_claim_restarts():
+    summary = retry.render_summary(
+        "owner/repo", ["PR #7, run 20: would retry failed jobs (attempt 2)."], True, 5
+    )
+    assert "Dry run: no rerun requests issued; 1 would restart (limit: 5)." in summary
+    assert "### Would restart (dry run) (1)" in summary
+    assert "### Restarted reviews" not in summary
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        "Review retries disabled (budget 0).",
+        "No failed review runs need recovery.",
+        "Retries deferred: an active legacy review cannot yet be associated with a PR.",
+        "Discovery failed (CalledProcessError); no retries issued.",
+        "PR #7, run 20: error (CalledProcessError); no further action on this PR.",
+    ],
+)
+def test_summary_preserves_zero_action_and_error_notices(row):
+    summary = retry.render_summary("owner/repo", [row], False, 5)
+    assert "Live run: 0 rerun requests accepted" in summary
+    assert row.split(": ")[-1] in summary
+
+
+def test_main_writes_same_linked_summary_to_stdout_and_actions(
+    monkeypatch, tmp_path, capsys
+):
+    output = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(output))
+    monkeypatch.setattr(
+        retry,
+        "sweep",
+        lambda *args: (["PR #7, run 20: would retry failed jobs (attempt 2)."], 0),
+    )
+    assert retry.main(["--repo", "owner/repo"]) == 0
+    assert capsys.readouterr().out.strip() == output.read_text().strip()
+    assert "https://github.com/owner/repo/actions/runs/20" in output.read_text()
+
+
+@pytest.mark.parametrize("mode", [[], ["--dry-run"]])
+def test_cli_defaults_to_read_only_even_with_a_writer_available(monkeypatch, mode):
+    writes = harness(monkeypatch)
+    assert retry.main(["--repo", "owner/repo", *mode]) == 0
+    assert not writes
+
+
+def test_execute_requires_writer_before_discovery(monkeypatch):
+    monkeypatch.delenv("GH_RETRY_TOKEN", raising=False)
+    monkeypatch.setattr(retry, "sweep", lambda *args: pytest.fail("discovery ran"))
+    with pytest.raises(SystemExit) as exc:
+        retry.main(["--repo", "owner/repo", "--execute"])
+    assert exc.value.code == 2
+
+
+def test_execute_cli_uses_explicit_live_mode(monkeypatch):
+    writes = harness(monkeypatch)
+    assert retry.main(["--repo", "owner/repo", "--execute", "--min-delay-hours", "0"]) == 0
+    assert len(writes) == 1

--- a/tests/test_retry_failed_reviews.py
+++ b/tests/test_retry_failed_reviews.py
@@ -2,7 +2,7 @@
 
 import importlib.util
 import subprocess
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -11,8 +11,10 @@ ROOT = Path(__file__).resolve().parents[1]
 SPEC = importlib.util.spec_from_file_location(
     "retry_reviews", ROOT / "scripts/retry_failed_reviews.py"
 )
+assert SPEC is not None and SPEC.loader is not None
 retry = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(retry)
+UTC = timezone.utc
 NOW = datetime(2026, 9, 6, 12, tzinfo=UTC)
 
 
@@ -217,6 +219,60 @@ def test_read_failure_does_not_retry(monkeypatch):
     assert "error" in rows[0]
 
 
+@pytest.mark.parametrize("field,error", [("base", "AttributeError"), ("head", "TypeError")])
+@pytest.mark.parametrize("refresh", [1, 2])
+def test_null_pr_metadata_does_not_abort_other_prs(monkeypatch, field, error, refresh):
+    older = run(
+        id=10,
+        pull_requests=[{"number": 8}],
+        updated_at=(NOW - timedelta(hours=8)).isoformat(),
+    )
+    writes = harness(monkeypatch, rows=[older, run()])
+    original = retry.api
+    reads = 0
+
+    def read(path):
+        nonlocal reads
+        if path.endswith("/pulls/8"):
+            reads += 1
+            if reads == refresh:
+                return pr(**{field: None})
+        return original(path)
+
+    monkeypatch.setattr(retry, "api", read)
+    rows, errors = retry.sweep("owner/repo", NOW, limit=1, dry_run=False)
+    assert errors == 1
+    assert f"PR #8, run 10: error ({error}); no further action on this PR." in rows
+    assert len(writes) == 1 and writes[0][0][2] == "20"
+    assert any("PR #7, run 20: retried failed jobs" in row for row in rows)
+
+
+@pytest.mark.parametrize("payload", [None, [], {"workflow_runs": None}])
+def test_malformed_branch_run_payload_does_not_abort_other_prs(monkeypatch, payload):
+    older = run(
+        id=10,
+        pull_requests=[{"number": 8}],
+        updated_at=(NOW - timedelta(hours=8)).isoformat(),
+    )
+    writes = harness(monkeypatch, rows=[older, run()])
+    original = retry.api
+    reads = 0
+
+    def read(path):
+        nonlocal reads
+        if "/workflows/" in path:
+            reads += 1
+            if reads == 1:
+                return payload
+        return original(path)
+
+    monkeypatch.setattr(retry, "api", read)
+    rows, errors = retry.sweep("owner/repo", NOW, limit=1, dry_run=False)
+    assert errors == 1
+    assert "PR #8, run 10: error (TypeError); no further action on this PR." in rows
+    assert len(writes) == 1 and writes[0][0][2] == "20"
+
+
 def test_exhausted_run_does_not_spend_retry_budget(monkeypatch):
     exhausted = run(
         id=10,
@@ -270,6 +326,29 @@ def test_resolve_dispatch_and_legacy_dispatch(monkeypatch):
         lambda *args: "2026-09-06 Dispatched PR #7: head_ref='feature' author='human'",
     )
     assert retry.run_pr(run(event="workflow_dispatch", pull_requests=[]), "o/r") == 7
+
+
+@pytest.mark.parametrize("payload,error", [(None, "AttributeError"), (run(pull_requests=None), "TypeError")])
+def test_malformed_run_association_returns_diagnostic(payload, error):
+    assert retry.resolve_run(payload, "owner/repo") == (payload, None, error)
+
+
+def test_malformed_completed_run_association_does_not_abort_other_prs(monkeypatch):
+    malformed = run(id=30, pull_requests=None)
+    writes = harness(monkeypatch, rows=[run(), malformed], fresh=[run()])
+    calls = 0
+
+    def discovered(*args):
+        nonlocal calls
+        calls += 1
+        return [run(), malformed] if calls == 1 else []
+
+    monkeypatch.setattr(retry, "workflow_runs", discovered)
+    rows, errors = retry.sweep("owner/repo", NOW, dry_run=False)
+    assert errors == 0
+    assert "Run 30: cannot resolve PR (TypeError)." in rows
+    assert "Run 30: deferred; PR association unavailable." in rows
+    assert len(writes) == 1 and writes[0][0][2] == "20"
 
 
 def test_legacy_aigr_dispatch_resolves_from_pr_number_environment(monkeypatch):
@@ -370,6 +449,28 @@ def test_stale_queue_refresh_read_failure_still_blocks(monkeypatch, lookup):
     monkeypatch.setattr(retry, lookup, fail)
     ignored, diagnostic = retry.unassociated_active_disposition(stale_queue(), "owner/repo", NOW)
     assert not ignored and "cannot verify" in diagnostic
+
+
+@pytest.mark.parametrize(
+    "endpoint,payload",
+    [
+        ("run", None),
+        ("run", []),
+        ("jobs", {"jobs": None}),
+        ("jobs", {"jobs": {}}),
+    ],
+)
+def test_stale_queue_malformed_refresh_cannot_prove_no_activity(monkeypatch, endpoint, payload):
+    def read(path):
+        if path.endswith("/30"):
+            return payload if endpoint == "run" else stale_queue()
+        assert "/30/jobs?" in path
+        return payload
+
+    monkeypatch.setattr(retry, "api", read)
+    ignored, diagnostic = retry.unassociated_active_disposition(stale_queue(), "owner/repo", NOW)
+    assert not ignored
+    assert "cannot verify an unassociated active review (TypeError)" in diagnostic
 
 
 def test_recent_unassociated_queue_during_final_scan_has_explicit_deferral(monkeypatch):
@@ -579,6 +680,43 @@ def test_main_writes_same_linked_summary_to_stdout_and_actions(
     assert retry.main(["--repo", "owner/repo"]) == 0
     assert capsys.readouterr().out.strip() == output.read_text().strip()
     assert "https://github.com/owner/repo/actions/runs/20" in output.read_text()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        {"total_count": None, "workflow_runs": []},
+        {"total_count": 0, "workflow_runs": None},
+        {"total_count": 0, "workflow_runs": {}},
+        {"total_count": 1, "workflow_runs": [None]},
+    ],
+)
+def test_cli_malformed_discovery_reports_error_without_writes(monkeypatch, capsys, payload):
+    writes = []
+    monkeypatch.setenv("GH_RETRY_TOKEN", "writer")
+    monkeypatch.setattr(retry, "api", lambda path: payload)
+    monkeypatch.setattr(retry, "gh", lambda *args, **kwargs: writes.append(args))
+    assert retry.main(["--repo", "owner/repo", "--execute"]) == 1
+    assert not writes
+    summary = capsys.readouterr().out
+    assert "Discovery failed (TypeError); no retries issued." in summary
+    assert "Live run: 0 rerun requests accepted" in summary
+
+
+def test_cli_discovery_request_failure_reports_error_without_writes(monkeypatch, capsys):
+    writes = []
+    monkeypatch.setenv("GH_RETRY_TOKEN", "writer")
+
+    def fail(path):
+        raise subprocess.CalledProcessError(1, ["gh"])
+
+    monkeypatch.setattr(retry, "api", fail)
+    monkeypatch.setattr(retry, "gh", lambda *args, **kwargs: writes.append(args))
+    assert retry.main(["--repo", "owner/repo", "--execute"]) == 1
+    assert not writes
+    assert "Discovery failed (CalledProcessError); no retries issued." in capsys.readouterr().out
 
 
 @pytest.mark.parametrize("mode", [[], ["--dry-run"]])


### PR DESCRIPTION
## Summary

- Remove the default file-path veto from the deterministic merge controller. PR #2804 was approved, green, and conflict-free but repeatedly skipped because it changed `cache/go/terms.csv`; six other PRs hit that exclusion and two more were blocked by curation history. All paths are now eligible by default. An explicit `--allowed-path-prefix` can still restrict a manual sweep. Cache regeneration during conflict repair is separate from merge eligibility.
- Port DisMech's independent failed/timed-out review recovery, with its own runner, concurrency group, Actions-write credential, retry budget, and persistent backoff. Scheduled runs retry up to five PRs; manual runs default to audit. A freshly verified, unassociated, jobless queue record unchanged for at least 24 hours cannot block every other retry. Recovery does not require merge queues.
- Include maintainer-created `codex/` branches in tending, scan beyond the CLI's first page, trigger reviews when PRs reopen or become ready, and serialize real review triggers per PR without ordinary comments cancelling a running review.

Exact-head approval, CI, conflict, hold, assignment, age, and branch-protection guards remain in place. Missing/cancelled reviews, successful runs without a verdict, and failures beyond GitHub's rerun limits remain in the tending agent's dispatch scope.

The maintainer explicitly chose the same approval policy for infrastructure and curation: bot-only approval can qualify an infrastructure PR, with no extra human/CODEOWNERS gate. The merge token now requests Workflows write to support workflow-changing PRs. **Before merging, grant Workflows write to the ai4c-agent App registration and approve the ai4curation installation upgrade.** Both currently lack it, and YAML cannot expand an installation grant. The migration document records the settings and rollout requirement.

Scheduled retry recovery can be switched to audit by setting `PR_SHEPHERD_RETRY_ENABLED=false`; unset preserves live schedules. Malformed API payloads are isolated to the affected PR, and a regression pins the complete comment-authorization predicate shared by review execution and concurrency.

## Validation

- 346 focused automation tests pass, covering merge policy, review recovery, workflows, agent configuration, run summaries, and cron profiles.
- `just mypy` passes across 191 files; `just format`, targeted Ruff, actionlint on the three changed workflows, and `git diff --check` pass. The initial CI typing failure is fixed without changing the repository's Python 3.10 type-checking target.
- Read-only GitHub checks: #2804 passes the full closing predicate; a one-day retry audit identifies four recoverable failed reviews and respects a two-PR budget. No live reruns or merges were issued during validation.

## Test plan

- [x] Verify approved, green PRs can include caches, history, code, workflows, and documentation without a default path veto; explicit scoped sweeps still check rename sources and destinations.
- [x] Verify retry backoff, current-head verdicts, newer/active reviews, stale jobless queues, manual fork reviews, and audit credential isolation.
- [x] Exercise the retry workflow's shell commands in audit, execute, and zero-budget modes.
- [ ] After merge, inspect the scheduled retry summary and closing pass; manual inspection can use `run_agent=false`, `merge_mode=off`, and `review_retry_mode=audit`.
- [ ] Before merge, grant Workflows write in the ai4c-agent App registration and approve it for the ai4curation installation.
